### PR TITLE
reflect href on buttons

### DIFF
--- a/src/components/button/button.ts
+++ b/src/components/button/button.ts
@@ -109,7 +109,7 @@ export default class WaButton extends WebAwesomeFormAssociatedElement {
   @property({ reflect: true }) value: string | null = null;
 
   /** When set, the underlying button will be rendered as an `<a>` with this `href` instead of a `<button>`. */
-  @property() href = '';
+  @property({ reflect: true }) href = null;
 
   /** Tells the browser where to open the link. Only used when `href` is present. */
   @property() target: '_blank' | '_parent' | '_self' | '_top';


### PR DESCRIPTION
Fixes https://github.com/shoelace-style/webawesome-alpha/issues/200#event-16915318670

This line in native buttons expect `href` on the host:

https://github.com/shoelace-style/webawesome/blob/07fe6d598ea8c56d029400d33286458f9086db7d/src/styles/native/button.css#L58