### PR TITLE
fix wa-split utility

### DIFF
--- a/src/styles/utilities/layout.css
+++ b/src/styles/utilities/layout.css
@@ -128,7 +128,7 @@
 }
 
 [class*='wa-split']:not([class*='\:column']) > :first-child {
-  flex: 1 1 auto;
+  flex: 0 1 auto;
 }
 
 [class*='wa-split'][class*='\:column'] {


### PR DESCRIPTION
It seems based on the preview, `.wa-split` was not behaving as intended, unless im missing something.


<img width="620" alt="Screenshot 2024-12-22 at 6 31 01 AM" src="https://github.com/user-attachments/assets/2a057c2e-fd25-497c-825d-f42136ba19bc" />
<img width="287" alt="Screenshot 2024-12-22 at 6 35 25 AM" src="https://github.com/user-attachments/assets/5db1bd03-eefe-408b-80f6-e8c4fb576921" />

