### PR TITLE
Basic color palette docs

### DIFF
--- a/docs/_data/hues.json
+++ b/docs/_data/hues.json
@@ -1,0 +1,1 @@
+["red", "yellow", "green", "teal", "blue", "indigo", "violet", "gray"]

--- a/docs/_includes/contrast-table.njk
+++ b/docs/_includes/contrast-table.njk
@@ -1,0 +1,31 @@
+<table class="colors wa-palette-{{ paletteId }}">
+  <thead>
+    <tr>
+      <th></th>
+      {% for tint_bg in tints -%}
+        {% for tint_fg in tints | reverse -%}
+          {% if (tint_fg - tint_bg) | abs == difference %}
+          <th>{{ tint_fg }} on {{ tint_bg }}</th>
+          {% endif %}
+        {%- endfor -%}
+      {%- endfor %}
+    </tr>
+  </thead>
+{% for hue in hues -%}
+<tr>
+  <th>{{ hue | capitalize }}</th>
+  {% for tint_bg in tints -%}
+  {% for tint_fg in tints | reverse -%}
+
+    {% if (tint_fg - tint_bg) | abs == difference %}
+    <td>
+      <div class="color swatch" style="background-color: var(--wa-color-{{ hue }}-{{ tint_bg }}); color: var(--wa-color-{{ hue }}-{{ tint_fg }})">
+        {{ tint_fg }} on {{ tint_bg }}
+      </div>
+    </td>
+    {% endif %}
+    {%- endfor -%}
+  {%- endfor -%}
+</tr>
+{%- endfor %}
+</table>

--- a/docs/_includes/sidebar.njk
+++ b/docs/_includes/sidebar.njk
@@ -25,6 +25,7 @@
   'utilities': 'Style Utilities',
   'layout': 'Layout',
   'patterns': 'Patterns',
+  'palettes': 'Color Palettes',
   'tokens': 'Design Tokens'
 } %}
   {% include 'sidebar-group.njk' %}

--- a/docs/_includes/svgs/palette.njk
+++ b/docs/_includes/svgs/palette.njk
@@ -1,0 +1,24 @@
+{% set paletteId = page.fileSlug %}
+{% set tints = [80, 60, 40, 20] %}
+{% set width = 20 %}
+{% set height = 13 %}
+{% set gap_x = 3 %}
+{% set gap_y = 3 %}
+
+<svg viewBox="0 0 {{ (width + gap_x) * hues|length }} {{ (height + gap_y) * tints|length }}" fill="none" xmlns="http://www.w3.org/2000/svg" class="wa-palette-{{ paletteId }} palette-icon">
+<style>
+	@import url('/dist/styles/color/{{ paletteId }}.css') layer(palette.{{ paletteId }});
+	.palette-icon {
+		height: 8ch;
+	}
+</style>
+
+{% for hue in hues -%}
+  {% set hueIndex = loop.index0 %}
+  {% for tint in tints -%}
+    <rect x="{{ hueIndex * (width + gap_x) }}" y="{{ loop.index0 * (height + gap_y) }}"
+	      width="{{ width }}" height="{{ height }}"
+	      fill="var(--wa-color-{{ hue }}-{{ tint }})" rx="4" />
+  {%- endfor %}
+{% endfor %}
+</svg>

--- a/docs/_layouts/palette.njk
+++ b/docs/_layouts/palette.njk
@@ -9,7 +9,6 @@
 {% block afterContent %}
 <style>@import url('/dist/styles/color/{{ paletteId }}.css') layer(palette.{{ paletteId }});</style>
 
-{% set hues = ["red", "yellow", "green", "teal", "blue", "indigo", "violet", "gray"] %}
 {% set tints = ["95", "90", "80", "70", "60", "50", "40", "30", "20", "10", "05"] %}
 
 <table class="colors wa-palette-{{ paletteId }}">

