### PR TITLE
fix color picker light dismiss

### DIFF
--- a/docs/docs/resources/changelog.md
+++ b/docs/docs/resources/changelog.md
@@ -16,7 +16,7 @@ During the alpha period, things might break! We take breaking changes very serio
 
 - Fixed `wa-pill` class for text fields
 - Fixed `pill` style for `<wa-input>` elements
-- Fixed a bug in `<wa-color-picker>` that prevented light dismiss when clicking immediately above the color picker dropdown
+- Fixed a bug in `<wa-color-picker>` that prevented light dismiss from working when clicking immediately above the color picker dropdown
 
 ## 3.0.0-alpha.11
 

--- a/docs/docs/resources/changelog.md
+++ b/docs/docs/resources/changelog.md
@@ -16,6 +16,7 @@ During the alpha period, things might break! We take breaking changes very serio
 
 - Fixed `wa-pill` class for text fields
 - Fixed `pill` style for `<wa-input>` elements
+- Fixed a bug in `<wa-color-picker>` that prevented light dismiss when clicking immediately above the color picker dropdown
 
 ## 3.0.0-alpha.11
 

--- a/src/components/color-picker/color-picker.css
+++ b/src/components/color-picker/color-picker.css
@@ -278,11 +278,11 @@
 }
 
 /*
-   * Color dropdown
-   */
+ * Color dropdown
+ */
 
 .color-dropdown {
-  display: flex;
+  display: contents;
 }
 
 .color-dropdown::part(panel) {


### PR DESCRIPTION
- Fixes https://github.com/shoelace-style/webawesome-alpha/issues/192#issuecomment-2718373126
- Sets `display: content` on the internal dropdown's host element so it doesn't span the width causing clicks visually outside the dropdown to be "inside" the dropdown and thus ignored