### PR TITLE
Fix #451 without changing logic/specificity

### DIFF
--- a/src/styles/native/input.css
+++ b/src/styles/native/input.css
@@ -14,13 +14,22 @@ input:where(:not(
     [type='reset'],
     [type='submit']
   )) {
-  &:not(:host *) {
+  /* Styling root, i.e. excluding elements within a host.
+     This is so that these properties can be overridden.
+   */
+  &:not(:host *),
+  /* Safari and FF don't like :host:not(:host *) or :where(:host) so we need to add :host explicitly.
+    However, we can't just specify :host, because then it would become & :host which matches nothing.
+    :host(*) is the same as :host and the & prevents it from becoming a descendant selector.
+   */
+  :host(:is(&, *)) {
     /* Defaults for root element. */
     --outlined-background-color: var(--wa-form-control-background-color);
     --outlined-border-color: var(--wa-form-control-border-color);
     --outlined-text-color: var(--wa-form-control-value-color);
 
-    :where(&) {
+    :where(&),
+    :host(:where(&, *)) {
       /* Defaults with 0 specificity.
        * Do NOT reset --background-color and --border-color here so they trickle in from the appearance utils
        * Instead we provide the fallback when setting

--- a/src/styles/native/select.css
+++ b/src/styles/native/select.css
@@ -6,7 +6,12 @@ label:has(select),
   --outlined-border-color: var(--wa-form-control-border-color);
   --outlined-text-color: var(--wa-form-control-value-color);
 
-  :where(&) {
+  /* Safari and FF don't like :where(:host) so we need to add :host explicitly.
+    However, we can't just specify :host, because then it would become & :host which matches nothing.
+    :host(*) is the same as :host and the & prevents it from becoming a descendant selector.
+   */
+  :where(&),
+  :host(:where(&, *)) {
     /* Defaults with 0 specificity.
        * Do NOT reset --background-color and --border-color here so they trickle in from the appearance utils
        * Instead we provide the fallback when setting


### PR DESCRIPTION
This is an alternative to #461 as @lindsaym-fa and I spotted some regressions.

This is a very convoluted fix so here's an explanation of what is going on (which I tried to summarize in the comments).

So, Safari doesn't consider `:where(:host)`/`:is(:host)` invalid or anything, **it just matches nothing**. So if we give it something that matches *in addition to that*, it will duly oblige.

The actual `:host` is the only selector in the list that is NOT matched by `:where(&)` in Safari/FF because of this bug. So we need to add something that WILL match `:host`. The rest are taken care of.

A few things:
- `:host()` will match the host as long as its argument matches the host. So `:host(*)` is equivalent to `:host`.
- `:host(:is(.foo, *))` is ALSO equivalent to `:host` no matter whether it has a `.foo` class or not. We can't write `:host(.foo, *)` however, because the argument needs to be a compound selector.
- In selector lists, each selector is processed separately. If a `&` is found ANYWHERE in the selector, the selector is not prepended by `& ` and thus is not interpreted as a descendant selector . So we want to add a `&` somewhere where it won't make a difference in the matching.

With `&:not(:host *)`  we're trying to exclude elements inside a host, so we still want to match `:host`, so we can just reuse the same selector, using `:is` or `:where` as appropriate to maintain the same specificity.

Simpler testcase of the technique: https://codepen.io/leaverou/pen/pvzaRwq