### PR TITLE
remove all references to /docs/installation

### DIFF
--- a/docs/_layouts/component.njk
+++ b/docs/_layouts/component.njk
@@ -255,7 +255,7 @@
   {# Importing #}
   <h2>Importing</h2>
   <p>
-    The <a href="/docs/installation/#quick-start-autoloading-via-cdn">autoloader</a> is the recommended way to import components. If you prefer to do it manually, use one of the following code snippets.
+    The <a href="/docs/#quick-start-autoloading-via-cdn">autoloader</a> is the recommended way to import components. If you prefer to do it manually, use one of the following code snippets.
   </p>
 
   <wa-tab-group label="How would you like to import this component?">

--- a/docs/docs/components/icon.md
+++ b/docs/docs/components/icon.md
@@ -17,7 +17,7 @@ Not sure which icon to use? [Find the perfect icon over at Font Awesome!](https:
 
 The default icon library is Font Awesome Free, which comes with two icon families: `classic` and `brands`. Use the `family` attribute to set the icon family.
 
-Many Font Awesome Pro icon families have variants such as `thin`, `light`, `regular`, and `solid`. Font Awesome Pro users can [provide their kit code](/docs/installation/#using-font-awesome-kit-codes) to unlock additional families, including `sharp` and `duotone`. For these icon families, use the `variant` attribute to set the variant.
+Many Font Awesome Pro icon families have variants such as `thin`, `light`, `regular`, and `solid`. Font Awesome Pro users can [provide their kit code](/docs/#using-font-awesome-kit-codes) to unlock additional families, including `sharp` and `duotone`. For these icon families, use the `variant` attribute to set the variant.
 
 ```html {.example}
 <wa-icon family="brands" name="font-awesome"></wa-icon>

--- a/docs/docs/customizing.md
+++ b/docs/docs/customizing.md
@@ -10,7 +10,7 @@ You can customize the look and feel of Web Awesome at a high level with themes. 
 
 Web Awesome uses [themes](/docs/themes) to apply a cohesive look and feel across the entire library. Themes are built with a collection of predefined CSS custom properties, which we call [design tokens](/docs/tokens), and there are many premade themes you can choose from.
 
-To use a theme, simply add a link to the theme's stylesheet to the `<head>` of your page. For example, you can replace the link to `default.css` in the [installation code](/docs/installation/#quick-start-autoloading-via-cdn) with this snippet to use the *Awesome* theme:
+To use a theme, simply add a link to the theme's stylesheet to the `<head>` of your page. For example, you can replace the link to `default.css` in the [installation code](/docs/#quick-start-autoloading-via-cdn) with this snippet to use the *Awesome* theme:
 
 ```html
 <link rel="stylesheet" href="{% cdnUrl 'styles/themes/awesome.css' %}" />
@@ -197,7 +197,7 @@ For example, we can give all outlined callouts a thick left border, regardless o
 
 <style>
   wa-callout:is(
-    [appearance~="outlined"], 
+    [appearance~="outlined"],
     .wa-outlined
   ) {
     border-left-width: var(--wa-panel-border-radius);

--- a/docs/docs/layout.njk
+++ b/docs/docs/layout.njk
@@ -10,7 +10,7 @@ override:tags: []
 {% markdown %}
 ## Installation
 
-Layout components are included in Web Awesome's [autoloader](/docs/installation/#quick-start-autoloading-via-cdn). You can also import them individually via [cherry picking](/docs/installation/#cherry-picking).
+Layout components are included in Web Awesome's [autoloader](/docs/#quick-start-autoloading-via-cdn). You can also import them individually via [cherry picking](/docs/#cherry-picking).
 
 Layout utilities are bundled with all [style utilities](/docs/utilities). You can import all Web Awesome page styles (including [native styles](/docs/native/)) by including the following stylesheet in your project:
 

--- a/docs/docs/patterns/index.njk
+++ b/docs/docs/patterns/index.njk
@@ -22,7 +22,7 @@ Patterns are written as standard HTML, so you can use them just as you would any
 
 To use a pattern in your project, refer to each pattern's docs for a copyable code snippet. Paste the snippet wherever you'd like the pattern to appear in your project.
 
-Because patterns use a combination of Web Awesome features, they work best when you have [native styles](/docs/native), [style utilities](/docs/utilities), and a [theme](/docs/themes) installed in addition to Web Awesome [components](/docs/components). Refer to the [Installation page](/docs/installation) to set up all of these features in your project.
+Because patterns use a combination of Web Awesome features, they work best when you have [native styles](/docs/native), [style utilities](/docs/utilities), and a [theme](/docs/themes) installed in addition to Web Awesome [components](/docs/components). Refer to the [Installation page](/docs/) to set up all of these features in your project.
 
 {% endmarkdown %}
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -286,7 +286,7 @@ layout: page
       </wa-callout>
     </div>
     <div>
-      <wa-button href="/docs/installation" appearance="outlined" class="tile">
+      <wa-button href="/docs/" appearance="outlined" class="tile">
         <div style="display: flex; justify-content: space-between; align-items: center; margin-block-end: 1rem;">
           <div class="icon-heading" style="margin-block-end: 0;">
             <wa-icon name="pen-ruler" fixed-width></wa-icon>


### PR DESCRIPTION
It appears `/docs/installation` has moved to `/docs/` but we had some old links still pointing to `/docs/installation`. This PR cleans that up.