### PR TITLE
Use theme properties for color picker border

### DIFF
--- a/src/components/color-picker/color-picker.css
+++ b/src/components/color-picker/color-picker.css
@@ -317,8 +317,8 @@
   border-radius: inherit;
   background-color: currentColor;
   box-shadow:
-    inset 0 0 0 0.0625rem var(--wa-form-control-border-color),
-    inset 0 0 0 0.25rem var(--wa-color-surface-default);
+    inset 0 0 0 var(--border-width) var(--wa-form-control-border-color),
+    inset 0 0 0 calc(var(--border-width) * 2) var(--wa-color-surface-default);
 }
 
 .trigger--empty:before {

--- a/src/styles/native/color-picker.css
+++ b/src/styles/native/color-picker.css
@@ -2,12 +2,11 @@ input[type='color'] {
   display: block;
   border-radius: calc(infinity * 1px);
   background: transparent;
-  padding: 3px;
+  padding: var(--wa-form-control-border-width);
   width: calc(var(--wa-form-control-height) - 2px);
   height: calc(var(--wa-form-control-height) - 2px);
-  border: var(--wa-border-width-s) var(--wa-border-style) var(--wa-form-control-border-color);
+  border: var(--wa-form-control-border-width) var(--wa-border-style) var(--wa-form-control-border-color);
   cursor: pointer;
-  margin-block-start: 3px;
   forced-color-adjust: none;
 
   &::-webkit-color-swatch-wrapper {


### PR DESCRIPTION
Updates `<wa-color-picker>` and `<input type='color'>` to use the same theme-derived widths for the trigger's border and whitespace  for better consistency and theme matching.

Before:
<img width="480" alt="Screenshot 2025-01-07 at 7 21 39 PM" src="https://github.com/user-attachments/assets/a9ecfde6-de5b-45cc-aa54-0023387e9342" />

After:
<img width="480" alt="Screenshot 2025-01-07 at 7 20 51 PM" src="https://github.com/user-attachments/assets/8bb887ff-ef11-4f56-9d43-158a5e16a66f" />
