### PR TITLE
Remove unused custom properties from badge

### DIFF
--- a/src/components/badge/badge.ts
+++ b/src/components/badge/badge.ts
@@ -17,9 +17,6 @@ import styles from './badge.css';
  *
  * @cssproperty --background-color - The badge's background color.
  * @cssproperty --border-color - The color of the badge's border.
- * @cssproperty --border-radius - The radius of the badge's corners.
- * @cssproperty --border-style - The style of the badge's border.
- * @cssproperty --border-width - The width of the badge's border.
  * @cssproperty --text-color - The color of the badge's content.
  */
 @customElement('wa-badge')


### PR DESCRIPTION
Per https://github.com/shoelace-style/webawesome-alpha/issues/186#issuecomment-2763381600, some custom properties are documented but unused. This PR removes them from the docs.