### PR TITLE
[Tiny PR, 8 loc diff] Reduce build process noise

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -379,7 +379,9 @@ if (isDeveloping) {
         return;
       }
 
-      await regenerateBundle();
+      if (filename.includes('src/') && /\.(js|ts)$/.test(filename)) {
+        await regenerateBundle();
+      }
 
       // Copy stylesheets when CSS files change
       if (isCssStylesheet) {
@@ -392,7 +394,9 @@ if (isDeveloping) {
       }
 
       // This needs to be outside of "isComponent" check because SSR needs to run on CSS files too.
-      await generateDocs();
+      if (filename.includes('/docs/')) {
+        await generateDocs();
+      }
 
       reload();
     } catch (err) {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -379,7 +379,7 @@ if (isDeveloping) {
         return;
       }
 
-      if (filename.includes('src/') && /\.(js|ts)$/.test(filename)) {
+      if (filename.includes('src/') && /\.(js|ts|css)$/.test(filename)) {
         await regenerateBundle();
       }
 


### PR DESCRIPTION
- Only run 11ty when something has changed within `docs/`
- Only run esbuild if a JS file has changed within `src/`