### PR TITLE
Clamped brand color tokens

### DIFF
--- a/docs/docs/experimental/clamped-colors.njk
+++ b/docs/docs/experimental/clamped-colors.njk
@@ -1,0 +1,47 @@
+---
+title: Clamped brand tokens
+layout: block
+---
+
+{% set tints = ['40-max', '50-max', '60-max', '40-min', '50-min', '60-min'] %}
+
+{% for hue in hues %}
+<link href="/dist/styles/brand/{{ hue }}.css" rel="stylesheet">
+{% endfor %}
+
+<table class="colors">
+  <thead>
+    <tr>
+      <th></th>
+      <th class="core-column">Core tint</th>
+      {% for tint in tints -%}
+      <th>{{ tint }}</th>
+      {%- endfor %}
+    </tr>
+  </thead>
+{% for hue in hues -%}
+<tr class="wa-brand-{{ hue }}">
+  <th>{{ hue | capitalize }}</th>
+  <td class="core-column">
+    <div class="color swatch" style="background-color: var(--wa-color-brand); color: var(--wa-color-brand-on);">
+      {{ palettes[paletteId][hue].maxChromaTint }}
+      <wa-copy-button value="--wa-color-brand" copy-label="--wa-color-brand"></wa-copy-button>
+    </div>
+  </td>
+  {% for tint in tints -%}
+    <td>
+      <div class="color swatch" style="background-color: var(--wa-color-brand-{{ tint }})">
+        <wa-copy-button value="--wa-color-brand-{{ tint }}" copy-label="--wa-color-brand-{{ tint }}"></wa-copy-button>
+      </div>
+    </td>
+  {%- endfor -%}
+</tr>
+{%- endfor %}
+</table>
+
+<style>
+.core-column .color.swatch::before {
+  counter-reset: key var(--wa-color-brand-key);
+  content: counter(key);
+}
+</style>

--- a/src/styles/brand/base.css
+++ b/src/styles/brand/base.css
@@ -1,0 +1,63 @@
+:where(:root),
+:host,
+:where([class^='wa-theme-'], [class*=' wa-theme-']),
+:where([class^='wa-palette-'], [class*=' wa-palette-']),
+:where([class^='wa-brand-'], [class*=' wa-brand-']) {
+  /**
+   * Conditional tokens for use in color-mix()
+   * --wa-color-brand-if-lt-N ➡️ 100% if key < N, 0% otherwise
+   * --wa-color-brand-if-gte-N ➡️ 100% if key >= N, 0% otherwise
+   */
+  --wa-color-brand-if-lt-40: calc(clamp(0, 40 - var(--wa-color-brand-key), 1) * 100%);
+  --wa-color-brand-if-lt-50: calc(clamp(0, 50 - var(--wa-color-brand-key), 1) * 100%);
+  --wa-color-brand-if-lt-60: calc(clamp(0, 60 - var(--wa-color-brand-key), 1) * 100%);
+  --wa-color-brand-if-lt-70: calc(clamp(0, 70 - var(--wa-color-brand-key), 1) * 100%);
+  --wa-color-brand-if-lt-80: calc(clamp(0, 80 - var(--wa-color-brand-key), 1) * 100%);
+
+  --wa-color-brand-if-gte-40: calc(100% - var(--wa-color-brand-if-lt-40));
+  --wa-color-brand-if-gte-50: calc(100% - var(--wa-color-brand-if-lt-50));
+  --wa-color-brand-if-gte-60: calc(100% - var(--wa-color-brand-if-lt-60));
+  --wa-color-brand-if-gte-70: calc(100% - var(--wa-color-brand-if-lt-70));
+  --wa-color-brand-if-gte-80: calc(100% - var(--wa-color-brand-if-lt-80));
+
+  /*
+   * Convenience tokens for common tint cutoffs
+   * --wa-color-brand-N-max ➡️ var(--color-brand) if key <= N, var(--color-brand-N) otherwise
+   * --wa-color-brand-N-min ➡️ var(--color-brand) if key >= N, var(--color-brand-N) otherwise
+   */
+  --wa-color-brand-40-max: color-mix(
+    in oklab,
+    var(--wa-color-brand) var(--wa-color-brand-if-lt-40),
+    var(--wa-color-brand-40)
+  );
+  --wa-color-brand-40-min: color-mix(
+    in oklab,
+    var(--wa-color-brand) var(--wa-color-brand-if-gte-40),
+    var(--wa-color-brand-40)
+  );
+
+  --wa-color-brand-50-max: color-mix(
+    in oklab,
+    var(--wa-color-brand) var(--wa-color-brand-if-lt-50),
+    var(--wa-color-brand-50)
+  );
+  --wa-color-brand-50-min: color-mix(
+    in oklab,
+    var(--wa-color-brand) var(--wa-color-brand-if-gte-50),
+    var(--wa-color-brand-50)
+  );
+
+  --wa-color-brand-60-max: color-mix(
+    in oklab,
+    var(--wa-color-brand) var(--wa-color-brand-if-lt-60),
+    var(--wa-color-brand-60)
+  );
+  --wa-color-brand-60-min: color-mix(
+    in oklab,
+    var(--wa-color-brand) var(--wa-color-brand-if-gte-60),
+    var(--wa-color-brand-60)
+  );
+
+  /* Text color: white if key < 70, brand-10 otherwise */
+  --wa-color-brand-on: color-mix(in oklab, var(--wa-color-brand-10) var(--wa-color-brand-if-gte-70), white);
+}

