### PR TITLE
[Option] Drop `base` part, rel #207

### DIFF
--- a/src/components/option/option.css
+++ b/src/components/option/option.css
@@ -8,13 +8,7 @@
   color: var(--wa-color-text-normal);
   -webkit-user-select: none;
   user-select: none;
-}
 
-:host(:focus) {
-  outline: none;
-}
-
-.option {
   position: relative;
   display: flex;
   align-items: center;
@@ -25,19 +19,23 @@
   cursor: pointer;
 }
 
-:host(:not([disabled])) .option--hover:not(.option--current) {
+:host(:focus) {
+  outline: none;
+}
+
+:host(:not([disabled], :state(current)):is(:state(hover), :hover)) {
   background-color: var(--background-color-hover);
   color: var(--text-color-hover);
 }
 
-.option--current,
-:host([disabled]) .option--current {
+:host(:state(current)),
+:host([disabled]:state(current)) {
   background-color: var(--background-color-current);
   color: var(--text-color-current);
   opacity: 1;
 }
 
-:host([disabled]) .option {
+:host([disabled]) {
   outline: none;
   opacity: 0.5;
   cursor: not-allowed;
@@ -48,7 +46,7 @@
   display: inline-block;
 }
 
-.option .check {
+.check {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
@@ -58,7 +56,7 @@
   width: var(--wa-space-xl);
 }
 
-.option--selected .check {
+:host(:state(selected)) .check {
   visibility: visible;
 }
 
@@ -78,7 +76,7 @@
 }
 
 @media (forced-colors: active) {
-  :host(:hover:not([aria-disabled='true'])) .option {
+  :host(:hover:not([aria-disabled='true'])) {
     outline: dashed 1px SelectedItem;
     outline-offset: -1px;
   }


### PR DESCRIPTION
I was working on #673 and at some point it seemed easier to fix `<wa-option>` than to work around it.

This PR:
- Drops the `base` part (related to #207)
- Adds states `current`, `selected`, `hover` (rel #129)
- Removes `hasHover` state, as it’s no longer needed
- Uses both `:hover` and `:state(:hover)` for SSR 
- Adds link to testcase, so we can remove this wart later
- Refactors the watchers to use `updated()` per @claviska’s plan for them

I kept it in case, but it appears like `current` is not being set anywhere, either here or in the [original code](https://github.com/shoelace-style/webawesome/blob/next/src/components/option/option.ts). Possibly leftover? It doesn't seem to be the same as `:state(hover)`.