### PR TITLE
Fix arrow color on slider tooltips

### DIFF
--- a/src/components/slider/slider.css
+++ b/src/components/slider/slider.css
@@ -38,7 +38,7 @@
   }
 
   --inset-block: calc(50% + (var(--thumb-size) / 2) + var(--tooltip-offset));
-  --border-block: var(--wa-tooltip-arrow-size) solid var(--wa-color-neutral-fill-loud);
+  --border-block: var(--wa-tooltip-arrow-size) solid var(--wa-tooltip-background-color);
 
   @media (forced-colors: active) {
     border: solid 1px transparent;


### PR DESCRIPTION
Fixes tooltip arrows in `<wa-slider>` using the wrong color.

Before:
<img width="116" alt="Screenshot 2025-01-07 at 7 12 17 PM" src="https://github.com/user-attachments/assets/fdb93dce-3e0c-4412-9112-49706151cbae" />


After:
<img width="116" alt="Screenshot 2025-01-07 at 7 12 04 PM" src="https://github.com/user-attachments/assets/25f43363-782a-4c21-9c22-629ebf2929d8" />
