### PR TITLE
Select tag fix

### DIFF
--- a/docs/docs/resources/changelog.md
+++ b/docs/docs/resources/changelog.md
@@ -15,6 +15,7 @@ During the alpha period, things might break! We take breaking changes very serio
 ## Next
 
 - Added an orientation example to the native radio docs
+- Added the `tag-counter` part to `<wa-select>` to allow targeting the tag that shows when more than the max number of visible items has been selected
 - Fixed a number of broken event listeners throughout the docs
 
 ## 3.0.0-alpha.10

--- a/docs/docs/resources/changelog.md
+++ b/docs/docs/resources/changelog.md
@@ -15,7 +15,7 @@ During the alpha period, things might break! We take breaking changes very serio
 ## Next
 
 - Added an orientation example to the native radio docs
-- Added the `tag-counter` part to `<wa-select>` to allow targeting the tag that shows when more than the max number of visible items has been selected
+- Added the `tag` part (and associated exported parts) to `<wa-select>` to allow targeting the tag that shows when more than the max number of visible items have been selected
 - Fixed a number of broken event listeners throughout the docs
 - Fixed a bug in `<wa-card>` that prevented slots from showing automatically without `with-` attributes
 

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -68,10 +68,13 @@ import styles from './select.css';
  * @csspart listbox - The listbox container where options are slotted.
  * @csspart tags - The container that houses option tags when `multiselect` is used.
  * @csspart tag - The individual tags that represent each multiselect option.
- * @csspart tag__base - The tag's base part.
  * @csspart tag__content - The tag's content part.
  * @csspart tag__remove-button - The tag's remove button.
  * @csspart tag__remove-button__base - The tag's remove button base part.
+ * @csspart tag-counter - The tag that shows when more than the max number of options have been shown.
+ * @csspart tag-counter__content - The tag counter's content part.
+ * @csspart tag-counter__remove-button - The tag counter's remove button.
+ * @csspart tag-counter__remove-button__base - The tag counter's remove button base part.
  * @csspart clear-button - The clear button.
  * @csspart expand-icon - The container that wraps the expand icon.
  *
@@ -661,7 +664,18 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
         </div>`;
       } else if (index === this.maxOptionsVisible) {
         // Hit tag limit
-        return html`<wa-tag>+${this.selectedOptions.length - index}</wa-tag>`;
+        return html`
+          <wa-tag
+            part="tag-counter"
+            exportparts="
+              base:tag-counter__base,
+              content:tag-counter__content,
+              remove-button:tag-counter__remove-button,
+              remove-button__base:tag-counter__remove-button__base
+            "
+            >+${this.selectedOptions.length - index}</wa-tag
+          >
+        `;
       }
       return html``;
     });

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -71,10 +71,6 @@ import styles from './select.css';
  * @csspart tag__content - The tag's content part.
  * @csspart tag__remove-button - The tag's remove button.
  * @csspart tag__remove-button__base - The tag's remove button base part.
- * @csspart tag-counter - The tag that shows when more than the max number of options have been shown.
- * @csspart tag-counter__content - The tag counter's content part.
- * @csspart tag-counter__remove-button - The tag counter's remove button.
- * @csspart tag-counter__remove-button__base - The tag counter's remove button base part.
  * @csspart clear-button - The clear button.
  * @csspart expand-icon - The container that wraps the expand icon.
  *
@@ -666,12 +662,12 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
         // Hit tag limit
         return html`
           <wa-tag
-            part="tag-counter"
+            part="tag"
             exportparts="
-              base:tag-counter__base,
-              content:tag-counter__content,
-              remove-button:tag-counter__remove-button,
-              remove-button__base:tag-counter__remove-button__base
+              base:tag__base,
+              content:tag__content,
+              remove-button:tag__remove-button,
+              remove-button__base:tag__remove-button__base
             "
             >+${this.selectedOptions.length - index}</wa-tag
           >


### PR DESCRIPTION
Fixes: https://github.com/shoelace-style/webawesome-alpha/issues/168

This adds the `tag` and exported `tag__*` parts to `<wa-select>` so the "+3" tag will be consistent with custom styles applied to other tags. I elected _not_ to also add, e.g. `tag-counter` and all of the related exports to prevent API bloat since it would add three additional parts and I'm not convinced it's good UX to style it differently from the other tags.

This also removes the `base` part from the docs, which was removed from tag in a prior PR.