### PR TITLE
Fix broken demo, improve passthrough CSS

### DIFF
--- a/docs/docs/tokens/focus.md
+++ b/docs/docs/tokens/focus.md
@@ -27,7 +27,7 @@ See your theme's focus ring in action by navigating this form example with your 
 <style>
   form > * + * {
     display: block;
-    --display-outside: block;
+    --display: block;
     width: fit-content;
     margin-block-start: var(--wa-space-m);
   }

--- a/docs/docs/tokens/focus.md
+++ b/docs/docs/tokens/focus.md
@@ -27,6 +27,7 @@ See your theme's focus ring in action by navigating this form example with your 
 <style>
   form > * + * {
     display: block;
+    --display-outside: block;
     width: fit-content;
     margin-block-start: var(--wa-space-m);
   }

--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -1,6 +1,5 @@
 :host {
-  --display-inside: flex;
-  --display-outside: inline;
+  --display: inline-flex;
 
   position: relative;
 }

--- a/src/components/button/button.css
+++ b/src/components/button/button.css
@@ -1,11 +1,8 @@
 :host {
-  display: contents;
-  position: relative;
-}
+  --display-inside: flex;
+  --display-outside: inline;
 
-:where([part~='base']) {
-  all: inherit;
-  display: inline-flex;
+  position: relative;
 }
 
 /*

--- a/src/components/button/button.ts
+++ b/src/components/button/button.ts
@@ -7,6 +7,7 @@ import { MirrorValidator } from '../../internal/validators/mirror-validator.js';
 import { watch } from '../../internal/watch.js';
 import { WebAwesomeFormAssociatedElement } from '../../internal/webawesome-form-associated-element.js';
 import nativeStyles from '../../styles/native/button.css';
+import passthroughStyles from '../../styles/shadow/passthrough.css';
 import appearanceStyles from '../../styles/utilities/appearance.css';
 import sizeStyles from '../../styles/utilities/size.css';
 import variantStyles from '../../styles/utilities/variants.css';
@@ -39,6 +40,9 @@ import styles from './button.css';
  * @csspart caret - The button's caret icon, a `<wa-icon>` element.
  * @csspart spinner - The spinner that shows when the button is in the loading state.
  *
+ * @cssproperty --display - Set to `none` to hide the element, or any other valid `display` value to override the internal `display` value of the `base` part.
+ * @cssproperty [--display-outside=inline] - How content flows around the element. Valid values are `inline` and `block`.
+ * @cssproperty [--display-inside=flex] - How to lay the button’s contents. Valid values are `flex`, `grid`, and every other valid [`<display-inside>`](https://developer.mozilla.org/en-US/docs/Web/CSS/display-inside) value
  * @cssproperty --background-color - The button's background color when the button is not being interacted with.
  * @cssproperty --background-color-active - The button's background color when active.
  * @cssproperty --background-color-hover - The button's background color on hover.
@@ -51,7 +55,7 @@ import styles from './button.css';
  */
 @customElement('wa-button')
 export default class WaButton extends WebAwesomeFormAssociatedElement {
-  static shadowStyle = [variantStyles, appearanceStyles, sizeStyles, nativeStyles, styles];
+  static shadowStyle = [passthroughStyles, variantStyles, appearanceStyles, sizeStyles, nativeStyles, styles];
   static rectProxy = 'button';
 
   static get validators() {

--- a/src/components/button/button.ts
+++ b/src/components/button/button.ts
@@ -41,8 +41,6 @@ import styles from './button.css';
  * @csspart spinner - The spinner that shows when the button is in the loading state.
  *
  * @cssproperty --display - Set to `none` to hide the element, or any other valid `display` value to override the internal `display` value of the `base` part.
- * @cssproperty [--display-outside=inline] - How content flows around the element. Valid values are `inline` and `block`.
- * @cssproperty [--display-inside=flex] - How to lay the button’s contents. Valid values are `flex`, `grid`, and every other valid [`<display-inside>`](https://developer.mozilla.org/en-US/docs/Web/CSS/display-inside) value
  * @cssproperty --background-color - The button's background color when the button is not being interacted with.
  * @cssproperty --background-color-active - The button's background color when active.
  * @cssproperty --background-color-hover - The button's background color on hover.

--- a/src/components/details/details.css
+++ b/src/components/details/details.css
@@ -1,13 +1,10 @@
 :host {
   --show-duration: 200ms;
   --hide-duration: 200ms;
-
-  display: contents !important;
+  --display-outside: block;
 }
 
 details {
-  all: inherit;
-  display: block;
   overflow-anchor: none;
 }
 

--- a/src/components/details/details.css
+++ b/src/components/details/details.css
@@ -1,7 +1,7 @@
 :host {
   --show-duration: 200ms;
   --hide-duration: 200ms;
-  --display-outside: block;
+  --display: block;
 }
 
 details {

--- a/src/components/details/details.ts
+++ b/src/components/details/details.ts
@@ -45,8 +45,6 @@ import styles from './details.css';
  * @cssproperty [--show-duration=200ms] - The show duration to use when applying built-in animation classes.
  * @cssproperty [--hide-duration=200ms] - The hide duration to use when applying built-in animation classes.
  * @cssproperty --display - Set to `none` to hide the element, or any other valid `display` value to override the internal `display` value of the `base` part.
- * @cssproperty [--display-outside=block] - How content flows around the element. Valid values are `inline` and `block`.
- * @cssproperty [--display-inside=flow] - How to lay the element’s contents. Valid values are `flex`, `grid`, `flow`, and every other valid [`<display-inside>`](https://developer.mozilla.org/en-US/docs/Web/CSS/display-inside) value
  */
 @customElement('wa-details')
 export default class WaDetails extends WebAwesomeElement {

--- a/src/components/details/details.ts
+++ b/src/components/details/details.ts
@@ -9,6 +9,7 @@ import { getTargetElement, waitForEvent } from '../../internal/event.js';
 import { watch } from '../../internal/watch.js';
 import WebAwesomeElement from '../../internal/webawesome-element.js';
 import nativeStyles from '../../styles/native/details.css';
+import passthroughStyles from '../../styles/shadow/passthrough.css';
 import appearanceStyles from '../../styles/utilities/appearance.css';
 import { LocalizeController } from '../../utilities/localize.js';
 import '../icon/icon.js';
@@ -43,10 +44,13 @@ import styles from './details.css';
  * @cssproperty --spacing - The amount of space around and between the details' content. Expects a single value.
  * @cssproperty [--show-duration=200ms] - The show duration to use when applying built-in animation classes.
  * @cssproperty [--hide-duration=200ms] - The hide duration to use when applying built-in animation classes.
+ * @cssproperty --display - Set to `none` to hide the element, or any other valid `display` value to override the internal `display` value of the `base` part.
+ * @cssproperty [--display-outside=block] - How content flows around the element. Valid values are `inline` and `block`.
+ * @cssproperty [--display-inside=flow] - How to lay the element’s contents. Valid values are `flex`, `grid`, `flow`, and every other valid [`<display-inside>`](https://developer.mozilla.org/en-US/docs/Web/CSS/display-inside) value
  */
 @customElement('wa-details')
 export default class WaDetails extends WebAwesomeElement {
-  static shadowStyle = [appearanceStyles, nativeStyles, styles];
+  static shadowStyle = [passthroughStyles, appearanceStyles, nativeStyles, styles];
 
   private detailsObserver: MutationObserver;
   private readonly localize = new LocalizeController(this);

--- a/src/components/progress-bar/progress-bar.css
+++ b/src/components/progress-bar/progress-bar.css
@@ -1,7 +1,6 @@
 :host {
   --indicator-color: var(--wa-color-brand-fill-loud);
-  --display-outside: block;
-  --display-inside: flex;
+  --display: flex;
 
   height: 1.25rem;
   border-radius: var(--wa-border-radius-pill);

--- a/src/components/progress-bar/progress-bar.css
+++ b/src/components/progress-bar/progress-bar.css
@@ -1,7 +1,8 @@
 :host {
   --indicator-color: var(--wa-color-brand-fill-loud);
+  --display-outside: block;
+  --display-inside: flex;
 
-  display: contents;
   height: 1.25rem;
   border-radius: var(--wa-border-radius-pill);
   background-color: var(--wa-color-neutral-fill-normal);
@@ -9,8 +10,6 @@
 }
 
 .progress-bar {
-  all: inherit;
-  display: flex;
   position: relative;
   overflow: hidden;
 }

--- a/src/components/progress-bar/progress-bar.ts
+++ b/src/components/progress-bar/progress-bar.ts
@@ -22,8 +22,6 @@ import styles from './progress-bar.css';
  *
  * @cssproperty --indicator-color - The color of the indicator.
  * @cssproperty --display - Set to `none` to hide the element, or any other valid `display` value to override the internal `display` value of the `base` part.
- * @cssproperty [--display-outside=block] - How content flows around the element. Valid values are `inline` and `block`.
- * @cssproperty [--display-inside=flex] - How to lay the element’s contents. Valid values are `flex`, `grid`, and every other valid [`<display-inside>`](https://developer.mozilla.org/en-US/docs/Web/CSS/display-inside) value
  */
 @customElement('wa-progress-bar')
 export default class WaProgressBar extends WebAwesomeElement {

--- a/src/components/progress-bar/progress-bar.ts
+++ b/src/components/progress-bar/progress-bar.ts
@@ -4,6 +4,7 @@ import { customElement, property } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { clamp } from '../../internal/math.js';
 import WebAwesomeElement from '../../internal/webawesome-element.js';
+import passthroughStyles from '../../styles/shadow/passthrough.css';
 import { LocalizeController } from '../../utilities/localize.js';
 import styles from './progress-bar.css';
 
@@ -20,10 +21,13 @@ import styles from './progress-bar.css';
  * @csspart label - The progress bar's label.
  *
  * @cssproperty --indicator-color - The color of the indicator.
+ * @cssproperty --display - Set to `none` to hide the element, or any other valid `display` value to override the internal `display` value of the `base` part.
+ * @cssproperty [--display-outside=block] - How content flows around the element. Valid values are `inline` and `block`.
+ * @cssproperty [--display-inside=flex] - How to lay the element’s contents. Valid values are `flex`, `grid`, and every other valid [`<display-inside>`](https://developer.mozilla.org/en-US/docs/Web/CSS/display-inside) value
  */
 @customElement('wa-progress-bar')
 export default class WaProgressBar extends WebAwesomeElement {
-  static shadowStyle = styles;
+  static shadowStyle = [passthroughStyles, styles];
   private readonly localize = new LocalizeController(this);
 
   /** The current progress as a percentage, 0 to 100. */

--- a/src/components/radio-button/radio-button.css
+++ b/src/components/radio-button/radio-button.css
@@ -1,5 +1,5 @@
 :host {
-  --display-outside: inline;
+  --display: inline-flex;
 }
 
 .prefix,

--- a/src/components/radio-button/radio-button.css
+++ b/src/components/radio-button/radio-button.css
@@ -1,10 +1,5 @@
 :host {
-  display: contents;
-}
-
-:where([part~='base']) {
-  all: inherit;
-  display: inline-flex;
+  --display-outside: inline;
 }
 
 .prefix,

--- a/src/components/radio-button/radio-button.ts
+++ b/src/components/radio-button/radio-button.ts
@@ -47,8 +47,6 @@ import styles from './radio-button.css';
  * @csspart label - The container that wraps the radio button's label.
  * @csspart suffix - The container that wraps the suffix.
  * @cssproperty --display - Set to `none` to hide the element, or any other valid `display` value to override the internal `display` value of the `base` part.
- * @cssproperty [--display-outside=block] - How content flows around the element. Valid values are `inline` and `block`.
- * @cssproperty [--display-inside=flex] - How to lay the element’s contents. Valid values are `flex`, `grid`, and every other valid [`<display-inside>`](https://developer.mozilla.org/en-US/docs/Web/CSS/display-inside) value
  */
 @customElement('wa-radio-button')
 export default class WaRadioButton extends WebAwesomeFormAssociatedElement {

--- a/src/components/radio-button/radio-button.ts
+++ b/src/components/radio-button/radio-button.ts
@@ -6,6 +6,7 @@ import { HasSlotController } from '../../internal/slot.js';
 import { watch } from '../../internal/watch.js';
 import { WebAwesomeFormAssociatedElement } from '../../internal/webawesome-form-associated-element.js';
 import nativeStyles from '../../styles/native/button.css';
+import passthroughStyles from '../../styles/shadow/passthrough.css';
 import appearanceStyles from '../../styles/utilities/appearance.css';
 import sizeStyles from '../../styles/utilities/size.css';
 import variantStyles from '../../styles/utilities/variants.css';
@@ -45,10 +46,13 @@ import styles from './radio-button.css';
  * @csspart prefix - The container that wraps the prefix.
  * @csspart label - The container that wraps the radio button's label.
  * @csspart suffix - The container that wraps the suffix.
+ * @cssproperty --display - Set to `none` to hide the element, or any other valid `display` value to override the internal `display` value of the `base` part.
+ * @cssproperty [--display-outside=block] - How content flows around the element. Valid values are `inline` and `block`.
+ * @cssproperty [--display-inside=flex] - How to lay the element’s contents. Valid values are `flex`, `grid`, and every other valid [`<display-inside>`](https://developer.mozilla.org/en-US/docs/Web/CSS/display-inside) value
  */
 @customElement('wa-radio-button')
 export default class WaRadioButton extends WebAwesomeFormAssociatedElement {
-  static shadowStyle = [variantStyles, appearanceStyles, sizeStyles, nativeStyles, styles];
+  static shadowStyle = [passthroughStyles, variantStyles, appearanceStyles, sizeStyles, nativeStyles, styles];
   static rectProxy = 'input';
 
   private readonly hasSlotController = new HasSlotController(this, '[default]', 'prefix', 'suffix');

--- a/src/styles/shadow/passthrough.css
+++ b/src/styles/shadow/passthrough.css
@@ -2,6 +2,18 @@
  * Styles for elements that need to use display: contents on the host to enable styling with regular CSS properties (see #207, #259).
  * To use, make sure that the element that needs to inherit properties set on the host has a part of base or a class of .styling-host.
  */
+@property --display {
+  syntax: '*';
+  inherits: false;
+}
+@property --display-outside {
+  syntax: '*';
+  inherits: false;
+}
+@property --display-inside {
+  syntax: '*';
+  inherits: false;
+}
 
 :host {
   display: contents !important;
@@ -9,9 +21,13 @@
 
 :where([part~='base'], .styling-host) {
   all: inherit;
-  display: var(--display, var(--display-outside, inline) var(--display-inside, flow));
 
   /* Add any non-inherited custom properties here, as all: inherit won't cover them */
+  --display: inherit;
+  --display-outside: inherit;
+  --display-inside: inherit;
+
+  display: var(--display, var(--display-outside, inline) var(--display-inside, flow));
 }
 
 :host([hidden]) {

--- a/src/styles/shadow/passthrough.css
+++ b/src/styles/shadow/passthrough.css
@@ -1,0 +1,15 @@
+/**
+ * Styles for elements that need to use display: contents on the host to enable styling with regular CSS properties (see #207, #259).
+ * To use, make sure that the element that needs to inherit properties set on the host has a part of base or a class of .styling-host.
+ */
+
+:host {
+  display: contents !important;
+}
+
+:where([part~='base'], .styling-host) {
+  all: inherit;
+  display: var(--display, var(--display-outside, inline) var(--display-inside, flow));
+
+  /* Add any non-inherited custom properties here, as all: inherit won't cover them */
+}

--- a/src/styles/shadow/passthrough.css
+++ b/src/styles/shadow/passthrough.css
@@ -6,14 +6,6 @@
   syntax: '*';
   inherits: false;
 }
-@property --display-outside {
-  syntax: '*';
-  inherits: false;
-}
-@property --display-inside {
-  syntax: '*';
-  inherits: false;
-}
 
 :host {
   display: contents !important;
@@ -24,10 +16,8 @@
 
   /* Add any non-inherited custom properties here, as all: inherit won't cover them */
   --display: inherit;
-  --display-outside: inherit;
-  --display-inside: inherit;
 
-  display: var(--display, var(--display-outside, inline) var(--display-inside, flow));
+  display: var(--display, inline);
 }
 
 :host([hidden]) {

--- a/src/styles/shadow/passthrough.css
+++ b/src/styles/shadow/passthrough.css
@@ -13,3 +13,8 @@
 
   /* Add any non-inherited custom properties here, as all: inherit won't cover them */
 }
+
+:host([hidden]) {
+  display: none;
+  --display: none;
+}

--- a/src/styles/shadow/passthrough.css
+++ b/src/styles/shadow/passthrough.css
@@ -31,6 +31,5 @@
 }
 
 :host([hidden]) {
-  display: none;
-  --display: none;
+  display: none !important;
 }


### PR DESCRIPTION
This PR:
- Fixes a glitch in the [focus tokens page](https://backers.webawesome.com/docs/tokens/focus):

| Before | After |
|--------|--------|
| <img width="732" alt="image" src="https://github.com/user-attachments/assets/eec49acf-ad06-4a2d-ac46-5fa8dcd2a2e6" /> |  <img width="738" alt="image" src="https://github.com/user-attachments/assets/0986d90a-7be6-4047-a99c-0d867b8179e2" /> | 
- Centralizes the `display: contents` technique to separate stylesheet (`src/styles/shadow/passthrough.css`) that components using it (currently button, details, progress-bar, radio-button) just reference.
- Introduces a `--display` custom propery for elements using it. 

Why?
- Ensure consistency in how the `display: contents` technique is applied:
	- Make sure `display: contents` is applied with `!important` so we never end up with duplicate containers like in the page above.
	- Make sure any custom properties defined as non-inherited are also inherited there (since `all: inherit;` doesn't cover them)
	- Make sure the HTML `hidden` attribute works as expected, which we are currently not taking care of at all.
- Make it easier to find components using said technique, if we later want to replace it with something else
- Make sure there is always a way to hide said components, since `display: none` won't work if `display: contents` is `!important` (`display: none !important` would though, and is often better)
- Make sure there's always a way to change the display value of said components

---

An earlier version of this PR also introduced `--display-inside` and `--display-outside` properties, which made it possible to flip between inline/block or hide/show an element without having to duplicate decisions about internal layout, by providing access to the [`<display-outside>` and `<display-inside>`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#grouped_values) values separately. 

I ended up removing them to streamline this PR, as they were not directly relevant or necessary, and increased complexity. If we do introduce them later, it can be a separate decision.