### PR TITLE
Template tweaks

### DIFF
--- a/docs/_includes/base-wide.njk
+++ b/docs/_includes/base-wide.njk
@@ -79,11 +79,12 @@
           </details>
         </nav>
 
-        {% block beforeContent %}{% endblock %}
+        {% block header %}
+          {% include 'breadcrumbs.njk' %}
+          <h1 class="title">{{ title }}</h1>
+        {% endblock %}
 
         {% block content %}
-          <h1 class="title">{{ title }}</h1>
-
           {{ content | safe }}
         {% endblock %}
 

--- a/docs/_includes/base.njk
+++ b/docs/_includes/base.njk
@@ -146,22 +146,14 @@
           </details>
         </nav>
 
-        {% set breadcrumbs = page.url | breadcrumbs %}
-        {% if breadcrumbs.length > 0 %}
-          <wa-breadcrumb id="docs-breadcrumbs">
-            {% for crumb in breadcrumbs %}
-              <wa-breadcrumb-item href="{{ crumb.url }}">{{ crumb.title }}</wa-breadcrumb-item>
-            {% endfor %}
-            <wa-breadcrumb-item>{# Current page #}</wa-breadcrumb-item>
-          </wa-breadcrumb>
-          {% else %}
-        {% endif %}
 
-        {% block beforeContent %}{% endblock %}
+
+        {% block header %}
+          {% include 'breadcrumbs.njk' %}
+          <h1 class="title">{{ title }}</h1>
+        {% endblock %}
 
         {% block content %}
-          <h1 class="title">{{ title }}</h1>
-
           {{ content | safe }}
         {% endblock %}
 

--- a/docs/_includes/breadcrumbs.njk
+++ b/docs/_includes/breadcrumbs.njk
@@ -1,0 +1,10 @@
+{% set breadcrumbs = page.url | breadcrumbs %}
+{% if breadcrumbs.length > 0 %}
+  <wa-breadcrumb id="docs-breadcrumbs">
+  {% for crumb in breadcrumbs %}
+    <wa-breadcrumb-item href="{{ crumb.url }}">{{ crumb.title }}</wa-breadcrumb-item>
+  {% endfor %}
+  <wa-breadcrumb-item>{# Current page #}</wa-breadcrumb-item>
+  </wa-breadcrumb>
+  {% else %}
+{% endif %}

--- a/docs/_layouts/blank.njk
+++ b/docs/_layouts/blank.njk
@@ -53,7 +53,7 @@
   </head>
   <body class="layout-{{ layout | stripExtension }}">
 
-        {% block beforeContent %}{% endblock %}
+        {% block header %}{% endblock %}
 
         {% block content %}
           {{ content | safe }}

--- a/docs/_layouts/block.njk
+++ b/docs/_layouts/block.njk
@@ -4,7 +4,8 @@
 {% extends '../_includes/base.njk' %}
 
 {# Component header #}
-{% block beforeContent %}
+{% block header %}
+  {% include 'breadcrumbs.njk' %}
   <h1 class="title">{{ title }}</h1>
   <div class="block-info">
     {% set snippets = (elements or element or snippets or snippet) | dict  %}


### PR DESCRIPTION
- Move breadcrumbs to separate template
- Rename `beforeContent` to `header`
- Move breadcrumbs inside header

(cherry picked from other changes to prevent a future PR from getting too big)