### PR TITLE
Floating label for Matter theme

### DIFF
--- a/docs/docs/themes/matter.md
+++ b/docs/docs/themes/matter.md
@@ -5,3 +5,13 @@ isPro: true
 tags: pro
 defaultPalette: mild
 ---
+
+## Floating labels
+
+This theme implements "floating labels" for `wa-input`, `wa-textarea`, `wa-select` (set the page theme to "{{ title }}" from the top right to preview the following examples).
+
+```html {.example}
+<wa-input label="What is your name?"></wa-input>
+<br>
+<wa-input label="What is your name?" appearance="filled"></wa-input>
+```

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -1,4 +1,4 @@
-import { html, isServer } from 'lit';
+import { html, isServer, type PropertyValues } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -57,6 +57,8 @@ import styles from './input.css';
  * @cssproperty --border-color - The color of the input's borders.
  * @cssproperty --border-width - The width of the input's borders. Expects a single value.
  * @cssproperty --box-shadow - The shadow effects around the edges of the input.
+ *
+ * @cssstate blank - The input is empty.
  */
 @customElement('wa-input')
 export default class WaInput extends WebAwesomeFormAssociatedElement {
@@ -306,6 +308,14 @@ export default class WaInput extends WebAwesomeFormAssociatedElement {
 
   private handlePasswordToggle() {
     this.passwordVisible = !this.passwordVisible;
+  }
+
+  updated(changedProperties: PropertyValues<this>) {
+    super.updated(changedProperties);
+
+    if (changedProperties.has('value')) {
+      this.toggleCustomState('blank', !this.value);
+    }
   }
 
   @watch('step', { waitUntilFirstUpdate: true })

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -1,4 +1,4 @@
-import type { TemplateResult } from 'lit';
+import type { PropertyValues, TemplateResult } from 'lit';
 import { html, isServer } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
@@ -674,6 +674,14 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
     });
   }
 
+  updated(changedProperties: PropertyValues<this>) {
+    super.updated(changedProperties);
+
+    if (changedProperties.has('value')) {
+      this.toggleCustomState('blank', !this.value);
+    }
+  }
+
   @watch('disabled', { waitUntilFirstUpdate: true })
   handleDisabledChange() {
     // Close the listbox when the control is disabled
@@ -799,7 +807,7 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
       >
         <label
           id="label"
-          part="form-control-label"
+          part="form-control-label label"
           class="label"
           aria-hidden=${hasLabel ? 'false' : 'true'}
           @click=${this.handleLabelClick}

--- a/src/components/textarea/textarea.ts
+++ b/src/components/textarea/textarea.ts
@@ -275,7 +275,12 @@ export default class WaTextarea extends WebAwesomeFormAssociatedElement {
     if (changedProperties.has('resize')) {
       this.setTextareaDimensions();
     }
+
     super.updated(changedProperties);
+
+    if (changedProperties.has('value')) {
+      this.toggleCustomState('blank', !this.value);
+    }
   }
 
   /** Sets focus on the textarea. */

--- a/src/styles/themes/matter/overrides.css
+++ b/src/styles/themes/matter/overrides.css
@@ -81,22 +81,36 @@
       }
     }
 
-    /* Floating label */
+    /**
+     * Floating labels
+     */
     &::part(label) {
       transition: all var(--wa-transition-normal);
 
       position: absolute;
-      top: calc(var(--wa-form-control-height) / 2 - 0.5lh);
       left: calc(var(--wa-space) - 0.25em);
       z-index: 1;
+
+      /* State: out of the way by default */
+      top: -0.5lh;
+      font-size: var(--wa-size-smaller);
 
       background-color: var(--wa-form-control-background-color);
       padding-inline: 0.25em;
     }
+
     &:focus::part(label) {
-      top: -0.5lh;
       color: var(--wa-color-focus);
-      font-size: var(--wa-size-smaller);
+    }
+
+    /* State: placeholder-like when:
+     * - the input is empty
+     * - the input is not focused
+     * - there is no actual placeholder
+     */
+    &:state(blank):not(:focus, [placeholder])::part(label) {
+      top: calc(var(--wa-form-control-height) / 2 - 0.5lh);
+      font-size: inherit;
     }
 
     /* Different positioning and appearance for filled */

