### PR TITLE
Revamp `<wa-card>` HTML & CSS, fix #431

### DIFF
--- a/docs/docs/components/card.md
+++ b/docs/docs/components/card.md
@@ -60,7 +60,8 @@ Basic cards aren't very exciting, but they can display any content you want them
 
 ### Card with Header
 
-Headers can be used to display titles and more. Use the `with-header` attribute to add a header to the card.
+Headers can be used to display titles and more.
+If using SSR, you need to also use the `with-header` attribute to add a header to the card (if not, it is added automatically).
 
 ```html {.example}
 <wa-card with-header class="card-header">
@@ -95,7 +96,8 @@ Headers can be used to display titles and more. Use the `with-header` attribute 
 
 ### Card with Footer
 
-Footers can be used to display actions, summaries, or other relevant content. Use the `with-footer` attribute to add a footer to the card.
+Footers can be used to display actions, summaries, or other relevant content.
+If using SSR, you need to also use the `with-footer` attribute to add a footer to the card (if not, it is added automatically).
 
 ```html {.example}
 <wa-card with-footer class="card-footer">
@@ -122,7 +124,8 @@ Footers can be used to display actions, summaries, or other relevant content. Us
 
 ### Images
 
-Card images are displayed atop the card and will stretch to fit. Use the `with-image` attribute to add an image to the card.
+Card images are displayed atop the card and will stretch to fit.
+If using SSR, you need to also use the `with-image` attribute to add an image to the card (if not, it is added automatically).
 
 ```html {.example}
 <wa-card with-image class="card-image">

--- a/docs/docs/resources/changelog.md
+++ b/docs/docs/resources/changelog.md
@@ -14,7 +14,7 @@ During the alpha period, things might break! We take breaking changes very serio
 
 ## Next
 
-- Simplified the internal structure of `<wa-card>`, removed `base` part.
+- Simplified the internal structure and CSS properties of `<wa-card>`, removed `base` part.
 - Fixed a bug in `<wa-switch>` where it would not properly change its "checked" state when its property changed.
 - Fixed a bug in the `wa-split` CSS utility that caused it to behave incorrectly
 - Improved performance of `<wa-select>` when using a large number of options

--- a/docs/docs/resources/changelog.md
+++ b/docs/docs/resources/changelog.md
@@ -14,6 +14,7 @@ During the alpha period, things might break! We take breaking changes very serio
 
 ## Next
 
+- Simplified the internal structure of `<wa-card>`, removed `base` part.
 - Fixed a bug in `<wa-switch>` where it would not properly change its "checked" state when its property changed.
 - Fixed a bug in the `wa-split` CSS utility that caused it to behave incorrectly
 - Improved performance of `<wa-select>` when using a large number of options

--- a/src/components/card/card.css
+++ b/src/components/card/card.css
@@ -7,10 +7,6 @@
   --box-shadow: var(--wa-shadow-s);
   --spacing: var(--wa-space-xl);
 
-  display: inline-block;
-}
-
-.card {
   display: flex;
   flex-direction: column;
   background-color: var(--background-color);
@@ -29,17 +25,13 @@
   border-top-right-radius: var(--border-radius);
   margin: calc(-1 * var(--border-width));
   overflow: hidden;
-}
 
-.image::slotted(img) {
-  display: block;
-  width: 100%;
-  border-bottom-left-radius: 0 !important;
-  border-bottom-right-radius: 0 !important;
-}
-
-.card:not(.card--has-image) .image {
-  display: none;
+  &::slotted(img) {
+    display: block;
+    width: 100%;
+    border-bottom-left-radius: 0 !important;
+    border-bottom-right-radius: 0 !important;
+  }
 }
 
 .header {
@@ -48,11 +40,7 @@
   padding: calc(var(--spacing) / 2) var(--spacing);
 }
 
-.card:not(.card--has-header) .header {
-  display: none;
-}
-
-.card:not(.card--has-image) .header {
+:host(:not([with-image])) .header {
   border-top-left-radius: var(--border-radius);
   border-top-right-radius: var(--border-radius);
 }
@@ -62,7 +50,7 @@
   padding: var(--spacing);
 }
 
-.card--has-footer .footer {
+.footer {
   display: block;
   border-top: inherit;
   border-bottom-left-radius: var(--border-radius);
@@ -70,6 +58,8 @@
   padding: var(--spacing);
 }
 
-.card:not(.card--has-footer) .footer {
+:host(:not([with-header])) .header,
+:host(:not([with-footer])) .footer,
+:host(:not([with-image])) .image {
   display: none;
 }

--- a/src/components/card/card.css
+++ b/src/components/card/card.css
@@ -1,28 +1,21 @@
 :host {
-  --background-color: var(--wa-color-surface-default);
-  --border-color: var(--wa-color-surface-border);
-  --border-radius: var(--wa-panel-border-radius);
-  --border-style: var(--wa-panel-border-style);
-  --border-width: var(--wa-panel-border-width);
-  --box-shadow: var(--wa-shadow-s);
   --spacing: var(--wa-space-xl);
 
   display: flex;
   flex-direction: column;
-  background-color: var(--background-color);
-  border-color: var(--border-color);
-  border-radius: var(--border-radius);
-  border-style: var(--border-style);
-  border-width: var(--border-width);
-  box-shadow: var(--box-shadow);
+  background-color: var(--wa-color-surface-default);
+  border-color: var(--wa-color-surface-border);
+  border-radius: var(--wa-panel-border-radius);
+  border-style: var(--wa-panel-border-style);
+  border-width: var(--wa-panel-border-width);
+  box-shadow: var(--wa-shadow-s);
   color: var(--wa-color-text-normal);
-  font: inherit;
 }
 
 .image {
   display: flex;
-  border-top-left-radius: var(--border-radius);
-  border-top-right-radius: var(--border-radius);
+  border-top-left-radius: inherit;
+  border-top-right-radius: inherit;
   margin: calc(-1 * var(--border-width));
   overflow: hidden;
 
@@ -41,8 +34,8 @@
 }
 
 :host(:not([with-image])) .header {
-  border-top-left-radius: var(--border-radius);
-  border-top-right-radius: var(--border-radius);
+  border-top-left-radius: inherit;
+  border-top-right-radius: inherit;
 }
 
 .body {
@@ -53,8 +46,8 @@
 .footer {
   display: block;
   border-top: inherit;
-  border-bottom-left-radius: var(--border-radius);
-  border-bottom-right-radius: var(--border-radius);
+  border-bottom-left-radius: inherit;
+  border-bottom-right-radius: inherit;
   padding: var(--spacing);
 }
 

--- a/src/components/card/card.test.ts
+++ b/src/components/card/card.test.ts
@@ -22,14 +22,6 @@ describe('<wa-card>', () => {
           `);
           await expect(el).to.be.accessible();
         });
