### PR TITLE
Only run autoloader once; show warnings when imports fail

### DIFF
--- a/src/webawesome.loader.ts
+++ b/src/webawesome.loader.ts
@@ -1,5 +1,5 @@
-import { discover } from './webawesome.js';
-
-discover(document.body);
+import { startLoader } from './webawesome.js';
 
 export * from './webawesome.js';
+
+startLoader();

--- a/src/webawesome.ts
+++ b/src/webawesome.ts
@@ -1,7 +1,7 @@
 export { getBasePath, setBasePath, getKitCode, setKitCode } from './utilities/base-path.js';
 export { registerIconLibrary, unregisterIconLibrary } from './components/icon/library.js';
 export { registerTranslation } from './utilities/localize.js';
-export { discover } from './utilities/autoloader.js';
+export { discover, startLoader, stopLoader } from './utilities/autoloader.js';
 
 // Utilities
 export * from './utilities/animation.js';


### PR DESCRIPTION
- Adds warnings when imports fail so it's more obvious to users
- Fixes a bug where the `discover()` function was being called twice

Fixes #199