### PR TITLE
Add default layout as a failsafe

### DIFF
--- a/docs/.eleventy.js
+++ b/docs/.eleventy.js
@@ -20,6 +20,12 @@ const packageData = JSON.parse(await readFile('./package.json', 'utf-8'));
 const isAlpha = process.argv.includes('--alpha');
 const isDev = process.argv.includes('--develop');
 
+const globalData = {
+  package: packageData,
+  isAlpha,
+  layout: 'page.njk',
+};
+
 export default function (eleventyConfig) {
   // NOTE - alpha setting removes certain pages
   if (isAlpha) {
@@ -32,8 +38,9 @@ export default function (eleventyConfig) {
   }
 
   // Add template data
-  eleventyConfig.addGlobalData('package', packageData);
-  eleventyConfig.addGlobalData('isAlpha', isAlpha);
+  for (let name in globalData) {
+    eleventyConfig.addGlobalData(name, globalData[name]);
+  }
 
   // Template filters - {{ content | filter }}
   eleventyConfig.addFilter('inlineMarkdown', content => markdown.renderInline(content || ''));


### PR DESCRIPTION
Otherwise every time we add a new page, even just an internal testing one, we need to remember to link it to a layout or we get a completely blank page with just the content (unstyled and everything).

Not sure if `page` is a good default or it should be `page-outline`. It seemed like the one that makes the fewest assumptions.