### PR TITLE
Add font metadata to themes + a couple `typography.css` fixes

### DIFF
--- a/docs/docs/themes/active.md
+++ b/docs/docs/themes/active.md
@@ -5,4 +5,6 @@ isPro: true
 tags: pro
 palette: rudimentary
 brand: green
+fonts:
+  body: Inter
 ---

--- a/docs/docs/themes/awesome.md
+++ b/docs/docs/themes/awesome.md
@@ -4,4 +4,6 @@ description: Punchy and vibrant, the rockstar of themes.
 order: 0.2
 palette: bright
 brand: blue
+fonts:
+  body: Quicksand
 ---

--- a/docs/docs/themes/brutalist.md
+++ b/docs/docs/themes/brutalist.md
@@ -5,4 +5,8 @@ isPro: true
 tags: pro
 palette: default
 brand: blue
+fonts:
+  body: Space Grotesk
+  heading: IBM Plex Sans Condensed
+  code: Space Mono
 ---

--- a/docs/docs/themes/classic.md
+++ b/docs/docs/themes/classic.md
@@ -3,4 +3,5 @@ title: Classic
 description: Timeless elegance that never goes out of style.
 order: 0.1
 palette: classic
+brand: blue
 ---

--- a/docs/docs/themes/default.md
+++ b/docs/docs/themes/default.md
@@ -4,4 +4,8 @@ description: Your trusty companion, like a perfectly broken-in pair of jeans.
 order: 0
 palette: default
 brand: blue
+fonts:
+  body: ui-sans-serif
+  code: ui-monospace
+  longform: ui-serif
 ---

--- a/docs/docs/themes/glossy.md
+++ b/docs/docs/themes/glossy.md
@@ -5,4 +5,6 @@ isPro: true
 tags: pro
 palette: elegant
 brand: indigo
+fonts:
+  body: Figtree
 ---

--- a/docs/docs/themes/matter.md
+++ b/docs/docs/themes/matter.md
@@ -5,6 +5,10 @@ isPro: true
 tags: pro
 palette: mild
 brand: indigo
+fonts:
+  body: 'Wix Madefor Text'
+  code: Roboto Mono
+  longform: Roboto Serif
 ---
 
 Set the page theme to "{{ title }}" from the top right to preview the following examples.

--- a/docs/docs/themes/mellow.md
+++ b/docs/docs/themes/mellow.md
@@ -4,4 +4,8 @@ description: Soft and soothing, like a lazy Sunday morning.
 isPro: true
 tags: pro
 palette: natural
+fonts:
+  body: Mulish
+  heading: Lora
+  longform: Lora
 ---

--- a/docs/docs/themes/playful.md
+++ b/docs/docs/themes/playful.md
@@ -5,4 +5,8 @@ isPro: true
 tags: pro
 palette: rudimentary
 brand: purple
+fonts:
+  body: Nunito
+  heading: Fredoka
+  code: Azeret Mono
 ---

--- a/docs/docs/themes/premium.md
+++ b/docs/docs/themes/premium.md
@@ -5,4 +5,8 @@ isPro: true
 tags: pro
 palette: anodized
 brand: cyan
+fonts:
+  body: DM Sans
+  heading: Playfair Display
+  longform: Playfair
 ---

--- a/docs/docs/themes/tailspin.md
+++ b/docs/docs/themes/tailspin.md
@@ -5,4 +5,6 @@ isPro: true
 tags: pro
 palette: vogue
 brand: indigo
+fonts:
+  body: Inter
 ---

--- a/src/styles/themes/awesome/typography.css
+++ b/src/styles/themes/awesome/typography.css
@@ -8,16 +8,11 @@
    * Typography
    */
   --wa-font-family-body: Quicksand, sans-serif;
-  --wa-font-family-heading: var(--wa-font-family-body);
-  --wa-font-family-code: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-  --wa-font-family-longform: ui-serif, serif;
 
   --wa-font-weight-light: 400;
   --wa-font-weight-normal: 500;
   --wa-font-weight-semibold: 600;
   --wa-font-weight-bold: 700;
 
-  --wa-font-weight-body: var(--wa-font-weight-normal);
-  --wa-font-weight-heading: var(--wa-font-weight-bold);
   --wa-font-weight-action: var(--wa-font-weight-bold);
 }

--- a/src/styles/themes/brutalist/typography.css
+++ b/src/styles/themes/brutalist/typography.css
@@ -7,7 +7,6 @@
   --wa-font-family-body: 'Space Grotesk', sans-serif;
   --wa-font-family-heading: 'IBM Plex Sans Condensed', sans-serif;
   --wa-font-family-code: 'Space Mono', monospace;
-  --wa-font-family-longform: ui-serif, serif;
 
   --wa-font-weight-bold: 700;
 

