### PR TITLE
[Select] More robust dynamic value / options handling, fixes #789

### DIFF
--- a/src/components/select/select.test.ts
+++ b/src/components/select/select.test.ts
@@ -647,6 +647,7 @@ describe('<wa-select>', () => {
             );
             const el = form.querySelector<WaSelect>('wa-select')!;
 
+            expect(el.defaultValue).to.equal('option-1');
             expect(el.value).to.equal('');
             expect(new FormData(form).get('select')).equal('');
 
@@ -657,6 +658,7 @@ describe('<wa-select>', () => {
 
             await aTimeout(10);
             await el.updateComplete;
+            expect(el.optionValues ? [...el.optionValues] : []).to.have.members(['option-1']);
             expect(el.value).to.equal('option-1');
             expect(new FormData(form).get('select')).equal('option-1');
           });
@@ -745,6 +747,8 @@ describe('<wa-select>', () => {
             );
 
             const el = form.querySelector<WaSelect>('wa-select')!;
+            expect(el.optionValues ? [...el.optionValues] : []).to.have.members(['bar', 'baz']);
+            expect(el.optionValues?.size).to.equal(2);
             expect(el.value).to.have.members(['bar', 'baz']);
             expect(el.value!.length).to.equal(2);
             expect(new FormData(form).getAll('select')).to.have.members(['bar', 'baz']);
@@ -758,6 +762,36 @@ describe('<wa-select>', () => {
             await el.updateComplete;
             expect(el.value).to.have.members(['foo', 'bar', 'baz']);
             expect(new FormData(form).getAll('select')).to.have.members(['foo', 'bar', 'baz']);
+          });
+        });
+
+        describe('With setting the value via JS', () => {
+          it('Should preserve value even if not returned', async () => {
+            const form = await fixture<HTMLFormElement>(
+              html` <form>
+                <wa-select name="select">
+                  <wa-option value="bar">Bar</wa-option>
+                  <wa-option value="baz">Baz</wa-option>
+                </wa-select>
+              </form>`,
+            );
+
+            const el = form.querySelector<WaSelect>('wa-select')!;
+            expect(el.value).to.equal('');
+
+            el.value = 'foo';
+            await aTimeout(10);
+            await el.updateComplete;
+            expect(el.value).to.equal('');
+
+            const option = document.createElement('wa-option');
+            option.value = 'foo';
+            option.innerText = 'Foo';
+            el.append(option);
+
+            await aTimeout(10);
+            await el.updateComplete;
+            expect(el.value).to.equal('foo');
           });
         });
       });


### PR DESCRIPTION
Fixes #789.

This PR implements a private property (`_value`) that keeps the full value of `this.value` around, whether its values exist in the DOM or not. Instead of subsetting it in place, which is lossy, it subsets it in a custom getter, so that these values are still preserved.

To avoid DOM I/O every time `el.value` is read, it also caches the values of DOM options in a set, stored in the private `optionValues` property. This is lazily evaluated when it is actually needed, using `undefined` as a dirty flag.

I discussed the general plan with @KonnorRogers earlier today and he agreed it was the way to go. Not my most elegant piece of code, but it does fix the issue, passes all tests (including new ones I added) and I cannot spot any regressions. 🤞🏼 