### PR TITLE
fix color picker initial 'isEmpty' state

### DIFF
--- a/src/components/color-picker/color-picker.ts
+++ b/src/components/color-picker/color-picker.ts
@@ -144,7 +144,7 @@ export default class WaColorPicker extends WebAwesomeFormAssociatedElement {
 
   @state() private hasFocus = false;
   @state() private isDraggingGridHandle = false;
-  @state() private isEmpty = false;
+  @state() private isEmpty = true;
   @state() private inputValue = '';
   @state() private hue = 0;
   @state() private saturation = 100;


### PR DESCRIPTION
minor fix for `isEmpty` in SSR not behaving the same as `isEmpty` with client rendering.