### PR TITLE
Fix tree item expand icon

### DIFF
--- a/src/components/tree-item/tree-item.styles.ts
+++ b/src/components/tree-item/tree-item.styles.ts
@@ -58,11 +58,9 @@ export default css`
     display: flex;
     align-items: center;
     justify-content: center;
-    box-sizing: content-box;
     color: var(--expand-button-color);
-    padding: var(--wa-space-xs);
-    width: 1rem;
-    height: 1rem;
+    width: 2em;
+    height: 2em;
     flex-shrink: 0;
     cursor: pointer;
   }


### PR DESCRIPTION
Fixes tree item's expand icon following [box-sizing adjustments in components.styles.ts](https://github.com/shoelace-style/webawesome/commit/33eccfc5f8d62bf54ea9392ea924adb2a7a4bf0a).