### PR TITLE
Fix turbo caching on script tag

### DIFF
--- a/docs/_includes/base.njk
+++ b/docs/_includes/base.njk
@@ -6,7 +6,6 @@
     <meta name="description" content="{{ description }}">
     <meta name="theme-color" content="#f36944">
     {% if noindex %}<meta name="robots" content="noindex">{% endif %}
-    <meta name="turbo-cache-control" content="no-preview">
 
     <title>{{ title }}</title>
 

--- a/docs/_includes/base.njk
+++ b/docs/_includes/base.njk
@@ -6,6 +6,7 @@
     <meta name="description" content="{{ description }}">
     <meta name="theme-color" content="#f36944">
     {% if noindex %}<meta name="robots" content="noindex">{% endif %}
+    <meta name="turbo-cache-control" content="no-preview">
 
     <title>{{ title }}</title>
 

--- a/docs/_includes/page-demo.njk
+++ b/docs/_includes/page-demo.njk
@@ -19,4 +19,8 @@
 <iframe srcdoc="" id="page_slots_iframe"></iframe>
 </wa-viewport-demo>
 </div>
-<script type="module" src="/assets/examples/page-demo/demo.js"></script>
+
+<script type="module">
+  const cacheBust = new Date().toString()
+  import(`/assets/examples/page-demo/demo.js?${cacheBust}`)
+</script>

--- a/docs/_includes/page-demo.njk
+++ b/docs/_includes/page-demo.njk
@@ -16,7 +16,7 @@
   </div>
 </fieldset>
 <wa-viewport-demo viewport="1000">
-<iframe srcdoc="" id="page_slots_iframe" data-turbo="false" data-turbo-temporary></iframe>
+<iframe srcdoc="" id="page_slots_iframe"></iframe>
 </wa-viewport-demo>
 </div>
-<script type=module src="/assets/examples/page-demo/demo.js"></script>
+<script type="module" src="/assets/examples/page-demo/demo.js"></script>