-
-        it('should contain the class card.', async () => {
-          const el = await fixture<WaCard>(html`
-            <wa-card>This is just a basic card. No image, no header, and no footer. Just your content.</wa-card>
-          `);
-          const card = el.shadowRoot!.querySelector('.card')!;
-          expect(card.classList.value.trim()).to.eq('card');
-        });
       });
 
       describe('when provided an element in the slot "header" to render a header', () => {
@@ -75,17 +67,6 @@ describe('<wa-card>', () => {
           const childNodes = slot.assignedNodes({ flatten: true });
 
           expect(childNodes.length).to.eq(1);
-        });
-
-        it('should contain the class card--has-header.', async () => {
-          const el = await fixture<WaCard>(
-            html`<wa-card with-header>
-              <div slot="header">Header Title</div>
-              This card has a header. You can put all sorts of things in it!
-            </wa-card>`,
-          );
-          const card = el.shadowRoot!.querySelector('.card')!;
-          expect(card.classList.value.trim()).to.eq('card card--has-header');
         });
       });
 
@@ -137,19 +118,6 @@ describe('<wa-card>', () => {
 
           expect(childNodes.length).to.eq(1);
         });
-
-        it('should contain the class card--has-footer.', async () => {
-          const el = await fixture<WaCard>(
-            html`<wa-card with-footer>
-              This card has a footer. You can put all sorts of things in it!
-
-              <div slot="footer">Footer Content</div>
-            </wa-card>`,
-          );
-
-          const card = el.shadowRoot!.querySelector('.card')!;
-          expect(card.classList.value.trim()).to.eq('card card--has-footer');
-        });
       });
 
       describe('when provided an element in the slot "image" to render a image', () => {
@@ -200,22 +168,6 @@ describe('<wa-card>', () => {
           const childNodes = slot.assignedNodes({ flatten: true });
 
           expect(childNodes.length).to.eq(1);
-        });
-
-        it('should contain the class card--has-image.', async () => {
-          const el = await fixture<WaCard>(
-            html`<wa-card with-image>
-              <img
-                slot="image"
-                src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
-                alt="A kitten walks towards camera on top of pallet."
-              />
-              This is a kitten, but not just any kitten. This kitten likes walking along pallets.
-            </wa-card>`,
-          );
-
-          const card = el.shadowRoot!.querySelector('.card')!;
-          expect(card.classList.value.trim()).to.eq('card card--has-image');
         });
       });
     });

