### PR TITLE
Fix card footer border radius

### DIFF
--- a/src/components/card/card.styles.ts
+++ b/src/components/card/card.styles.ts
@@ -68,6 +68,8 @@ export default css`
   .card--has-footer .card__footer {
     display: block;
     border-top: inherit;
+    border-bottom-left-radius: var(--border-radius);
+    border-bottom-right-radius: var(--border-radius);
     padding: var(--spacing);
   }
 


### PR DESCRIPTION
A test site from one of our backers revealed that card footers don't have any border radius. So, when a background color is applied specifically to the footer, the corners don't match those of the parent card.

Their example:
<img width="1330" alt="Screenshot 2024-08-13 at 1 33 00 PM" src="https://github.com/user-attachments/assets/d278cb4d-23d1-45e1-b52a-56efa8d8749b">

This simple change resolves the issue.