### PR TITLE
Use 100% width for text field and select labels, fixes #578

### DIFF
--- a/src/styles/native/forms.css
+++ b/src/styles/native/forms.css
@@ -5,11 +5,30 @@ label {
   font-weight: var(--wa-form-control-label-font-weight);
   line-height: var(--wa-form-control-label-line-height);
   position: relative;
-}
 
-label + :is(input:not([type='checkbox'], [type='radio']), textarea, select),
-label > :is(input:not([type='checkbox'], [type='radio']), textarea, select) {
-  margin-block-start: var(--wa-space-xs);
+  &:has(
+      input:not(
+          [type='button'],
+          [type='checkbox'],
+          [type='color'],
+          [type='file'],
+          [type='hidden'],
+          [type='image'],
+          [type='radio'],
+          [type='range'],
+          [type='reset'],
+          [type='submit']
+        ),
+      textarea,
+      select
+    ) {
+    width: 100%;
+  }
+
+  & + :is(input:not([type='checkbox'], [type='radio']), textarea, select),
+  & > :is(input:not([type='checkbox'], [type='radio']), textarea, select) {
+    margin-block-start: var(--wa-space-xs);
+  }
 }
 
 /* Fieldsets */

--- a/src/styles/shadow/form-control.css
+++ b/src/styles/shadow/form-control.css
@@ -1,6 +1,6 @@
 /* Label */
 :is([part~='form-control-label'], [part~='label']):has(*:not(:empty)) {
-  display: block;
+  display: inline-block;
   color: var(--wa-form-control-label-color);
   font-weight: var(--wa-form-control-label-font-weight);
   line-height: var(--wa-form-control-label-line-height);


### PR DESCRIPTION
This change:

- Allows labels containing a `<select>`, `<textarea>`, or `<input>` of a specific type to use 100% width
- Sets `display: inline-block` on labels for `<wa-input>`, `<wa-select>`, and `<wa-textarea>` to fix an issue where clicking the adjacent whitespace applied focus to the control

---

The issue described for `<select>` in #578 also affected `<textarea>` and `<input>`, so this PR addresses all three.

Before:
<img width="685" alt="Screenshot 2025-01-24 at 4 16 15 PM" src="https://github.com/user-attachments/assets/0c43c3a1-6d9b-4d0c-845a-cd406b310a58" />
<img width="685" alt="Screenshot 2025-01-24 at 4 16 52 PM" src="https://github.com/user-attachments/assets/ba3a6bfa-1dac-48cb-9012-f5bc3bbca3e6" />
<img width="685" alt="Screenshot 2025-01-24 at 4 17 22 PM" src="https://github.com/user-attachments/assets/8ef61023-0d6e-4bec-b6de-8e6ec8743dea" />


After:
<img width="685" alt="Screenshot 2025-01-24 at 4 16 25 PM" src="https://github.com/user-attachments/assets/3141bcdc-e96b-4585-963c-8720fb6c9ca4" />
<img width="685" alt="Screenshot 2025-01-24 at 4 17 05 PM" src="https://github.com/user-attachments/assets/a07c93f6-f086-471c-bb97-b0bec9618f74" />
<img width="685" alt="Screenshot 2025-01-24 at 4 17 33 PM" src="https://github.com/user-attachments/assets/d091b016-8563-4642-8d22-49f5d985aac8" />

I couldn't find a way to prevent the whitespace adjacent to the label from being clickable when using an implicit label. The best solution I could come up with was adding `pointer-events: none` to the label, then `pointer-events: auto` to the control, but that also removes clickability from the label text, which is an important UX feature — so I didn't implement this. Folks who won't find the clickable whitespace advantageous for their users can always use explicit labels with the `for` attribute.

Additionally, the whitespace was also clickable in WA components. This was not the case in Shoelace, and I'm not totally sure this was an intentional change, so this PR fixes that.