--- a/src/components/card/card.ts
+++ b/src/components/card/card.ts
@@ -19,12 +19,6 @@ import styles from './card.css';
  * @csspart body - The container that wraps the card's main content.
  * @csspart footer - The container that wraps the card's footer.
  *
- * @cssproperty --background-color - The card's background color.
- * @cssproperty --border-color - The card's border color, including borders that occur inside the card.
- * @cssproperty --border-radius - The radius for the card's corners. Expects a single value.
- * @cssproperty --border-style - The style of the card's borders.
- * @cssproperty --border-width - The width of the card's borders. Expects a single value.
- * @cssproperty --box-shadow - The shadow effects around the edges of the card.
  * @cssproperty --spacing - The amount of space around and between sections of the card. Expects a single value.
  */
 @customElement('wa-card')

--- a/src/components/card/card.ts
+++ b/src/components/card/card.ts
@@ -1,6 +1,5 @@
 import { html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { classMap } from 'lit/directives/class-map.js';
 import WebAwesomeElement from '../../internal/webawesome-element.js';
 import styles from './card.css';
 
@@ -15,7 +14,6 @@ import styles from './card.css';
  * @slot footer - An optional footer for the card.
  * @slot image - An optional image to render at the start of the card.
  *
- * @csspart base - The component's base wrapper.
  * @csspart image - The container that wraps the card's image.
  * @csspart header - The container that wraps the card's header.
  * @csspart body - The container that wraps the card's main content.
@@ -44,20 +42,10 @@ export default class WaCard extends WebAwesomeElement {
 
   render() {
     return html`
-      <div
-        part="base"
-        class=${classMap({
-          card: true,
-          'card--has-footer': this.withFooter,
-          'card--has-image': this.withImage,
-          'card--has-header': this.withHeader,
-        })}
-      >
-        <slot name="image" part="image" class="image"></slot>
-        <slot name="header" part="header" class="header"></slot>
-        <slot part="body" class="body"></slot>
-        <slot name="footer" part="footer" class="footer"></slot>
-      </div>
+      <slot name="image" part="image" class="image"></slot>
+      <slot name="header" part="header" class="header"></slot>
+      <slot part="body" class="body"></slot>
+      <slot name="footer" part="footer" class="footer"></slot>
     `;
   }
 }

--- a/src/components/card/card.ts
+++ b/src/components/card/card.ts
@@ -33,13 +33,13 @@ import styles from './card.css';
 export default class WaCard extends WebAwesomeElement {
   static shadowStyle = styles;
 
-  /** Renders the card with a header */
+  /** Renders the card with a header. Only needed for SSR, otherwise is automatically added. */
   @property({ attribute: 'with-header', type: Boolean }) withHeader = false;
 
-  /** Renders the card with an image */
+  /** Renders the card with an image. Only needed for SSR, otherwise is automatically added. */
   @property({ attribute: 'with-image', type: Boolean }) withImage = false;
 
-  /** Renders the card with a footer */
+  /** Renders the card with a footer. Only needed for SSR, otherwise is automatically added. */
   @property({ attribute: 'with-footer', type: Boolean }) withFooter = false;
 
   render() {


### PR DESCRIPTION
- Dropped `base` part (rel #207)
- Dropped custom properties that mirror standard ones (rel #259)
- Dropped classes mirroring host attributes
- If #432 doesn’t fix #431, this one definitely does.