### PR TITLE
fix search for webawesome app

### DIFF
--- a/docs/_utils/search.js
+++ b/docs/_utils/search.js
@@ -1,8 +1,8 @@
 /* eslint-disable no-invalid-this */
-import * as path from "path"
 import { mkdir, writeFile } from 'fs/promises';
 import lunr from 'lunr';
 import { parse } from 'node-html-parser';
+import * as path from 'path';
 import { dirname, join } from 'path';
 
 function collapseWhitespace(string) {
@@ -54,7 +54,7 @@ export function searchPlugin(options = {}) {
     });
 
     eleventyConfig.on('eleventy.after', ({ directories }) => {
-      const { output } = directories
+      const { output } = directories;
       const outputFilename = path.resolve(join(output, 'search.json'));
       const map = [];
       const searchIndex = lunr(async function () {

--- a/docs/_utils/search.js
+++ b/docs/_utils/search.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-invalid-this */
+import * as path from "path"
 import { mkdir, writeFile } from 'fs/promises';
 import lunr from 'lunr';
 import { parse } from 'node-html-parser';
@@ -52,8 +53,9 @@ export function searchPlugin(options = {}) {
       return content;
     });
 
-    eleventyConfig.on('eleventy.after', ({ dir }) => {
-      const outputFilename = join(dir.output, 'search.json');
+    eleventyConfig.on('eleventy.after', ({ directories }) => {
+      const { output } = directories
+      const outputFilename = path.resolve(join(output, 'search.json'));
       const map = [];
       const searchIndex = lunr(async function () {
         let index = 0;


### PR DESCRIPTION
Big thank you to @zachleat to helping me get this solved.

`dir.output` was always resolving to `"_site"` despite the web awesome app pre-compiling to a temp directory and then "hotswapping" the build directories.

Turns out, `dir` is basically deprecated and we should be using `directories.output`

This fixed search.json not working in the webawesome app.