### PR TITLE
Adds a hard coded delay to drastically reduce theme picker jank

### DIFF
--- a/docs/assets/scripts/theme-picker.js
+++ b/docs/assets/scripts/theme-picker.js
@@ -4,9 +4,12 @@ export function domChange(fn, { behavior = 'smooth' } = {}) {
     document.startViewTransition && !window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
   if (canUseViewTransitions && behavior === 'smooth') {
-    document.startViewTransition(fn);
-  } else {
-    fn(true);
+    const transition = document.startViewTransition(() => {
+      fn(true);
+      // Wait a brief delay before finishing the transition to prevent jumpiness
+      return new Promise(resolve => setTimeout(resolve, 200));
+    });
+    return transition;
   }
 }
 


### PR DESCRIPTION
The theme picker is janky when changing themes, likely due to the short delay in loading the new stylesheet. This is a fast, cheap way to reduce it for most users by adding a 200ms delay in the view transition.