--- a/docs/assets/examples/page-demo/demo.js
+++ b/docs/assets/examples/page-demo/demo.js
@@ -1,54 +1,43 @@
-async function run() {
-  await customElements.whenDefined('wa-checkbox');
-  let container = document.getElementById('page_slots_demo');
+await customElements.whenDefined('wa-checkbox');
+let container = document.getElementById('page_slots_demo');
 
-  if (!container) {
-    return;
-  }
+let fieldset = container.querySelector('fieldset');
+let iframe = container.querySelector('iframe');
+let stylesheets = Array.from(document.querySelectorAll("link[rel=stylesheet][href^='/dist/']"))
+  .map(i => i.outerHTML)
+  .join('\n');
+let includes = `${stylesheets}
+  <script src="/dist/webawesome.loader.js" type="module"></script>
+  <link rel="stylesheet" href="/assets/examples/page-demo/page.css">`;
 
-  let fieldset = container.querySelector('fieldset');
-  let iframe = container.querySelector('iframe');
-  let stylesheets = Array.from(document.querySelectorAll("link[rel=stylesheet][href^='/dist/']"))
-    .map(i => i.outerHTML)
+function render() {
+  let slots = Array.from(fieldset.querySelectorAll('wa-checkbox[name=slot]:is([data-wa-checked])'));
+  let slotsHTML = slots
+    .map(slot => {
+      let name = slot.getAttribute('value');
+      let description = slot.getAttribute('data-description');
+
+      let tag = 'div';
+      if (name.endsWith('header')) {
+        tag = 'header';
+      }
+      if (name.endsWith('footer')) {
+        tag = 'footer';
+      }
+
+      return `<${tag} class="slot-content" slot="${name}">
+		<strong>${name || 'main <em>(default)</em>'}</strong>
+		<p>${description}</p>
+	</${tag}>`;
+    })
     .join('\n');
-  let includes = `${stylesheets}
-    <script src="/dist/webawesome.loader.js" type="module"></script>
-    <link rel="stylesheet" href="/assets/examples/page-demo/page.css">`;
+  let page = iframe.contentDocument?.querySelector('wa-page');
 
-  function render() {
-    let slots = Array.from(fieldset.querySelectorAll('wa-checkbox[name=slot]:is([data-wa-checked])'));
-    let slotsHTML = slots
-      .map(slot => {
-        let name = slot.getAttribute('value');
-        let description = slot.getAttribute('data-description');
-
-        let tag = 'div';
-        if (name.endsWith('header')) {
-          tag = 'header';
-        }
-        if (name.endsWith('footer')) {
-          tag = 'footer';
-        }
-
-        return `<${tag} class="slot-content" slot="${name}">
-		  <strong>${name || 'main <em>(default)</em>'}</strong>
-		  <p>${description}</p>
-	  </${tag}>`;
-      })
-      .join('\n');
-    let page = iframe.contentDocument?.querySelector('wa-page');
-
-    if (page) {
-      page.innerHTML = slotsHTML;
-    } else {
-      iframe.srcdoc = `${includes}<wa-page>${slotsHTML}</wa-page>`;
-    }
+  if (page) {
+    page.innerHTML = slotsHTML;
+  } else {
+    iframe.srcdoc = `${includes}<wa-page>${slotsHTML}</wa-page>`;
   }
-  fieldset?.addEventListener('input', render);
-  render();
 }
-
-(async () => {
-  await run();
-  document.addEventListener('turbo:load', run);
-})();
+fieldset?.addEventListener('input', render);
+render();

--- a/docs/assets/examples/page-demo/demo.js
+++ b/docs/assets/examples/page-demo/demo.js
@@ -1,50 +1,53 @@
-await customElements.whenDefined('wa-checkbox');
-let container = document.getElementById('page_slots_demo');
-let fieldset = container.querySelector('fieldset');
-let iframe = container.querySelector('iframe');
-let stylesheets = Array.from(document.querySelectorAll("link[rel=stylesheet][href^='/dist/']"))
-  .map(i => i.outerHTML)
-  .join('\n');
-let includes = `${stylesheets}
-  <script src="/dist/webawesome.loader.js" type="module"></script>
-  <link rel="stylesheet" href="/assets/examples/page-demo/page.css">`;
+async function run () {
+  await customElements.whenDefined('wa-checkbox');
+  let container = document.getElementById('page_slots_demo');
 
-function render() {
-  let slots = Array.from(fieldset.querySelectorAll('wa-checkbox[name=slot]:is([data-wa-checked])'));
-  let slotsHTML = slots
-    .map(slot => {
-      let name = slot.getAttribute('value');
-      let description = slot.getAttribute('data-description');
+  if (!container) { return }
 
-      let tag = 'div';
-      if (name.endsWith('header')) {
-        tag = 'header';
-      }
-      if (name.endsWith('footer')) {
-        tag = 'footer';
-      }
-
-      return `<${tag} class="slot-content" slot="${name}">
-		<strong>${name || 'main <em>(default)</em>'}</strong>
-		<p>${description}</p>
-	</${tag}>`;
-    })
+  let fieldset = container.querySelector('fieldset');
+  let iframe = container.querySelector('iframe');
+  let stylesheets = Array.from(document.querySelectorAll("link[rel=stylesheet][href^='/dist/']"))
+    .map(i => i.outerHTML)
     .join('\n');
-  let page = iframe.contentDocument?.querySelector('wa-page');
+  let includes = `${stylesheets}
+    <script src="/dist/webawesome.loader.js" type="module"></script>
+    <link rel="stylesheet" href="/assets/examples/page-demo/page.css">`;
 
-  if (page) {
-    page.innerHTML = slotsHTML;
-  } else {
-    iframe.srcdoc = `${includes}<wa-page>${slotsHTML}</wa-page>`;
+  function render() {
+    let slots = Array.from(fieldset.querySelectorAll('wa-checkbox[name=slot]:is([data-wa-checked])'));
+    let slotsHTML = slots
+      .map(slot => {
+        let name = slot.getAttribute('value');
+        let description = slot.getAttribute('data-description');
+
+        let tag = 'div';
+        if (name.endsWith('header')) {
+          tag = 'header';
+        }
+        if (name.endsWith('footer')) {
+          tag = 'footer';
+        }
+
+        return `<${tag} class="slot-content" slot="${name}">
+		  <strong>${name || 'main <em>(default)</em>'}</strong>
+		  <p>${description}</p>
+	  </${tag}>`;
+      })
+      .join('\n');
+    let page = iframe.contentDocument?.querySelector('wa-page');
+
+    if (page) {
+      page.innerHTML = slotsHTML;
+    } else {
+      iframe.srcdoc = `${includes}<wa-page>${slotsHTML}</wa-page>`;
+    }
   }
+  fieldset?.addEventListener('input', render);
+  render();
 }
-fieldset?.addEventListener('input', render);
-render();
 
-//
-// TODO - fix Turbo caching. When this is removed, visiting the <wa-page> docs via Turbo will cause the <iframe srcdoc>
-// to not render. Even with this, there are console errors when leaving the page.
-//
-// NOTE - the iframe already has `data-turbo="false"` and `data-turbo-temporary` on it.
-//
-document.body.setAttribute('data-turbo', 'false');
+;(async () => {
+  await run()
+  document.addEventListener("turbo:load", run)
+})()
+

--- a/docs/assets/examples/page-demo/demo.js
+++ b/docs/assets/examples/page-demo/demo.js
@@ -1,8 +1,10 @@
-async function run () {
+async function run() {
   await customElements.whenDefined('wa-checkbox');
   let container = document.getElementById('page_slots_demo');
 
-  if (!container) { return }
+  if (!container) {
+    return;
+  }
 
   let fieldset = container.querySelector('fieldset');
   let iframe = container.querySelector('iframe');
@@ -46,8 +48,7 @@ async function run () {
   render();
 }
 
-;(async () => {
-  await run()
-  document.addEventListener("turbo:load", run)
-})()
-
+(async () => {
+  await run();
+  document.addEventListener('turbo:load', run);
+})();


### PR DESCRIPTION
While this one feels weird to have the cache busting, its much closer to the expected behavior.

The other version [here](https://github.com/shoelace-style/webawesome/pull/295) with the event listener + `turbo:load` will fire on every page.