### PR TITLE
Fix bugs in style utilities

### DIFF
--- a/src/styles/utilities/appearance.css
+++ b/src/styles/utilities/appearance.css
@@ -45,7 +45,8 @@
 
   --outlined-border-color: var(--wa-color-border-normal);
 
-  --text-color: var(--wa-color-on-normal, var(--wa-color-neutral-on-normal));
+  --text-color: var(--wa-color-on-quiet, var(--wa-color-neutral-on-quiet));
+  --text-color-hover: var(--wa-color-on-normal, var(--wa-color-neutral-on-normal));
 }
 
 .wa-plain,

--- a/src/styles/utilities/size.css
+++ b/src/styles/utilities/size.css
@@ -9,10 +9,10 @@
 
 :host {
   /* Components are meant to override these */
-  --size-xs: var(--wa-space-xs);
-  --size-s: var(--wa-space-s);
-  --size-m: var(--wa-space-m);
-  --size-l: var(--wa-space-l);
+  --size-xs: var(--wa-font-size-xs);
+  --size-s: var(--wa-font-size-s);
+  --size-m: var(--wa-font-size-m);
+  --size-l: var(--wa-font-size-l);
 
   --space-xs: var(--wa-space-xs);
   --space-s: var(--wa-space-s);


### PR DESCRIPTION
Fixes two key bugs in our style utilities.

---

### 1) `filled` used `on-quiet` with `fill-normal`

Before this fix, `appearance="filled"` / `.wa-filled` specified `--wa-color-fill-normal` for `--background-color` and `--wa-color-on-quiet` for `--text-color`. This yields unexpected results when the `normal` and `quiet` colors in a theme are significantly difference.

For example, the following styles —
```css
--wa-color-brand-fill-quiet: var(--wa-color-brand-95);
--wa-color-brand-fill-normal: var(--wa-color-brand-50);
--wa-color-brand-on-quiet: var(--wa-color-brand-40);
--wa-color-brand-on-normal: white;
```

— yields the following results:
<img width="190" alt="Filled tags with light blue backgrounds and white text" src="https://github.com/user-attachments/assets/d4a9f3c0-3ee1-4c94-bb2f-c9e6f370bdd8" />

After this fix, the same styles yield the following results:
<img width="190" alt="Filled tags with light blue backgrounds and dark blue text" src="https://github.com/user-attachments/assets/d47e54ce-b713-4dca-8ad5-54585deba8d9" />


---

### 2) `size` based on space, not font size

Before this fix, the `--size-*` variables in our `size` utilities mapped to spacing tokens, e.g. `--size-m: var(--wa-space-m)`. This yields unexpected results in all themes, often resulting in a components that are smaller than intended since the spacing scale is not intended for sizes. Instead, we want these to map to font size tokens, e.g. e.g. `--size-m: var(--wa-font-size-m)`.

For example, our `size` utilities yielded larger than intended components for the Awesome theme, which has an increased spacing scale —
Before:
<img width="659" alt="Awesome buttons larger than the default font size" src="https://github.com/user-attachments/assets/05832bf4-55da-4ecb-a1ee-ae603123d47f" />

After:
<img width="659" alt="Awesome buttons matching the default font size" src="https://github.com/user-attachments/assets/053a8340-6ea5-4e73-b1a6-2d22c3db5789" />

And, our `size` utilities yielded smaller than intended `small` components for the Default theme (and many others), given the default spacing scale —
Before:
<img width="721" alt="Pair of small and medium dropdowns, small dropdown smaller than expected" src="https://github.com/user-attachments/assets/6bfc0264-4a2e-42b6-9bd4-798dc6d16f22" />

After:
<img width="721" alt="Pair of small and medium dropdowns, small dropdown not too small" src="https://github.com/user-attachments/assets/24ba5d48-a91c-4afc-b9e8-3a805ee6762a" />