### PR TITLE
updated usage example

### DIFF
--- a/docs/docs/components/color-picker.md
+++ b/docs/docs/components/color-picker.md
@@ -45,7 +45,7 @@ To prevent users from toggling the format themselves, add the `no-format-toggle`
 
 ### Swatches
 
-Use the `swatches` attribute to add convenient presets to the color picker. Any format the color picker can parse is acceptable (including CSS color names), but each value must be separated by a semicolon (`;`). Alternatively, you can pass an array of color values to this property using JavaScript.
+Use the `swatches` attribute to add convenient presets to the color picker. Any format the color picker can parse is acceptable (including [CSS color names](https://www.w3schools.com/colors/colors_names.asp)), but each value must be separated by a semicolon (`;`). Alternatively, you can pass an array of color values to this property using JavaScript.
 
 ```html {.example}
 <wa-color-picker

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -22,19 +22,6 @@ Some properties are boolean, so they only have true/false values. To activate a 
 <wa-button disabled>Click me</wa-button>
 ```
 
-In rare cases, a property may require an array, an object, or a function. For example, to customize the color picker's list of preset swatches, you set the `swatches` property to an array of colors. This must be done with JavaScript.
-
-```html
-<wa-color-picker></wa-color-picker>
-
-<script>
-  const colorPicker = document.querySelector('wa-color-picker');
-  colorPicker.swatches = ['red', 'orange', 'yellow', 'green', 'blue', 'purple'];
-</script>
-```
-
-Refer to a component's documentation for a complete list of its properties.
-
 ## Events
 
 You can listen for standard events such as `click`, `mouseover`, etc. as you normally would. However, it's important to note that many events emitted within a component's shadow root will be [retargeted](https://dom.spec.whatwg.org/#retarget) to the host element. This may result in, for example, multiple `click` handlers executing even if the user clicks just once. Furthermore, `event.target` will point to the host element, making things even more confusing.


### PR DESCRIPTION
Since the js way can't be set declaratively, I deleted that example completely. While it's still possible to do, deemphasizing it may be the best course of action. 

Also, I added a link to the [html named colors](https://www.w3schools.com/colors/colors_names.asp) so customers would have a jumping off point should they need it.