### PR TITLE
Revisit `natural` palette, closes #721

### DIFF
--- a/src/styles/color/natural.css
+++ b/src/styles/color/natural.css
@@ -46,17 +46,17 @@
 
   --wa-color-cyan-95: #eff3f4 /* oklch(96.14% 0.00448 214.33) */;
   --wa-color-cyan-90: #dee7e9 /* oklch(92.173% 0.01004 212.52) */;
-  --wa-color-cyan-80: #b7cccf /* oklch(83.033% 0.02314 207.07) */;
-  --wa-color-cyan-70: #96b4b9 /* oklch(74.914% 0.03351 208.76) */;
-  --wa-color-cyan-60: #759ba1 /* oklch(66.351% 0.04257 208.18) */;
-  --wa-color-cyan-50: #4d7d84 /* oklch(55.819% 0.05314 207.5) */;
-  --wa-color-cyan-40: #2b6067 /* oklch(45.606% 0.05711 206.88) */;
-  --wa-color-cyan-30: #194c53 /* oklch(38.597% 0.05436 207.82) */;
-  --wa-color-cyan-20: #0a383e /* oklch(31.395% 0.04827 207.89) */;
+  --wa-color-cyan-80: #b8cdd1 /* oklch(83.375% 0.02342 210.4) */;
+  --wa-color-cyan-70: #96b4ba /* oklch(74.946% 0.03385 211.12) */;
+  --wa-color-cyan-60: #759ba2 /* oklch(66.386% 0.0429 210.11) */;
+  --wa-color-cyan-50: #4a7d86 /* oklch(55.736% 0.05643 209.98) */;
+  --wa-color-cyan-40: #2f6067 /* oklch(45.783% 0.05405 207.62) */;
+  --wa-color-cyan-30: #1e4c52 /* oklch(38.743% 0.05069 206.89) */;
+  --wa-color-cyan-20: #0c383e /* oklch(31.452% 0.04725 208.21) */;
   --wa-color-cyan-10: #022125 /* oklch(22.735% 0.03682 207.1) */;
   --wa-color-cyan-05: #011518 /* oklch(17.963% 0.02908 207.19) */;
-  --wa-color-cyan: var(--wa-color-cyan-40);
-  --wa-color-cyan-key: 40;
+  --wa-color-cyan: var(--wa-color-cyan-50);
+  --wa-color-cyan-key: 50;
 
   --wa-color-blue-95: #eef1f5 /* oklch(95.7% 0.00626 255.48) */;
   --wa-color-blue-90: #e1e6ef /* oklch(92.375% 0.01334 262.38) */;

