### PR TITLE
fix safari placeholder

### DIFF
--- a/docs/docs/native/input.md
+++ b/docs/docs/native/input.md
@@ -15,7 +15,7 @@ elements:
 <style>
 wa-code-demo::part(preview) {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: minmax(150px, 1fr) minmax(150px, 1fr);
   gap: 2rem;
 }
 </style>

--- a/src/styles/native/input.css
+++ b/src/styles/native/input.css
@@ -80,6 +80,14 @@ input:where(:not(
   }
 }
 
+.wa-text-field input {
+  /*
+    Fixes an alignment issue with placeholders.
+    https://github.com/shoelace-style/webawesome/issues/342
+  */
+  height: 100%;
+}
+
 .wa-text-field input,
 .wa-text-field textarea {
   padding: 0;


### PR DESCRIPTION
Also fixes an issue in safari where inputs would become 250px tall when you resize the code demo.