### PR TITLE
Use tintless and clamped `brand` colors in themes

### DIFF
--- a/docs/docs/resources/changelog.md
+++ b/docs/docs/resources/changelog.md
@@ -27,8 +27,9 @@ You can find them in the first column of each color palette.
 
 ### Themes
 
+- Updated Active, Glossy, Playful, and Premium themes so that `--wa-color-brand-fill-loud` uses the core color of the chosen brand color, regardless of tint.
 - You can now override the brand color of any theme with any of the 9 hues supported.
-- Improved UI for theme remixing, with previews and generated copyable code snippets
+- Improved UI for theme remixing, with previews and generated copyable code snippets.
 
 ### Components
 

--- a/src/styles/brand/base.css
+++ b/src/styles/brand/base.css
@@ -30,6 +30,11 @@
     var(--wa-color-brand) var(--wa-color-brand-if-lt-40),
     var(--wa-color-brand-40)
   );
+  --wa-color-brand-40-min: color-mix(
+    in oklab,
+    var(--wa-color-brand) var(--wa-color-brand-if-gte-40),
+    var(--wa-color-brand-40)
+  );
 
   --wa-color-brand-50-max: color-mix(
     in oklab,
@@ -53,6 +58,11 @@
     var(--wa-color-brand-60)
   );
 
+  --wa-color-brand-70-max: color-mix(
+    in oklab,
+    var(--wa-color-brand) var(--wa-color-brand-if-lt-70),
+    var(--wa-color-brand-70)
+  );
   --wa-color-brand-70-min: color-mix(
     in oklab,
     var(--wa-color-brand) var(--wa-color-brand-if-gte-70),

--- a/src/styles/brand/base.css
+++ b/src/styles/brand/base.css
@@ -30,11 +30,6 @@
     var(--wa-color-brand) var(--wa-color-brand-if-lt-40),
     var(--wa-color-brand-40)
   );
-  --wa-color-brand-40-min: color-mix(
-    in oklab,
-    var(--wa-color-brand) var(--wa-color-brand-if-gte-40),
-    var(--wa-color-brand-40)
-  );
 
   --wa-color-brand-50-max: color-mix(
     in oklab,
@@ -58,6 +53,12 @@
     var(--wa-color-brand-60)
   );
 
-  /* Text color: white if key < 70, brand-10 otherwise */
+  --wa-color-brand-70-min: color-mix(
+    in oklab,
+    var(--wa-color-brand) var(--wa-color-brand-if-gte-70),
+    var(--wa-color-brand-70)
+  );
+
+  /* Text color: white if key < 60, brand-10 otherwise */
   --wa-color-brand-on: color-mix(in oklab, var(--wa-color-brand-10) var(--wa-color-brand-if-gte-60), white);
 }

--- a/src/styles/themes/active/color.css
+++ b/src/styles/themes/active/color.css
@@ -26,13 +26,13 @@
    */
   --wa-color-brand-fill-quiet: var(--wa-color-brand-95);
   --wa-color-brand-fill-normal: var(--wa-color-brand-90);
-  --wa-color-brand-fill-loud: var(--wa-color-brand-80);
+  --wa-color-brand-fill-loud: var(--wa-color-brand);
   --wa-color-brand-border-quiet: var(--wa-color-brand-90);
   --wa-color-brand-border-normal: var(--wa-color-brand-80);
   --wa-color-brand-border-loud: var(--wa-color-brand-70);
   --wa-color-brand-on-quiet: var(--wa-color-brand-40);
   --wa-color-brand-on-normal: var(--wa-color-brand-30);
-  --wa-color-brand-on-loud: black;
+  --wa-color-brand-on-loud: var(--wa-color-brand-on);
 
   --wa-color-success-fill-quiet: var(--wa-color-green-95);
   --wa-color-success-fill-normal: var(--wa-color-green-90);
@@ -90,13 +90,13 @@
    */
   --wa-color-brand-fill-quiet: var(--wa-color-brand-10);
   --wa-color-brand-fill-normal: var(--wa-color-brand-20);
