### PR TITLE
Fix: Using Appearance Attribute for Text Buttons in Themes

### DIFF
--- a/src/themes/depth_2_chunky.css
+++ b/src/themes/depth_2_chunky.css
@@ -45,7 +45,7 @@ wa-button {
   --wa-transition-normal: 0ms;
   --wa-transition-fast: 0ms;
 
-  &:not([variant='text']) {
+  &:not([appearance='text']) {
     --box-shadow: var(--wa-shadow-offset-x-s) var(--wa-shadow-offset-y-s) var(--wa-shadow-blur-s)
       var(--box-shadow-color);
     margin-bottom: var(--wa-shadow-offset-y-s);

--- a/src/themes/depth_3_punchy.css
+++ b/src/themes/depth_3_punchy.css
@@ -40,7 +40,7 @@
 }
 
 /* #region Buttons */
-wa-button:not([variant='text']) {
+wa-button:not([appearance='text']) {
   --box-shadow: inset 0 0.0625rem 0 0 rgb(255 255 255 / 0.2) /* shine */,
     inset 0 0.0625rem 0.125rem 0 rgb(255 255 255 / 0.2) /* inner highlight */,
     inset 0 -0.0625rem 0.0625rem 0 rgb(0 0 0 / 0.2) /* inner shadow */, var(--wa-shadow-s) /* outer shadow */;

--- a/src/themes/depth_4_glossy.css
+++ b/src/themes/depth_4_glossy.css
@@ -97,7 +97,7 @@
 /* #endregion */
 
 /* #region Buttons */
-wa-button:not([variant='text']) {
+wa-button:not([appearance='text']) {
   --box-shadow: inset 0 0.0625rem 0 0 rgb(255 255 255 / 0.2) /* shine */,
     inset 0 0.125rem 0 0 rgb(255 255 255 / 0.1) /* top highlight */,
     inset 0 1.25em 0 0 rgb(255 255 255 / 0.1) /* upper tint */, inset 0 -1.125em 0 0 rgb(0 0 0 / 0.04) /* lower shade */,

--- a/src/themes/fa.css
+++ b/src/themes/fa.css
@@ -510,7 +510,7 @@
     }
   }
 
-  wa-button:not([variant='text']) {
+  wa-button:not([appearance='text']) {
     --border-color: var(--label-color);
     --border-color-hover: var(--border-color);
     --border-color-active: var(--border-color);


### PR DESCRIPTION
This work catches a few spots that need to be updated given the latest Alpha's release change to `<wa-button`>. 

The previous `variant=text` attribute has been deprecated in favor of using `appearance=text` - the changes here catch a few CSS rules targeting the former and update them to the latter.