### PR TITLE
fix labels when updated dynamically

### DIFF
--- a/docs/docs/resources/changelog.md
+++ b/docs/docs/resources/changelog.md
@@ -18,6 +18,7 @@ During the alpha period, things might break! We take breaking changes very serio
 - Added more resilient support for lazy loaded options in `<wa-select>`
 - Fixed a bug in `<wa-relative-time>` where the title attribute would show with redundant info
 - Fixed a bug in `<wa-tooltip>` that caused a memory leak in disconnected elements
+- Fixed a bug in `<wa-select>` that prevented label changes in `<wa-option>` from updating the controller
 - Improved alignment of the play icon in `<wa-animated-image>`
 
 ## 3.0.0-alpha.3

--- a/src/components/option/option.test.ts
+++ b/src/components/option/option.test.ts
@@ -1,7 +1,6 @@
-import { aTimeout, expect, waitUntil } from '@open-wc/testing';
+import { aTimeout, expect } from '@open-wc/testing';
 import { fixtures } from '../../internal/test/fixture.js';
 import { html } from 'lit';
-import sinon from 'sinon';
 import type WaOption from './option.js';
 
 describe('<wa-option>', () => {
@@ -33,17 +32,6 @@ describe('<wa-option>', () => {
         el.disabled = true;
         await aTimeout(100);
         expect(el.getAttribute('aria-disabled')).to.equal('true');
-      });
-
-      it('emits the slotchange event when the label changes', async () => {
-        const el = await fixture<WaOption>(html` <wa-option>Text</wa-option> `);
-        const slotChangeHandler = sinon.spy();
-
-        el.addEventListener('slotchange', slotChangeHandler);
-        el.textContent = 'New Text';
-        await waitUntil(() => slotChangeHandler.calledOnce);
-
-        expect(slotChangeHandler).to.have.been.calledOnce;
       });
 
       it('should convert non-string values to string', async () => {

--- a/src/components/option/option.ts
+++ b/src/components/option/option.ts
@@ -36,7 +36,6 @@ import type { CSSResultGroup } from 'lit';
 export default class WaOption extends WebAwesomeElement {
   static styles: CSSResultGroup = [componentStyles, styles];
 
-  private cachedTextLabel: string;
   // @ts-expect-error - Controller is currently unused
   private readonly localize = new LocalizeController(this);
 
@@ -63,20 +62,13 @@ export default class WaOption extends WebAwesomeElement {
   }
 
   private handleDefaultSlotChange() {
-    const textLabel = this.getTextLabel();
-
-    // Ignore the first time the label is set
-    if (typeof this.cachedTextLabel === 'undefined') {
-      this.cachedTextLabel = textLabel;
-      return;
-    }
-
-    // When the label changes, emit a slotchange event so parent controls see it
-    if (textLabel !== this.cachedTextLabel) {
-      this.cachedTextLabel = textLabel;
-      /** @internal - prevent the CEM from recording this event */
-      this.dispatchEvent(new Event('slotchange', { bubbles: true, composed: false, cancelable: false }));
-    }
+    // When the label changes, tell the controller to update
+    customElements.whenDefined('wa-select').then(() => {
+      const controller = this.closest('wa-select');
+      if (controller) {
+        controller.handleDefaultSlotChange();
+      }
+    });
   }
 
   private handleMouseEnter() {

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -541,7 +541,8 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
     }
   }
 
-  private handleDefaultSlotChange() {
+  /* @internal - used by options to update labels */
+  public handleDefaultSlotChange() {
     if (!customElements.get('wa-option')) {
       customElements.whenDefined('wa-option').then(() => this.handleDefaultSlotChange());
     }


### PR DESCRIPTION
Context: https://github.com/shoelace-style/shoelace/issues/1971

@KonnorRogers please check my work on this one. Tests are passing and the labels update. No need for a mutation observer.

If we're OK with this, I can backport it to SL.