### PR TITLE
Do not reflect default values

### DIFF
--- a/src/components/button/button.ts
+++ b/src/components/button/button.ts
@@ -72,7 +72,8 @@ export default class WaButton extends WebAwesomeFormAssociatedElement {
   @property({ reflect: true }) variant: 'neutral' | 'brand' | 'success' | 'warning' | 'danger' = 'neutral';
 
   /** The button's visual appearance. */
-  @property({ reflect: true }) appearance: 'accent' | 'filled' | 'outlined' | 'plain' = 'accent';
+  @property({ reflect: true, default: 'accent' })
+  appearance: 'accent' | 'filled' | 'outlined' | 'plain' = 'accent';
 
   /** The button's size. */
   @property({ reflect: true }) size: 'small' | 'medium' | 'large' = 'medium';


### PR DESCRIPTION
Implementation on the base class and sample usage on the `appearance` property of `<wa-button>`.

- Fixes #506
- Fixes https://github.com/shoelace-style/shoelace/discussions/2339
- Paves the way for a ton of improvements

This implements a new `default` descriptor for `@property` and
- wraps the [default converter](https://lit.dev/docs/components/properties/#conversion-type) with a check: if the value is equal to the default value (regardless of how it was set), it does not create an attribute (and removes it if it was already there). Since it imports the default converter and passes the value back to it, the implementation is very minimal, and quite robust.
- wraps the default getter to return the default value if the getter returns `null` or `undefined`.

The only DX "cost" for us is specifying the default value twice — which is actually only needed for the CE manifest, the actual functionality doesn't need it, so perhaps down the line we can just patch the CEM.
