### PR TITLE
Fix: Specify default card background

### DIFF
--- a/src/components/card/card.css
+++ b/src/components/card/card.css
@@ -5,6 +5,7 @@
 
   --spacing: var(--wa-space);
   --border-width: var(--wa-panel-border-width);
+  --outlined-background-color: var(--wa-color-surface-default);
   --outlined-border-color: var(--wa-color-surface-border);
   --border-radius: var(--wa-panel-border-radius);
   --inner-border-radius: calc(var(--border-radius) - var(--border-width));


### PR DESCRIPTION
Otherwise the default outlined background of `transparent` takes over, which breaks our theme preview.

Before:
<img width="1113" alt="image" src="https://github.com/user-attachments/assets/a733b47a-1d38-47c5-b4e0-a62a0fdb4fd9" />

After:
<img width="1123" alt="image" src="https://github.com/user-attachments/assets/d4729b3d-38c2-4809-a3e6-381fd1fb20de" />
