### PR TITLE
Theme icons, take 1

### DIFF
--- a/docs/_includes/head.njk
+++ b/docs/_includes/head.njk
@@ -24,6 +24,9 @@
 <link rel="stylesheet" href="/assets/styles/hydration-errors.css">
 <link rel="preconnect" href="https://cdn.jsdelivr.net">
 
+{# Internal components #}
+<script type="module" src="/assets/components/scoped.js"></script>
+
 {# Web Awesome #}
 <script type="module" src="/dist/webawesome.loader.js"></script>
 
@@ -46,7 +49,6 @@
 <link rel="stylesheet" href="/dist/styles/webawesome.css" />
 <link id="color-stylesheet" rel="stylesheet" href="/dist/styles/utilities.css" />
 <link rel="stylesheet" href="/dist/styles/forms.css" />
-
 
 {# Used by Web Awesome App to inject other assets into the head. #}
 {% server "head" %}

--- a/docs/_includes/svgs/theme-color.njk
+++ b/docs/_includes/svgs/theme-color.njk
@@ -1,13 +1,13 @@
 {% set themeId = theme.fileSlug %}
 
-<div>
-  <template shadowrootmode="open">
+<wa-scoped class="theme-icon-host theme-color-icon-host">
+  <template>
     <link rel="stylesheet" href="/dist/styles/utilities.css">
     <link rel="stylesheet" href="/dist/styles/themes/{{ page.fileSlug or 'default' }}.css">
     <link rel="stylesheet" href="/dist/styles/themes/{{ themeId }}/color.css">
     <link rel="stylesheet" href="/assets/styles/theme-icons.css">
 
-    <div class="theme-color-icon wa-theme-{{ themeId }}">
+    <div class="theme-icon theme-color-icon wa-theme-{{ themeId }}">
       <div class="wa-brand wa-accent">A</div>
       <div class="wa-brand wa-outlined">A</div>
       <div class="wa-brand wa-filled">A</div>
@@ -21,4 +21,4 @@
       {# <div class="wa-warning wa-outlined wa-filled"><wa-icon slot="icon" name="triangle-exclamation" variant="regular"></wa-icon></div> #}
     </div>
   </template>
-</div>
+</wa-scoped>

--- a/docs/_includes/svgs/theme-typography.njk
+++ b/docs/_includes/svgs/theme-typography.njk
@@ -1,16 +1,16 @@
-{% set themeId = theme.fileSlug %}
+{% set themeId = theme.fileSlug or page.fileSlug %}
 
-<div>
-  <template shadowrootmode="open">
+<wa-scoped class="theme-icon-host theme-typography-icon-host">
+  <template>
     <link rel="stylesheet" href="/dist/styles/native/content.css">
     <link rel="stylesheet" href="/dist/styles/native/blockquote.css">
     <link rel="stylesheet" href="/dist/styles/themes/{{ page.fileSlug or 'default' }}.css">
     <link rel="stylesheet" href="/dist/styles/themes/{{ themeId }}/typography.css">
     <link rel="stylesheet" href="/assets/styles/theme-icons.css">
 
-    <div class="theme-typography-icon wa-theme-{{ themeId }}" data-no-outline data-no-anchor role="presentation">
+    <div class="theme-icon theme-typography-icon wa-theme-{{ themeId }}" data-no-outline data-no-anchor role="presentation">
       <h3>Title</h3>
       <p>Body text</p>
     </div>
   </template>
-</div>
+</wa-scoped>

--- a/docs/_includes/svgs/theme.njk
+++ b/docs/_includes/svgs/theme.njk
@@ -1,0 +1,28 @@
+{% set themeId = theme.fileSlug or page.fileSlug %}
+
+<div class="theme-icon-host theme-overall-icon-host">
+  <template shadowrootmode="open">
+    <link rel="stylesheet" href="/dist/styles/utilities.css">
+    <link rel="stylesheet" href="/dist/styles/native/content.css">
+    <link rel="stylesheet" href="/dist/styles/themes/{{ themeId }}.css">
+    <link rel="stylesheet" href="/assets/styles/theme-icons.css">
+
+    <div class="theme-icon theme-overall-icon wa-theme-{{ themeId }}" role="presentation" data-no-anchor data-no-outline>
+      <div class="row row-1">
+        <h2>Aa</h2>
+        <div class="swatches">
+          <div class="wa-brand"></div>
+
+          <div class="wa-success"></div>
+          <div class="wa-warning"></div>
+          <div class="wa-danger"></div>
+          <div class="wa-neutral"></div>
+        </div>
+      </div>
+      <div class="row row-2">
+        <wa-input value="Input" size="small"></wa-input>
+        <wa-button size="small" variant="brand">Go</wa-button>
+      </div>
+    </div>
+  </template>
+</div>

--- a/docs/_includes/svgs/theme.njk
+++ b/docs/_includes/svgs/theme.njk
@@ -1,7 +1,8 @@
 {% set themeId = theme.fileSlug or page.fileSlug %}
 
-<div class="theme-icon-host theme-overall-icon-host">
-  <template shadowrootmode="open">
+
+<wa-scoped class="theme-icon-host theme-overall-icon-host">
+  <template>
     <link rel="stylesheet" href="/dist/styles/utilities.css">
     <link rel="stylesheet" href="/dist/styles/native/content.css">
     <link rel="stylesheet" href="/dist/styles/themes/{{ themeId }}.css">
@@ -25,4 +26,4 @@
       </div>
     </div>
   </template>
-</div>
+</wa-scoped>

--- a/docs/_includes/svgs/theme.njk
+++ b/docs/_includes/svgs/theme.njk
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="/dist/styles/themes/{{ themeId }}.css">
     <link rel="stylesheet" href="/assets/styles/theme-icons.css">
 
-    <div class="theme-icon theme-overall-icon wa-theme-{{ themeId }}" role="presentation" data-no-anchor data-no-outline>
+    <div class="theme-icon theme-overall-icon" role="presentation" data-no-anchor data-no-outline>
       <div class="row row-1">
         <h2>Aa</h2>
         <div class="swatches">

--- a/docs/assets/components/scoped.js
+++ b/docs/assets/components/scoped.js
@@ -18,6 +18,9 @@ export default class WaScoped extends HTMLElement {
 
   connectedCallback() {
     this.render();
+    this.ownerDocument.documentElement.addEventListener('wa-color-scheme-change', e =>
+      this.#applyDarkMode(e.detail.dark),
+    );
   }
 
   render() {
@@ -47,8 +50,18 @@ export default class WaScoped extends HTMLElement {
     this.shadowRoot.append(...nodes);
 
     this.#fixStyles();
+    this.#applyDarkMode();
 
     this.observer.observe(this, { childList: true, subtree: true, characterData: true });
+  }
+
+  #applyDarkMode(isDark = getComputedStyle(this).colorScheme === 'dark') {
+    // Hack to make dark mode work
+    // NOTE If any child nodes actually have .wa-dark, this will override it
+    for (let node of this.shadowRoot.children) {
+      node.classList.toggle('wa-dark', isDark);
+    }
+    this.classList.toggle('wa-dark', isDark);
   }
 
   /**

--- a/docs/assets/components/scoped.js
+++ b/docs/assets/components/scoped.js
@@ -1,0 +1,156 @@
+/**
+ * Low-level utility to encapsulate a bit of HTML (mainly to apply certain stylesheets to it without them leaking to the rest of the page)
+ * Usage: <wa-scoped><template><!-- your HTML here --></template></wa-scoped>
+ */
+
+// Map of <wa-scoped> elements to any global <style> elements they’ve created
+const imports = new Set();
+const fontFaceRules = new Set();
+
+export default class WaScoped extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+
+    this.observer = new MutationObserver(() => this.render());
+    this.observer.observe(this, { childList: true, subtree: true, characterData: true });
+  }
+
+  connectedCallback() {
+    this.render();
+  }
+
+  render() {
+    this.observer.takeRecords();
+    this.observer.disconnect();
+
+    this.shadowRoot.innerHTML = '';
+
+    // To avoid mutating this.childNodes while iterating over it
+    let nodes = [];
+
+    for (let template of this.childNodes) {
+      // Other solutions we can try if needed: <script type="text/html">, or comment nodes
+      if (template instanceof HTMLTemplateElement) {
+        if (template.content.childNodes.length > 0) {
+          nodes.push(template.content.cloneNode(true));
+        } else if (template.childNodes.length > 0) {
+          // Fake template, suck its children out of the light DOM
+          nodes.push(...template.childNodes);
+        }
+      } else {
+        // Regular child, suck it out of the light DOM
+        nodes.push(template);
+      }
+    }
+
+    this.shadowRoot.append(...nodes);
+
+    this.#fixStyles();
+
+    this.observer.observe(this, { childList: true, subtree: true, characterData: true });
+  }
+
+  /**
+   * @font-face does not work in shadow DOM in Chrome & FF, as of March 2025 https://issues.chromium.org/issues/41085401
+   * This works around this issue by traversing the shadow DOM CSS looking
+   * for @font-face rules or CSS imports to known font providers and copies them to the main document
+   */
+  async #fixStyles() {
+    let styleElements = [...this.shadowRoot.querySelectorAll('link[rel="stylesheet"], style')];
+
+    let loadStates = styleElements.map(element => {
+      try {
+        if (element.sheet?.cssRules) {
+          // Already loaded
+          return Promise.resolve(element.sheet);
+        }
+      } catch (e) {
+        // CORS
+        return Promise.resolve(null);
+      }
+
+      return new Promise((resolve, reject) => {
+        element.addEventListener('load', e => resolve(element.sheet));
+        element.addEventListener('error', e => reject(null));
+      });
+    });
+
+    await Promise.allSettled(loadStates);
+
+    let fontRules = findFontFaceRules(...this.shadowRoot.styleSheets);
+
+    if (!fontRules.length) {
+      return;
+    }
+
+    let doc = this.ownerDocument;
+    // Why not adoptedStyleSheets? Can't have @import in those yet
+    let id = `wa-scoped-hoisted-fonts`;
+    let style = doc.head.querySelector('style#' + id);
+    if (!style) {
+      style = Object.assign(doc.createElement('style'), { id, textContent: ' ' });
+      doc.head.append(style);
+    }
+    let sheet = style.sheet;
+
+    for (let rule of fontRules) {
+      let cssText = rule.cssText;
+      if (rule.type === CSSRule.FONT_FACE_RULE) {
+        if (fontFaceRules.has(cssText)) {
+          continue;
+        }
+        fontFaceRules.add(cssText);
+        sheet.insertRule(cssText);
+      } else if (rule.type === CSSRule.IMPORT_RULE) {
+        if (imports.has(rule.href)) {
+          continue;
+        }
+        imports.add(rule.href);
+        sheet.insertRule(cssText, 0);
+      }
+    }
+  }
+
+  static observedAttributes = [];
+}
+
+customElements.define('wa-scoped', WaScoped);
+
+export const WEB_FONT_HOSTS = [
+  'fonts.googleapis.com',
+  'fonts.gstatic.com',
+  'use.typekit.net',
+  'fonts.adobe.com',
+  'kit.fontawesome.com',
+  'pro.fontawesome.com',
+  'cdn.materialdesignicons.com',
+];
+
+function findFontFaceRules(...stylesheets) {
+  let ret = [];
+
+  for (let sheet of stylesheets) {
+    let rules;
+    try {
+      rules = sheet.cssRules;
+    } catch (e) {
+      // CORS
+      continue;
+    }
+
+    for (let rule of rules) {
+      if (rule.type === CSSRule.FONT_FACE_RULE) {
+        ret.push(rule);
+      } else if (rule.type === CSSRule.IMPORT_RULE) {
+        if (WEB_FONT_HOSTS.some(host => rule.href.includes(host))) {
+          ret.push(rule);
+        } else if (rule.styleSheet) {
+          ret.push(...findFontFaceRules(rule.styleSheet));
+        }
+      }
+    }
+  }
+
+  return ret;
+}

--- a/docs/assets/scripts/theme-picker.js
+++ b/docs/assets/scripts/theme-picker.js
@@ -103,6 +103,7 @@ const colorScheme = new ThemeAspect({
     domChange(() => {
       let dark = this.computedValue === 'dark';
       document.documentElement.classList.toggle(`wa-dark`, dark);
+      document.documentElement.dispatchEvent(new CustomEvent('wa-color-scheme-change', { detail: { dark } }));
     });
   },
 });

--- a/docs/assets/styles/docs.css
+++ b/docs/assets/styles/docs.css
@@ -4,6 +4,7 @@
 @import 'outline.css';
 @import 'search.css';
 @import 'cera_typeface.css';
+@import 'theme-icons.css';
 
 :root {
   --wa-brand-orange: #f36944;
@@ -400,7 +401,6 @@ wa-page > main:has(> .index-grid) {
 
     &::part(header) {
       background-color: var(--header-background, var(--wa-color-neutral-fill-quiet));
-      border-bottom: none;
       display: flex;
       align-items: center;
       justify-content: center;

--- a/docs/assets/styles/theme-icons.css
+++ b/docs/assets/styles/theme-icons.css
@@ -91,17 +91,17 @@ wa-card:has(> .theme-icon-host, > [slot='header'] > .theme-icon-host) {
 
   .swatches {
     display: flex;
-    gap: var(--wa-space-2xs);
+    gap: var(--wa-space-3xs);
 
     > div {
-      width: 1em;
-      height: 2em;
+      width: 1.25rem;
+      height: 1.25rem;
       border-radius: var(--wa-border-radius-s);
       background: var(--wa-color-fill-loud);
       color: var(--wa-color-on-loud);
 
       &.wa-brand {
-        width: 2em;
+        width: 2.5rem;
       }
     }
   }

--- a/docs/assets/styles/theme-icons.css
+++ b/docs/assets/styles/theme-icons.css
@@ -20,6 +20,7 @@ wa-card:has(> .theme-icon-host, > [slot='header'] > .theme-icon-host) {
 }
 
 .theme-icon {
+  padding: var(--wa-space-xs) var(--wa-space-m);
   border-radius: inherit;
   box-sizing: border-box;
 
@@ -68,7 +69,6 @@ wa-card:has(> .theme-icon-host, > [slot='header'] > .theme-icon-host) {
   width: 100%;
   min-height: 7.5rem;
   box-sizing: border-box;
-  padding: var(--wa-space-xs) var(--wa-space-m);
   background: var(--wa-color-surface-lowered);
 
   .row {

--- a/docs/assets/styles/theme-icons.css
+++ b/docs/assets/styles/theme-icons.css
@@ -1,3 +1,36 @@
+wa-card:has(> .theme-icon-host, > [slot='header'] > .theme-icon-host) {
+  min-width: 22ch;
+
+  &::part(header) {
+    /* We want to add a background color, so any spacing needs to go on .theme-icon */
+    padding: 0;
+    min-block-size: 0;
+  }
+
+  [slot='header'] {
+    display: block;
+    width: 100%;
+    border-radius: inherit;
+  }
+}
+
+.theme-icon-host {
+  display: block;
+  border-radius: inherit;
+}
+
+.theme-icon {
+  border-radius: inherit;
+  box-sizing: border-box;
+
+  h2,
+  h3,
+  p {
+    margin-block: 0;
+    padding: 0;
+  }
+}
+
 .theme-color-icon {
   display: grid;
   gap: var(--wa-space-xs);
@@ -25,10 +58,51 @@
   display: flex;
   flex-direction: column;
   gap: var(--wa-space-xs);
+}
 
-  h3,
-  p {
-    margin-block: 0;
-    padding: 0;
+.theme-overall-icon {
+  display: flex;
+  flex-flow: column;
+  gap: var(--wa-space-xs);
+  justify-content: center;
+  width: 100%;
+  min-height: 7.5rem;
+  box-sizing: border-box;
+  padding: var(--wa-space-xs) var(--wa-space-m);
+  background: var(--wa-color-surface-lowered);
+
+  .row {
+    display: flex;
+    gap: var(--wa-space-xs);
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .row-2 {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    contain: inline-size;
+    width: 100%;
+
+    wa-input {
+      min-width: 1em;
+    }
+  }
+
+  .swatches {
+    display: flex;
+    gap: var(--wa-space-2xs);
+
+    > div {
+      width: 1em;
+      height: 2em;
+      border-radius: var(--wa-border-radius-s);
+      background: var(--wa-color-fill-loud);
+      color: var(--wa-color-on-loud);
+
+      &.wa-brand {
+        width: 2em;
+      }
+    }
   }
 }

--- a/docs/docs/themes/themes.json
+++ b/docs/docs/themes/themes.json
@@ -3,6 +3,7 @@
   "wide": true,
   "tags": ["themes", "theme"],
   "brand": "blue",
+  "icon": "theme",
   "eleventyComputed": {
     "file": "styles/themes/{{ page.fileSlug }}.css"
   }


### PR DESCRIPTION
This is a prototype of theme icons based on @lindsaym-fa’s sketch: 

![image](https://github.com/user-attachments/assets/912a81b1-e94b-443c-934c-7754466c7f18)

> Current thinking is something like this —
> 
> - Overall background uses the default surface color. Maybe we also outline this with the surface border color.
> - Text sample uses the heading font
> - Swatches show the loud fills for brand, success, warning, and danger
> - Brand swatch is larger and has icon that uses the corresponding “on” color
> - Alternatively, we could focus in on the brand color and show loud, normal, and quiet fills as swatches
> - Second row includes a small input with placeholder text and a small brand button
> 
> That seems like it would be the minimum to get an impression of fonts, colors, rounding, borders, tactility, etc.
> 
> Open to suggestions or other explorations!

Screenshot:
<img width="1143" alt="image" src="https://github.com/user-attachments/assets/73123151-bfe7-4cd0-9f79-24a3bd216947" />

With `--wa-color-surface-default`:
<img width="1139" alt="image" src="https://github.com/user-attachments/assets/1813d0b9-f4e5-4aa0-8bf3-ac84ce3e141c" />

The icons are using the actual CSS files (rendered in shadow DOM) so they can easily work with custom themes.
I did not include the icon on the brand swatch since it will just be noise until we can have different icons per theme (but I’m not opposed to adding them now if you feel that's best).

I feel they look a bit too noisy all together, but it gives us a starting point we can improve on. Of course it goes without saying that if you have the cycles @lindsaym-fa feel free to go in this PR and tweak them to your heart's content.