### PR TITLE
Rework active tab indicator and more tab goodness

### DIFF
--- a/docs/docs/components/tab-group.md
+++ b/docs/docs/components/tab-group.md
@@ -52,6 +52,22 @@ const App = () => (
 
 ## Examples
 
+### Setting the Active Tab
+
+To make a tab active, set the `active` attribute to the name of the appropriate panel.
+
+```html {.example}
+<wa-tab-group active="advanced">
+  <wa-tab slot="nav" panel="general">General</wa-tab>
+  <wa-tab slot="nav" panel="custom">Custom</wa-tab>
+  <wa-tab slot="nav" panel="advanced">Advanced</wa-tab>
+
+  <wa-tab-panel name="general">This is the general tab panel.</wa-tab-panel>
+  <wa-tab-panel name="custom">This is the custom tab panel.</wa-tab-panel>
+  <wa-tab-panel name="advanced">This is the advanced tab panel.</wa-tab-panel>
+</wa-tab-group>
+```
+
 ### Tabs on Bottom
 
 Tabs can be shown on the bottom by setting `placement` to `bottom`.
@@ -198,37 +214,51 @@ const App = () => (
 
 ### Closable Tabs
 
-Add the `closable` attribute to a tab to show a close button. This example shows how you can dynamically remove tabs from the DOM when the close button is activated.
+You can make a tab closable by adding a close button next to the tab and inside the `nav` slot. You can position the button to your liking with CSS and handle close/restore behaviors by removing/appending the tab as desired. Note the use of `tabindex="-1"`, which prevents the close button from interfering with the tab order. The close button is still recognizable to the virtual cursor in screen readers.
 
 ```html {.example}
 <wa-tab-group class="tabs-closable">
   <wa-tab slot="nav" panel="general">General</wa-tab>
-  <wa-tab slot="nav" panel="closable-1" closable>Closable 1</wa-tab>
-  <wa-tab slot="nav" panel="closable-2" closable>Closable 2</wa-tab>
-  <wa-tab slot="nav" panel="closable-3" closable>Closable 3</wa-tab>
+  <wa-tab slot="nav" panel="closable">Closable</wa-tab>
+  <wa-icon-button slot="nav" tabindex="-1" name="xmark" label="Close the closable tab"></wa-icon-button>
+  <wa-tab slot="nav" panel="closable-2">Advanced</wa-tab>
 
   <wa-tab-panel name="general">This is the general tab panel.</wa-tab-panel>
-  <wa-tab-panel name="closable-1">This is the first closable tab panel.</wa-tab-panel>
-  <wa-tab-panel name="closable-2">This is the second closable tab panel.</wa-tab-panel>
-  <wa-tab-panel name="closable-3">This is the third closable tab panel.</wa-tab-panel>
+  <wa-tab-panel name="closable">This is the closable tab panel.</wa-tab-panel>
+  <wa-tab-panel name="advanced">This is the advanced tab panel.</wa-tab-panel>
 </wa-tab-group>
+
+<br>
+
+<wa-button disabled>Restore tab</wa-button>
+
+<style>
+  .tabs-closable wa-icon-button {
+    position: relative;
+    left: -1rem;
+    top: .75rem;  }
+</style>
 
 <script>
   const tabGroup = document.querySelector('.tabs-closable');
-
-  tabGroup.addEventListener('wa-close', async event => {
-    const tab = event.target;
-    const panel = tabGroup.querySelector(`wa-tab-panel[name="${tab.panel}"]`);
-
-    // Show the previous tab if the tab is currently active
-    if (tab.active) {
-      tabGroup.show(tab.previousElementSibling.panel);
-    }
-
-    // Remove the tab + panel
-    tab.remove();
-    panel.remove();
+  const generalTab = tabGroup.querySelectorAll('wa-tab')[0];
+  const closableTab = tabGroup.querySelectorAll('wa-tab')[1];
+  const closeButton = tabGroup.querySelector('wa-icon-button[slot="nav"]');
+  const restoreButton = tabGroup.nextElementSibling.nextElementSibling;
+  
+  // Remove the tab when the close button is clicked
+  closeButton.addEventListener('click', () => {
+    closableTab.remove();
+    closeButton.remove();
+    restoreButton.disabled = false;
   });
+
+  // Restore the tab
+  restoreButton.addEventListener('click', () => {
+    restoreButton.disabled = true;
+    generalTab.insertAdjacentElement('afterend', closeButton);
+    generalTab.insertAdjacentElement('afterend', closableTab);
+  })
 </script>
 ```
 

--- a/docs/docs/resources/changelog.md
+++ b/docs/docs/resources/changelog.md
@@ -14,14 +14,18 @@ New versions of Web Awesome are released as-needed and generally occur when a cr
 
 - Added `setKitCode()` and `getKitCode()` functions as well as support for setting kit codes declaratively with `data-webawesome-kit`
 - Added `family` and `variant` attributes to `<wa-icon>` and `<wa-icon-button>`
+- Added the `active` attribute to `<wa-tab-group>`
 - Changed the attribute for setting the base path declaratively to `data-webawesome` instead of `data-shoelace`; additionally, you can place it on any element now instead of just the associated `<script>` tag
 - `<wa-icon>` icons are no longer fixed width by default to accommodate variable width icons
 - Changed the `sl` prefix to `wa` for Web Awesome, including tags, events, etc.
 - Changed `primary` variants to `brand` in all components
 - Improved submenu selection by implementing the [safe triangle](https://www.smashingmagazine.com/2023/08/better-context-menus-safe-triangles/) method [#1550]
+- Improved tabbing in `<wa-tab-group>` so it uses a roving tab index instead of being able to cycle through each tab
 - Removed `default` from `<wa-button>` and made `neutral` the new default
 - Removed the `circle` modifier from `<wa-button>` because button's no longer have a set height
 - Removed the `active-tab-indicator` part from `<wa-tab-group>`
+- Removed the `closable` attribute from `<wa-tab>` because you can't nest interactive elements (see the updated example for a better method)
+- Removed the `show()` method from `<wa-tab-group>` (use the `active` attribute instead)
 
 ## Next
 

--- a/docs/docs/resources/changelog.md
+++ b/docs/docs/resources/changelog.md
@@ -21,6 +21,7 @@ New versions of Web Awesome are released as-needed and generally occur when a cr
 - Improved submenu selection by implementing the [safe triangle](https://www.smashingmagazine.com/2023/08/better-context-menus-safe-triangles/) method [#1550]
 - Removed `default` from `<wa-button>` and made `neutral` the new default
 - Removed the `circle` modifier from `<wa-button>` because button's no longer have a set height
+- Removed the `active-tab-indicator` part from `<wa-tab-group>`
 
 ## Next
 

--- a/src/components/tab-group/tab-group.styles.ts
+++ b/src/components/tab-group/tab-group.styles.ts
@@ -106,6 +106,11 @@ export default css`
     order: 2;
   }
 
+  .tab-group--top ::slotted(wa-tab[active]) {
+    border-block-end: solid var(--track-width) var(--indicator-color);
+    margin-block-end: calc(-1 * var(--track-width));
+  }
+
   .tab-group--top ::slotted(wa-tab-panel) {
     --padding: var(--wa-space-m) 0;
   }
@@ -152,6 +157,11 @@ export default css`
     order: 1;
   }
 
+  .tab-group--bottom ::slotted(wa-tab[active]) {
+    border-block-start: solid var(--track-width) var(--indicator-color);
+    margin-block-start: calc(-1 * var(--track-width));
+  }
+
   .tab-group--bottom ::slotted(wa-tab-panel) {
     --padding: var(--wa-space-m) 0;
   }
@@ -189,6 +199,11 @@ export default css`
     order: 2;
   }
 
+  .tab-group--start ::slotted(wa-tab[active]) {
+    border-inline-end: solid var(--track-width) var(--indicator-color);
+    margin-inline-end: calc(-1 * var(--track-width));
+  }
+
   .tab-group--start ::slotted(wa-tab-panel) {
     --padding: 0 var(--wa-space-m);
   }
@@ -224,6 +239,11 @@ export default css`
   .tab-group--end .tab-group__body {
     flex: 1 1 auto;
     order: 1;
+  }
+
+  .tab-group--end ::slotted(wa-tab[active]) {
+    border-inline-start: solid var(--track-width) var(--indicator-color);
+    margin-inline-start: calc(-1 * var(--track-width));
   }
 
   .tab-group--end ::slotted(wa-tab-panel) {

--- a/src/components/tab-group/tab-group.test.ts
+++ b/src/components/tab-group/tab-group.test.ts
@@ -443,7 +443,7 @@ describe('<wa-tab-group>', () => {
       `);
 
       return expectCustomTabToBeActiveAfter(tabGroup, () => {
-        tabGroup.show('custom');
+        tabGroup.active = 'custom';
         return aTimeout(0);
       });
     });

--- a/src/components/tab/tab.styles.ts
+++ b/src/components/tab/tab.styles.ts
@@ -10,7 +10,6 @@ export default css`
     align-items: center;
     font: inherit;
     font-weight: var(--wa-font-weight-action);
-    border-radius: var(--wa-corners-s);
     color: var(--wa-color-neutral-text-on-surface);
     padding: var(--wa-space-m) var(--wa-space-l);
     white-space: nowrap;

--- a/src/components/tab/tab.test.ts
+++ b/src/components/tab/tab.test.ts
@@ -1,8 +1,5 @@
 import { expect, fixture, html } from '@open-wc/testing';
-import sinon from 'sinon';
-import type WaIconButton from '../icon-button/icon-button.js';
 import type WaTab from './tab.js';
-import type WaTabGroup from '../tab-group/tab-group.js';
 
 describe('<wa-tab>', () => {
   it('passes accessibility test', async () => {

--- a/src/components/tab/tab.test.ts
+++ b/src/components/tab/tab.test.ts
@@ -22,10 +22,9 @@ describe('<wa-tab>', () => {
     expect(el.getAttribute('role')).to.equal('tab');
     expect(el.getAttribute('aria-disabled')).to.equal('false');
     expect(el.getAttribute('aria-selected')).to.equal('false');
-    expect(base.getAttribute('tabindex')).to.equal('0');
+    expect(base.getAttribute('tabindex')).to.equal('-1');
     expect(base.getAttribute('class')).to.equal(' tab ');
     expect(el.active).to.equal(false);
-    expect(el.closable).to.equal(false);
     expect(el.disabled).to.equal(false);
   });
 
@@ -49,17 +48,6 @@ describe('<wa-tab>', () => {
     expect(el.getAttribute('aria-selected')).to.equal('true');
     expect(base.getAttribute('class')).to.equal(' tab tab--active ');
     expect(base.getAttribute('tabindex')).to.equal('0');
-  });
-
-  it('should set closable by attribute', async () => {
-    const el = await fixture<WaTab>(html` <wa-tab closable>Test</wa-tab> `);
-
-    const base = el.shadowRoot!.querySelector<HTMLElement>('[part~="base"]')!;
-    const closeButton = el.shadowRoot!.querySelector('[part~="close-button"]');
-
-    expect(el.closable).to.equal(true);
-    expect(base.getAttribute('class')).to.equal(' tab tab--closable ');
-    expect(closeButton).not.to.be.null;
   });
 
   describe('focus', () => {
@@ -86,35 +74,6 @@ describe('<wa-tab>', () => {
       await el.updateComplete;
 
       expect(el.shadowRoot!.activeElement).to.equal(null);
-    });
-  });
-
-  describe('closable', () => {
-    it('should emit close event when the close button is clicked', async () => {
-      const tabGroup = await fixture<WaTabGroup>(html`
-        <wa-tab-group>
-          <wa-tab slot="nav" panel="general" closable>General</wa-tab>
-          <wa-tab slot="nav" panel="custom" closable>Custom</wa-tab>
-          <wa-tab-panel name="general">This is the general tab panel.</wa-tab-panel>
-          <wa-tab-panel name="custom">This is the custom tab panel.</wa-tab-panel>
-        </wa-tab-group>
-      `);
-      const closeButton = tabGroup
-        .querySelectorAll('wa-tab')[0]
-        .shadowRoot!.querySelector<WaIconButton>('[part~="close-button"]')!;
-
-      const handleClose = sinon.spy();
-      const handleTabShow = sinon.spy();
-
-      tabGroup.addEventListener('wa-close', handleClose, { once: true });
-      // The wa-tab-show event shouldn't be emitted when clicking the close button
-      tabGroup.addEventListener('wa-tab-show', handleTabShow);
-
-      closeButton.click();
-      await closeButton?.updateComplete;
-
-      expect(handleClose.called).to.equal(true);
-      expect(handleTabShow.called).to.equal(false);
     });
   });
 });

--- a/src/components/tab/tab.ts
+++ b/src/components/tab/tab.ts
@@ -1,8 +1,6 @@
-import '../icon-button/icon-button.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { customElement, property, query } from 'lit/decorators.js';
 import { html } from 'lit';
-import { LocalizeController } from '../../utilities/localize.js';
 import { watch } from '../../internal/watch.js';
 import componentStyles from '../../styles/component.styles.js';
 import styles from './tab.styles.js';
@@ -17,11 +15,7 @@ let id = 0;
  * @status stable
  * @since 2.0
  *
- * @dependency wa-icon-button
- *
  * @slot - The tab's label.
- *
- * @event wa-close - Emitted when the tab is closable and the close button is activated.
  *
  * @csspart base - The component's base wrapper.
  * @csspart close-button - The close button, an `<wa-icon-button>`.
@@ -31,8 +25,6 @@ let id = 0;
 export default class WaTab extends WebAwesomeElement {
   static styles: CSSResultGroup = [componentStyles, styles];
 
-  private readonly localize = new LocalizeController(this);
-
   private readonly attrId = ++id;
   private readonly componentId = `wa-tab-${this.attrId}`;
 
@@ -41,11 +33,8 @@ export default class WaTab extends WebAwesomeElement {
   /** The name of the tab panel this tab is associated with. The panel must be located in the same tab group. */
   @property({ reflect: true }) panel = '';
 
-  /** Draws the tab in an active state. */
+  /** @internal Draws the tab in an active state. */
   @property({ type: Boolean, reflect: true }) active = false;
-
-  /** Makes the tab closable and shows a close button. */
-  @property({ type: Boolean }) closable = false;
 
   /** Disables the tab and prevents selection. */
   @property({ type: Boolean, reflect: true }) disabled = false;
@@ -53,11 +42,6 @@ export default class WaTab extends WebAwesomeElement {
   connectedCallback() {
     super.connectedCallback();
     this.setAttribute('role', 'tab');
-  }
-
-  private handleCloseClick(event: Event) {
-    event.stopPropagation();
-    this.emit('wa-close');
   }
 
   @watch('active')
@@ -90,27 +74,11 @@ export default class WaTab extends WebAwesomeElement {
         class=${classMap({
           tab: true,
           'tab--active': this.active,
-          'tab--closable': this.closable,
           'tab--disabled': this.disabled
         })}
-        tabindex=${this.disabled ? '-1' : '0'}
+        tabindex=${this.active && !this.disabled ? '0' : '-1'}
       >
         <slot></slot>
-        ${this.closable
-          ? html`
-              <wa-icon-button
-                part="close-button"
-                exportparts="base:close-button__base"
-                name="xmark"
-                library="system"
-                variant="solid"
-                label=${this.localize.term('close')}
-                class="tab__close-button"
-                @click=${this.handleCloseClick}
-                tabindex="-1"
-              ></wa-icon-button>
-            `
-          : ''}
       </div>
     `;
   }


### PR DESCRIPTION
- Added the `active` attribute to `<wa-tab-group>`
- Improved tabbing in `<wa-tab-group>` so it uses a roving tab index instead of being able to cycle through each tab
- Removed the `active-tab-indicator` part from `<wa-tab-group>`
- Removed the `closable` attribute from `<wa-tab>` because you can't nest interactive elements (see the updated example for a better method)
- Reworked the closable example 

---

Fixes #67
Fixes #68