### PR TITLE
Several fixes around overviews, outlines etc

### DIFF
--- a/docs/_includes/grouped-pages.njk
+++ b/docs/_includes/grouped-pages.njk
@@ -3,7 +3,7 @@
 <section id="grid" class="index-grid">
 {% set groupedPages = allPages | groupPages(categories, page) %}
 {% for category, pages in groupedPages -%}
-  {% if groupedPages.meta.groupCount > 1 %}
+  {% if groupedPages.meta.groupCount > 1 and pages.length > 0 %}
   <h2 class="index-category" id="{{ category | slugify }}">
     {% if pages.meta.url %}<a href="{{ pages.meta.url }}">{{ pages.meta.title }}</a>
     {% else %}

--- a/docs/_includes/grouped-pages.njk
+++ b/docs/_includes/grouped-pages.njk
@@ -4,7 +4,7 @@
 {% set groupedPages = allPages | groupPages(categories, page) %}
 {% for category, pages in groupedPages -%}
   {% if groupedPages.meta.groupCount > 1 %}
-  <h2 class="index-category">
+  <h2 class="index-category" id="{{ category | slugify }}">
     {% if pages.meta.url %}<a href="{{ pages.meta.url }}">{{ pages.meta.title }}</a>
     {% else %}
     {{ pages.meta.title }}

--- a/docs/_includes/sidebar-link.njk
+++ b/docs/_includes/sidebar-link.njk
@@ -1,4 +1,4 @@
-{% if not (isAlpha and page.data.noAlpha) and not page.data.unlisted -%}
+{% if page | show -%}
 	<li>
 		<a href="{{ page.url }}">{{ page.data.title }}</a>
 		{% if page.data.status == 'experimental' %}<wa-icon name="flask"></wa-icon>{% endif %}

--- a/docs/_utils/filters.js
+++ b/docs/_utils/filters.js
@@ -321,6 +321,13 @@ export function groupPages(collection, options = {}, page) {
 
   if (sortedGroups) {
     ret = sortObject(ret, sortedGroups);
+  } else {
+    // At least make sure other is last
+    if (ret.other) {
+      let otherGroup = ret.other;
+      delete ret.other;
+      ret.other = otherGroup;
+    }
   }
 
   Object.defineProperty(ret, 'meta', {

--- a/docs/_utils/filters.js
+++ b/docs/_utils/filters.js
@@ -178,6 +178,10 @@ export function sort(arr, by = { 'data.order': 1, 'data.title': '' }) {
   });
 }
 
+export function show(page) {
+  return !(page.data.noAlpha && page.data.isAlpha) && !page.data.unlisted;
+}
+
 /**
  * Group an 11ty collection (or any array of objects with a `data.tags` property) by certain tags.
  * @param {object[]} collection
@@ -198,7 +202,7 @@ export function groupPages(collection, options = {}, page) {
     options = { tags: options };
   }
 
-  let { tags, groups, titles = {}, other = 'Other' } = options;
+  let { tags, groups, titles = {}, other = 'Other', filter = show } = options;
 
   if (groups === undefined && Array.isArray(tags)) {
     groups = tags;
@@ -236,6 +240,10 @@ export function groupPages(collection, options = {}, page) {
 
   let byUrl = {};
   let byParentUrl = {};
+
+  if (filter) {
+    collection = collection.filter(filter);
+  }
 
   for (let item of collection) {
     let url = item.page.url;

--- a/docs/_utils/outline.js
+++ b/docs/_utils/outline.js
@@ -39,7 +39,7 @@ export function outlinePlugin(options = {}) {
         }
 
         // Create a clone of the heading so we can remove links and [data-no-outline] elements from the text content
-        clone.querySelectorAll('a').forEach(a => a.remove());
+        clone.querySelectorAll('.wa-visually-hidden, [hidden], [aria-hidden="true"]').forEach(el => el.remove());
         clone.querySelectorAll('[data-no-outline]').forEach(el => el.remove());
 
         // Generate the link


### PR DESCRIPTION
These came up as I was working towards overviews for Patterns, and since they are more general fixes, I extracted them into a separate PR.

#### 1. Fix outline for headings that have links

Currently produces blank items because it assumes any link in a heading is an anchor link. Now it actually removes `.wa-visually-hidden, [hidden], [aria-hidden="true"]` instead of any `<a>` element. This removes anchor links AND other decorations, and does not interfere with regular content links.

#### 2. [Overview] Hide headings with only unlisted items

Currently pages are filtered only when the card is rendered, so a group with only unlisted pages still shows a heading.
This was done by:
- Adding a `show` filter for whether a page should be shown and using it in the sidebar too
- Adding a `filter` option to `groupPages()` that defaults to `show`

#### 3. [Overview] Ensure "Other" category is always last