--- a/src/styles/themes/matter/overrides.css
+++ b/src/styles/themes/matter/overrides.css
@@ -61,6 +61,9 @@
   .wa-text-field {
     --wa-form-control-value-line-height: var(--wa-line-height-normal);
 
+    /* Needed for floating label */
+    position: relative;
+
     &:is([appearance~='filled'], .wa-filled):not([appearance~='outlined'], .wa-outlined, [pill], .wa-pill) {
       --wa-focus-ring: ;
       --border-color: transparent transparent var(--wa-form-control-border-color) transparent;
@@ -75,6 +78,39 @@
       &::part(input),
       &::part(combobox) {
         border-radius: var(--wa-form-control-border-radius) var(--wa-form-control-border-radius) 0px 0px;
+      }
+    }
+
+    /* Floating label */
+    &::part(label) {
+      transition: all var(--wa-transition-normal);
+
+      position: absolute;
+      top: calc(var(--wa-form-control-height) / 2 - 0.5lh);
+      left: calc(var(--wa-space) - 0.25em);
+      z-index: 1;
+
+      background-color: var(--wa-form-control-background-color);
+      padding-inline: 0.25em;
+    }
+    &:focus::part(label) {
+      top: -0.5lh;
+      color: var(--wa-color-focus);
+      font-size: var(--wa-size-smaller);
+    }
+
+    /* Different positioning and appearance for filled */
+    &:is([appearance~='filled'], .wa-filled) {
+      &::part(input) {
+        padding-block: calc(var(--wa-space) * 1.5) calc(var(--wa-space) * 0.5);
+      }
+
+      &::part(label) {
+        background-color: var(--background-color);
+      }
+
+      &:focus::part(label) {
+        top: 0;
       }
     }
   }

--- a/src/styles/themes/matter/overrides.css
+++ b/src/styles/themes/matter/overrides.css
@@ -114,16 +114,18 @@
     }
 
     /* Different positioning and appearance for filled */
-    &:is([appearance~='filled'], .wa-filled) {
-      &::part(input) {
-        padding-block: calc(var(--wa-space) * 1.5) calc(var(--wa-space) * 0.5);
+    &:where([appearance~='filled'], .wa-filled)[label]:not([placeholder]) {
+      &::part(base) {
+        /* We want to move this down a bit to make space for the floating label */
+        translate: 0 0.3em;
       }
 
       &::part(label) {
-        background-color: var(--background-color);
+        /* In filled inputs, the floating label stays within the input */
+        background-color: transparent;
       }
 
-      &:focus::part(label) {
+      &:not(:state(blank):not(:focus, [placeholder]))::part(label) {
         top: 0;
       }
     }


### PR DESCRIPTION
Prior art —
Outlined:
<img width="231" alt="Screenshot 2025-01-16 at 1 48 00 PM" src="https://github.com/user-attachments/assets/b24c6117-552f-443b-b5a0-07c8d70274de" />
<img width="231" alt="Screenshot 2025-01-16 at 1 48 10 PM" src="https://github.com/user-attachments/assets/3fa71630-fcb4-4e10-a1e8-addb8f8260f0" />
<img width="231" alt="Screenshot 2025-01-16 at 1 51 44 PM" src="https://github.com/user-attachments/assets/f46f5637-2d55-4952-9ba8-b5ae9fa61fed" />


Filled:
<img width="231" alt="Screenshot 2025-01-16 at 1 48 24 PM" src="https://github.com/user-attachments/assets/a9172b69-1dc2-4555-83e5-e1c45f23d647" />
<img width="231" alt="Screenshot 2025-01-16 at 1 48 20 PM" src="https://github.com/user-attachments/assets/37682d1c-4ce4-4da2-8840-77e5a2412653" />
<img width="231" alt="Screenshot 2025-01-16 at 1 51 20 PM" src="https://github.com/user-attachments/assets/f2b52f21-d228-4284-a167-8723a33cb068" />

