### PR TITLE
Import CRUD parts from #828, fix #851 

### DIFF
--- a/docs/_layouts/palette.njk
+++ b/docs/_layouts/palette.njk
@@ -30,12 +30,21 @@
 
   {% include 'breadcrumbs.njk' %}
 
-  <h1 v-if="saved" class="title">
-    {% raw %}{{ saved.title }}{% endraw %}
-    <wa-icon-button name="pencil" label="Rename palette" @click="rename"></wa-icon-button>
-    <wa-icon-button class="delete" name="trash" label="Delete palette" @click="deleteSaved"></wa-icon-button>
+  <h1 class="title">
+    <span v-content="paletteTitle">{{ title }}</span>
+    <template v-if="saved || tweaked">
+      <wa-icon-button name="pencil" label="Rename palette" @click="rename"></wa-icon-button>
+      <wa-icon-button v-if="saved" class="delete" name="trash" label="Delete palette" @click="deleteSaved"></wa-icon-button>
+      <wa-button @click="save()" :disabled="!unsavedChanges"
+        :variant="unsavedChanges ? 'success' : 'neutral'" size="small" :appearance="unsavedChanges ? 'accent' : 'outlined'">
+        <span slot="prefix" class="icon-modifier">
+          <wa-icon name="sidebar" variant="regular"></wa-icon>
+          <wa-icon name="circle-plus" class="modifier" style="color: light-dark(var(--wa-color-green-70), var(--wa-color-green-60));"></wa-icon>
+        </span>
+        <span v-content="unsavedChanges ? 'Save' : 'Saved'">Save</span>
+      </wa-button>
+    </template>
   </h1>
-  <h1 v-if="!saved" class="title">{{ title }}</h1>
 
   <div class="block-info">
     <code class="class">.wa-palette-{{ paletteId }}</code>
@@ -67,13 +76,6 @@
       <wa-icon name="circle-xmark" variant="regular"></wa-icon>
     </span>
     Reset
-  </wa-button>
-  <wa-button v-if="!saved" @click="save" variant="success">
-    <span slot="prefix" class="icon-modifier">
-      <wa-icon name="sidebar" variant="regular"></wa-icon>
-      <wa-icon name="circle-plus" class="modifier" style="color: light-dark(var(--wa-color-green-70), var(--wa-color-green-60));"></wa-icon>
-    </span>
-    Save
   </wa-button>
 </wa-callout>
 

--- a/docs/_layouts/palette.njk
+++ b/docs/_layouts/palette.njk
@@ -68,7 +68,7 @@
   <wa-icon name="sliders-simple" slot="icon" variant="regular"></wa-icon>
    This palette has been tweaked.
    <div class="wa-cluster wa-gap-xs">
-    <wa-tag v-for="tweakHumanReadable, param in tweaksHumanReadable" removable @wa-remove="reset(param)">{% raw %}{{ tweakHumanReadable }}{% endraw %}</wa-tag>
+    <wa-tag v-for="tweakHumanReadable, param in tweaksHumanReadable" removable @wa-remove="reset(param)" v-content="tweakHumanReadable"></wa-tag>
    </div>
 
   <wa-button @click="reset()" appearance="outlined" variant="danger">

--- a/docs/docs/themes/remix.js
+++ b/docs/docs/themes/remix.js
@@ -54,8 +54,12 @@ function init() {
     urlParams: new Permalink(),
   };
 
-  data.urlParams.mapObject(data.params);
-  data.urlParams.writeTo(data.params);
+  // Apply params from permalink
+  for (let key in data.params) {
+    if (data.urlParams.has(key)) {
+      data.params[key] = data.urlParams.get(key);
+    }
+  }
 
   if (computed.isRemixed) {
     // Start with the remixing UI open if the theme has been remixed
@@ -128,7 +132,11 @@ function render(changedAspect) {
     selects[aspect].value = value;
   }
 
-  data.urlParams.readFrom(data.params);
+  for (let key in data.params) {
+    if (data.params[key]) {
+      data.urlParams.set(key, data.params[key]);
+    }
+  }
 
   // Update demo URL
   domChange(() => {


### PR DESCRIPTION
This is a tiny subset of #828 (and thus, an even tinier subset of #777). 

It only includes a bugfix for #851 (by using `v-content` instead of `{% raw %}`) plus its CRUD (saving, renaming) changes, since these are the ones most needed for the themer. I left CRUD functionality last, but its time has come.

Besides the bugfix, the changes are:

(note: "entities" below refers to palettes and themes)

## User-facing

- Decoupled saving from naming: Saving now saves using the default title, and renaming is a separate action. Tweaking changes the title to the default title (original title + ' (tweaked)') even before saving (whereas currently it retains its existing title which can be confusing)
- Made saving explicit. While reaming automatically saves, tweaking further does not change your saved entity.
- Moved the Save button to the heading
- Save button becomes visible when tweaking and inactive when there are no unsaved changes 

## Refactor

### `Permalink` class

- Remove weird `mapObject()`, `readFrom()`, `writeTo()` methods from `Permalink` class and just use regular get/set. These abstractions did not provide enough utility to be worth their complexity.
- Support multi-valued params set via arrays 

### My saved stuff (`sidebar-tweaks.js` — yes, needs renaming)

Yes, this file is in dire need of renaming, but that needs to be done separately otherwise the diff will be a disaster. 

Notable changes:
- Saved entities (palettes, themes, etc) are now maintained in-memory, and synced with localStorage as needed, rather than reading from/to localStorage every time the data is accessed, which is costly
- Use uids exclusively to determine whether two entities are equal
- Move uid assignment logic to the saving method there instead of having it in the palette app