-  --wa-color-brand-fill-loud: var(--wa-color-brand-80);
+  --wa-color-brand-fill-loud: var(--wa-color-brand);
   --wa-color-brand-border-quiet: var(--wa-color-brand-20);
   --wa-color-brand-border-normal: var(--wa-color-brand-30);
   --wa-color-brand-border-loud: var(--wa-color-brand-60);
   --wa-color-brand-on-quiet: var(--wa-color-brand-80);
   --wa-color-brand-on-normal: var(--wa-color-brand-90);
-  --wa-color-brand-on-loud: black;
+  --wa-color-brand-on-loud: var(--wa-color-brand-on);
 
   --wa-color-success-fill-quiet: var(--wa-color-green-10);
   --wa-color-success-fill-normal: var(--wa-color-green-20);

--- a/src/styles/themes/awesome/color.css
+++ b/src/styles/themes/awesome/color.css
@@ -17,7 +17,7 @@
    */
   --wa-color-brand-fill-quiet: var(--wa-color-brand-95);
   --wa-color-brand-fill-normal: var(--wa-color-brand-90);
-  --wa-color-brand-fill-loud: var(--wa-color-brand-70);
+  --wa-color-brand-fill-loud: var(--wa-color-brand-70-min);
   --wa-color-brand-border-quiet: var(--wa-color-brand-70);
   --wa-color-brand-border-normal: var(--wa-color-brand-50);
   --wa-color-brand-border-loud: var(--wa-color-brand-30);
@@ -77,7 +77,7 @@
    */
   --wa-color-brand-fill-quiet: var(--wa-color-brand-10);
   --wa-color-brand-fill-normal: var(--wa-color-brand-20);
-  --wa-color-brand-fill-loud: var(--wa-color-brand-50);
+  --wa-color-brand-fill-loud: var(--wa-color-brand-50-max);
   --wa-color-brand-border-quiet: var(--wa-color-brand-30);
   --wa-color-brand-border-normal: var(--wa-color-brand-50);
   --wa-color-brand-border-loud: var(--wa-color-brand-80);

--- a/src/styles/themes/brutalist/color.css
+++ b/src/styles/themes/brutalist/color.css
@@ -24,7 +24,7 @@
    */
   --wa-color-brand-fill-quiet: var(--wa-color-brand-95);
   --wa-color-brand-fill-normal: var(--wa-color-brand-90);
-  --wa-color-brand-fill-loud: var(--wa-color-brand-50);
+  --wa-color-brand-fill-loud: var(--wa-color-brand-50-max);
   --wa-color-brand-border-quiet: var(--wa-color-brand-80);
   --wa-color-brand-border-normal: var(--wa-color-brand-60);
   --wa-color-brand-border-loud: var(--wa-color-brand-40);
@@ -96,7 +96,7 @@
    */
   --wa-color-brand-fill-quiet: var(--wa-color-brand-20);
   --wa-color-brand-fill-normal: var(--wa-color-brand-30);
-  --wa-color-brand-fill-loud: var(--wa-color-brand-70);
+  --wa-color-brand-fill-loud: var(--wa-color-brand-70-min);
   --wa-color-brand-border-quiet: var(--wa-color-brand-30);
   --wa-color-brand-border-normal: var(--wa-color-brand-40);
   --wa-color-brand-border-loud: var(--wa-color-brand-80);

--- a/src/styles/themes/default/color.css
+++ b/src/styles/themes/default/color.css
@@ -61,7 +61,7 @@
    */
   --wa-color-brand-fill-quiet: var(--wa-color-brand-95);
   --wa-color-brand-fill-normal: var(--wa-color-brand-90);
-  --wa-color-brand-fill-loud: var(--wa-color-brand-50);
+  --wa-color-brand-fill-loud: var(--wa-color-brand-50-max);
   --wa-color-brand-border-quiet: var(--wa-color-brand-90);
   --wa-color-brand-border-normal: var(--wa-color-brand-80);
   --wa-color-brand-border-loud: var(--wa-color-brand-60);
@@ -149,7 +149,7 @@
    */
   --wa-color-brand-fill-quiet: var(--wa-color-brand-10);
   --wa-color-brand-fill-normal: var(--wa-color-brand-20);