--- a/src/styles/themes/default/typography.css
+++ b/src/styles/themes/default/typography.css
@@ -2,6 +2,7 @@
  * Typography
  */
 :where(:root),
+:where([class^='wa-theme-'], [class*=' wa-theme-']),
 :host {
   --wa-font-family-body: ui-sans-serif, system-ui, sans-serif;
   --wa-font-family-heading: var(--wa-font-family-body);

--- a/src/styles/themes/glossy/typography.css
+++ b/src/styles/themes/glossy/typography.css
@@ -5,12 +5,7 @@
 :host,
 .wa-theme-glossy {
   --wa-font-family-body: 'Figtree', sans-serif;
-  --wa-font-family-heading: var(--wa-font-family-body);
-  --wa-font-family-code: ui-monospace, monospace;
-  --wa-font-family-longform: ui-serif, serif;
 
-  --wa-font-weight-light: 300;
-  --wa-font-weight-normal: 400;
   --wa-font-weight-semibold: 600;
   --wa-font-weight-bold: 800;
 

--- a/src/styles/themes/matter/typography.css
+++ b/src/styles/themes/matter/typography.css
@@ -8,11 +8,7 @@
   --wa-font-family-code: 'Roboto Mono', monospace;
   --wa-font-family-longform: 'Roboto Serif', serif;
 
-  --wa-font-weight-light: 300;
-  --wa-font-weight-normal: 400;
-  --wa-font-weight-semibold: 500;
   --wa-font-weight-bold: 700;
-
   --wa-font-weight-heading: var(--wa-font-weight-semibold);
 
   --wa-link-decoration-default: underline;

--- a/src/styles/themes/mellow/typography.css
+++ b/src/styles/themes/mellow/typography.css
@@ -6,7 +6,6 @@
 .wa-theme-mellow {
   --wa-font-family-body: 'Mulish', sans-serif;
   --wa-font-family-heading: 'Lora', serif;
-  --wa-font-family-code: ui-monospace, monospace;
   --wa-font-family-longform: 'Lora', serif;
 
   --wa-font-weight-semibold: 600;

--- a/src/styles/themes/playful/typography.css
+++ b/src/styles/themes/playful/typography.css
@@ -6,8 +6,7 @@
 .wa-theme-playful {
   --wa-font-family-body: 'Nunito', sans-serif;
   --wa-font-family-heading: 'Fredoka', sans-serif;
-  --wa-font-family-code: 'Azeret Mono', monospace;
-  --wa-font-family-longform: ui-serif, serif;
+  --wa-font-family-code: 'Azeret Mono', ui-monospace, monospace;
 
   --wa-font-size-scale: 1.125;
 

--- a/src/styles/themes/premium/typography.css
+++ b/src/styles/themes/premium/typography.css
@@ -6,13 +6,11 @@
 .wa-theme-premium,
 .wa-light,
 .wa-dark .wa-invert {
-  --wa-font-family-heading: 'Playfair Display', serif;
   --wa-font-family-body: 'DM Sans', sans-serif;
+  --wa-font-family-heading: 'Playfair Display', serif;
   --wa-font-family-longform: 'Playfair', serif;
 
   --wa-font-weight-heading: var(--wa-font-weight-semibold);
-  --wa-font-weight-body: var(--wa-font-weight-normal);
-  --wa-font-weight-action: var(--wa-font-weight-semibold);
 
   --wa-line-height-condensed: 1.1;
   --wa-line-height-normal: 1.5;

--- a/src/styles/themes/tailspin/typography.css
+++ b/src/styles/themes/tailspin/typography.css
@@ -5,11 +5,7 @@
 :host,
 .wa-theme-tailspin {
   --wa-font-family-body: 'Inter', sans-serif;
-  --wa-font-family-heading: var(--wa-font-family-body);
 
-  --wa-font-weight-light: 300;
-  --wa-font-weight-normal: 400;
-  --wa-font-weight-semibold: 500;
   --wa-font-weight-bold: 700;
 
   --wa-font-size-scale: 0.875;


### PR DESCRIPTION
This PR adds metadata about fonts used on each theme page (just like we do for `brand` and `palette`). 
Metadata that is the same as the default theme is omitted. Same with metadata we don't want to expose (e.g. the typography of Classic).

Also, a couple `typography.css` fixes:
- Add `:where([class^='wa-theme-'], [class*=' wa-theme-'])` to default `typography.css` since we declare mappings that need to be inherited by other themes (such as `--wa-font-family-heading: var(--wa-font-family-body);`).
- Remove declarations that redeclare defaults
- Ensure consistent order (`body` before `heading`)
- [Awesome] Switch code font to default (`ui-monospace`)