### PR TITLE
Refactor native select caret styles, fixes #571 and #572

### DIFF
--- a/src/styles/native/select.css
+++ b/src/styles/native/select.css
@@ -73,19 +73,11 @@ select:focus,
 /* Replace native select caret */
 select {
   appearance: none;
-}
-label:has(select) {
-  position: relative;
-  --icon-caret: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 512 512"><path d="M233.4 406.6c12.5 12.5 32.8 12.5 45.3 0l192-192c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L256 338.7 86.6 169.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l192 192z"/></svg>');
 
-  &::after {
-    content: '';
-    background-color: var(--wa-color-neutral-on-quiet);
-    mask: var(--icon-caret) 50% 50% no-repeat;
-    width: 1rem;
-    height: var(--wa-form-control-height);
-    position: absolute;
-    bottom: var(--wa-form-control-border-width);
-    right: var(--wa-space);
-  }
+  --icon-caret: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 512 512"><path fill="rgb(180 180 200)" d="M233.4 406.6c12.5 12.5 32.8 12.5 45.3 0l192-192c12.5-12.5 12.5-32.8 0-45.3s-32.8-12.5-45.3 0L256 338.7 86.6 169.4c-12.5-12.5-32.8-12.5-45.3 0s-12.5 32.8 0 45.3l192 192z"/></svg>');
+
+  background-image: var(--icon-caret), var(--icon-caret);
+  background-repeat: no-repeat;
+  background-position: center right var(--wa-space);
+  background-blend-mode: hue, difference;
 }


### PR DESCRIPTION
For styling a native `<select>`, the story goes:
- We can't use `::after` on a `<select>`.
- We can't use `::after` on a `<label>` containing the select because it won't appear for selects outside of a label.
- We can't use the technique of `background-color` + `mask` on a `<select>` to get the right shape and color of the caret since...well, the select itself will be masked.

So, in a live discussion of #571, we chose to use the browser's default caret rather than trying to replace it with our own. As it turns out...

We can't do that because each browser's default select styling creates inconsistencies, but most of all..._**Safari**_.

---

### ❌ Fail: Using the browser's default caret
Removing `appearance: none` to use the browser's default caret yielded these results:
Firefox (close!)
<img width="679" alt="Screenshot 2025-01-23 at 4 06 30 PM" src="https://github.com/user-attachments/assets/1b418ebb-5122-4690-8d2a-bf44d9a84a22" />

Chrome and Edge (they add space around the selected value that we can't seem to target)
<img width="679" alt="Screenshot 2025-01-23 at 4 07 20 PM" src="https://github.com/user-attachments/assets/7bbcdb9a-0ce1-4827-8a05-6a5646fb18ae" />

Safari (straight-up doesn't care)
<img width="663" alt="Screenshot 2025-01-23 at 4 06 10 PM" src="https://github.com/user-attachments/assets/5935ebd5-fa14-46e5-bac1-e502243df349" />

---

### ✅ Pass: Using `background-image` with `background-blend-mode`
So, I ended up taking the approach of keeping `appearance: none` and using a `background-image` with `background-blend-mode`.

**The results are not exact, but they are passable.** Here are some examples:
Default theme:
<img width="188" alt="Screenshot 2025-01-23 at 7 04 12 PM" src="https://github.com/user-attachments/assets/756b54e2-8cf4-4a16-a61d-9f2db4c39ce7" />
<img width="188" alt="Screenshot 2025-01-23 at 7 04 19 PM" src="https://github.com/user-attachments/assets/c58bc5d5-dffa-41b2-9937-333e550fe0ce" />
<img width="188" alt="Screenshot 2025-01-23 at 7 04 33 PM" src="https://github.com/user-attachments/assets/7f8ca2c5-607a-468a-b8e9-07332a3c6967" />
<img width="188" alt="Screenshot 2025-01-23 at 7 04 27 PM" src="https://github.com/user-attachments/assets/4c991d38-d901-4b35-ac00-2c16830cfb81" />


Awesome theme:
<img width="188" alt="Screenshot 2025-01-23 at 7 04 52 PM" src="https://github.com/user-attachments/assets/a6e4e920-9c5f-4dca-bc12-0496c76d2770" />
<img width="188" alt="Screenshot 2025-01-23 at 7 04 58 PM" src="https://github.com/user-attachments/assets/b7ae2a22-d4af-4441-b1b9-4d01e908e926" />
<img width="188" alt="Screenshot 2025-01-23 at 7 04 44 PM" src="https://github.com/user-attachments/assets/c54a88dc-2e79-4ef4-b168-001b49293869" />
<img width="188" alt="Screenshot 2025-01-23 at 7 05 03 PM" src="https://github.com/user-attachments/assets/381a903c-201a-420b-a392-19cac0c172a2" />


The worst offenders are selects in the Premium theme, where `background-blend-mode` is less effective because the theme sets `--wa-form-control-background-color: transparent`. 

A filled select in dark mode is not especially great:
<img width="188" alt="Screenshot 2025-01-23 at 6 43 30 PM" src="https://github.com/user-attachments/assets/76ab8cfc-38c6-4c8b-8807-37b1b46e00a5" />

An outlined select in light mode is meh:
<img width="188" alt="Screenshot 2025-01-23 at 6 43 53 PM" src="https://github.com/user-attachments/assets/968731ed-6751-4959-bbd5-d159580da717" />

There may be a closer match, but I've exceeded the allotment of time I'd like to spend mixing and matching blend modes for now.