--- a/docs/_layouts/palette.njk
+++ b/docs/_layouts/palette.njk
@@ -36,7 +36,7 @@
 
 <h2>Used By</h2>
 
-<section id="grid" class="index-grid">
+<section class="index-grid">
 {% for page in collections.theme %}
   {%- if page.data.palette == paletteId -%}
     {% include "page-card.njk" %}

--- a/docs/_layouts/palette.njk
+++ b/docs/_layouts/palette.njk
@@ -49,7 +49,7 @@
 
 Web Awesome color scales are designed to guarantee certain contrast ratios,
 both per [WCAG 2.1 success criteria](https://www.w3.org/TR/WCAG21/#contrast-minimum)
-as well as the emergent APCA specification _(planned)_.
+as well as the emergent APCA specification _(planned)_,
 so you can ensure that text is both legible to all users, and legally conformant.
 
 ### Level 1

--- a/docs/_layouts/palette.njk
+++ b/docs/_layouts/palette.njk
@@ -1,0 +1,108 @@
+{% set hasSidebar = true %}
+{% set hasOutline = true %}
+{# {% set forceTheme = page.fileSlug %} #}
+
+{% extends '../_layouts/block.njk' %}
+
+{% set paletteId = page.fileSlug %}
+
+{% block afterContent %}
+<style>@import url('/dist/styles/color/{{ paletteId }}.css') layer(palette.{{ paletteId }});</style>
+
+{% set hues = ["red", "yellow", "green", "teal", "blue", "indigo", "violet", "gray"] %}
+{% set tints = ["95", "90", "80", "70", "60", "50", "40", "30", "20", "10", "05"] %}
+
+<table class="colors wa-palette-{{ paletteId }}">
+  <thead>
+    <tr>
+      <th></th>
+      {% for tint in tints -%}
+      <th>{{ tint }}</th>
+      {%- endfor %}
+    </tr>
+  </thead>
+{% for hue in hues -%}
+<tr>
+  <th>{{ hue | capitalize }}</th>
+  {% for tint in tints -%}
+    <td>
+      <div class="color swatch" style="background-color: var(--wa-color-{{ hue }}-{{ tint }})">
+        <wa-copy-button value="--wa-color-{{ hue }}-{{ tint }}" copy-label="--wa-color-{{ hue }}-{{ tint }}"></wa-copy-button>
+      </div>
+    </td>
+  {%- endfor -%}
+</tr>
+{%- endfor %}
+</table>
+
+<h2>Used By</h2>
+
+<section id="grid" class="index-grid">
+{% for page in collections.theme %}
+  {%- if page.data.palette == paletteId -%}
+    {% include "page-card.njk" %}
+  {%- endif -%}
+{% endfor %}
+</section>
+
+{% markdown %}
+## Color Contrast
+
+Web Awesome color scales are designed to guarantee certain contrast ratios,
+both per [WCAG 2.1 success criteria](https://www.w3.org/TR/WCAG21/#contrast-minimum)
+as well as the emergent APCA specification _(planned)_.
+so you can ensure that text is both legible to all users, and legally conformant.
+
+### Level 1
+
+A difference of `40` ensures a minimum **3:1** contrast ratio, suitable for large text and icons (AA).
+{% endmarkdown %}
+
+{% set difference = 40 %}
+{% include "contrast-table.njk" %}
+
+{% markdown %}
+### Level 2
+
+A difference of `50` ensures a minimum **4.5:1** contrast ratio, suitable for normal text (AA) and large text (AAA)
+{% endmarkdown %}
+
+{% set difference = 50 %}
+{% include "contrast-table.njk" %}
+
+{% markdown %}
+### Level 3
+
+A difference of `60` ensures a minimum **7:1** contrast ratio, suitable for all text (AAA)
+{% endmarkdown %}
+
+{% set difference = 60 %}
+{% include "contrast-table.njk" %}
+
+{% markdown %}
+## How to use this palette
+
+If you are using a Web Awesome theme that uses this palette, it will already be included.
+To use a different palette than a theme default, or to use it in a custom theme, you can import this palette directly from the Web Awesome CDN.
+
+<wa-tab-group>
+<wa-tab panel="html">In HTML</wa-tab>
+<wa-tab panel="css">In CSS</wa-tab>
+<wa-tab-panel name="html">
+
+Simply add the following code to the `<head>` of your page:
+```html
+<link rel="stylesheet" href="{% cdnUrl 'styles/color/' + page.fileSlug + '.css' %}" />
+```
+</wa-tab-panel>
+<wa-tab-panel name="css">
+
+Simply add the following code at the top of your CSS file:
+```css
+@import url('{% cdnUrl 'styles/color/' + page.fileSlug + '.css' %}');
+```
+</wa-tab-panel>
+</wa-tab-group>
+
+{% endmarkdown %}
+{% endblock %}

--- a/docs/_layouts/theme.njk
+++ b/docs/_layouts/theme.njk
@@ -6,6 +6,16 @@
 
 {% block header %}
 <iframe src='{{ page.url }}demo.html'></iframe>
+
+<h2>Default Color Palette</h2>
+{% set paletteURL = '/docs/palettes/' + palette + '/' %}
+{% set themePage = page %}
+{% set page = paletteURL | getCollectionItemFromUrl %}
+<div class="index-grid">
+{% include 'page-card.njk' %}
+</div>
+{% set page = themePage %}
+
 {% endblock %}
 
 {% block afterContent %}

--- a/docs/assets/styles/docs.css
+++ b/docs/assets/styles/docs.css
@@ -333,6 +333,7 @@ wa-page > main:has(> .index-grid) {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(min(22ch, 100%), 1fr));
   gap: var(--wa-space-2xl);
+  margin-block-end: var(--wa-space-3xl);
 
   a {
     border-radius: var(--wa-border-radius-l);
@@ -383,15 +384,22 @@ wa-page > main:has(> .index-grid) {
 /* Swatches */
 .swatch {
   position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   background-color: transparent;
   border-color: var(--wa-color-neutral-border-normal);
   border-style: var(--wa-border-style);
   border-width: var(--wa-border-width-s);
   border-radius: var(--wa-border-radius-m);
   box-sizing: border-box;
-  line-height: 2.5;
-  height: 2.5em;
-  padding-inline: var(--wa-space-xs);
+  min-height: 2.5em;
+  padding: var(--wa-space-xs);
+  font-weight: var(--wa-font-weight-semibold);
+
+  &.color {
+    border-color: transparent;
+  }
 
   wa-copy-button {
     position: absolute;
@@ -417,6 +425,34 @@ wa-page > main:has(> .index-grid) {
     &::part(success-icon),
     &::part(error-icon) {
       opacity: 0 !important;
+    }
+  }
+}
+
+table.colors {
+  thead {
+    th {
+      text-align: center;
+      padding-block: 0;
+    }
+  }
+  tbody {
+    tr {
+      border: none;
+      &:hover {
+        background: transparent;
+      }
+    }
+
+    th {
+      width: 0;
+      vertical-align: middle;
+      text-align: right;
+    }
+
+    td {
+      padding-inline: var(--wa-space-3xs);
+      padding-block: var(--wa-space-s);
     }
   }
 }

--- a/docs/assets/styles/docs.css
+++ b/docs/assets/styles/docs.css
@@ -396,6 +396,7 @@ wa-page > main:has(> .index-grid) {
   min-height: 2.5em;
   padding: var(--wa-space-xs);
   font-weight: var(--wa-font-weight-semibold);
+  line-height: var(--wa-line-height-condensed);
 
   &.color {
     border-color: transparent;

--- a/docs/docs/palettes/anodized.md
+++ b/docs/docs/palettes/anodized.md
@@ -1,0 +1,5 @@
+---
+title: Anodized
+isPro: true
+tags: pro
+---

--- a/docs/docs/palettes/bright.md
+++ b/docs/docs/palettes/bright.md
@@ -1,0 +1,3 @@
+---
+title: Bright
+---

--- a/docs/docs/palettes/classic.md
+++ b/docs/docs/palettes/classic.md
@@ -1,0 +1,4 @@
+---
+title: Classic
+description: The original Shoelace color palette.
+---

--- a/docs/docs/palettes/default.md
+++ b/docs/docs/palettes/default.md
@@ -1,0 +1,4 @@
+---
+title: Default
+description: This is the palette used in the default theme.
+---

--- a/docs/docs/palettes/elegant.md
+++ b/docs/docs/palettes/elegant.md
@@ -1,0 +1,5 @@
+---
+title: Elegant
+isPro: true
+tags: pro
+---

--- a/docs/docs/palettes/index.njk
+++ b/docs/docs/palettes/index.njk
@@ -1,0 +1,10 @@
+---
+title: Color Palettes
+description: Palettes define [literal colors](/docs/tokens/colors) that are used in the design system.
+layout: overview
+override:tags: []
+forTag: palette
+categories:
+  other: Free
+  pro: Pro
+---

--- a/docs/docs/palettes/natural.md
+++ b/docs/docs/palettes/natural.md
@@ -1,0 +1,5 @@
+---
+title: Natural
+isPro: true
+tags: pro
+---

--- a/docs/docs/palettes/palettes.json
+++ b/docs/docs/palettes/palettes.json
@@ -1,7 +1,9 @@
 {
   "layout": "palette.njk",
   "tags": ["palettes", "palette"],
+  "hues": ["red", "yellow", "green", "teal", "blue", "indigo", "violet", "gray"],
   "eleventyComputed": {
-    "snippet": ".wa-palette-{{ page.fileSlug }}"
+    "snippet": ".wa-palette-{{ page.fileSlug }}",
+    "icon": "palette"
   }
 }

--- a/docs/docs/palettes/palettes.json
+++ b/docs/docs/palettes/palettes.json
@@ -1,7 +1,6 @@
 {
   "layout": "palette.njk",
   "tags": ["palettes", "palette"],
-  "hues": ["red", "yellow", "green", "teal", "blue", "indigo", "violet", "gray"],
   "eleventyComputed": {
     "snippet": ".wa-palette-{{ page.fileSlug }}",
     "icon": "palette"

--- a/docs/docs/palettes/palettes.json
+++ b/docs/docs/palettes/palettes.json
@@ -1,0 +1,7 @@
+{
+  "layout": "palette.njk",
+  "tags": ["palettes", "palette"],
+  "eleventyComputed": {
+    "snippet": ".wa-palette-{{ page.fileSlug }}"
+  }
+}

--- a/docs/docs/palettes/rudimentary.md
+++ b/docs/docs/palettes/rudimentary.md
@@ -1,0 +1,5 @@
+---
+title: Rudimentary
+isPro: true
+tags: pro
+---

--- a/docs/docs/palettes/vogue.md
+++ b/docs/docs/palettes/vogue.md
@@ -1,0 +1,5 @@
+---
+title: Vogue
+isPro: true
+tags: pro
+---

--- a/docs/docs/themes/active.md
+++ b/docs/docs/themes/active.md
@@ -3,5 +3,5 @@ title: Active
 description: Energetic and tactile, always in motion.
 isPro: true
 tags: pro
-defaultPalette: rudimentary
+palette: rudimentary
 ---

--- a/docs/docs/themes/awesome.md
+++ b/docs/docs/themes/awesome.md
@@ -2,5 +2,5 @@
 title: Awesome
 description: Punchy and vibrant, the rockstar of themes.
 order: 0.2
-defaultPalette: bright
+palette: bright
 ---

--- a/docs/docs/themes/brutalist.md
+++ b/docs/docs/themes/brutalist.md
@@ -3,5 +3,5 @@ title: Brutalist
 description: Sharp, square, and unapologetically bold.
 isPro: true
 tags: pro
-defaultPalette: default
+palette: default
 ---

--- a/docs/docs/themes/classic.md
+++ b/docs/docs/themes/classic.md
@@ -2,5 +2,5 @@
 title: Classic
 description: Timeless elegance that never goes out of style.
 order: 0.1
-defaultPalette: classic
+palette: classic
 ---

--- a/docs/docs/themes/default.md
+++ b/docs/docs/themes/default.md
@@ -2,5 +2,5 @@
 title: Default
 description: Your trusty companion, like a perfectly broken-in pair of jeans.
 order: 0
-defaultPalette: default
+palette: default
 ---

--- a/docs/docs/themes/glossy.md
+++ b/docs/docs/themes/glossy.md
@@ -3,5 +3,5 @@ title: Glossy
 description: Bustling with plenty of luster and shine.
 isPro: true
 tags: pro
-defaultPalette: elegant
+palette: elegant
 ---

--- a/docs/docs/themes/mellow.md
+++ b/docs/docs/themes/mellow.md
@@ -3,5 +3,5 @@ title: Mellow
 description: Soft and soothing, like a lazy Sunday morning.
 isPro: true
 tags: pro
-defaultPalette: natural
+palette: natural
 ---

--- a/docs/docs/themes/playful.md
+++ b/docs/docs/themes/playful.md
@@ -3,5 +3,5 @@ title: Playful
 description: Cheerful and engaging, like a playground on screen.
 isPro: true
 tags: pro
-defaultPalette: rudimentary
+palette: rudimentary
 ---

--- a/docs/docs/themes/premium.md
+++ b/docs/docs/themes/premium.md
@@ -3,5 +3,5 @@ title: Premium
 description: The ultimate in sophistication and style.
 isPro: true
 tags: pro
-defaultPalette: anodized
+palette: anodized
 ---

--- a/docs/docs/themes/tailspin.md
+++ b/docs/docs/themes/tailspin.md
@@ -3,5 +3,5 @@ title: Tailspin
 description: Like a bird in flight, guiding you from there to here.
 isPro: true
 tags: pro
-defaultPalette: vogue
+palette: vogue
 ---

--- a/docs/docs/tokens/color.md
+++ b/docs/docs/tokens/color.md
@@ -71,7 +71,9 @@ Web Awesome defines seven literal colors each with 11 lightness values using the
 <ul class="color-group">
   {% for tint in ["95", "90", "80", "70", "60", "50", "40", "30", "20", "10", "05"] -%}
     <li class="color-preview">
-      <div class="swatch" style="background-color: var(--wa-color-{{ hue }}-{{ tint }})"></div>
+      <div class="color swatch" style="background-color: var(--wa-color-{{ hue }}-{{ tint }})">
+        <wa-copy-button value="--wa-color-{{ hue }}-{{ tint }}" copy-label="--wa-color-{{ hue }}-{{ tint }}"></wa-copy-button>
+      </div>
       <small>{{ tint }}</small>
     </li>
   {%- endfor %}
@@ -187,23 +189,3 @@ Finally, each color is named according to how much attention it draws. Here, we 
     {%- endfor %}
     {%- endfor %}
 </table>
-
-<script type="module">
-  const computedStyle = getComputedStyle(document.body)
-  document.querySelectorAll(".swatch").forEach((swatch) => {
-    let varName = swatch.getAttribute("value")
-
-    if (!varName) {
-      const bgColor = swatch.style.backgroundColor
-      varName = bgColor.replace(/^var\((--.*)\)$/, "$1")
-    }
-
-    const copyButton = Object.assign(document.createElement("wa-copy-button"), {
-      value: varName,
-      copyLabel: varName,
-      errorLabel: "Whoops, your browser doesn't support this!",
-    })
-
-    swatch.appendChild(copyButton)
-  })
-</script>

--- a/docs/docs/tokens/color.md
+++ b/docs/docs/tokens/color.md
@@ -49,22 +49,22 @@ Web Awesome's color system is made up of CSS custom properties to help with cons
 
 Color is organized by three main categories:
 
-- [Literal colors](/#literal-colors) that give familiar names to your starting color palette
+- [Literal colors](/#literal-colors) that give familiar names to your starting [color palette](/docs/palettes/)
 - [Foundational colors](/#foundational-colors) that lay the groundwork for your theme
 - [Semantic colors](/#semantic-colors) that draw attention and convey meaning
 
 
 ## Literal Colors
 
-Literal colors are the lowest level color properties in your theme. Each color is identified by a name, like red or gray, and a number that roughly corresponds to the color's perceived lightness. On this scale, 100 is equal to pure white and 0 is equal to pure black.
+Literal colors are defined by your theme's [color palette](/docs/palettes/) and are the lowest level color tokens in your theme. Each token is identified by a name, like red or gray, and a number based on the color's lightness. On this scale, 100 is equal to pure white and 0 is equal to pure black.
 
-Lightness values on this scale have a strong correlation to [relative luminance](https://www.w3.org/WAI/GL/wiki/Relative_luminance), which is used to calculate color contrast. To meet [WCAG 2.1 success criteria for minimum or enhanced contrast](https://www.w3.org/TR/WCAG21/#contrast-minimum), even across hues, calculate the difference between the lightness values of any two colors:
+You can use these numbers to ensure accessible color contrast per [WCAG 2.1 success criteria](https://www.w3.org/TR/WCAG21/#contrast-minimum):
 
 - A difference of 40 ensures a minimum 3:1 contrast ratio, suitable for large text and icons (AA)
 - A difference of 50 ensures a minimum 4.5:1 contrast ratio, suitable for normal text (AA) and large text (AAA)
 - A difference of 60 ensures a minimum 7:1 contrast ratio, suitable for all text (AAA)
 
-Web Awesome defines seven literal colors each with 11 lightness values using the format `--wa-color-{hue}-{tint}`.
+Each Web Awesome palette defines seven literal colors each with 11 lightness values using the format `--wa-color-{hue}-{tint}`.
 
 {% for hue in ["red", "yellow", "green", "teal", "blue", "indigo", "violet", "gray"] -%}
 <div class="color-name">{{ hue | capitalize }}</div>


### PR DESCRIPTION
Adds:
- color palette pages
- an overview page
- a new sidebar group with color palettes
- a color palette card to theme pages

Each color palette page currently includes:

1. A table of all tints, with copyable color names:
<img width="1040" alt="image" src="https://github.com/user-attachments/assets/3d0c343c-9b4f-4d96-9eab-013c1bd2a93a" />

2. Themes using this palette

<img width="1032" alt="image" src="https://github.com/user-attachments/assets/8a6806dc-0bcf-47c6-bc52-d843b7a3fbf2" />

3. Color contrast pairs

<img width="1041" alt="image" src="https://github.com/user-attachments/assets/ce18d557-8fca-409d-8c66-390c68e60977" />

Once #541 is merged I could reuse the logic in 11ty to actually print out contrast ratios for both WCAG and APCA.

4. Usage instructions for CSS and HTML

<img width="1034" alt="image" src="https://github.com/user-attachments/assets/c8ff7114-cdd2-4ddb-bec0-f4e2f521d83f" />

---

For the overview, I've attempted to generate some rudimentary icons, though I'm sure @lindsaym-fa could make them look better:
<img width="1070" alt="image" src="https://github.com/user-attachments/assets/ec079970-cbe2-41ca-b362-9f68171e92a1" />

Notes:
- I've assumed that every palette not used by a Free theme is Pro. 
- Themes still need icons (unless we just reuse the showcase iframe?)
- I did not remove anything from the page on Color tokens, I'll leave that up to @lindsaym-fa's judgement.