-  --wa-color-brand-fill-loud: var(--wa-color-brand-50);
+  --wa-color-brand-fill-loud: var(--wa-color-brand-50-max);
   --wa-color-brand-border-quiet: var(--wa-color-brand-20);
   --wa-color-brand-border-normal: var(--wa-color-brand-30);
   --wa-color-brand-border-loud: var(--wa-color-brand-40);

--- a/src/styles/themes/glossy/color.css
+++ b/src/styles/themes/glossy/color.css
@@ -19,13 +19,13 @@
    */
   --wa-color-brand-fill-quiet: var(--wa-color-brand-95);
   --wa-color-brand-fill-normal: var(--wa-color-brand-90);
-  --wa-color-brand-fill-loud: var(--wa-color-brand-40);
+  --wa-color-brand-fill-loud: var(--wa-color-brand);
   --wa-color-brand-border-quiet: var(--wa-color-brand-90);
   --wa-color-brand-border-normal: var(--wa-color-brand-80);
   --wa-color-brand-border-loud: var(--wa-color-brand-60);
   --wa-color-brand-on-quiet: var(--wa-color-brand-40);
   --wa-color-brand-on-normal: var(--wa-color-brand-30);
-  --wa-color-brand-on-loud: white;
+  --wa-color-brand-on-loud: var(--wa-color-brand-on);
 
   --wa-color-success-fill-loud: var(--wa-color-green-40);
 
@@ -51,13 +51,13 @@
     */
   --wa-color-brand-fill-quiet: var(--wa-color-brand-10);
   --wa-color-brand-fill-normal: var(--wa-color-brand-20);
-  --wa-color-brand-fill-loud: var(--wa-color-brand-40);
+  --wa-color-brand-fill-loud: var(--wa-color-brand);
   --wa-color-brand-border-quiet: var(--wa-color-brand-20);
   --wa-color-brand-border-normal: var(--wa-color-brand-30);
   --wa-color-brand-border-loud: var(--wa-color-brand-40);
   --wa-color-brand-on-quiet: var(--wa-color-brand-60);
   --wa-color-brand-on-normal: var(--wa-color-brand-70);
-  --wa-color-brand-on-loud: white;
+  --wa-color-brand-on-loud: var(--wa-color-brand-on);
 
   --wa-color-success-fill-loud: var(--wa-color-green-40);
 

--- a/src/styles/themes/mellow/color.css
+++ b/src/styles/themes/mellow/color.css
@@ -30,7 +30,7 @@
   --wa-color-brand-fill-quiet: var(--wa-color-brand-90);
   --wa-color-brand-fill-normal: var(--wa-color-brand-80);
   --wa-color-brand-fill-loud: var(--wa-color-brand-40);
-  --wa-color-brand-border-quiet: var(--wa-color-brand-80);
+  --wa-color-brand-border-quiet: var(--wa-color-brand-50-max);
   --wa-color-brand-border-normal: var(--wa-color-brand-70);
   --wa-color-brand-border-loud: var(--wa-color-brand-60);
   --wa-color-brand-on-quiet: var(--wa-color-brand-40);

--- a/src/styles/themes/mellow/color.css
+++ b/src/styles/themes/mellow/color.css
@@ -29,8 +29,8 @@
    */
   --wa-color-brand-fill-quiet: var(--wa-color-brand-90);
   --wa-color-brand-fill-normal: var(--wa-color-brand-80);
-  --wa-color-brand-fill-loud: var(--wa-color-brand-40);
-  --wa-color-brand-border-quiet: var(--wa-color-brand-50-max);
+  --wa-color-brand-fill-loud: var(--wa-color-brand-50-max);
+  --wa-color-brand-border-quiet: var(--wa-color-brand-80);
   --wa-color-brand-border-normal: var(--wa-color-brand-70);
   --wa-color-brand-border-loud: var(--wa-color-brand-60);
   --wa-color-brand-on-quiet: var(--wa-color-brand-40);
@@ -39,7 +39,7 @@
 
   --wa-color-success-fill-quiet: var(--wa-color-green-90);
   --wa-color-success-fill-normal: var(--wa-color-green-80);
