### PR TITLE
Fix radio group margin

### DIFF
--- a/docs/docs/resources/changelog.md
+++ b/docs/docs/resources/changelog.md
@@ -15,6 +15,7 @@ During the alpha period, things might break! We take breaking changes very serio
 ## Next
 
 - 🚨 BREAKING: Renamed `<image-comparer>` to `<wa-comparer>` and improved compatibility for non-image content.
+- Fixed a bug that caused an undesired margin below radio groups
 
 ## 3.0.0-alpha.12
 

--- a/src/components/radio-group/radio-group.css
+++ b/src/components/radio-group/radio-group.css
@@ -27,7 +27,6 @@
   flex-direction: column;
   flex-wrap: wrap;
   gap: var(--wa-space-s);
-  margin-block-end: var(--wa-space-xs);
 }
 
 /* Horizontal */
@@ -44,5 +43,5 @@
 
 /* Help text */
 [part~='hint'] {
-  margin-block-start: var(--wa-space-2xs);
+  margin-block-start: var(--wa-space-xs);
 }


### PR DESCRIPTION
Radio group has a small margin that leaks out when no hint is present. This PR removes that margin and adjusts the spacing above the hint.

Fixes https://github.com/shoelace-style/webawesome-alpha/issues/249