### PR TITLE
Make sidebar headings links whenever an overview is available

### DIFF
--- a/docs/_includes/sidebar.njk
+++ b/docs/_includes/sidebar.njk
@@ -20,11 +20,8 @@
 </ul>
 
 {# Components #}
-<h2>Components</h2>
+<h2><a href="/docs/components/">Components</a></h2>
 <ul>
-  <li>
-    <a href="/docs/components/">Components Overview</a>
-  </li>
   <li>
     <a href="/docs/components/animated-image">Animated Image</a>
   </li>
@@ -216,9 +213,8 @@
 </ul>
 
 {# Layout #}
-<h2>Layout</h2>
+<h2><a href="/docs/layout">Layout</a></h2>
 <ul>
-  <li><a href="/docs/layout">Layout Overview</a></li>
   <li><a href="/docs/components/page">Page</a></li>
   <li><a href="/docs/layout/cluster">Cluster</a></li>
   <li><a href="/docs/layout/flank">Flank</a></li>
@@ -229,11 +225,8 @@
 </ul>
 
 {# Patterns #}
-<h2>Patterns</h2>
+<h2><a href="/docs/patterns/">Patterns</a></h2>
 <ul>
-  <li>
-    <a href="/docs/patterns/">Pattern Overview</a>
-  </li>
   <li><a href="/docs/patterns/app">Web App</a></li>
   <li><a href="/docs/patterns/ecommerce">E-commerce</a>
     <ul>

--- a/docs/_includes/sidebar.njk
+++ b/docs/_includes/sidebar.njk
@@ -20,7 +20,11 @@
 </ul>
 
 {# Components #}
-<h2><a href="/docs/components/">Components</a></h2>
+<h2>
+  <a href="/docs/components/" title="Overview">Components
+    <wa-icon name="grid-2"></wa-icon>
+  </a>
+</h2>
 <ul>
   <li>
     <a href="/docs/components/animated-image">Animated Image</a>
@@ -213,7 +217,11 @@
 </ul>
 
 {# Layout #}
-<h2><a href="/docs/layout">Layout</a></h2>
+<h2>
+  <a href="/docs/layout" title="Overview">Layout
+    <wa-icon name="grid-2"></wa-icon>
+  </a>
+</h2>
 <ul>
   <li><a href="/docs/components/page">Page</a></li>
   <li><a href="/docs/layout/cluster">Cluster</a></li>
@@ -225,7 +233,11 @@
 </ul>
 
 {# Patterns #}
-<h2><a href="/docs/patterns/">Patterns</a></h2>
+<h2>
+  <a href="/docs/patterns/" title="Overview">Patterns
+    <wa-icon name="grid-2"></wa-icon>
+  </a>
+</h2>
 <ul>
   <li><a href="/docs/patterns/app">Web App</a></li>
   <li><a href="/docs/patterns/ecommerce">E-commerce</a>

--- a/docs/assets/styles/docs.css
+++ b/docs/assets/styles/docs.css
@@ -88,9 +88,10 @@ wa-page > header {
   h2 {
     font-size: var(--wa-font-size-m);
     margin-block-end: var(--wa-space-m);
-  }
-  h2:not(:first-of-type) {
-    margin-block-start: var(--wa-space-xl);
+
+    &:not(:first-of-type) {
+      margin-block-start: var(--wa-space-xl);
+    }
   }
   ul {
     border-inline-start: var(--wa-border-width-s) solid var(--wa-color-surface-border);
@@ -112,6 +113,35 @@ wa-page > header {
   }
   li a:hover {
     text-decoration: underline;
+  }
+}
+
+#sidebar {
+  h2 {
+    color: var(--wa-color-text-quiet);
+
+    a {
+      display: flex;
+      align-items: center;
+      gap: 0.4em;
+      color: var(--wa-color-text-normal);
+      text-decoration: none;
+
+      wa-icon {
+        margin-block-end: -0.15em;
+        font-size: var(--wa-font-size-s);
+        font-weight: var(--wa-font-weight-action);
+        color: var(--wa-color-gray-70);
+      }
+
+      &:hover {
+        color: var(--wa-color-brand-on-normal);
+
+        wa-icon {
+          color: var(--wa-color-brand-on-quiet);
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This has bugged me for a while — I keep clicking on the headings expecting some kind of index or overview, but nothing happens. Integrating the overviews into the headings of each category creates a consistent association for where the overview is AND saves space.

I didn't do anything to style these better so the styling leaves a lot to be desired, but we can fix that later:

<img width="224" alt="image" src="https://github.com/user-attachments/assets/d972cc67-c958-4f00-b379-13613dda2338">
