### PR TITLE
Tiny fixes in saving mixin

### DIFF
--- a/docs/assets/scripts/sidebar-tweaks.js
+++ b/docs/assets/scripts/sidebar-tweaks.js
@@ -12,6 +12,11 @@ const sidebar = {
     // If we are on the same page, update the current link
     let url = location.href.replace(/#.+$/, '');
     if (url.startsWith(a.href)) {
+      // Remove existing current
+      for (let current of document.querySelectorAll('#sidebar a.current')) {
+        current.classList.remove('current');
+      }
+
       a.classList.add('current');
     }
 

--- a/docs/assets/scripts/vue/mixins/saved.js
+++ b/docs/assets/scripts/vue/mixins/saved.js
@@ -17,8 +17,8 @@ export default {
       this.saved = this.controller.saved.find(p => p.uid === this.uid);
     }
 
-    this.controller.addEventListener('delete', ({ detail: palette }) => {
-      if (palette.uid === this.saved?.uid) {
+    this.controller.addEventListener('delete', ({ detail: entity }) => {
+      if (entity.uid === this.saved?.uid) {
         this.postDelete();
       }
     });
@@ -61,7 +61,8 @@ export default {
     async save({ title } = {}) {
       let uid = this.uid;
 
-      this.saved ??= { id: this.paletteId, uid: this.uid };
+      this.saved ??= { uid: this.uid };
+      this.saved.id = this.id;
 
       if (title) {
         // Renaming
@@ -75,7 +76,7 @@ export default {
       this.saved = this.controller.save(this.saved);
 
       if (uid !== this.saved.uid) {
-        // UID changed (most likely from saving a new palette)
+        // UID changed (most likely from saving a new entity)
         this.uid = this.saved.uid;
         this.permalink.set('uid', this.uid);
         this.permalink.updateLocation();

--- a/docs/docs/palettes/tweak.js
+++ b/docs/docs/palettes/tweak.js
@@ -44,11 +44,11 @@ let paletteAppSpec = {
 
   data() {
     let appRoot = document.querySelector('#palette-app');
-    let paletteId = appRoot.dataset.paletteId;
-    let palette = allPalettes[paletteId];
+    let id = appRoot.dataset.paletteId;
+    let palette = allPalettes[id];
 
     return {
-      paletteId,
+      id,
       originalTitle: palette.title,
       originalColors: palette.colors,
       hueRanges,
@@ -121,7 +121,7 @@ let paletteAppSpec = {
     code() {
       let ret = {};
       for (let language of ['html', 'css']) {
-        let code = getPaletteCode(this.paletteId, this.colors, this.tweaked, { language, cdnUrl });
+        let code = getPaletteCode(this.id, this.colors, this.tweaked, { language, cdnUrl });
         ret[language] = {
           raw: code,
           highlighted: Prism.highlight(code, Prism.languages[language], language),


### PR DESCRIPTION
- Fix: Remove `current` class from existing sidebar link before adding it to new one or parents of saved entities are also highlighted
- Fix: Do not assume parent id of saved entity never changes, update it when saving
- Use `id` instead of `paletteId`
- Leftover rename palette → entity in some comments and variables