--- a/src/styles/brand/base.css
+++ b/src/styles/brand/base.css
@@ -59,5 +59,5 @@
   );
 
   /* Text color: white if key < 70, brand-10 otherwise */
-  --wa-color-brand-on: color-mix(in oklab, var(--wa-color-brand-10) var(--wa-color-brand-if-gte-70), white);
+  --wa-color-brand-on: color-mix(in oklab, var(--wa-color-brand-10) var(--wa-color-brand-if-gte-60), white);
 }

--- a/src/styles/brand/blue.css
+++ b/src/styles/brand/blue.css
@@ -1,7 +1,10 @@
+@import url('base.css');
+
 :where(:root),
 :host,
 :where([class^='wa-theme-'], [class*=' wa-theme-']),
-:where([class^='wa-palette-'], [class*=' wa-palette-']) {
+:where([class^='wa-palette-'], [class*=' wa-palette-']),
+.wa-brand-blue {
   --wa-color-brand-95: var(--wa-color-blue-95);
   --wa-color-brand-90: var(--wa-color-blue-90);
   --wa-color-brand-80: var(--wa-color-blue-80);

--- a/src/styles/brand/cyan.css
+++ b/src/styles/brand/cyan.css
@@ -1,7 +1,10 @@
+@import url('base.css');
+
 :where(:root),
 :host,
 :where([class^='wa-theme-'], [class*=' wa-theme-']),
-:where([class^='wa-palette-'], [class*=' wa-palette-']) {
+:where([class^='wa-palette-'], [class*=' wa-palette-']),
+.wa-brand-cyan {
   --wa-color-brand-95: var(--wa-color-cyan-95);
   --wa-color-brand-90: var(--wa-color-cyan-90);
   --wa-color-brand-80: var(--wa-color-cyan-80);

--- a/src/styles/brand/gray.css
+++ b/src/styles/brand/gray.css
@@ -1,7 +1,10 @@
+@import url('base.css');
+
 :where(:root),
 :host,
 :where([class^='wa-theme-'], [class*=' wa-theme-']),
-:where([class^='wa-palette-'], [class*=' wa-palette-']) {
+:where([class^='wa-palette-'], [class*=' wa-palette-']),
+.wa-brand-gray {
   --wa-color-brand-95: var(--wa-color-gray-95);
   --wa-color-brand-90: var(--wa-color-gray-90);
   --wa-color-brand-80: var(--wa-color-gray-80);

--- a/src/styles/brand/green.css
+++ b/src/styles/brand/green.css
@@ -1,7 +1,10 @@
+@import url('base.css');
+
 :where(:root),
 :host,
 :where([class^='wa-theme-'], [class*=' wa-theme-']),
-:where([class^='wa-palette-'], [class*=' wa-palette-']) {
+:where([class^='wa-palette-'], [class*=' wa-palette-']),
+.wa-brand-green {
   --wa-color-brand-95: var(--wa-color-green-95);
   --wa-color-brand-90: var(--wa-color-green-90);
   --wa-color-brand-80: var(--wa-color-green-80);

--- a/src/styles/brand/indigo.css
+++ b/src/styles/brand/indigo.css
@@ -1,7 +1,10 @@
+@import url('base.css');
+
 :where(:root),
 :host,
 :where([class^='wa-theme-'], [class*=' wa-theme-']),
-:where([class^='wa-palette-'], [class*=' wa-palette-']) {
+:where([class^='wa-palette-'], [class*=' wa-palette-']),
+.wa-brand-indigo {
   --wa-color-brand-95: var(--wa-color-indigo-95);
   --wa-color-brand-90: var(--wa-color-indigo-90);
   --wa-color-brand-80: var(--wa-color-indigo-80);

--- a/src/styles/brand/orange.css
+++ b/src/styles/brand/orange.css
@@ -1,7 +1,10 @@
+@import url('base.css');
+
 :where(:root),
 :host,
 :where([class^='wa-theme-'], [class*=' wa-theme-']),
-:where([class^='wa-palette-'], [class*=' wa-palette-']) {
+:where([class^='wa-palette-'], [class*=' wa-palette-']),
+.wa-brand-orange {
   --wa-color-brand-95: var(--wa-color-orange-95);
   --wa-color-brand-90: var(--wa-color-orange-90);
   --wa-color-brand-80: var(--wa-color-orange-80);

--- a/src/styles/brand/pink.css
+++ b/src/styles/brand/pink.css
@@ -1,7 +1,10 @@
+@import url('base.css');
+
 :where(:root),
 :host,
 :where([class^='wa-theme-'], [class*=' wa-theme-']),
-:where([class^='wa-palette-'], [class*=' wa-palette-']) {
+:where([class^='wa-palette-'], [class*=' wa-palette-']),
+.wa-brand-pink {
   --wa-color-brand-95: var(--wa-color-pink-95);
   --wa-color-brand-90: var(--wa-color-pink-90);
   --wa-color-brand-80: var(--wa-color-pink-80);

--- a/src/styles/brand/purple.css
+++ b/src/styles/brand/purple.css
@@ -1,7 +1,10 @@
+@import url('base.css');
+
 :where(:root),
 :host,
 :where([class^='wa-theme-'], [class*=' wa-theme-']),
-:where([class^='wa-palette-'], [class*=' wa-palette-']) {
+:where([class^='wa-palette-'], [class*=' wa-palette-']),
+.wa-brand-purple {
   --wa-color-brand-95: var(--wa-color-purple-95);
   --wa-color-brand-90: var(--wa-color-purple-90);
   --wa-color-brand-80: var(--wa-color-purple-80);

--- a/src/styles/brand/red.css
+++ b/src/styles/brand/red.css
@@ -1,7 +1,10 @@
+@import url('base.css');
+
 :where(:root),
 :host,
 :where([class^='wa-theme-'], [class*=' wa-theme-']),
-:where([class^='wa-palette-'], [class*=' wa-palette-']) {
+:where([class^='wa-palette-'], [class*=' wa-palette-']),
+.wa-brand-red {
   --wa-color-brand-95: var(--wa-color-red-95);
   --wa-color-brand-90: var(--wa-color-red-90);
   --wa-color-brand-80: var(--wa-color-red-80);

--- a/src/styles/brand/yellow.css
+++ b/src/styles/brand/yellow.css
@@ -1,7 +1,10 @@
+@import url('base.css');
+
 :where(:root),
 :host,
 :where([class^='wa-theme-'], [class*=' wa-theme-']),
-:where([class^='wa-palette-'], [class*=' wa-palette-']) {
+:where([class^='wa-palette-'], [class*=' wa-palette-']),
+.wa-brand-yellow {
   --wa-color-brand-95: var(--wa-color-yellow-95);
   --wa-color-brand-90: var(--wa-color-yellow-90);
   --wa-color-brand-80: var(--wa-color-yellow-80);


### PR DESCRIPTION
Per discussion with @lindsaym-fa, this PR adds:

- `--wa-color-brand-if-lt-N` and `--wa-color-brand-if-gte-N` tokens for use in `color-mix()`. Notes:
  - I only defined these for 40, 50, 60, 80 since it seems these are the most common branching cutoffs and we have no accent colors on other levels, but it's trivial to add variables for all levels.
  - I can define `-lte-` and `-gt-` versions if you think fixing the assummetry is worth the extra weight.
- `--wa-color-brand-N-min` and `--wa-color-brand-N-max` color tokens for the most common cutoffs (40, 50, 60)
  - After working with these a bit, I found `lt(e)`/`gt(e)` easy(ish) to reason about for the conditional tokens, but I found they were making me think a bit too hard when used in color names. I'm still not super happy with `N-(min|max)` but I think they're a little better. I also tried `N-or-(more|less)` but I found it too long and not necessarily more understandable than min/max. The jury is still out on what is a good naming scheme for these.

For convenience, I also added:
- `--wa-color-brand-on` for the common case of using `brand-10` for light accent colors (key >= 70) and `white` otherwise. Happy to add more contrasting versions too (though naming is hard).
- `.wa-brand-*` classes to change the brand color of an element. This was originally added for testing, but I think it can be more broadly useful.

I created a testing page in http://localhost:4000/docs/experimental/clamped-colors/ which we could move to visual tests once these are more mature and we're more confident about exposing them.
Note the text color in the core column below is using `--wa-color-brand-on` 😉 

<img width="718" alt="image" src="https://github.com/user-attachments/assets/f8d91d72-5c1a-4acb-ab19-4ea0716788b7" />
