### PR TITLE
Theme remixing fix: Order of params should not matter

### DIFF
--- a/docs/assets/scripts/tweak.js
+++ b/docs/assets/scripts/tweak.js
@@ -1,6 +1,6 @@
 /**
  * Get import code for remixed themes and tweaked palettes.
  */
-export { theme as getThemeCode } from './tweak/code.js';
+export { getThemeCode } from './tweak/code.js';
 export { cdnUrl, hueRanges, hues, selectors, tints, urls } from './tweak/data.js';
 export { default as Permalink } from './tweak/permalink.js';

--- a/docs/assets/scripts/tweak/code.js
+++ b/docs/assets/scripts/tweak/code.js
@@ -25,18 +25,23 @@ export function cssLiteral(value, options = {}) {
   }
 }
 
-export function theme(base, params, options) {
+// Params in correct order
+export const themeParams = ['colors', 'palette', 'brand', 'typography'];
+
+export function getThemeCode(base, params, options) {
   let ret = [];
 
   if (base) {
     ret.push(urls.theme(base));
   }
 
-  ret.push(
-    ...Object.entries(params)
-      .filter(([aspect, id]) => Boolean(id))
-      .map(([aspect, id]) => urls[aspect](id)),
-  );
+  for (let aspect of themeParams) {
+    let value = params[aspect];
+
+    if (value) {
+      ret.push(urls[aspect](value));
+    }
+  }
 
   return ret.map(url => cssImport(url, options)).join('\n');
 }

--- a/docs/docs/themes/demo.njk
+++ b/docs/docs/themes/demo.njk
@@ -37,7 +37,7 @@ eleventyComputed:
 
 <script type="module">
 import { urls as stylesheetURLs, docsURLs, icons } from "/assets/scripts/tweak/data.js";
-import { theme as getThemeCode } from "/assets/scripts/tweak/code.js";
+import { getThemeCode } from "/assets/scripts/tweak/code.js";
 
 function updateTheme() {
   let params = new URLSearchParams(window.location.search);


### PR DESCRIPTION
Currently, the order of params in a remixed theme makes a difference in the outcome. Worse yet, the URLs the theme remixing UI generates mean some tweaks don't take, namely, selecting a theme override for colors, and then overriding the accent color.

Example (local links)
* Works: http://localhost:4000/docs/themes/default/demo.html?colors=matter&brand=pink
* Doesn't work: http://localhost:4000/docs/themes/default/demo.html?brand=pink&colors=matter

This PR uses a fixed order that ensures everything gets applied correctly. 

_(Also renamed the `theme` export to `getThemeCode` since it was being renamed everywhere it was imported.)_