### PR TITLE
Display attribute and property in separate columns

### DIFF
--- a/docs/_layouts/component.njk
+++ b/docs/_layouts/component.njk
@@ -62,13 +62,14 @@
 
   {# Properties #}
   {% if component.properties.length %}
-    <h2>Properties</h2>
+    <h2>Properties & Attributes</h2>
 
     <div class="table-scroll">
       <table class="component-table">
         <thead>
           <tr>
-            <th class="table-name">Name</th>
+            <th class="table-name">Property</th>
+            <th class="table-name">Attribute</th>
             <th class="table-description">Description</th>
             <th class="table-reflects">Reflects</th>
           </tr>
@@ -78,8 +79,10 @@
             <tr>
               <td class="table-name">
                 <code>{{ prop.name }}</code><br>
+              </td>
+              <td class="table-name">
                 {% if prop.attribute %}
-                  <div><small><code>{{ prop.attribute }}</code></small></div>
+                <code>{{ prop.attribute }}</code>
                 {% endif %}
               </td>
               <td class="table-description">


### PR DESCRIPTION
Before:
<img width="843" alt="image" src="https://github.com/user-attachments/assets/d9afcbbf-6739-43db-bd21-4c289d1c94dd">


After:
<img width="815" alt="image" src="https://github.com/user-attachments/assets/e630c9d3-6079-4ac4-bbc3-ab78b0045627">

Rationale:
- It wasn't super clear that the second identifier was an attribute
- There was no attribute section, so those looking for it couldn't find it

I did try to just use `colspan` when property and attribute where the same, but because of the left alignment, it just looked like the attribute is missing, so I ended up showing them even when they're the same.

(This is probably for another issue, but what does reflect mean? Reflects *from* an attribute *to* an attribute, or both?)