### PR TITLE
Improve UX of Layout section

### DIFF
--- a/docs/_includes/sidebar-group.njk
+++ b/docs/_includes/sidebar-group.njk
@@ -1,6 +1,6 @@
 {# Some collections (like "patterns") will not have any items in the alpha build for example. So this checks to make sure the collection exists. #}
 {% if collections[tag] -%}
-  <wa-details {{ (('/' + tag + '/') in page.url) | attr('open') }}>
+  <wa-details {{ (tag in (tags or [])) | attr('open') }}>
     <h2 slot="summary">
       {% set groupUrl %}/docs/{{ tag }}/{% endset %}
       {% if groupUrl | getCollectionItemFromUrl %}


### PR DESCRIPTION
At least now all relevant sections will be open, not just the primary one.
E.g. you click on Page under Layout, Layout will remain open (but Components will also be open).