### PR TITLE
Only apply `wa-button-group-vertical` class when relevant

### DIFF
--- a/src/components/radio-group/radio-group.ts
+++ b/src/components/radio-group/radio-group.ts
@@ -356,7 +356,7 @@ export default class WaRadioGroup extends WebAwesomeFormAssociatedElement {
           part="form-control-input"
           class=${classMap({
             'wa-button-group': this.hasRadioButtons,
-            'wa-button-group-vertical': this.orientation === 'vertical',
+            'wa-button-group-vertical': this.hasRadioButtons && this.orientation === 'vertical',
           })}
           @slotchange=${this.syncRadioElements}
         ></slot>


### PR DESCRIPTION
Only apply `wa-button-group-vertical` class when `<wa-radio-group>` is a radio button group, fixes #870