### PR TITLE
Implement brand stylesheets for missing hues

### DIFF
--- a/src/styles/brand/gray.css
+++ b/src/styles/brand/gray.css
@@ -1,0 +1,18 @@
+:where(:root),
+:host,
+:where([class^='wa-theme-'], [class*=' wa-theme-']),
+:where([class^='wa-palette-'], [class*=' wa-palette-']) {
+  --wa-color-brand-95: var(--wa-color-gray-95);
+  --wa-color-brand-90: var(--wa-color-gray-90);
+  --wa-color-brand-80: var(--wa-color-gray-80);
+  --wa-color-brand-70: var(--wa-color-gray-70);
+  --wa-color-brand-60: var(--wa-color-gray-60);
+  --wa-color-brand-50: var(--wa-color-gray-50);
+  --wa-color-brand-40: var(--wa-color-gray-40);
+  --wa-color-brand-30: var(--wa-color-gray-30);
+  --wa-color-brand-20: var(--wa-color-gray-20);
+  --wa-color-brand-10: var(--wa-color-gray-10);
+  --wa-color-brand-05: var(--wa-color-gray-05);
+  --wa-color-brand: var(--wa-color-gray);
+  --wa-color-brand-key: var(--wa-color-gray-key);
+}

--- a/src/styles/brand/orange.css
+++ b/src/styles/brand/orange.css
@@ -1,0 +1,18 @@
+:where(:root),
+:host,
+:where([class^='wa-theme-'], [class*=' wa-theme-']),
+:where([class^='wa-palette-'], [class*=' wa-palette-']) {
+  --wa-color-brand-95: var(--wa-color-orange-95);
+  --wa-color-brand-90: var(--wa-color-orange-90);
+  --wa-color-brand-80: var(--wa-color-orange-80);
+  --wa-color-brand-70: var(--wa-color-orange-70);
+  --wa-color-brand-60: var(--wa-color-orange-60);
+  --wa-color-brand-50: var(--wa-color-orange-50);
+  --wa-color-brand-40: var(--wa-color-orange-40);
+  --wa-color-brand-30: var(--wa-color-orange-30);
+  --wa-color-brand-20: var(--wa-color-orange-20);
+  --wa-color-brand-10: var(--wa-color-orange-10);
+  --wa-color-brand-05: var(--wa-color-orange-05);
+  --wa-color-brand: var(--wa-color-orange);
+  --wa-color-brand-key: var(--wa-color-orange-key);
+}

--- a/src/styles/brand/pink.css
+++ b/src/styles/brand/pink.css
@@ -1,0 +1,18 @@
+:where(:root),
+:host,
+:where([class^='wa-theme-'], [class*=' wa-theme-']),
+:where([class^='wa-palette-'], [class*=' wa-palette-']) {
+  --wa-color-brand-95: var(--wa-color-pink-95);
+  --wa-color-brand-90: var(--wa-color-pink-90);
+  --wa-color-brand-80: var(--wa-color-pink-80);
+  --wa-color-brand-70: var(--wa-color-pink-70);
+  --wa-color-brand-60: var(--wa-color-pink-60);
+  --wa-color-brand-50: var(--wa-color-pink-50);
+  --wa-color-brand-40: var(--wa-color-pink-40);
+  --wa-color-brand-30: var(--wa-color-pink-30);
+  --wa-color-brand-20: var(--wa-color-pink-20);
+  --wa-color-brand-10: var(--wa-color-pink-10);
+  --wa-color-brand-05: var(--wa-color-pink-05);
+  --wa-color-brand: var(--wa-color-pink);
+  --wa-color-brand-key: var(--wa-color-pink-key);
+}

--- a/src/styles/brand/red.css
+++ b/src/styles/brand/red.css
@@ -1,0 +1,18 @@
+:where(:root),
+:host,
+:where([class^='wa-theme-'], [class*=' wa-theme-']),
+:where([class^='wa-palette-'], [class*=' wa-palette-']) {
+  --wa-color-brand-95: var(--wa-color-red-95);
+  --wa-color-brand-90: var(--wa-color-red-90);
+  --wa-color-brand-80: var(--wa-color-red-80);
+  --wa-color-brand-70: var(--wa-color-red-70);
+  --wa-color-brand-60: var(--wa-color-red-60);
+  --wa-color-brand-50: var(--wa-color-red-50);
+  --wa-color-brand-40: var(--wa-color-red-40);
+  --wa-color-brand-30: var(--wa-color-red-30);
+  --wa-color-brand-20: var(--wa-color-red-20);
+  --wa-color-brand-10: var(--wa-color-red-10);
+  --wa-color-brand-05: var(--wa-color-red-05);
+  --wa-color-brand: var(--wa-color-red);
+  --wa-color-brand-key: var(--wa-color-red-key);
+}

--- a/src/styles/brand/yellow.css
+++ b/src/styles/brand/yellow.css
@@ -1,0 +1,18 @@
+:where(:root),
+:host,
+:where([class^='wa-theme-'], [class*=' wa-theme-']),
+:where([class^='wa-palette-'], [class*=' wa-palette-']) {
+  --wa-color-brand-95: var(--wa-color-yellow-95);
+  --wa-color-brand-90: var(--wa-color-yellow-90);
+  --wa-color-brand-80: var(--wa-color-yellow-80);
+  --wa-color-brand-70: var(--wa-color-yellow-70);
+  --wa-color-brand-60: var(--wa-color-yellow-60);
+  --wa-color-brand-50: var(--wa-color-yellow-50);
+  --wa-color-brand-40: var(--wa-color-yellow-40);
+  --wa-color-brand-30: var(--wa-color-yellow-30);
+  --wa-color-brand-20: var(--wa-color-yellow-20);
+  --wa-color-brand-10: var(--wa-color-yellow-10);
+  --wa-color-brand-05: var(--wa-color-yellow-05);
+  --wa-color-brand: var(--wa-color-yellow);
+  --wa-color-brand-key: var(--wa-color-yellow-key);
+}


### PR DESCRIPTION
Fixes #728 . I also added `orange` and `pink` so that they’re ready for #657 and #658.