### PR TITLE
Support opting out of anchor headings with `data-no-anchor`

### DIFF
--- a/docs/_utils/anchor-headings.js
+++ b/docs/_utils/anchor-headings.js
@@ -37,7 +37,8 @@ export function anchorHeadingsPlugin(options = {}) {
       }
 
       // Look for headings
-      container.querySelectorAll(options.headingSelector).forEach(heading => {
+      let selector = `:is(${options.headingSelector}):not([data-no-anchor], [data-no-anchor] *)`;
+      container.querySelectorAll(selector).forEach(heading => {
         const hasAnchor = heading.querySelector('a');
         const existingId = heading.getAttribute('id');
         const clone = parse(heading.outerHTML);


### PR DESCRIPTION
`data-no-anchor` was already used *within* the headings to exclude content, so I figured it may be a good candidate for excluding the headings themselves.