--- a/src/styles/color/natural.css
+++ b/src/styles/color/natural.css
@@ -3,27 +3,27 @@
 :where([class^='wa-theme-'], [class*=' wa-theme-']),
 .wa-palette-natural {
   --wa-color-red-95: #f9f0ee /* oklch(96.159% 0.0101 32.516) */;
-  --wa-color-red-90: #f5e2dd /* oklch(92.669% 0.02202 35.121) */;
-  --wa-color-red-80: #e8bfb5 /* oklch(83.775% 0.0493 33.987) */;
-  --wa-color-red-70: #dba294 /* oklch(76.229% 0.07115 34.235) */;
-  --wa-color-red-60: #c98373 /* oklch(67.81% 0.09043 33.504) */;
-  --wa-color-red-50: #ae6150 /* oklch(57.709% 0.10386 33.445) */;
-  --wa-color-red-40: #8c4434 /* oklch(47.455% 0.10187 33.787) */;
-  --wa-color-red-30: #713225 /* oklch(40.002% 0.09248 33.14) */;
+  --wa-color-red-90: #f5e1dc /* oklch(92.449% 0.0231 34.298) */;
+  --wa-color-red-80: #e9c1b7 /* oklch(84.299% 0.04808 34.353) */;
+  --wa-color-red-70: #daa193 /* oklch(75.915% 0.07123 34.238) */;
+  --wa-color-red-60: #c48576 /* oklch(67.655% 0.08143 33.955) */;
+  --wa-color-red-50: #a86252 /* oklch(57.121% 0.09478 33.75) */;
+  --wa-color-red-40: #864839 /* oklch(47.352% 0.08833 34.595) */;
+  --wa-color-red-30: #6f3428 /* oklch(40.073% 0.08669 32.867) */;
   --wa-color-red-20: #562318 /* oklch(32.765% 0.07872 33.646) */;
   --wa-color-red-10: #36130b /* oklch(23.996% 0.05851 34.254) */;
   --wa-color-red-05: #240a05 /* oklch(18.708% 0.04625 34.412) */;
   --wa-color-red: var(--wa-color-red-50);
   --wa-color-red-key: 50;
 
-  --wa-color-yellow-95: #f5f0e8 /* oklch(95.682% 0.01193 79.784) */;
-  --wa-color-yellow-90: #ede4d5 /* oklch(92.192% 0.0223 80.684) */;
-  --wa-color-yellow-80: #dac6a4 /* oklch(83.455% 0.05079 80.939) */;
+  --wa-color-yellow-95: #f6f1ea /* oklch(96.009% 0.01076 76.598) */;
+  --wa-color-yellow-90: #eee5d7 /* oklch(92.521% 0.02111 79.091) */;
+  --wa-color-yellow-80: #dbc8a8 /* oklch(84.033% 0.04791 80.753) */;
   --wa-color-yellow-70: #c7ab7b /* oklch(75.433% 0.07174 80.723) */;
-  --wa-color-yellow-60: #b29054 /* oklch(67.181% 0.08832 80.564) */;
-  --wa-color-yellow-50: #94702b /* oklch(56.778% 0.09671 80.65) */;
-  --wa-color-yellow-40: #735310 /* oklch(46.47% 0.08924 80.445) */;
-  --wa-color-yellow-30: #5c4003 /* oklch(39.286% 0.07968 79.822) */;
+  --wa-color-yellow-60: #af905b /* oklch(66.983% 0.07981 80.152) */;
+  --wa-color-yellow-50: #8f703a /* oklch(56.392% 0.08172 79.742) */;
+  --wa-color-yellow-40: #71541d /* oklch(46.546% 0.08061 80.169) */;
+  --wa-color-yellow-30: #5b4111 /* oklch(39.475% 0.07191 78.67) */;
   --wa-color-yellow-20: #442f00 /* oklch(32.136% 0.06628 81.612) */;
   --wa-color-yellow-10: #2a1b00 /* oklch(23.521% 0.04872 79.998) */;
   --wa-color-yellow-05: #1b1000 /* oklch(18.327% 0.03796 79.944) */;

--- a/src/styles/color/natural.css
+++ b/src/styles/color/natural.css
@@ -58,19 +58,19 @@
   --wa-color-cyan: var(--wa-color-cyan-50);
   --wa-color-cyan-key: 50;
 
-  --wa-color-blue-95: #eef1f5 /* oklch(95.7% 0.00626 255.48) */;
-  --wa-color-blue-90: #e1e6ef /* oklch(92.375% 0.01334 262.38) */;
-  --wa-color-blue-80: #bdc9dc /* oklch(83.261% 0.0297 259.59) */;
+  --wa-color-blue-95: #f0f2f6 /* oklch(96.077% 0.00576 264.53) */;
+  --wa-color-blue-90: #e0e5ef /* oklch(92.101% 0.0146 264.5) */;
+  --wa-color-blue-80: #c0cbde /* oklch(83.957% 0.02915 261.47) */;
   --wa-color-blue-70: #9fb0ca /* oklch(75.271% 0.04205 258.8) */;
   --wa-color-blue-60: #8196b8 /* oklch(66.901% 0.05611 259.98) */;
-  --wa-color-blue-50: #5f779e /* oklch(56.593% 0.06705 259.94) */;
-  --wa-color-blue-40: #415981 /* oklch(46.262% 0.07185 260.29) */;
+  --wa-color-blue-50: #5c76a0 /* oklch(56.262% 0.07235 259.79) */;
+  --wa-color-blue-40: #425981 /* oklch(46.327% 0.07137 261.08) */;
   --wa-color-blue-30: #2f466a /* oklch(39.269% 0.06791 259.08) */;
   --wa-color-blue-20: #203351 /* oklch(32.043% 0.05935 259.22) */;
   --wa-color-blue-10: #101e34 /* oklch(23.495% 0.04695 259.11) */;
-  --wa-color-blue-05: #081223 /* oklch(18.293% 0.03819 260.22) */;
-  --wa-color-blue: var(--wa-color-blue-40);
-  --wa-color-blue-key: 40;
+  --wa-color-blue-05: #081224 /* oklch(18.37% 0.04003 261.12) */;
+  --wa-color-blue: var(--wa-color-blue-50);
+  --wa-color-blue-key: 50;
 
   --wa-color-indigo-95: #f2f2f7 /* oklch(96.257% 0.00665 286.27) */;
   --wa-color-indigo-90: #e6e5f1 /* oklch(92.619% 0.01616 289.92) */;
@@ -91,14 +91,14 @@
   --wa-color-purple-80: #d2c4dc /* oklch(83.913% 0.03624 311.38) */;
   --wa-color-purple-70: #bca8ca /* oklch(75.974% 0.05263 311.37) */;
   --wa-color-purple-60: #a48cb6 /* oklch(67.622% 0.06639 310.43) */;
-  --wa-color-purple-50: #876b9a /* oklch(57.261% 0.07753 311.16) */;
-  --wa-color-purple-40: #694e7b /* oklch(47.05% 0.07756 311.1) */;
+  --wa-color-purple-50: #866a99 /* oklch(56.923% 0.07763 311.15) */;
+  --wa-color-purple-40: #694f7a /* oklch(47.198% 0.07429 311.36) */;
   --wa-color-purple-30: #543c64 /* oklch(39.99% 0.07155 310.98) */;
   --wa-color-purple-20: #3e2b4b /* oklch(32.584% 0.06005 310.65) */;
   --wa-color-purple-10: #26182f /* oklch(23.839% 0.04672 311.22) */;
   --wa-color-purple-05: #180e1f /* oklch(18.634% 0.03651 310.29) */;
-  --wa-color-purple: var(--wa-color-purple-40);
-  --wa-color-purple-key: 40;
+  --wa-color-purple: var(--wa-color-purple-50);
+  --wa-color-purple-key: 50;
 
   --wa-color-gray-95: #f1f1f0 /* oklch(95.787% 0.00133 106.42) */;
   --wa-color-gray-90: #e7e6e4 /* oklch(92.515% 0.0029 84.559) */;


### PR DESCRIPTION
Adjusts `natural` palette so that all earthy hues have low chroma, without bias towards lighter or darker tints.

---

### Before
<img width="1015" alt="Screenshot 2025-02-08 at 10 19 13 PM" src="https://github.com/user-attachments/assets/89dfb7ca-15de-4a8f-917f-265e02ea1af9" />


### After
<img width="1015" alt="Screenshot 2025-02-08 at 10 19 08 PM" src="https://github.com/user-attachments/assets/aad7b9bc-2f6f-4bfa-94c9-b515f237c394" />
