### PR TITLE
fix alpha builds

### DIFF
--- a/docs/_includes/sidebar-group.njk
+++ b/docs/_includes/sidebar-group.njk
@@ -19,4 +19,4 @@
       {% endfor %}
     </ul>
   </wa-details>
-{% endif %}
+{%- endif %}

--- a/docs/_includes/sidebar-group.njk
+++ b/docs/_includes/sidebar-group.njk
@@ -1,20 +1,22 @@
-
-<wa-details {{ (('/' + tag + '/') in page.url) | attr('open') }}>
-  <h2 slot="summary">
-    {% set groupUrl %}/docs/{{ tag }}/{% endset %}
-    {% if groupUrl | getCollectionItemFromUrl %}
-      <a href="{{ groupUrl }}" title="Overview">{{ title or (tag | capitalize) }}
-        <wa-icon name="grid-2"></wa-icon>
-      </a>
-    {% else %}
-      {{ title or (tag | capitalize) }}
-    {% endif %}
-  </h2>
-  <ul>
-    {% for page in collections[tag] | sort %}
-      {% if not page.data.parent -%}
-        {% include 'sidebar-link.njk' %}
-      {%- endif %}
-    {% endfor %}
-  </ul>
-</wa-details>
+{# Some collections (like "patterns") will not have any items in the alpha build for example. So this checks to make sure the collection exists. #}
+{% if collections[tag] %}
+  <wa-details {{ (('/' + tag + '/') in page.url) | attr('open') }}>
+    <h2 slot="summary">
+      {% set groupUrl %}/docs/{{ tag }}/{% endset %}
+      {% if groupUrl | getCollectionItemFromUrl %}
+        <a href="{{ groupUrl }}" title="Overview">{{ title or (tag | capitalize) }}
+          <wa-icon name="grid-2"></wa-icon>
+        </a>
+      {% else %}
+        {{ title or (tag | capitalize) }}
+      {% endif %}
+    </h2>
+    <ul>
+      {% for page in collections[tag] | sort %}
+        {% if not page.data.parent -%}
+          {% include 'sidebar-link.njk' %}
+        {%- endif %}
+      {% endfor %}
+    </ul>
+  </wa-details>
+{% endif %}

--- a/docs/_includes/sidebar-group.njk
+++ b/docs/_includes/sidebar-group.njk
@@ -1,5 +1,5 @@
 {# Some collections (like "patterns") will not have any items in the alpha build for example. So this checks to make sure the collection exists. #}
-{% if collections[tag] %}
+{% if collections[tag] -%}
   <wa-details {{ (('/' + tag + '/') in page.url) | attr('open') }}>
     <h2 slot="summary">
       {% set groupUrl %}/docs/{{ tag }}/{% endset %}


### PR DESCRIPTION
Some collections like "patterns" were undefined in alpha builds, this PR checks if a collection exists first.