### PR TITLE
Fix regression

### DIFF
--- a/src/styles/utilities/size.css
+++ b/src/styles/utilities/size.css
@@ -7,6 +7,19 @@
   font-size: var(--wa-size, var(--wa-font-size-m));
 }
 
+:host {
+  /* Components are meant to override these */
+  --size-xs: var(--wa-space-xs);
+  --size-s: var(--wa-space-s);
+  --size-m: var(--wa-space-m);
+  --size-l: var(--wa-space-l);
+
+  --space-xs: var(--wa-space-xs);
+  --space-s: var(--wa-space-s);
+  --space-m: var(--wa-space-m);
+  --space-l: var(--wa-space-l);
+}
+
 :where(:root),
 :host,
 .wa-size-s,


### PR DESCRIPTION
Welp, it turns out these should _not_ have been deleted after all.

Without this change, breakpoints inherit into components with no size.
Before and after:
<img width="326" alt="image" src="https://github.com/user-attachments/assets/e646371e-5b90-4bf1-bf7b-eaae504a293c" />
<img width="327" alt="image" src="https://github.com/user-attachments/assets/273c541e-1b19-488a-80da-527ab5f589c6" />