### PR TITLE
Move `/docs/installation` to `/docs/`, fix parent URL logic, closes #585

### DIFF
--- a/docs/_includes/sidebar.njk
+++ b/docs/_includes/sidebar.njk
@@ -1,7 +1,7 @@
 {# Getting started #}
 <h2>Getting Started</h2>
 <ul>
-  <li><a href="/docs/installation">Installation</a></li>
+  <li><a href="/docs/">Installation</a></li>
   <li><a href="/docs/usage">Usage</a></li>
   <li><a href="/docs/customizing">Customizing</a></li>
   <li><a href="/docs/form-controls">Form Controls</a></li>

--- a/docs/docs/docs.11tydata.js
+++ b/docs/docs/docs.11tydata.js
@@ -94,12 +94,13 @@ function getParentUrl(url, parent) {
     ret = '/' + ret;
   }
 
-  if (!retParts.at(-1).includes('.') && !ret.endsWith('/')) {
+  if (!retParts.at(-1)?.includes('.') && !ret.endsWith('/')) {
     // If no extension, make sure to end with a slash
     ret += '/';
   }
 
   if (ret === '/docs/') {
+    // We don't want anyone's parent to be "Installation"!
     ret = '/';
   }
 

--- a/docs/docs/docs.11tydata.js
+++ b/docs/docs/docs.11tydata.js
@@ -5,8 +5,11 @@ import { sort } from '../_utils/filters.js';
 
 export default {
   eleventyComputed: {
-    // Default parent. Can be overridden by explicitly setting parent in the data.
-    // parent can refer to either an ancestor page in the URL or another page in the same directory
+    /**
+     * Default parent slug. Can be overridden by explicitly setting parent in the data.
+     * It can be either the URL slug of a page in the same directory or a parent directory.
+     * @returns {string | undefined}
+     */
     parent(data) {
       let { parent, page } = data;
 
@@ -17,16 +20,28 @@ export default {
       return page.url.split('/').filter(Boolean).at(-2);
     },
 
+    /**
+     * URL of parent page
+     * @returns {string | undefined}
+     */
     parentUrl(data) {
       let { parent, page } = data;
       return getParentUrl(page.url, parent);
     },
 
+    /**
+     * Collection item of parent page
+     * @returns {object | undefined} Parent page item
+     */
     parentItem(data) {
       let { parentUrl } = data;
       return data.collections.all.find(item => item.url === parentUrl);
     },
 
+    /**
+     * Child pages of current page
+     * @returns {object[]} Array of child pages
+     */
     children(data) {
       let { collections, page, parentOf } = data;
 
@@ -48,6 +63,12 @@ export default {
   },
 };
 
+/**
+ * Resolve a parent slug against a page URL
+ * @param {string} url - The URL of the page
+ * @param {string} parent - The slug of the parent page
+ * @returns {string} The resolved URL of the parent page
+ */
 function getParentUrl(url, parent) {
   if (!parent) {
     return undefined;
@@ -68,6 +89,8 @@ function getParentUrl(url, parent) {
   let ret = retParts.join('/');
 
   if (url.startsWith('/')) {
+    // If the current page starts with a slash, make sure the parent does too
+    // This is pretty much always the case with 11ty page URLs
     ret = '/' + ret;
   }
 

--- a/docs/docs/docs.11tydata.js
+++ b/docs/docs/docs.11tydata.js
@@ -49,6 +49,10 @@ export default {
 };
 
 function getParentUrl(url, parent) {
+  if (!parent) {
+    return undefined;
+  }
+
   let parts = url.split('/').filter(Boolean);
   let ancestorIndex = parts.findLastIndex(part => part === parent);
   let retParts = parts.slice();

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -32,7 +32,7 @@ To get everything included in Web Awesome, add the following code to the `<head>
 
 This snippet includes three parts:
 1. **The default theme**, a stylesheet that gives a cohesive look to Web Awesome components with both light and dark modes
-2. **Web Awesome styles**, an optional stylesheet that [styles native HTML elements](/docs/native) and includes [utility classes](/docs/utilities) you can use in your project 
+2. **Web Awesome styles**, an optional stylesheet that [styles native HTML elements](/docs/native) and includes [utility classes](/docs/utilities) you can use in your project
 3. **The autoloader**, a lightweight script watches the DOM for unregistered Web Awesome elements and lazy loads them for you — even if they're added dynamically
 
 Now you can [start using Web Awesome!](/docs/usage)
@@ -58,7 +58,7 @@ Font Awesome users can set their kit code to unlock Font Awesome Pro icons. You 
 
 ## Advanced Setup
 
-The autoloader is the easiest way to use Web Awesome, but different projects (or your own preferences!) may require different installation methods. 
+The autoloader is the easiest way to use Web Awesome, but different projects (or your own preferences!) may require different installation methods.
 
 ### Installing via npm
 


### PR DESCRIPTION
Closes #585 

- Moves `/docs/installation` to `/docs/`
- Fixes bug that @claviska hit. The fix was very simple (and indeed had nothing to do with 11ty's features!): the function that computed the parent page's URL did not account for pages with an empty parent. The only such page previously was the homepage, and that didn't have breadcrumbs so presumably the function never got called there so we hadn't noticed.
- I’ve also documented these data properties better (feedback welcome, do the comments make sense?) 