### PR TITLE
Ensure the `<wa-select hoist>` fix works on the backers website

### DIFF
--- a/docs/docs/components/select.md
+++ b/docs/docs/components/select.md
@@ -420,5 +420,7 @@ This can be hard to conceptualize, so heres a fairly large example showing how l
   //
   // TODO - remove once we switch to the Popover API
   //
-  document.querySelectorAll('wa-code-demo [slot="preview"] wa-select').forEach(select => select.hoist = true);
+  customElements.whenDefined('wa-select').then(() => {
+    document.querySelectorAll('wa-code-demo [slot="preview"] wa-select').forEach(select => select.hoist = true);
+  });
 </script>


### PR DESCRIPTION
This was working locally because imports are faster in dev, but it's broken on the backers website.

To repro, visit: https://backers.webawesome.com/docs/components/select

And open any select.

![CleanShot 2025-01-21 at 12 29 47@2x](https://github.com/user-attachments/assets/5bfe2509-de9d-4155-8303-fe9ffcaf01c0)

Fixes #332
