### PR TITLE
Docs: Add Page component link to Docs Sidebar

### DIFF
--- a/docs/_includes/sidebar.njk
+++ b/docs/_includes/sidebar.njk
@@ -148,6 +148,9 @@
     <a href="/docs/components/option">Option</a>
   </li>
   <li>
+    <a href="/docs/components/page">Page</a>
+  </li>
+  <li>
     <a href="/docs/components/popup">Popup</a>
   </li>
   <li>


### PR DESCRIPTION
This adds the Page component to the main docs sidebar (it had gone missing somewhere in the shuffle between Astro and Eleventy ports).