### PR TITLE
Add Glossy and Premium themes to alpha build

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -126,7 +126,9 @@ async function generateStyles() {
         file.includes('themes/default') ||
         file.includes('themes/awesome') ||
         file.includes('themes/active') ||
+        file.includes('themes/glossy') ||
         file.includes('themes/mellow') ||
+        file.includes('themes/premium') ||
         file.includes('themes/tailspin') ||
         file.includes('themes/brutalist')
       ) {


### PR DESCRIPTION
I failed to add Glossy and Premium to the build in #525 and #510. ☹️ This change fixes my mistake.

At some point, we probably want to remove this part of the build script since all Pro themes will be included, right?