### PR TITLE
fix missing components and format number

### DIFF
--- a/docs/docs/components/checkbox.md
+++ b/docs/docs/components/checkbox.md
@@ -1,7 +1,7 @@
 ---
 title: Checkbox
 description: Checkboxes allow the user to toggle an option on or off.
-tags: forms
+tags: component
 native: checkbox
 ---
 

--- a/docs/docs/components/range.md
+++ b/docs/docs/components/range.md
@@ -1,7 +1,7 @@
 ---
 title: Range
 description: Ranges allow the user to select a single value within a given range using a slider.
-tags: forms
+tags: component
 native: slider
 ---
 

--- a/docs/docs/components/select.md
+++ b/docs/docs/components/select.md
@@ -1,7 +1,7 @@
 ---
 title: Select
 description: Selects allow you to choose items from a menu of predefined options.
-tags: forms
+tags: component
 native: select
 ---
 

--- a/docs/docs/components/textarea.md
+++ b/docs/docs/components/textarea.md
@@ -1,7 +1,7 @@
 ---
 title: Textarea
 description: Textareas collect data from the user and allow multiple lines of text.
-tags: forms
+tags: component
 icon: textarea
 native: input
 ---

--- a/src/components/format-number/format-number.ts
+++ b/src/components/format-number/format-number.ts
@@ -34,10 +34,10 @@ export default class WaFormatNumber extends WebAwesomeElement {
   /** The minimum number of integer digits to use. Possible values are 1-21. */
   @property({ attribute: 'minimum-integer-digits', type: Number }) minimumIntegerDigits: number;
 
-  /** The minimum number of fraction digits to use. Possible values are 0-20. */
+  /** The minimum number of fraction digits to use. Possible values are 0-100. */
   @property({ attribute: 'minimum-fraction-digits', type: Number }) minimumFractionDigits: number;
 
-  /** The maximum number of fraction digits to use. Possible values are 0-0. */
+  /** The maximum number of fraction digits to use. Possible values are 0-100. */
   @property({ attribute: 'maximum-fraction-digits', type: Number }) maximumFractionDigits: number;
 
   /** The minimum number of significant digits to use. Possible values are 1-21. */


### PR DESCRIPTION
Fixes https://github.com/shoelace-style/webawesome-alpha/issues/119#issue-2754567030

In checking:

https://github.com/shoelace-style/webawesome/commit/7d3f8b175c3efc218490f7562cbfc595cfab19dc#r150650130

This doesnt seem to affect anything because the native checkbox links are overriding the `<wa-checkbox>`.

@LeaVerou Seems like you were looking to do something with the new "tags", so probably needs both tags and then filter out the "component" collection? idk. But changing this back for now so links appear again.