-  --wa-color-success-fill-loud: var(--wa-color-green-40);
+  --wa-color-success-fill-loud: var(--wa-color-green-50);
   --wa-color-success-border-quiet: var(--wa-color-green-80);
   --wa-color-success-border-normal: var(--wa-color-green-70);
   --wa-color-success-border-loud: var(--wa-color-green-60);
@@ -49,7 +49,7 @@
 
   --wa-color-warning-fill-quiet: var(--wa-color-yellow-90);
   --wa-color-warning-fill-normal: var(--wa-color-yellow-80);
-  --wa-color-warning-fill-loud: var(--wa-color-yellow-40);
+  --wa-color-warning-fill-loud: var(--wa-color-yellow-50);
   --wa-color-warning-border-quiet: var(--wa-color-yellow-80);
   --wa-color-warning-border-normal: var(--wa-color-yellow-70);
   --wa-color-warning-border-loud: var(--wa-color-yellow-60);
@@ -59,7 +59,7 @@
 
   --wa-color-danger-fill-quiet: var(--wa-color-red-90);
   --wa-color-danger-fill-normal: var(--wa-color-red-80);
-  --wa-color-danger-fill-loud: var(--wa-color-red-40);
+  --wa-color-danger-fill-loud: var(--wa-color-red-50);
   --wa-color-danger-border-quiet: var(--wa-color-red-80);
   --wa-color-danger-border-normal: var(--wa-color-red-70);
   --wa-color-danger-border-loud: var(--wa-color-red-60);
@@ -69,7 +69,7 @@
 
   --wa-color-neutral-fill-quiet: var(--wa-color-gray-90);
   --wa-color-neutral-fill-normal: var(--wa-color-gray-80);
-  --wa-color-neutral-fill-loud: var(--wa-color-gray-40);
+  --wa-color-neutral-fill-loud: var(--wa-color-gray-50);
   --wa-color-neutral-border-quiet: var(--wa-color-gray-80);
   --wa-color-neutral-border-normal: var(--wa-color-gray-70);
   --wa-color-neutral-border-loud: var(--wa-color-gray-60);

--- a/src/styles/themes/playful/color.css
+++ b/src/styles/themes/playful/color.css
@@ -21,13 +21,13 @@
    */
   --wa-color-brand-fill-quiet: var(--wa-color-brand-90);
   --wa-color-brand-fill-normal: var(--wa-color-brand-80);
-  --wa-color-brand-fill-loud: var(--wa-color-brand-50);
+  --wa-color-brand-fill-loud: var(--wa-color-brand);
   --wa-color-brand-border-quiet: var(--wa-color-brand-90);
   --wa-color-brand-border-normal: var(--wa-color-brand-70);
   --wa-color-brand-border-loud: var(--wa-color-brand-50);
   --wa-color-brand-on-quiet: var(--wa-color-brand-30);
   --wa-color-brand-on-normal: var(--wa-color-brand-30);
-  --wa-color-brand-on-loud: white;
+  --wa-color-brand-on-loud: var(--wa-color-brand-on);
 
   --wa-color-success-fill-quiet: var(--wa-color-green-90);
   --wa-color-success-fill-normal: var(--wa-color-green-80);
@@ -94,13 +94,13 @@
    */
   --wa-color-brand-fill-quiet: var(--wa-color-brand-20);
   --wa-color-brand-fill-normal: var(--wa-color-brand-40);
-  --wa-color-brand-fill-loud: var(--wa-color-brand-50);
+  --wa-color-brand-fill-loud: var(--wa-color-brand);
   --wa-color-brand-border-quiet: var(--wa-color-brand-30);
   --wa-color-brand-border-normal: var(--wa-color-brand-40);
   --wa-color-brand-border-loud: var(--wa-color-brand-50);
   --wa-color-brand-on-quiet: var(--wa-color-brand-70);
   --wa-color-brand-on-normal: var(--wa-color-brand-90);
-  --wa-color-brand-on-loud: white;
+  --wa-color-brand-on-loud: var(--wa-color-brand-on);
 
   --wa-color-success-fill-quiet: var(--wa-color-green-20);
   --wa-color-success-fill-normal: var(--wa-color-green-40);

