### PR TITLE
add native icon to search

### DIFF
--- a/docs/assets/scripts/search.js
+++ b/docs/assets/scripts/search.js
@@ -9,6 +9,7 @@ const icons = {
   component: 'puzzle-piece',
   document: 'file',
   home: 'house',
+  native: 'code',
   theme: 'palette',
 };
 let searchTimeout;
@@ -166,6 +167,7 @@ async function updateResults(query = '') {
       li.setAttribute('data-selected', index === 0 ? 'true' : 'false');
 
       if (page.url === '/') icon = icons.home;
+      if (page.url.startsWith('/docs/native')) icon = icons.native;
       if (page.url.startsWith('/docs/components')) icon = icons.component;
       if (page.url.startsWith('/docs/theme') || page.url.startsWith('/docs/restyle')) icon = icons.theme;
 


### PR DESCRIPTION
This makes it a bit more obvious when you're searching and see native elements vs. WA components, since many pages have the same title.

![image](https://github.com/user-attachments/assets/b1efc203-ad76-4e59-80f2-c807b41ece6b)

To this:

![image](https://github.com/user-attachments/assets/d1f0c11c-4dd9-46f3-a1e0-b3af37fec2f3)
