### PR TITLE
Rename `gray` to `neutral`, fixes #660

### DIFF
--- a/docs/_data/hues.json
+++ b/docs/_data/hues.json
@@ -1,1 +1,1 @@
-["red", "yellow", "green", "teal", "blue", "indigo", "violet", "gray"]
+["red", "yellow", "green", "teal", "blue", "indigo", "violet", "neutral"]

--- a/docs/assets/styles/code-highlighter.css
+++ b/docs/assets/styles/code-highlighter.css
@@ -1,9 +1,9 @@
 pre {
-  background-color: var(--wa-color-gray-20);
+  background-color: var(--wa-color-neutral-20);
   color: white;
 
   /* Ensures a discernible background color in dark mode
-   * Useful for themes that use gray-20 as --wa-color-surface-default  */
+   * Useful for themes that use neutral-20 as --wa-color-surface-default  */
   .wa-dark & {
     background-color: var(--wa-color-surface-lowered);
   }
@@ -14,7 +14,7 @@ pre {
 .code-cdata,
 .code-operator,
 .code-punctuation {
-  color: var(--wa-color-gray-70);
+  color: var(--wa-color-neutral-70);
 }
 
 .code-namespace {

--- a/docs/assets/styles/copy-code.css
+++ b/docs/assets/styles/copy-code.css
@@ -1,11 +1,11 @@
 wa-copy-button.copy-button {
-  --background-color: var(--wa-color-gray-20);
+  --background-color: var(--wa-color-neutral-20);
   --background-color-hover: color-mix(in oklab, var(--background-color), white 5%);
   position: absolute;
   top: 0.25rem;
   right: 0.25rem;
   font-family: var(--wa-font-family-body);
-  color: var(--wa-color-gray-80);
+  color: var(--wa-color-neutral-80);
   border-radius: var(--wa-border-radius-m);
   padding: 0.25rem;
 

--- a/docs/assets/styles/docs.css
+++ b/docs/assets/styles/docs.css
@@ -176,7 +176,7 @@ wa-badge.pro::part(base) {
         margin-block-end: -0.15em;
         font-size: var(--wa-font-size-s);
         font-weight: var(--wa-font-weight-action);
-        color: var(--wa-color-gray-70);
+        color: var(--wa-color-neutral-70);
       }
 
       &:hover {

--- a/docs/assets/styles/theme-headers.css
+++ b/docs/assets/styles/theme-headers.css
@@ -222,7 +222,7 @@ html.wa-theme-brutalist .preview-container {
   }
 
   .message-composer .grouped-buttons {
-    --wa-color-neutral-border-quiet: color-mix(in oklab, var(--wa-color-gray-30), white 40%);
+    --wa-color-neutral-border-quiet: color-mix(in oklab, var(--wa-color-neutral-30), white 40%);
   }
 
   .message-composer [slot='header'] wa-icon-button::part(base) {
@@ -275,7 +275,7 @@ html.wa-theme-brutalist .preview-container {
 
     & wa-rating {
       --symbol-color: color-mix(in oklab, var(--wa-color-base-80), transparent 50%);
-      --symbol-color-active: var(--wa-color-gray-80);
+      --symbol-color-active: var(--wa-color-neutral-80);
     }
 
     & wa-alert {
@@ -411,13 +411,13 @@ html.wa-theme-playful .preview-container {
   }
 
   .message-composer wa-card::part(header) {
-    --wa-color-neutral-border-quiet: var(--wa-color-gray-70);
+    --wa-color-neutral-border-quiet: var(--wa-color-neutral-70);
     border-width: 0;
     background-color: var(--wa-color-neutral-fill-quiet);
   }
 
   &:not(.wa-theme-premium.wa-dark) .message-composer wa-card {
-    --wa-color-neutral-fill-quiet: var(--wa-color-gray-90);
+    --wa-color-neutral-fill-quiet: var(--wa-color-neutral-90);
   }
 
   .message-composer wa-icon-button {
@@ -475,11 +475,11 @@ html.wa-theme-playful .preview-container {
     }
 
     & .message-composer wa-card {
-      border-color: var(--wa-color-gray-30);
+      border-color: var(--wa-color-neutral-30);
     }
 
     & .message-composer wa-card::part(header) {
-      background: var(--wa-color-gray-40);
+      background: var(--wa-color-neutral-40);
     }
 
     & .message-composer wa-card::part(footer) {
@@ -487,7 +487,7 @@ html.wa-theme-playful .preview-container {
     }
 
     & .message-composer .tools .grouped-buttons:not(:last-of-type) {
-      --wa-color-neutral-border-quiet: var(--wa-color-gray-40);
+      --wa-color-neutral-border-quiet: var(--wa-color-neutral-40);
     }
 
     & .support-table th {

--- a/docs/docs/components/page/demo-page.css
+++ b/docs/docs/components/page/demo-page.css
@@ -47,8 +47,8 @@ wa-page {
 
   &[slot^='main'],
   &[slot=''] {
-    background: var(--wa-color-gray-80);
-    color: var(--wa-color-gray-20);
+    background: var(--wa-color-neutral-80);
+    color: var(--wa-color-neutral-20);
   }
 
   &[slot^='navigation'] {

--- a/docs/docs/experimental/themer.md
+++ b/docs/docs/experimental/themer.md
@@ -580,7 +580,7 @@ hasOutline: false
       <wa-radio value="blue"><span style="background-color:var(--wa-color-blue-60);"></span></wa-radio>
       <wa-radio value="indigo"><span style="background-color:var(--wa-color-indigo-60);"></span></wa-radio>
       <wa-radio value="violet"><span style="background-color:var(--wa-color-violet-60);"></span></wa-radio>
-      <wa-radio value="gray"><span style="background-color:var(--wa-color-gray-60);"></span></wa-radio>
+      <wa-radio value="neutral"><span style="background-color:var(--wa-color-neutral-60);"></span></wa-radio>
     </wa-radio-group>
   </wa-details>
   <wa-details summary="Typography">

--- a/docs/docs/patterns/ecommerce-product-list.md
+++ b/docs/docs/patterns/ecommerce-product-list.md
@@ -76,7 +76,7 @@ TODO Page Description
       }
       .grid-item-reviews {
         --wa-link-decoration-default: none;
-        --wa-color-text-link: var(--wa-color-gray-50);
+        --wa-color-text-link: var(--wa-color-neutral-50);
         font-size: var(--wa-font-size-m);
       }
       .grid-item-price {
@@ -142,14 +142,14 @@ TODO Page Description
 
     .details {
       .detail-description {
-        color: var(--wa-color-gray-50);
+        color: var(--wa-color-neutral-50);
       }
       .detail-name {
         font-size: var(--wa-font-size-l);
         font-weight: var(--wa-font-weight-action);
       }
       .detail-color {
-        color: var(--wa-color-gray-50);
+        color: var(--wa-color-neutral-50);
         font-style: italic;
       }
       .detail-price {

--- a/docs/docs/patterns/news.md
+++ b/docs/docs/patterns/news.md
@@ -148,7 +148,7 @@ TODO Page Description
       display: flex;
       align-items: center;
       text-decoration: none;
-      --wa-color-text-link: var(--wa-color-gray-20);
+      --wa-color-text-link: var(--wa-color-neutral-20);
 
       wa-icon {
         margin-right: .5rem;

--- a/docs/docs/tokens/color.md
+++ b/docs/docs/tokens/color.md
@@ -56,7 +56,7 @@ Color is organized by three main categories:
 
 ## Literal Colors
 
-Literal colors are defined by your theme's [color palette](/docs/palettes/) and are the lowest level color tokens in your theme. Each token is identified by a name, like red or gray, and a number based on the color's lightness. On this scale, 100 is equal to pure white and 0 is equal to pure black.
+Literal colors are defined by your theme's [color palette](/docs/palettes/) and are the lowest level color tokens in your theme. Each token is identified by a name, like red or neutral, and a number based on the color's lightness. On this scale, 100 is equal to pure white and 0 is equal to pure black.
 
 You can use these numbers to ensure accessible color contrast per [WCAG 2.1 success criteria](https://www.w3.org/TR/WCAG21/#contrast-minimum):
 
@@ -66,7 +66,7 @@ You can use these numbers to ensure accessible color contrast per [WCAG 2.1 succ
 
 Each Web Awesome palette defines seven literal colors each with 11 lightness values using the format `--wa-color-{hue}-{tint}`.
 
-{% for hue in ["red", "yellow", "green", "teal", "blue", "indigo", "violet", "gray"] -%}
+{% for hue in ["red", "yellow", "green", "teal", "blue", "indigo", "violet", "neutral"] -%}
 <div class="color-name">{{ hue | capitalize }}</div>
 <ul class="color-group">
   {% for tint in ["95", "90", "80", "70", "60", "50", "40", "30", "20", "10", "05"] -%}

--- a/docs/docs/tokens/component-groups.md
+++ b/docs/docs/tokens/component-groups.md
@@ -26,7 +26,7 @@ Not every form control uses all of these custom properties. For example, `<wa-ra
 | `--wa-form-control-value-color`             | `var(--wa-color-text-normal)`                                                                     |
 | `--wa-form-control-value-font-weight`       | `var(--wa-font-weight-body)`                                                                      |
 | `--wa-form-control-value-line-height`       | `var(--wa-line-height-condensed)`                                                                 |
-| `--wa-form-control-placeholder-color`       | `var(--wa-color-gray-60)`                                                                         |
+| `--wa-form-control-placeholder-color`       | `var(--wa-color-neutral-60)`                                                                         |
 | `--wa-form-control-required-content`        | `'*'`                                                                                             |
 | `--wa-form-control-required-content-color`  | `inherit`                                                                                         |
 | `--wa-form-control-required-content-offset` | `-0.1em`                                                                                          |

--- a/src/components/viewport-demo/viewport-demo.css
+++ b/src/components/viewport-demo/viewport-demo.css
@@ -47,10 +47,10 @@
       1.1em var(--button-params),
     radial-gradient(circle closest-side, var(--wa-color-green-70) 80%, var(--wa-color-green-60) 98%, transparent) 1.8em
       var(--button-params),
-    var(--wa-color-gray-95);
+    var(--wa-color-neutral-95);
   background-repeat: no-repeat;
   box-shadow:
-    0 0 0 1px var(--wa-color-gray-90),
+    0 0 0 1px var(--wa-color-neutral-90),
     var(--wa-shadow-m);
 
   &.resized {
@@ -90,7 +90,7 @@ slot {
   min-height: calc(var(--viewport-min-height) / var(--zoom));
 
   /* Divide with var(--zoom) to get lengths that stay constant regardless of zoom level */
-  border: calc(1px / var(--zoom)) solid var(--wa-color-gray-90);
+  border: calc(1px / var(--zoom)) solid var(--wa-color-neutral-90);
   background: var(--viewport-background-color);
 }
 
@@ -120,7 +120,7 @@ slot {
     display: none;
     vertical-align: -0.1em;
     font-size: 85%;
-    color: var(--wa-color-gray-70);
+    color: var(--wa-color-neutral-70);
   }
 
   wa-icon-button {

--- a/src/styles/color/anodized.css
+++ b/src/styles/color/anodized.css
@@ -93,16 +93,16 @@
   --wa-color-violet-05: #210822 /* oklch(19.065% 0.0603 326.11) */;
   --wa-color-violet: var(--wa-color-violet-50);
 
-  --wa-color-gray-95: #f1f2f4 /* oklch(96.095% 0.00288 264.54) */;
-  --wa-color-gray-90: #e2e5e8 /* oklch(92.046% 0.00521 247.88) */;
-  --wa-color-gray-80: #c2c9d0 /* oklch(83.255% 0.01246 247.98) */;
-  --wa-color-gray-70: #a6b0ba /* oklch(75.244% 0.01824 248.07) */;
-  --wa-color-gray-60: #8897a3 /* oklch(66.841% 0.02477 242.06) */;
-  --wa-color-gray-50: #657888 /* oklch(56.309% 0.0335 243.8) */;
-  --wa-color-gray-40: #435c6f /* oklch(46.235% 0.04323 241.6) */;
-  --wa-color-gray-30: #2d485d /* oklch(38.946% 0.04864 242.89) */;
-  --wa-color-gray-20: #18354a /* oklch(31.701% 0.05142 242.24) */;
-  --wa-color-gray-10: #012034 /* oklch(23.295% 0.05299 241.23) */;
-  --wa-color-gray-05: #001421 /* oklch(18.122% 0.03959 237.04) */;
-  --wa-color-gray: var(--wa-color-gray-40);
+  --wa-color-neutral-95: #f1f2f4 /* oklch(96.095% 0.00288 264.54) */;
+  --wa-color-neutral-90: #e2e5e8 /* oklch(92.046% 0.00521 247.88) */;
+  --wa-color-neutral-80: #c2c9d0 /* oklch(83.255% 0.01246 247.98) */;
+  --wa-color-neutral-70: #a6b0ba /* oklch(75.244% 0.01824 248.07) */;
+  --wa-color-neutral-60: #8897a3 /* oklch(66.841% 0.02477 242.06) */;
+  --wa-color-neutral-50: #657888 /* oklch(56.309% 0.0335 243.8) */;
+  --wa-color-neutral-40: #435c6f /* oklch(46.235% 0.04323 241.6) */;
+  --wa-color-neutral-30: #2d485d /* oklch(38.946% 0.04864 242.89) */;
+  --wa-color-neutral-20: #18354a /* oklch(31.701% 0.05142 242.24) */;
+  --wa-color-neutral-10: #012034 /* oklch(23.295% 0.05299 241.23) */;
+  --wa-color-neutral-05: #001421 /* oklch(18.122% 0.03959 237.04) */;
+  --wa-color-neutral: var(--wa-color-neutral-40);
 }

--- a/src/styles/color/bright.css
+++ b/src/styles/color/bright.css
@@ -93,16 +93,16 @@
   --wa-color-violet-05: #150d2a /* oklch(18.859% 0.05661 292.88) */;
   --wa-color-violet: var(--wa-color-violet-50);
 
-  --wa-color-gray-95: #f1f2f4 /* oklch(96.095% 0.00288 264.54) */;
-  --wa-color-gray-90: #e3e5ea /* oklch(92.181% 0.00709 268.54) */;
-  --wa-color-gray-80: #c7cad4 /* oklch(83.966% 0.01424 272.66) */;
-  --wa-color-gray-70: #a9afbe /* oklch(75.397% 0.0225 268.37) */;
-  --wa-color-gray-60: #8d95a8 /* oklch(66.968% 0.02959 267.4) */;
-  --wa-color-gray-50: #6a7591 /* oklch(56.369% 0.04546 268.14) */;
-  --wa-color-gray-40: #4b5977 /* oklch(46.454% 0.05212 265.05) */;
-  --wa-color-gray-30: #344566 /* oklch(39.129% 0.06051 263) */;
-  --wa-color-gray-20: #1a3356 /* oklch(32.021% 0.07012 257.11) */;
-  --wa-color-gray-10: #0e1e35 /* oklch(23.442% 0.04969 257.55) */;
-  --wa-color-gray-05: #081220 /* oklch(18.072% 0.03272 256.72) */;
-  --wa-color-gray: var(--wa-color-gray-40);
+  --wa-color-neutral-95: #f1f2f4 /* oklch(96.095% 0.00288 264.54) */;
+  --wa-color-neutral-90: #e3e5ea /* oklch(92.181% 0.00709 268.54) */;
+  --wa-color-neutral-80: #c7cad4 /* oklch(83.966% 0.01424 272.66) */;
+  --wa-color-neutral-70: #a9afbe /* oklch(75.397% 0.0225 268.37) */;
+  --wa-color-neutral-60: #8d95a8 /* oklch(66.968% 0.02959 267.4) */;
+  --wa-color-neutral-50: #6a7591 /* oklch(56.369% 0.04546 268.14) */;
+  --wa-color-neutral-40: #4b5977 /* oklch(46.454% 0.05212 265.05) */;
+  --wa-color-neutral-30: #344566 /* oklch(39.129% 0.06051 263) */;
+  --wa-color-neutral-20: #1a3356 /* oklch(32.021% 0.07012 257.11) */;
+  --wa-color-neutral-10: #0e1e35 /* oklch(23.442% 0.04969 257.55) */;
+  --wa-color-neutral-05: #081220 /* oklch(18.072% 0.03272 256.72) */;
+  --wa-color-neutral: var(--wa-color-neutral-40);
 }

--- a/src/styles/color/classic.css
+++ b/src/styles/color/classic.css
@@ -93,16 +93,16 @@
   --wa-color-violet-05: #1d0331 /* oklch(18.767% 0.08707 305.63) */;
   --wa-color-violet: var(--wa-color-violet-50);
 
-  --wa-color-gray-95: #f2f2f3 /* oklch(96.143% 0.00133 286.37) */;
-  --wa-color-gray-90: #e5e5e8 /* oklch(92.276% 0.00403 286.32) */;
-  --wa-color-gray-80: #c9c9cc /* oklch(83.679% 0.00413 286.31) */;
-  --wa-color-gray-70: #aeafb1 /* oklch(75.381% 0.00306 264.54) */;
-  --wa-color-gray-60: #94959b /* oklch(67.089% 0.00884 278.56) */;
-  --wa-color-gray-50: #72747d /* oklch(56.027% 0.01402 275.93) */;
-  --wa-color-gray-40: #565861 /* oklch(46.18% 0.01474 275.83) */;
-  --wa-color-gray-30: #43454d /* oklch(39.154% 0.01373 274.58) */;
-  --wa-color-gray-20: #313134 /* oklch(31.432% 0.00529 286.09) */;
-  --wa-color-gray-10: #1d1d20 /* oklch(23.201% 0.00571 285.95) */;
-  --wa-color-gray-05: #101113 /* oklch(17.739% 0.00442 264.46) */;
-  --wa-color-gray: var(--wa-color-gray-40);
+  --wa-color-neutral-95: #f2f2f3 /* oklch(96.143% 0.00133 286.37) */;
+  --wa-color-neutral-90: #e5e5e8 /* oklch(92.276% 0.00403 286.32) */;
+  --wa-color-neutral-80: #c9c9cc /* oklch(83.679% 0.00413 286.31) */;
+  --wa-color-neutral-70: #aeafb1 /* oklch(75.381% 0.00306 264.54) */;
+  --wa-color-neutral-60: #94959b /* oklch(67.089% 0.00884 278.56) */;
+  --wa-color-neutral-50: #72747d /* oklch(56.027% 0.01402 275.93) */;
+  --wa-color-neutral-40: #565861 /* oklch(46.18% 0.01474 275.83) */;
+  --wa-color-neutral-30: #43454d /* oklch(39.154% 0.01373 274.58) */;
+  --wa-color-neutral-20: #313134 /* oklch(31.432% 0.00529 286.09) */;
+  --wa-color-neutral-10: #1d1d20 /* oklch(23.201% 0.00571 285.95) */;
+  --wa-color-neutral-05: #101113 /* oklch(17.739% 0.00442 264.46) */;
+  --wa-color-neutral: var(--wa-color-neutral-40);
 }

--- a/src/styles/color/default.css
+++ b/src/styles/color/default.css
@@ -93,16 +93,16 @@
   --wa-color-violet-05: #22042b /* oklch(19.232% 0.08005 317.42) */;
   --wa-color-violet: var(--wa-color-violet-50);
 
-  --wa-color-gray-95: #f1f2f3 /* oklch(96.067% 0.00172 247.84) */;
-  --wa-color-gray-90: #e4e5e9 /* oklch(92.228% 0.0055 274.96) */;
-  --wa-color-gray-80: #c7c9d0 /* oklch(83.641% 0.00994 273.33) */;
-  --wa-color-gray-70: #abaeb9 /* oklch(75.183% 0.01604 273.78) */;
-  --wa-color-gray-60: #9194a2 /* oklch(66.863% 0.02088 276.18) */;
-  --wa-color-gray-50: #717584 /* oklch(56.418% 0.02359 273.77) */;
-  --wa-color-gray-40: #545868 /* oklch(46.281% 0.02644 274.26) */;
-  --wa-color-gray-30: #424554 /* oklch(39.355% 0.02564 276.27) */;
-  --wa-color-gray-20: #2f323f /* oklch(31.97% 0.02354 274.82) */;
-  --wa-color-gray-10: #1b1d26 /* oklch(23.277% 0.01762 275.14) */;
-  --wa-color-gray-05: #101219 /* oklch(18.342% 0.01472 272.42) */;
-  --wa-color-gray: var(--wa-color-gray-40);
+  --wa-color-neutral-95: #f1f2f3 /* oklch(96.067% 0.00172 247.84) */;
+  --wa-color-neutral-90: #e4e5e9 /* oklch(92.228% 0.0055 274.96) */;
+  --wa-color-neutral-80: #c7c9d0 /* oklch(83.641% 0.00994 273.33) */;
+  --wa-color-neutral-70: #abaeb9 /* oklch(75.183% 0.01604 273.78) */;
+  --wa-color-neutral-60: #9194a2 /* oklch(66.863% 0.02088 276.18) */;
+  --wa-color-neutral-50: #717584 /* oklch(56.418% 0.02359 273.77) */;
+  --wa-color-neutral-40: #545868 /* oklch(46.281% 0.02644 274.26) */;
+  --wa-color-neutral-30: #424554 /* oklch(39.355% 0.02564 276.27) */;
+  --wa-color-neutral-20: #2f323f /* oklch(31.97% 0.02354 274.82) */;
+  --wa-color-neutral-10: #1b1d26 /* oklch(23.277% 0.01762 275.14) */;
+  --wa-color-neutral-05: #101219 /* oklch(18.342% 0.01472 272.42) */;
+  --wa-color-neutral: var(--wa-color-neutral-40);
 }

--- a/src/styles/color/elegant.css
+++ b/src/styles/color/elegant.css
@@ -93,16 +93,16 @@
   --wa-color-violet-05: #1c0823 /* oklch(18.278% 0.05827 316.48) */;
   --wa-color-violet: var(--wa-color-violet-40);
 
-  --wa-color-gray-95: #f2f2f3 /* oklch(96.143% 0.00133 286.37) */;
-  --wa-color-gray-90: #e6e5e8 /* oklch(92.354% 0.00415 301.42) */;
-  --wa-color-gray-80: #cbc8ce /* oklch(83.695% 0.00885 308.34) */;
-  --wa-color-gray-70: #b1adb6 /* oklch(75.367% 0.01345 305.97) */;
-  --wa-color-gray-60: #98939f /* oklch(67.134% 0.01834 304.67) */;
-  --wa-color-gray-50: #7a7382 /* oklch(56.69% 0.0242 306.59) */;
-  --wa-color-gray-40: #5d5568 /* oklch(46.422% 0.03185 304.29) */;
-  --wa-color-gray-30: #494352 /* oklch(39.46% 0.02608 303.4) */;
-  --wa-color-gray-20: #35313c /* oklch(32.176% 0.01998 301.84) */;
-  --wa-color-gray-10: #1f1c23 /* oklch(23.288% 0.01397 304.73) */;
-  --wa-color-gray-05: #131115 /* oklch(18.185% 0.00865 307.93) */;
-  --wa-color-gray: var(--wa-color-gray-40);
+  --wa-color-neutral-95: #f2f2f3 /* oklch(96.143% 0.00133 286.37) */;
+  --wa-color-neutral-90: #e6e5e8 /* oklch(92.354% 0.00415 301.42) */;
+  --wa-color-neutral-80: #cbc8ce /* oklch(83.695% 0.00885 308.34) */;
+  --wa-color-neutral-70: #b1adb6 /* oklch(75.367% 0.01345 305.97) */;
+  --wa-color-neutral-60: #98939f /* oklch(67.134% 0.01834 304.67) */;
+  --wa-color-neutral-50: #7a7382 /* oklch(56.69% 0.0242 306.59) */;
+  --wa-color-neutral-40: #5d5568 /* oklch(46.422% 0.03185 304.29) */;
+  --wa-color-neutral-30: #494352 /* oklch(39.46% 0.02608 303.4) */;
+  --wa-color-neutral-20: #35313c /* oklch(32.176% 0.01998 301.84) */;
+  --wa-color-neutral-10: #1f1c23 /* oklch(23.288% 0.01397 304.73) */;
+  --wa-color-neutral-05: #131115 /* oklch(18.185% 0.00865 307.93) */;
+  --wa-color-neutral: var(--wa-color-neutral-40);
 }

--- a/src/styles/color/mild.css
+++ b/src/styles/color/mild.css
@@ -93,16 +93,16 @@
   --wa-color-violet-05: #22042d /* oklch(19.41% 0.08225 315.39) */;
   --wa-color-violet: var(--wa-color-violet-40);
 
-  --wa-color-gray-95: #f4f3f4 /* oklch(96.52% 0.00169 325.59) */;
-  --wa-color-gray-90: #e7e5e8 /* oklch(92.431% 0.00454 314.8) */;
-  --wa-color-gray-80: #ccc8cd /* oklch(83.746% 0.00813 319.45) */;
-  --wa-color-gray-70: #b2adb2 /* oklch(75.325% 0.00901 325.67) */;
-  --wa-color-gray-60: #979498 /* oklch(67.032% 0.00675 317.75) */;
-  --wa-color-gray-50: #777478 /* oklch(56.292% 0.00705 317.74) */;
-  --wa-color-gray-40: #5b585d /* oklch(46.491% 0.0088 312.22) */;
-  --wa-color-gray-30: #464547 /* oklch(39.209% 0.00357 308.36) */;
-  --wa-color-gray-20: #333235 /* oklch(31.929% 0.00542 301.22) */;
-  --wa-color-gray-10: #1f1d22 /* oklch(23.51% 0.0099 303.74) */;
-  --wa-color-gray-05: #121214 /* oklch(18.309% 0.00404 285.99) */;
-  --wa-color-gray: var(--wa-color-gray-40);
+  --wa-color-neutral-95: #f4f3f4 /* oklch(96.52% 0.00169 325.59) */;
+  --wa-color-neutral-90: #e7e5e8 /* oklch(92.431% 0.00454 314.8) */;
+  --wa-color-neutral-80: #ccc8cd /* oklch(83.746% 0.00813 319.45) */;
+  --wa-color-neutral-70: #b2adb2 /* oklch(75.325% 0.00901 325.67) */;
+  --wa-color-neutral-60: #979498 /* oklch(67.032% 0.00675 317.75) */;
+  --wa-color-neutral-50: #777478 /* oklch(56.292% 0.00705 317.74) */;
+  --wa-color-neutral-40: #5b585d /* oklch(46.491% 0.0088 312.22) */;
+  --wa-color-neutral-30: #464547 /* oklch(39.209% 0.00357 308.36) */;
+  --wa-color-neutral-20: #333235 /* oklch(31.929% 0.00542 301.22) */;
+  --wa-color-neutral-10: #1f1d22 /* oklch(23.51% 0.0099 303.74) */;
+  --wa-color-neutral-05: #121214 /* oklch(18.309% 0.00404 285.99) */;
+  --wa-color-neutral: var(--wa-color-neutral-40);
 }

--- a/src/styles/color/natural.css
+++ b/src/styles/color/natural.css
@@ -93,16 +93,16 @@
   --wa-color-violet-05: #180e1f /* oklch(18.634% 0.03651 310.29) */;
   --wa-color-violet: var(--wa-color-violet-40);
 
-  --wa-color-gray-95: #f1f1f0 /* oklch(95.787% 0.00133 106.42) */;
-  --wa-color-gray-90: #e7e6e4 /* oklch(92.515% 0.0029 84.559) */;
-  --wa-color-gray-80: #cac8c3 /* oklch(83.296% 0.00723 88.651) */;
-  --wa-color-gray-70: #b2afa8 /* oklch(75.445% 0.01044 87.487) */;
-  --wa-color-gray-60: #98958c /* oklch(66.972% 0.01348 91.575) */;
-  --wa-color-gray-50: #7a766a /* oklch(56.579% 0.01864 91.662) */;
-  --wa-color-gray-40: #5c594f /* oklch(46.366% 0.0162 93.155) */;
-  --wa-color-gray-30: #49453e /* oklch(39.205% 0.01273 81.754) */;
-  --wa-color-gray-20: #35322d /* oklch(31.85% 0.00968 80.663) */;
-  --wa-color-gray-10: #1f1d1a /* oklch(23.185% 0.00644 78.196) */;
-  --wa-color-gray-05: #131210 /* oklch(18.257% 0.00432 84.592) */;
-  --wa-color-gray: var(--wa-color-gray-50);
+  --wa-color-neutral-95: #f1f1f0 /* oklch(95.787% 0.00133 106.42) */;
+  --wa-color-neutral-90: #e7e6e4 /* oklch(92.515% 0.0029 84.559) */;
+  --wa-color-neutral-80: #cac8c3 /* oklch(83.296% 0.00723 88.651) */;
+  --wa-color-neutral-70: #b2afa8 /* oklch(75.445% 0.01044 87.487) */;
+  --wa-color-neutral-60: #98958c /* oklch(66.972% 0.01348 91.575) */;
+  --wa-color-neutral-50: #7a766a /* oklch(56.579% 0.01864 91.662) */;
+  --wa-color-neutral-40: #5c594f /* oklch(46.366% 0.0162 93.155) */;
+  --wa-color-neutral-30: #49453e /* oklch(39.205% 0.01273 81.754) */;
+  --wa-color-neutral-20: #35322d /* oklch(31.85% 0.00968 80.663) */;
+  --wa-color-neutral-10: #1f1d1a /* oklch(23.185% 0.00644 78.196) */;
+  --wa-color-neutral-05: #131210 /* oklch(18.257% 0.00432 84.592) */;
+  --wa-color-neutral: var(--wa-color-neutral-50);
 }

--- a/src/styles/color/rudimentary.css
+++ b/src/styles/color/rudimentary.css
@@ -93,16 +93,16 @@
   --wa-color-violet-05: #20052d /* oklch(19.24% 0.07931 312.44) */;
   --wa-color-violet: var(--wa-color-violet-50);
 
-  --wa-color-gray-95: #f2f2f2 /* oklch(96.115% 0 none) */;
-  --wa-color-gray-90: #e6e6e6 /* oklch(92.494% 0 none) */;
-  --wa-color-gray-80: #c9c9c9 /* oklch(83.591% 0 none) */;
-  --wa-color-gray-70: #afafaf /* oklch(75.402% 0 none) */;
-  --wa-color-gray-60: #959595 /* oklch(66.984% 0 none) */;
-  --wa-color-gray-50: #747474 /* oklch(55.897% 0 none) */;
-  --wa-color-gray-40: #585858 /* oklch(46.04% 0 none) */;
-  --wa-color-gray-30: #454545 /* oklch(39.042% 0 none) */;
-  --wa-color-gray-20: #313131 /* oklch(31.317% 0 none) */;
-  --wa-color-gray-10: #1d1d1d /* oklch(23.075% 0 none) */;
-  --wa-color-gray-05: #131313 /* oklch(18.674% 0 none) */;
-  --wa-color-gray: var(--wa-color-gray-60);
+  --wa-color-neutral-95: #f2f2f2 /* oklch(96.115% 0 none) */;
+  --wa-color-neutral-90: #e6e6e6 /* oklch(92.494% 0 none) */;
+  --wa-color-neutral-80: #c9c9c9 /* oklch(83.591% 0 none) */;
+  --wa-color-neutral-70: #afafaf /* oklch(75.402% 0 none) */;
+  --wa-color-neutral-60: #959595 /* oklch(66.984% 0 none) */;
+  --wa-color-neutral-50: #747474 /* oklch(55.897% 0 none) */;
+  --wa-color-neutral-40: #585858 /* oklch(46.04% 0 none) */;
+  --wa-color-neutral-30: #454545 /* oklch(39.042% 0 none) */;
+  --wa-color-neutral-20: #313131 /* oklch(31.317% 0 none) */;
+  --wa-color-neutral-10: #1d1d1d /* oklch(23.075% 0 none) */;
+  --wa-color-neutral-05: #131313 /* oklch(18.674% 0 none) */;
+  --wa-color-neutral: var(--wa-color-neutral-60);
 }

--- a/src/styles/color/vogue.css
+++ b/src/styles/color/vogue.css
@@ -93,16 +93,16 @@
   --wa-color-violet-05: #1e0238 /* oklch(19.51% 0.09712 301.8) */;
   --wa-color-violet: var(--wa-color-violet-50);
 
-  --wa-color-gray-95: #f1f2f4 /* oklch(96.095% 0.00288 264.54) */;
-  --wa-color-gray-90: #e3e5e9 /* oklch(92.152% 0.00582 264.53) */;
-  --wa-color-gray-80: #c5cad1 /* oklch(83.72% 0.01119 256.7) */;
-  --wa-color-gray-70: #a9afba /* oklch(75.266% 0.01714 262.74) */;
-  --wa-color-gray-60: #8e95a2 /* oklch(66.836% 0.02085 262.97) */;
-  --wa-color-gray-50: #6e7583 /* oklch(56.134% 0.02325 264.37) */;
-  --wa-color-gray-40: #505968 /* oklch(46.179% 0.02697 260.65) */;
-  --wa-color-gray-30: #3c4656 /* oklch(39.174% 0.03024 259.75) */;
-  --wa-color-gray-20: #293342 /* oklch(31.849% 0.03023 258.34) */;
-  --wa-color-gray-10: #161e2d /* oklch(23.484% 0.03142 262.56) */;
-  --wa-color-gray-05: #0c1220 /* oklch(18.396% 0.03036 265.82) */;
-  --wa-color-gray: var(--wa-color-gray-40);
+  --wa-color-neutral-95: #f1f2f4 /* oklch(96.095% 0.00288 264.54) */;
+  --wa-color-neutral-90: #e3e5e9 /* oklch(92.152% 0.00582 264.53) */;
+  --wa-color-neutral-80: #c5cad1 /* oklch(83.72% 0.01119 256.7) */;
+  --wa-color-neutral-70: #a9afba /* oklch(75.266% 0.01714 262.74) */;
+  --wa-color-neutral-60: #8e95a2 /* oklch(66.836% 0.02085 262.97) */;
+  --wa-color-neutral-50: #6e7583 /* oklch(56.134% 0.02325 264.37) */;
+  --wa-color-neutral-40: #505968 /* oklch(46.179% 0.02697 260.65) */;
+  --wa-color-neutral-30: #3c4656 /* oklch(39.174% 0.03024 259.75) */;
+  --wa-color-neutral-20: #293342 /* oklch(31.849% 0.03023 258.34) */;
+  --wa-color-neutral-10: #161e2d /* oklch(23.484% 0.03142 262.56) */;
+  --wa-color-neutral-05: #0c1220 /* oklch(18.396% 0.03036 265.82) */;
+  --wa-color-neutral: var(--wa-color-neutral-40);
 }

--- a/src/styles/themes/active/color.css
+++ b/src/styles/themes/active/color.css
@@ -13,7 +13,7 @@
   /**
    * Foundational Colors
    */
-  --wa-color-text-normal: var(--wa-color-gray-05);
+  --wa-color-text-normal: var(--wa-color-neutral-05);
   --wa-color-text-link: var(--wa-color-brand-40);
 
   --wa-color-focus: var(--wa-color-blue-60);
@@ -64,14 +64,14 @@
   --wa-color-danger-on-normal: var(--wa-color-red-30);
   --wa-color-danger-on-loud: black;
 
-  --wa-color-neutral-fill-quiet: var(--wa-color-gray-95);
-  --wa-color-neutral-fill-normal: var(--wa-color-gray-90);
-  --wa-color-neutral-fill-loud: var(--wa-color-gray-80);
-  --wa-color-neutral-border-quiet: var(--wa-color-gray-90);
-  --wa-color-neutral-border-normal: var(--wa-color-gray-80);
-  --wa-color-neutral-border-loud: var(--wa-color-gray-70);
-  --wa-color-neutral-on-quiet: var(--wa-color-gray-40);
-  --wa-color-neutral-on-normal: var(--wa-color-gray-30);
+  --wa-color-neutral-fill-quiet: var(--wa-color-neutral-95);
+  --wa-color-neutral-fill-normal: var(--wa-color-neutral-90);
+  --wa-color-neutral-fill-loud: var(--wa-color-neutral-80);
+  --wa-color-neutral-border-quiet: var(--wa-color-neutral-90);
+  --wa-color-neutral-border-normal: var(--wa-color-neutral-80);
+  --wa-color-neutral-border-loud: var(--wa-color-neutral-70);
+  --wa-color-neutral-on-quiet: var(--wa-color-neutral-40);
+  --wa-color-neutral-on-normal: var(--wa-color-neutral-30);
   --wa-color-neutral-on-loud: black;
 }
 
@@ -128,13 +128,13 @@
   --wa-color-danger-on-normal: var(--wa-color-red-90);
   --wa-color-danger-on-loud: black;
 
-  --wa-color-neutral-fill-quiet: var(--wa-color-gray-10);
-  --wa-color-neutral-fill-normal: var(--wa-color-gray-20);
-  --wa-color-neutral-fill-loud: var(--wa-color-gray-80);
-  --wa-color-neutral-border-quiet: var(--wa-color-gray-20);
-  --wa-color-neutral-border-normal: var(--wa-color-gray-30);
-  --wa-color-neutral-border-loud: var(--wa-color-gray-60);
-  --wa-color-neutral-on-quiet: var(--wa-color-gray-80);
-  --wa-color-neutral-on-normal: var(--wa-color-gray-90);
+  --wa-color-neutral-fill-quiet: var(--wa-color-neutral-10);
+  --wa-color-neutral-fill-normal: var(--wa-color-neutral-20);
+  --wa-color-neutral-fill-loud: var(--wa-color-neutral-80);
+  --wa-color-neutral-border-quiet: var(--wa-color-neutral-20);
+  --wa-color-neutral-border-normal: var(--wa-color-neutral-30);
+  --wa-color-neutral-border-loud: var(--wa-color-neutral-60);
+  --wa-color-neutral-on-quiet: var(--wa-color-neutral-80);
+  --wa-color-neutral-on-normal: var(--wa-color-neutral-90);
   --wa-color-neutral-on-loud: black;
 }

--- a/src/styles/themes/awesome/color.css
+++ b/src/styles/themes/awesome/color.css
@@ -10,7 +10,7 @@
   /**
    * Foundational Colors
    */
-  --wa-color-text-normal: var(--wa-color-gray-20);
+  --wa-color-text-normal: var(--wa-color-neutral-20);
 
   /**
    * Semantic Colors
@@ -55,14 +55,14 @@
   --wa-color-danger-on-normal: var(--wa-color-red-40);
   --wa-color-danger-on-loud: var(--wa-color-text-normal);
 
-  --wa-color-neutral-fill-quiet: var(--wa-color-gray-95);
-  --wa-color-neutral-fill-normal: var(--wa-color-gray-90);
-  --wa-color-neutral-fill-loud: var(--wa-color-gray-80);
-  --wa-color-neutral-border-quiet: var(--wa-color-gray-70);
-  --wa-color-neutral-border-normal: var(--wa-color-gray-50);
-  --wa-color-neutral-border-loud: var(--wa-color-gray-30);
-  --wa-color-neutral-on-quiet: var(--wa-color-gray-40);
-  --wa-color-neutral-on-normal: var(--wa-color-gray-40);
+  --wa-color-neutral-fill-quiet: var(--wa-color-neutral-95);
+  --wa-color-neutral-fill-normal: var(--wa-color-neutral-90);
+  --wa-color-neutral-fill-loud: var(--wa-color-neutral-80);
+  --wa-color-neutral-border-quiet: var(--wa-color-neutral-70);
+  --wa-color-neutral-border-normal: var(--wa-color-neutral-50);
+  --wa-color-neutral-border-loud: var(--wa-color-neutral-30);
+  --wa-color-neutral-on-quiet: var(--wa-color-neutral-40);
+  --wa-color-neutral-on-normal: var(--wa-color-neutral-40);
   --wa-color-neutral-on-loud: var(--wa-color-text-normal);
 }
 
@@ -115,13 +115,13 @@
   --wa-color-danger-on-normal: var(--wa-color-red-80);
   --wa-color-danger-on-loud: white;
 
-  --wa-color-neutral-fill-quiet: var(--wa-color-gray-10);
-  --wa-color-neutral-fill-normal: var(--wa-color-gray-20);
-  --wa-color-neutral-fill-loud: var(--wa-color-gray-50);
-  --wa-color-neutral-border-quiet: var(--wa-color-gray-30);
-  --wa-color-neutral-border-normal: var(--wa-color-gray-50);
-  --wa-color-neutral-border-loud: var(--wa-color-gray-80);
-  --wa-color-neutral-on-quiet: var(--wa-color-gray-70);
-  --wa-color-neutral-on-normal: var(--wa-color-gray-80);
+  --wa-color-neutral-fill-quiet: var(--wa-color-neutral-10);
+  --wa-color-neutral-fill-normal: var(--wa-color-neutral-20);
+  --wa-color-neutral-fill-loud: var(--wa-color-neutral-50);
+  --wa-color-neutral-border-quiet: var(--wa-color-neutral-30);
+  --wa-color-neutral-border-normal: var(--wa-color-neutral-50);
+  --wa-color-neutral-border-loud: var(--wa-color-neutral-80);
+  --wa-color-neutral-on-quiet: var(--wa-color-neutral-70);
+  --wa-color-neutral-on-normal: var(--wa-color-neutral-80);
   --wa-color-neutral-on-loud: white;
 }

--- a/src/styles/themes/brutalist/color.css
+++ b/src/styles/themes/brutalist/color.css
@@ -10,9 +10,9 @@
   /**
    * Foundational Colors
    */
-  --wa-color-surface-border: var(--wa-color-gray-10);
+  --wa-color-surface-border: var(--wa-color-neutral-10);
 
-  --wa-color-text-link: var(--wa-color-gray-40);
+  --wa-color-text-link: var(--wa-color-neutral-40);
 
   --wa-color-shadow: rgb(0 0 0 / 0.2);
 
@@ -62,14 +62,14 @@
   --wa-color-danger-on-normal: var(--wa-color-red-40);
   --wa-color-danger-on-loud: white;
 
-  --wa-color-neutral-fill-quiet: var(--wa-color-gray-90);
-  --wa-color-neutral-fill-normal: var(--wa-color-gray-70);
-  --wa-color-neutral-fill-loud: var(--wa-color-gray-20);
-  --wa-color-neutral-border-quiet: var(--wa-color-gray-80);
-  --wa-color-neutral-border-normal: var(--wa-color-gray-40);
-  --wa-color-neutral-border-loud: var(--wa-color-gray-20);
-  --wa-color-neutral-on-quiet: var(--wa-color-gray-10);
-  --wa-color-neutral-on-normal: var(--wa-color-gray-30);
+  --wa-color-neutral-fill-quiet: var(--wa-color-neutral-90);
+  --wa-color-neutral-fill-normal: var(--wa-color-neutral-70);
+  --wa-color-neutral-fill-loud: var(--wa-color-neutral-20);
+  --wa-color-neutral-border-quiet: var(--wa-color-neutral-80);
+  --wa-color-neutral-border-normal: var(--wa-color-neutral-40);
+  --wa-color-neutral-border-loud: var(--wa-color-neutral-20);
+  --wa-color-neutral-on-quiet: var(--wa-color-neutral-10);
+  --wa-color-neutral-on-normal: var(--wa-color-neutral-30);
   --wa-color-neutral-on-loud: white;
 }
 
@@ -82,12 +82,12 @@
   /**
    * Foundational Colors
    */
-  --wa-color-surface-raised: var(--wa-color-gray-05);
-  --wa-color-surface-default: var(--wa-color-gray-10);
-  --wa-color-surface-lowered: var(--wa-color-gray-05);
-  --wa-color-surface-border: var(--wa-color-gray-40);
+  --wa-color-surface-raised: var(--wa-color-neutral-05);
+  --wa-color-surface-default: var(--wa-color-neutral-10);
+  --wa-color-surface-lowered: var(--wa-color-neutral-05);
+  --wa-color-surface-border: var(--wa-color-neutral-40);
 
-  --wa-color-text-link: var(--wa-color-gray-70);
+  --wa-color-text-link: var(--wa-color-neutral-70);
 
   --wa-color-shadow: rgb(0 0 0 / 0.5);
 
@@ -134,13 +134,13 @@
   --wa-color-danger-on-normal: var(--wa-color-red-95);
   --wa-color-danger-on-loud: var(--wa-color-red-10);
 
-  --wa-color-neutral-fill-quiet: var(--wa-color-gray-20);
-  --wa-color-neutral-fill-normal: var(--wa-color-gray-30);
-  --wa-color-neutral-fill-loud: var(--wa-color-gray-70);
-  --wa-color-neutral-border-quiet: var(--wa-color-gray-50);
-  --wa-color-neutral-border-normal: var(--wa-color-gray-80);
-  --wa-color-neutral-border-loud: var(--wa-color-gray-90);
-  --wa-color-neutral-on-quiet: var(--wa-color-gray-80);
-  --wa-color-neutral-on-normal: var(--wa-color-gray-95);
-  --wa-color-neutral-on-loud: var(--wa-color-gray-10);
+  --wa-color-neutral-fill-quiet: var(--wa-color-neutral-20);
+  --wa-color-neutral-fill-normal: var(--wa-color-neutral-30);
+  --wa-color-neutral-fill-loud: var(--wa-color-neutral-70);
+  --wa-color-neutral-border-quiet: var(--wa-color-neutral-50);
+  --wa-color-neutral-border-normal: var(--wa-color-neutral-80);
+  --wa-color-neutral-border-loud: var(--wa-color-neutral-90);
+  --wa-color-neutral-on-quiet: var(--wa-color-neutral-80);
+  --wa-color-neutral-on-normal: var(--wa-color-neutral-95);
+  --wa-color-neutral-on-loud: var(--wa-color-neutral-10);
 }

--- a/src/styles/themes/classic/color.css
+++ b/src/styles/themes/classic/color.css
@@ -52,14 +52,14 @@
   --wa-color-danger-on-normal: var(--wa-color-red-40);
   --wa-color-danger-on-loud: white;
 
-  --wa-color-neutral-fill-quiet: var(--wa-color-gray-95);
-  --wa-color-neutral-fill-normal: var(--wa-color-gray-90);
-  --wa-color-neutral-fill-loud: var(--wa-color-gray-40);
-  --wa-color-neutral-border-quiet: var(--wa-color-gray-90);
-  --wa-color-neutral-border-normal: var(--wa-color-gray-80);
-  --wa-color-neutral-border-loud: var(--wa-color-gray-50);
-  --wa-color-neutral-on-quiet: var(--wa-color-gray-40);
-  --wa-color-neutral-on-normal: var(--wa-color-gray-30);
+  --wa-color-neutral-fill-quiet: var(--wa-color-neutral-95);
+  --wa-color-neutral-fill-normal: var(--wa-color-neutral-90);
+  --wa-color-neutral-fill-loud: var(--wa-color-neutral-40);
+  --wa-color-neutral-border-quiet: var(--wa-color-neutral-90);
+  --wa-color-neutral-border-normal: var(--wa-color-neutral-80);
+  --wa-color-neutral-border-loud: var(--wa-color-neutral-50);
+  --wa-color-neutral-on-quiet: var(--wa-color-neutral-40);
+  --wa-color-neutral-on-normal: var(--wa-color-neutral-30);
   --wa-color-neutral-on-loud: white;
 }
 
@@ -69,7 +69,7 @@
   /**
    * Foundational Colors
    */
-  --wa-color-text-normal: var(--wa-color-gray-80);
+  --wa-color-text-normal: var(--wa-color-neutral-80);
 
   /**
    * Semantic Colors
@@ -82,7 +82,7 @@
   --wa-color-brand-border-loud: var(--wa-color-brand-50);
   --wa-color-brand-on-quiet: var(--wa-color-brand-70);
   --wa-color-brand-on-normal: var(--wa-color-brand-80);
-  --wa-color-brand-on-loud: var(--wa-color-gray-10);
+  --wa-color-brand-on-loud: var(--wa-color-neutral-10);
 
   --wa-color-success-fill-quiet: var(--wa-color-green-20);
   --wa-color-success-fill-normal: var(--wa-color-green-30);
@@ -92,7 +92,7 @@
   --wa-color-success-border-loud: var(--wa-color-green-50);
   --wa-color-success-on-quiet: var(--wa-color-green-70);
   --wa-color-success-on-normal: var(--wa-color-green-80);
-  --wa-color-success-on-loud: var(--wa-color-gray-10);
+  --wa-color-success-on-loud: var(--wa-color-neutral-10);
 
   --wa-color-warning-fill-quiet: var(--wa-color-yellow-20);
   --wa-color-warning-fill-normal: var(--wa-color-yellow-30);
@@ -102,7 +102,7 @@
   --wa-color-warning-border-loud: var(--wa-color-yellow-50);
   --wa-color-warning-on-quiet: var(--wa-color-yellow-70);
   --wa-color-warning-on-normal: var(--wa-color-yellow-80);
-  --wa-color-warning-on-loud: var(--wa-color-gray-10);
+  --wa-color-warning-on-loud: var(--wa-color-neutral-10);
 
   --wa-color-danger-fill-quiet: var(--wa-color-red-20);
   --wa-color-danger-fill-normal: var(--wa-color-red-30);
@@ -112,15 +112,15 @@
   --wa-color-danger-border-loud: var(--wa-color-red-50);
   --wa-color-danger-on-quiet: var(--wa-color-red-70);
   --wa-color-danger-on-normal: var(--wa-color-red-80);
-  --wa-color-danger-on-loud: var(--wa-color-gray-10);
+  --wa-color-danger-on-loud: var(--wa-color-neutral-10);
 
-  --wa-color-neutral-fill-quiet: var(--wa-color-gray-10);
-  --wa-color-neutral-fill-normal: var(--wa-color-gray-20);
-  --wa-color-neutral-fill-loud: var(--wa-color-gray-60);
-  --wa-color-neutral-border-quiet: var(--wa-color-gray-20);
-  --wa-color-neutral-border-normal: var(--wa-color-gray-30);
-  --wa-color-neutral-border-loud: var(--wa-color-gray-50);
-  --wa-color-neutral-on-quiet: var(--wa-color-gray-60);
-  --wa-color-neutral-on-normal: var(--wa-color-gray-70);
-  --wa-color-neutral-on-loud: var(--wa-color-gray-05);
+  --wa-color-neutral-fill-quiet: var(--wa-color-neutral-10);
+  --wa-color-neutral-fill-normal: var(--wa-color-neutral-20);
+  --wa-color-neutral-fill-loud: var(--wa-color-neutral-60);
+  --wa-color-neutral-border-quiet: var(--wa-color-neutral-20);
+  --wa-color-neutral-border-normal: var(--wa-color-neutral-30);
+  --wa-color-neutral-border-loud: var(--wa-color-neutral-50);
+  --wa-color-neutral-on-quiet: var(--wa-color-neutral-60);
+  --wa-color-neutral-on-normal: var(--wa-color-neutral-70);
+  --wa-color-neutral-on-loud: var(--wa-color-neutral-05);
 }

--- a/src/styles/themes/classic/overrides.css
+++ b/src/styles/themes/classic/overrides.css
@@ -109,7 +109,7 @@
   }
 
   wa-switch {
-    --background-color: var(--wa-color-gray-50);
+    --background-color: var(--wa-color-neutral-50);
     --border-color: var(--background-color);
     --height: calc(1em * var(--wa-form-control-value-line-height) - var(--border-width) * 2);
     --thumb-color: var(--wa-color-surface-default);

--- a/src/styles/themes/default/color.css
+++ b/src/styles/themes/default/color.css
@@ -20,25 +20,25 @@
    * Surface colors help convey hierarchy through elevation, where raised is closest to the user and lowered is farthest away. */
   --wa-color-surface-raised: white;
   --wa-color-surface-default: white;
-  --wa-color-surface-lowered: var(--wa-color-gray-95);
-  --wa-color-surface-border: var(--wa-color-gray-90);
+  --wa-color-surface-lowered: var(--wa-color-neutral-95);
+  --wa-color-surface-border: var(--wa-color-neutral-90);
 
   /* Text colors are used for standard text elements.
    * Recommended: minimum 4.5:1 contrast ratio between text colors and surface colors. */
-  --wa-color-text-normal: var(--wa-color-gray-10);
-  --wa-color-text-quiet: var(--wa-color-gray-40);
+  --wa-color-text-normal: var(--wa-color-neutral-10);
+  --wa-color-text-quiet: var(--wa-color-neutral-40);
   --wa-color-text-link: var(--wa-color-brand-40);
 
   /* Overlays provide a backdrop for isolated content, often allowing background context to show through. */
-  --wa-color-overlay-modal: color-mix(in oklab, var(--wa-color-gray-05) 50%, transparent);
-  --wa-color-overlay-inline: color-mix(in oklab, var(--wa-color-gray-80) 20%, transparent);
+  --wa-color-overlay-modal: color-mix(in oklab, var(--wa-color-neutral-05) 50%, transparent);
+  --wa-color-overlay-inline: color-mix(in oklab, var(--wa-color-neutral-80) 20%, transparent);
 
   /* Shadows indicate elevation. Shadow color is used in your theme's shadow properties.
    * By default, the opacity of your shadow color is tied to the blur of shadows in your theme.
    * Because solid shadows appear stronger in color than diffused shadows, this helps keep consistent color intensity. */
   --wa-color-shadow: color-mix(
     in oklab,
-    var(--wa-color-gray-05) calc(var(--wa-shadow-blur-scale) * 4% + 8%),
+    var(--wa-color-neutral-05) calc(var(--wa-shadow-blur-scale) * 4% + 8%),
     transparent
   );
 
@@ -99,14 +99,14 @@
   --wa-color-danger-on-normal: var(--wa-color-red-30);
   --wa-color-danger-on-loud: white;
 
-  --wa-color-neutral-fill-quiet: var(--wa-color-gray-95);
-  --wa-color-neutral-fill-normal: var(--wa-color-gray-90);
-  --wa-color-neutral-fill-loud: var(--wa-color-gray-20);
-  --wa-color-neutral-border-quiet: var(--wa-color-gray-90);
-  --wa-color-neutral-border-normal: var(--wa-color-gray-80);
-  --wa-color-neutral-border-loud: var(--wa-color-gray-60);
-  --wa-color-neutral-on-quiet: var(--wa-color-gray-40);
-  --wa-color-neutral-on-normal: var(--wa-color-gray-30);
+  --wa-color-neutral-fill-quiet: var(--wa-color-neutral-95);
+  --wa-color-neutral-fill-normal: var(--wa-color-neutral-90);
+  --wa-color-neutral-fill-loud: var(--wa-color-neutral-20);
+  --wa-color-neutral-border-quiet: var(--wa-color-neutral-90);
+  --wa-color-neutral-border-normal: var(--wa-color-neutral-80);
+  --wa-color-neutral-border-loud: var(--wa-color-neutral-60);
+  --wa-color-neutral-on-quiet: var(--wa-color-neutral-40);
+  --wa-color-neutral-on-normal: var(--wa-color-neutral-30);
   --wa-color-neutral-on-loud: white;
 }
 
@@ -120,17 +120,17 @@
   /**
    * Foundational Colors
    */
-  --wa-color-surface-raised: var(--wa-color-gray-10);
-  --wa-color-surface-default: var(--wa-color-gray-05);
+  --wa-color-surface-raised: var(--wa-color-neutral-10);
+  --wa-color-surface-default: var(--wa-color-neutral-05);
   --wa-color-surface-lowered: color-mix(in oklab, var(--wa-color-surface-default), black 20%);
-  --wa-color-surface-border: var(--wa-color-gray-20);
+  --wa-color-surface-border: var(--wa-color-neutral-20);
 
-  --wa-color-text-normal: var(--wa-color-gray-95);
-  --wa-color-text-quiet: var(--wa-color-gray-60);
+  --wa-color-text-normal: var(--wa-color-neutral-95);
+  --wa-color-text-quiet: var(--wa-color-neutral-60);
   --wa-color-text-link: var(--wa-color-brand-70);
 
   --wa-color-overlay-modal: color-mix(in oklab, black 60%, transparent);
-  --wa-color-overlay-inline: color-mix(in oklab, var(--wa-color-gray-50) 10%, transparent);
+  --wa-color-overlay-inline: color-mix(in oklab, var(--wa-color-neutral-50) 10%, transparent);
 
   /* Mixing with --wa-color-surface-lowered prevents shadows from becoming excessively dark relative to --wa-color-surface-default. */
   --wa-color-shadow: color-mix(
@@ -187,13 +187,13 @@
   --wa-color-danger-on-normal: var(--wa-color-red-70);
   --wa-color-danger-on-loud: white;
 
-  --wa-color-neutral-fill-quiet: var(--wa-color-gray-10);
-  --wa-color-neutral-fill-normal: var(--wa-color-gray-20);
-  --wa-color-neutral-fill-loud: var(--wa-color-gray-90);
-  --wa-color-neutral-border-quiet: var(--wa-color-gray-20);
-  --wa-color-neutral-border-normal: var(--wa-color-gray-30);
-  --wa-color-neutral-border-loud: var(--wa-color-gray-40);
-  --wa-color-neutral-on-quiet: var(--wa-color-gray-60);
-  --wa-color-neutral-on-normal: var(--wa-color-gray-70);
-  --wa-color-neutral-on-loud: var(--wa-color-gray-05);
+  --wa-color-neutral-fill-quiet: var(--wa-color-neutral-10);
+  --wa-color-neutral-fill-normal: var(--wa-color-neutral-20);
+  --wa-color-neutral-fill-loud: var(--wa-color-neutral-90);
+  --wa-color-neutral-border-quiet: var(--wa-color-neutral-20);
+  --wa-color-neutral-border-normal: var(--wa-color-neutral-30);
+  --wa-color-neutral-border-loud: var(--wa-color-neutral-40);
+  --wa-color-neutral-on-quiet: var(--wa-color-neutral-60);
+  --wa-color-neutral-on-normal: var(--wa-color-neutral-70);
+  --wa-color-neutral-on-loud: var(--wa-color-neutral-05);
 }

--- a/src/styles/themes/default/groups.css
+++ b/src/styles/themes/default/groups.css
@@ -26,7 +26,7 @@
   --wa-form-control-value-font-weight: var(--wa-font-weight-body);
   --wa-form-control-value-line-height: var(--wa-line-height-condensed);
 
-  --wa-form-control-placeholder-color: var(--wa-color-gray-60);
+  --wa-form-control-placeholder-color: var(--wa-color-neutral-60);
 
   --wa-form-control-required-content: '*';
   --wa-form-control-required-content-color: inherit;

--- a/src/styles/themes/glossy/color.css
+++ b/src/styles/themes/glossy/color.css
@@ -33,7 +33,7 @@
 
   --wa-color-danger-fill-loud: var(--wa-color-red-40);
 
-  --wa-color-neutral-fill-loud: var(--wa-color-gray-10);
+  --wa-color-neutral-fill-loud: var(--wa-color-neutral-10);
 }
 
 .wa-dark,

--- a/src/styles/themes/matter/color.css
+++ b/src/styles/themes/matter/color.css
@@ -15,7 +15,7 @@
    */
 
   --wa-color-surface-raised: var(--wa-color-brand-95);
-  --wa-color-surface-lowered: var(--wa-color-gray-90);
+  --wa-color-surface-lowered: var(--wa-color-neutral-90);
 
   --wa-color-text-link: var(--wa-color-brand-40);
 
@@ -69,14 +69,14 @@
   --wa-color-danger-on-normal: var(--wa-color-red-30);
   --wa-color-danger-on-loud: white;
 
-  --wa-color-neutral-fill-quiet: var(--wa-color-gray-95);
-  --wa-color-neutral-fill-normal: var(--wa-color-gray-90);
-  --wa-color-neutral-fill-loud: var(--wa-color-gray-40);
-  --wa-color-neutral-border-quiet: var(--wa-color-gray-90);
-  --wa-color-neutral-border-normal: var(--wa-color-gray-80);
-  --wa-color-neutral-border-loud: var(--wa-color-gray-50);
-  --wa-color-neutral-on-quiet: var(--wa-color-gray-30);
-  --wa-color-neutral-on-normal: var(--wa-color-gray-20);
+  --wa-color-neutral-fill-quiet: var(--wa-color-neutral-95);
+  --wa-color-neutral-fill-normal: var(--wa-color-neutral-90);
+  --wa-color-neutral-fill-loud: var(--wa-color-neutral-40);
+  --wa-color-neutral-border-quiet: var(--wa-color-neutral-90);
+  --wa-color-neutral-border-normal: var(--wa-color-neutral-80);
+  --wa-color-neutral-border-loud: var(--wa-color-neutral-50);
+  --wa-color-neutral-on-quiet: var(--wa-color-neutral-30);
+  --wa-color-neutral-on-normal: var(--wa-color-neutral-20);
   --wa-color-neutral-on-loud: white;
 }
 
@@ -132,13 +132,13 @@
   --wa-color-danger-on-normal: var(--wa-color-red-80);
   --wa-color-danger-on-loud: var(--wa-color-red-10);
 
-  --wa-color-neutral-fill-quiet: var(--wa-color-gray-20);
-  --wa-color-neutral-fill-normal: var(--wa-color-gray-30);
-  --wa-color-neutral-fill-loud: var(--wa-color-gray-70);
-  --wa-color-neutral-border-quiet: var(--wa-color-gray-20);
-  --wa-color-neutral-border-normal: var(--wa-color-gray-30);
-  --wa-color-neutral-border-loud: var(--wa-color-gray-80);
-  --wa-color-neutral-on-quiet: var(--wa-color-gray-70);
-  --wa-color-neutral-on-normal: var(--wa-color-gray-80);
-  --wa-color-neutral-on-loud: var(--wa-color-gray-10);
+  --wa-color-neutral-fill-quiet: var(--wa-color-neutral-20);
+  --wa-color-neutral-fill-normal: var(--wa-color-neutral-30);
+  --wa-color-neutral-fill-loud: var(--wa-color-neutral-70);
+  --wa-color-neutral-border-quiet: var(--wa-color-neutral-20);
+  --wa-color-neutral-border-normal: var(--wa-color-neutral-30);
+  --wa-color-neutral-border-loud: var(--wa-color-neutral-80);
+  --wa-color-neutral-on-quiet: var(--wa-color-neutral-70);
+  --wa-color-neutral-on-normal: var(--wa-color-neutral-80);
+  --wa-color-neutral-on-loud: var(--wa-color-neutral-10);
 }

--- a/src/styles/themes/mellow/color.css
+++ b/src/styles/themes/mellow/color.css
@@ -14,9 +14,9 @@
    * Foundational Colors
    */
   --wa-color-surface-raised: white;
-  --wa-color-surface-default: var(--wa-color-gray-95);
-  --wa-color-surface-lowered: var(--wa-color-gray-90);
-  --wa-color-surface-border: color-mix(in oklab, var(--wa-color-gray-80), transparent);
+  --wa-color-surface-default: var(--wa-color-neutral-95);
+  --wa-color-surface-lowered: var(--wa-color-neutral-90);
+  --wa-color-surface-border: color-mix(in oklab, var(--wa-color-neutral-80), transparent);
 
   --wa-color-text-normal: var(--wa-color-brand-20);
   --wa-color-text-quiet: var(--wa-color-brand-40);
@@ -67,14 +67,14 @@
   --wa-color-danger-on-normal: var(--wa-color-red-30);
   --wa-color-danger-on-loud: white;
 
-  --wa-color-neutral-fill-quiet: var(--wa-color-gray-90);
-  --wa-color-neutral-fill-normal: var(--wa-color-gray-80);
-  --wa-color-neutral-fill-loud: var(--wa-color-gray-40);
-  --wa-color-neutral-border-quiet: var(--wa-color-gray-80);
-  --wa-color-neutral-border-normal: var(--wa-color-gray-70);
-  --wa-color-neutral-border-loud: var(--wa-color-gray-60);
-  --wa-color-neutral-on-quiet: var(--wa-color-gray-40);
-  --wa-color-neutral-on-normal: var(--wa-color-gray-30);
+  --wa-color-neutral-fill-quiet: var(--wa-color-neutral-90);
+  --wa-color-neutral-fill-normal: var(--wa-color-neutral-80);
+  --wa-color-neutral-fill-loud: var(--wa-color-neutral-40);
+  --wa-color-neutral-border-quiet: var(--wa-color-neutral-80);
+  --wa-color-neutral-border-normal: var(--wa-color-neutral-70);
+  --wa-color-neutral-border-loud: var(--wa-color-neutral-60);
+  --wa-color-neutral-on-quiet: var(--wa-color-neutral-40);
+  --wa-color-neutral-on-normal: var(--wa-color-neutral-30);
   --wa-color-neutral-on-loud: white;
 }
 
@@ -84,7 +84,7 @@
   /**
    * Foundational Colors
    */
-  --wa-color-surface-border: color-mix(in oklab, var(--wa-color-gray-30), transparent);
+  --wa-color-surface-border: color-mix(in oklab, var(--wa-color-neutral-30), transparent);
 
   --wa-color-text-normal: var(--wa-color-brand-90);
   --wa-color-text-quiet: var(--wa-color-brand-70);
@@ -92,6 +92,6 @@
   /**
    * Semantic Colors
    */
-  --wa-color-neutral-fill-loud: var(--wa-color-gray-50);
+  --wa-color-neutral-fill-loud: var(--wa-color-neutral-50);
   --wa-color-neutral-on-loud: white;
 }

--- a/src/styles/themes/playful/color.css
+++ b/src/styles/themes/playful/color.css
@@ -10,7 +10,7 @@
   /**
    * Foundational Colors
    */
-  --wa-color-surface-border: var(--wa-color-gray-80);
+  --wa-color-surface-border: var(--wa-color-neutral-80);
 
   --wa-color-text-link: var(--wa-color-yellow-40);
 
@@ -59,15 +59,15 @@
   --wa-color-danger-on-normal: var(--wa-color-red-30);
   --wa-color-danger-on-loud: white;
 
-  --wa-color-neutral-fill-quiet: var(--wa-color-gray-90);
-  --wa-color-neutral-fill-normal: var(--wa-color-gray-80);
-  --wa-color-neutral-fill-loud: var(--wa-color-gray-40);
-  --wa-color-neutral-border-quiet: var(--wa-color-gray-90);
-  --wa-color-neutral-border-normal: var(--wa-color-gray-70);
-  --wa-color-neutral-border-loud: var(--wa-color-gray-50);
-  --wa-color-neutral-on-quiet: var(--wa-color-gray-30);
-  --wa-color-neutral-on-normal: var(--wa-color-gray-30);
-  --wa-color-neutral-on-loud: var(--wa-color-gray-95);
+  --wa-color-neutral-fill-quiet: var(--wa-color-neutral-90);
+  --wa-color-neutral-fill-normal: var(--wa-color-neutral-80);
+  --wa-color-neutral-fill-loud: var(--wa-color-neutral-40);
+  --wa-color-neutral-border-quiet: var(--wa-color-neutral-90);
+  --wa-color-neutral-border-normal: var(--wa-color-neutral-70);
+  --wa-color-neutral-border-loud: var(--wa-color-neutral-50);
+  --wa-color-neutral-on-quiet: var(--wa-color-neutral-30);
+  --wa-color-neutral-on-normal: var(--wa-color-neutral-30);
+  --wa-color-neutral-on-loud: var(--wa-color-neutral-95);
 }
 
 .wa-dark,
@@ -76,13 +76,13 @@
   /**
    * Foundational Colors
    */
-  --wa-color-surface-raised: var(--wa-color-gray-20);
-  --wa-color-surface-default: var(--wa-color-gray-10);
-  --wa-color-surface-lowered: var(--wa-color-gray-05);
-  --wa-color-surface-border: var(--wa-color-gray-20);
+  --wa-color-surface-raised: var(--wa-color-neutral-20);
+  --wa-color-surface-default: var(--wa-color-neutral-10);
+  --wa-color-surface-lowered: var(--wa-color-neutral-05);
+  --wa-color-surface-border: var(--wa-color-neutral-20);
 
-  --wa-color-text-normal: var(--wa-color-gray-95);
-  --wa-color-text-quiet: var(--wa-color-gray-60);
+  --wa-color-text-normal: var(--wa-color-neutral-95);
+  --wa-color-text-quiet: var(--wa-color-neutral-60);
   --wa-color-text-link: var(--wa-color-yellow-80);
 
   --wa-color-focus: var(--wa-color-brand-60);
@@ -132,13 +132,13 @@
   --wa-color-danger-on-normal: var(--wa-color-red-90);
   --wa-color-danger-on-loud: white;
 
-  --wa-color-neutral-fill-quiet: var(--wa-color-gray-20);
-  --wa-color-neutral-fill-normal: var(--wa-color-gray-40);
-  --wa-color-neutral-fill-loud: var(--wa-color-gray-70);
-  --wa-color-neutral-border-quiet: var(--wa-color-gray-30);
-  --wa-color-neutral-border-normal: var(--wa-color-gray-40);
-  --wa-color-neutral-border-loud: var(--wa-color-gray-50);
-  --wa-color-neutral-on-quiet: var(--wa-color-gray-70);
-  --wa-color-neutral-on-normal: var(--wa-color-gray-90);
-  --wa-color-neutral-on-loud: var(--wa-color-gray-05);
+  --wa-color-neutral-fill-quiet: var(--wa-color-neutral-20);
+  --wa-color-neutral-fill-normal: var(--wa-color-neutral-40);
+  --wa-color-neutral-fill-loud: var(--wa-color-neutral-70);
+  --wa-color-neutral-border-quiet: var(--wa-color-neutral-30);
+  --wa-color-neutral-border-normal: var(--wa-color-neutral-40);
+  --wa-color-neutral-border-loud: var(--wa-color-neutral-50);
+  --wa-color-neutral-on-quiet: var(--wa-color-neutral-70);
+  --wa-color-neutral-on-normal: var(--wa-color-neutral-90);
+  --wa-color-neutral-on-loud: var(--wa-color-neutral-05);
 }

--- a/src/styles/themes/premium/color.css
+++ b/src/styles/themes/premium/color.css
@@ -10,7 +10,7 @@
   /**
    * Foundational Colors
    */
-  --wa-color-surface-border: var(--wa-color-gray-80);
+  --wa-color-surface-border: var(--wa-color-neutral-80);
 
   --wa-color-text-link: var(--wa-color-brand-40);
 
@@ -62,15 +62,15 @@
   --wa-color-danger-on-normal: var(--wa-color-red-30);
   --wa-color-danger-on-loud: var(--wa-color-red-10);
 
-  --wa-color-neutral-fill-quiet: var(--wa-color-gray-95);
-  --wa-color-neutral-fill-normal: var(--wa-color-gray-90);
-  --wa-color-neutral-fill-loud: var(--wa-color-gray-30);
-  --wa-color-neutral-border-quiet: var(--wa-color-gray-80);
-  --wa-color-neutral-border-normal: var(--wa-color-gray-70);
-  --wa-color-neutral-border-loud: var(--wa-color-gray-50);
-  --wa-color-neutral-on-quiet: var(--wa-color-gray-40);
-  --wa-color-neutral-on-normal: var(--wa-color-gray-30);
-  --wa-color-neutral-on-loud: var(--wa-color-gray-95);
+  --wa-color-neutral-fill-quiet: var(--wa-color-neutral-95);
+  --wa-color-neutral-fill-normal: var(--wa-color-neutral-90);
+  --wa-color-neutral-fill-loud: var(--wa-color-neutral-30);
+  --wa-color-neutral-border-quiet: var(--wa-color-neutral-80);
+  --wa-color-neutral-border-normal: var(--wa-color-neutral-70);
+  --wa-color-neutral-border-loud: var(--wa-color-neutral-50);
+  --wa-color-neutral-on-quiet: var(--wa-color-neutral-40);
+  --wa-color-neutral-on-normal: var(--wa-color-neutral-30);
+  --wa-color-neutral-on-loud: var(--wa-color-neutral-95);
 }
 
 .wa-dark,
@@ -79,13 +79,13 @@
   /**
    * Foundational Colors
    */
-  --wa-color-surface-raised: var(--wa-color-gray-30);
-  --wa-color-surface-default: var(--wa-color-gray-20);
-  --wa-color-surface-lowered: var(--wa-color-gray-10);
-  --wa-color-surface-border: var(--wa-color-gray-30);
+  --wa-color-surface-raised: var(--wa-color-neutral-30);
+  --wa-color-surface-default: var(--wa-color-neutral-20);
+  --wa-color-surface-lowered: var(--wa-color-neutral-10);
+  --wa-color-surface-border: var(--wa-color-neutral-30);
 
-  --wa-color-text-normal: var(--wa-color-gray-95);
-  --wa-color-text-quiet: var(--wa-color-gray-80);
+  --wa-color-text-normal: var(--wa-color-neutral-95);
+  --wa-color-text-quiet: var(--wa-color-neutral-80);
   --wa-color-text-link: var(--wa-color-brand-80);
 
   --wa-color-focus: var(--wa-color-brand-60);
@@ -136,13 +136,13 @@
   --wa-color-danger-on-normal: var(--wa-color-red-90);
   --wa-color-danger-on-loud: var(--wa-color-red-10);
 
-  --wa-color-neutral-fill-quiet: var(--wa-color-gray-30);
-  --wa-color-neutral-fill-normal: var(--wa-color-gray-40);
-  --wa-color-neutral-fill-loud: var(--wa-color-gray-90);
-  --wa-color-neutral-border-quiet: var(--wa-color-gray-30);
-  --wa-color-neutral-border-normal: var(--wa-color-gray-40);
-  --wa-color-neutral-border-loud: var(--wa-color-gray-70);
-  --wa-color-neutral-on-quiet: var(--wa-color-gray-70);
-  --wa-color-neutral-on-normal: var(--wa-color-gray-90);
-  --wa-color-neutral-on-loud: var(--wa-color-gray-20);
+  --wa-color-neutral-fill-quiet: var(--wa-color-neutral-30);
+  --wa-color-neutral-fill-normal: var(--wa-color-neutral-40);
+  --wa-color-neutral-fill-loud: var(--wa-color-neutral-90);
+  --wa-color-neutral-border-quiet: var(--wa-color-neutral-30);
+  --wa-color-neutral-border-normal: var(--wa-color-neutral-40);
+  --wa-color-neutral-border-loud: var(--wa-color-neutral-70);
+  --wa-color-neutral-on-quiet: var(--wa-color-neutral-70);
+  --wa-color-neutral-on-normal: var(--wa-color-neutral-90);
+  --wa-color-neutral-on-loud: var(--wa-color-neutral-20);
 }

--- a/src/styles/themes/tailspin/color.css
+++ b/src/styles/themes/tailspin/color.css
@@ -16,8 +16,8 @@
 
   --wa-color-focus: var(--wa-color-brand-50);
 
-  --wa-color-mix-hover: var(--wa-color-gray-80) 20%;
-  --wa-color-mix-active: var(--wa-color-gray-80) 10%;
+  --wa-color-mix-hover: var(--wa-color-neutral-80) 20%;
+  --wa-color-mix-active: var(--wa-color-neutral-80) 10%;
 
   /**
    * Semantic Colors
@@ -62,14 +62,14 @@
   --wa-color-danger-on-normal: var(--wa-color-red-30);
   --wa-color-danger-on-loud: white;
 
-  --wa-color-neutral-fill-quiet: color-mix(in oklab, var(--wa-color-gray-95) 85%, transparent);
-  --wa-color-neutral-fill-normal: var(--wa-color-gray-90);
-  --wa-color-neutral-fill-loud: var(--wa-color-gray-10);
-  --wa-color-neutral-border-quiet: color-mix(in oklab, var(--wa-color-gray-80), transparent);
-  --wa-color-neutral-border-normal: color-mix(in oklab, var(--wa-color-gray-70) 60%, transparent);
-  --wa-color-neutral-border-loud: color-mix(in oklab, var(--wa-color-gray-60) 70%, transparent);
-  --wa-color-neutral-on-quiet: var(--wa-color-gray-30);
-  --wa-color-neutral-on-normal: var(--wa-color-gray-30);
+  --wa-color-neutral-fill-quiet: color-mix(in oklab, var(--wa-color-neutral-95) 85%, transparent);
+  --wa-color-neutral-fill-normal: var(--wa-color-neutral-90);
+  --wa-color-neutral-fill-loud: var(--wa-color-neutral-10);
+  --wa-color-neutral-border-quiet: color-mix(in oklab, var(--wa-color-neutral-80), transparent);
+  --wa-color-neutral-border-normal: color-mix(in oklab, var(--wa-color-neutral-70) 60%, transparent);
+  --wa-color-neutral-border-loud: color-mix(in oklab, var(--wa-color-neutral-60) 70%, transparent);
+  --wa-color-neutral-on-quiet: var(--wa-color-neutral-30);
+  --wa-color-neutral-on-normal: var(--wa-color-neutral-30);
   --wa-color-neutral-on-loud: white;
 
   /**
@@ -88,15 +88,15 @@
   --wa-color-surface-border: rgb(255 255 255 / 0.1);
 
   --wa-color-text-normal: white;
-  --wa-color-text-quiet: var(--wa-color-gray-60);
+  --wa-color-text-quiet: var(--wa-color-neutral-60);
   --wa-color-text-link: var(--wa-color-brand-70);
 
   --wa-color-shadow: rgb(0 0 0 / 0.2);
 
   --wa-color-focus: var(--wa-color-brand-60);
 
-  --wa-color-mix-hover: var(--wa-color-gray-70) 20%;
-  --wa-color-mix-active: var(--wa-color-gray-70) 10%;
+  --wa-color-mix-hover: var(--wa-color-neutral-70) 20%;
+  --wa-color-mix-active: var(--wa-color-neutral-70) 10%;
 
   /**
    * Semantic Colors
@@ -141,13 +141,13 @@
   --wa-color-danger-on-normal: var(--wa-color-red-70);
   --wa-color-danger-on-loud: white;
 
-  --wa-color-neutral-fill-quiet: color-mix(in oklab, var(--wa-color-gray-10) 90%, transparent);
-  --wa-color-neutral-fill-normal: var(--wa-color-gray-20);
+  --wa-color-neutral-fill-quiet: color-mix(in oklab, var(--wa-color-neutral-10) 90%, transparent);
+  --wa-color-neutral-fill-normal: var(--wa-color-neutral-20);
   --wa-color-neutral-fill-loud: white;
-  --wa-color-neutral-border-quiet: color-mix(in oklab, var(--wa-color-gray-20), transparent);
-  --wa-color-neutral-border-normal: color-mix(in oklab, var(--wa-color-gray-30) 60%, transparent);
-  --wa-color-neutral-border-loud: color-mix(in oklab, var(--wa-color-gray-40) 70%, transparent);
-  --wa-color-neutral-on-quiet: var(--wa-color-gray-60);
-  --wa-color-neutral-on-normal: var(--wa-color-gray-70);
-  --wa-color-neutral-on-loud: var(--wa-color-gray-10);
+  --wa-color-neutral-border-quiet: color-mix(in oklab, var(--wa-color-neutral-20), transparent);
+  --wa-color-neutral-border-normal: color-mix(in oklab, var(--wa-color-neutral-30) 60%, transparent);
+  --wa-color-neutral-border-loud: color-mix(in oklab, var(--wa-color-neutral-40) 70%, transparent);
+  --wa-color-neutral-on-quiet: var(--wa-color-neutral-60);
+  --wa-color-neutral-on-normal: var(--wa-color-neutral-70);
+  --wa-color-neutral-on-loud: var(--wa-color-neutral-10);
 }


### PR DESCRIPTION
Renames `gray` to `neutral` to describe a broader range of possible hues and chromas.