--- a/src/styles/themes/premium/color.css
+++ b/src/styles/themes/premium/color.css
@@ -1,6 +1,6 @@
 @import url('../../color/anodized.css');
 @import url('../default/color.css');
-@import url('../../brand/cyan.css');
+@import url('../../brand/pink.css');
 
 :where(:root),
 :host,
@@ -24,13 +24,13 @@
    */
   --wa-color-brand-fill-quiet: var(--wa-color-brand-95);
   --wa-color-brand-fill-normal: var(--wa-color-brand-90);
-  --wa-color-brand-fill-loud: var(--wa-color-brand-80);
+  --wa-color-brand-fill-loud: var(--wa-color-brand);
   --wa-color-brand-border-quiet: var(--wa-color-brand-80);
   --wa-color-brand-border-normal: var(--wa-color-brand-70);
   --wa-color-brand-border-loud: var(--wa-color-brand-50);
   --wa-color-brand-on-quiet: var(--wa-color-brand-40);
   --wa-color-brand-on-normal: var(--wa-color-brand-30);
-  --wa-color-brand-on-loud: var(--wa-color-brand-20);
+  --wa-color-brand-on-loud: var(--wa-color-brand-on);
 
   --wa-color-success-fill-quiet: var(--wa-color-green-95);
   --wa-color-success-fill-normal: var(--wa-color-green-90);
@@ -98,13 +98,13 @@
     */
   --wa-color-brand-fill-quiet: var(--wa-color-brand-30);
   --wa-color-brand-fill-normal: var(--wa-color-brand-40);
-  --wa-color-brand-fill-loud: var(--wa-color-brand-80);
+  --wa-color-brand-fill-loud: var(--wa-color-brand);
   --wa-color-brand-border-quiet: var(--wa-color-brand-30);
   --wa-color-brand-border-normal: var(--wa-color-brand-40);
   --wa-color-brand-border-loud: var(--wa-color-brand-70);
   --wa-color-brand-on-quiet: var(--wa-color-brand-70);
   --wa-color-brand-on-normal: var(--wa-color-brand-90);
-  --wa-color-brand-on-loud: var(--wa-color-brand-20);
+  --wa-color-brand-on-loud: var(--wa-color-brand-on);
 
   --wa-color-success-fill-quiet: var(--wa-color-green-30);
   --wa-color-success-fill-normal: var(--wa-color-green-40);

--- a/src/styles/themes/premium/color.css
+++ b/src/styles/themes/premium/color.css
@@ -1,6 +1,6 @@
 @import url('../../color/anodized.css');
 @import url('../default/color.css');
-@import url('../../brand/pink.css');
+@import url('../../brand/cyan.css');
 
 :where(:root),
 :host,


### PR DESCRIPTION
Updates our themes to use tintless or clamped `brand` colors where applicable.

The following themes now use whatever the core color is for any hue assigned to `brand`:

- Active
- Glossy
- Playful
- Premium

The following themes use the core color clamped to a specific range:
- Awesome (light: `70-min`, dark: `50-max` — limits contrast with surfaces and ensures button borders stand out)
- Brutalist (light: `50-max`, dark: `70-min` — ensures high contrast with surfaces)
- Default (light and dark: `50-max` — ensures compliant contrast with surfaces)
- Mellow (light and dark: `50-max` — ensures compliant contrast with surfaces)

The following themes are left unchanged because they intentionally target a specific tint to match their sources of inspiration:
- Classic (Shoelace)
- Matter (Material)
- Tailspin (Tailwind)


Additionally, I've added convenience tokens for `--wa-color-brand-70-max` and `--wa-color-brand-70-min`. The latter was immediately useful!

---

Comments on scope:

- `--wa-color-brand-on` is only useful when paired with `--wa-color-brand`. We can't use this token with a clamped value, like `--wa-color-brand-60-max`, because `brand-on` is based on the core color, not the clamped value that's taking effect. So, if the core color is e.g. `70`, `brand-on` will always be `10`, whether the resulting background color is `60`, `50`, or `40`.
- We can only use these tintless/clamped tokens on other `brand` tokens. I wonder if we ought to support `success`, `neutral`, etc. with this system as well. Worth exploring further!