### PR TITLE
Fix missing listbox border, closes #653

### DIFF
--- a/src/components/select/select.css
+++ b/src/components/select/select.css
@@ -194,7 +194,7 @@
   background: var(--wa-color-surface-raised);
   border-color: var(--wa-color-surface-border);
   border-radius: var(--wa-border-radius-m);
-  border-style: var(--border-style);
+  border-style: var(--wa-border-style);
   border-width: var(--border-width);
   padding-block: var(--wa-space-xs);
   padding-inline: 0;


### PR DESCRIPTION
Fixes the missing border on the listbox in `<wa-select>`. All other styles already match those used in `<wa-menu>` (referenced as `<wa-dropdown>` in the original issue).

I opted to simply change `border-style: var(--border-style)` to `border-style: var(--wa-border-style)` since the lack of `--border-style` in the docs leads me to believe that our intention was to retire this custom property. Notably, this does mean that folks have to target `::part(listbox)` to style this border, though I think that's a better expression of intent over sharing `--border-style` between the combobox and listbox.

We could instead define and use `--border-style` in `styles/native/select.css`, and keep `--border-style` in `components/select/select.css`, in which case it would affect both the combobox border and the listbox border. I don't feel strongly either way.