### PR TITLE
Add breaks between radios in Radio Group examples

### DIFF
--- a/docs/docs/components/radio-group.md
+++ b/docs/docs/components/radio-group.md
@@ -7,8 +7,8 @@ icon: radio-group
 
 ```html {.example}
 <wa-radio-group label="Select an option" name="a" value="1">
-  <wa-radio value="1">Option 1</wa-radio>
-  <wa-radio value="2">Option 2</wa-radio>
+  <wa-radio value="1">Option 1</wa-radio><br>
+  <wa-radio value="2">Option 2</wa-radio><br>
   <wa-radio value="3">Option 3</wa-radio>
 </wa-radio-group>
 ```
@@ -21,8 +21,8 @@ Add descriptive hint to a radio group with the `hint` attribute. For hints that 
 
 ```html {.example}
 <wa-radio-group label="Select an option" hint="Choose the most appropriate option." name="a" value="1">
-  <wa-radio value="1">Option 1</wa-radio>
-  <wa-radio value="2">Option 2</wa-radio>
+  <wa-radio value="1">Option 1</wa-radio><br>
+  <wa-radio value="2">Option 2</wa-radio><br>
   <wa-radio value="3">Option 3</wa-radio>
 </wa-radio-group>
 ```
@@ -45,8 +45,8 @@ Radios and radio buttons can be disabled by adding the `disabled` attribute to t
 
 ```html {.example}
 <wa-radio-group label="Select an option" name="a" value="1">
-  <wa-radio value="1">Option 1</wa-radio>
-  <wa-radio value="2" disabled>Option 2</wa-radio>
+  <wa-radio value="1">Option 1</wa-radio><br>
+  <wa-radio value="2" disabled>Option 2</wa-radio><br>
   <wa-radio value="3">Option 3</wa-radio>
 </wa-radio-group>
 ```
@@ -57,8 +57,8 @@ The size of [Radios](/docs/components/radio) and [Radio Buttons](/docs/component
 
 ```html preview
 <wa-radio-group label="Select an option" size="medium" value="medium" class="radio-group-size">
-  <wa-radio value="small">Small</wa-radio>
-  <wa-radio value="medium">Medium</wa-radio>
+  <wa-radio value="small">Small</wa-radio><br>
+  <wa-radio value="medium">Medium</wa-radio><br>
   <wa-radio value="large">Large</wa-radio>
 </wa-radio-group>
 
@@ -82,8 +82,8 @@ Setting the `required` attribute to make selecting an option mandatory. If a val
 ```html {.example}
 <form class="validation">
   <wa-radio-group label="Select an option" name="a" required>
-    <wa-radio value="1">Option 1</wa-radio>
-    <wa-radio value="2">Option 2</wa-radio>
+    <wa-radio value="1">Option 1</wa-radio><br>
+    <wa-radio value="2">Option 2</wa-radio><br>
     <wa-radio value="3">Option 3</wa-radio>
   </wa-radio-group>
   <br />
@@ -108,8 +108,8 @@ Use the `setCustomValidity()` method to set a custom validation message. This wi
 ```html {.example}
 <form class="custom-validity">
   <wa-radio-group label="Select an option" name="a" value="1">
-    <wa-radio value="1">Not me</wa-radio>
-    <wa-radio value="2">Me neither</wa-radio>
+    <wa-radio value="1">Not me</wa-radio><br>
+    <wa-radio value="2">Me neither</wa-radio><br>
     <wa-radio value="3">Choose me</wa-radio>
   </wa-radio-group>
   <br />


### PR DESCRIPTION
Fixes some unsightliness in the Radio Group docs by adding breaks between `<wa-radio>`s in the examples.

Before:
<img width="325" alt="Screenshot 2025-01-24 at 1 57 12 PM" src="https://github.com/user-attachments/assets/1c0df681-fa1a-49b9-9117-a7a148e02ede" />

After:
<img width="176" alt="Screenshot 2025-01-24 at 1 56 53 PM" src="https://github.com/user-attachments/assets/a8b9af0c-708f-43aa-9fa7-b1da2cb4d416" />

As a more substantial improvement, I'd love to offer some layout options for `<wa-radio-group>` to arrange the controls within either vertically or horizontally with reasonable default gaps that can be overridden, but that might be best considered following #504.
