### PR TITLE
Cloak improvement

### DIFF
--- a/docs/docs/resources/changelog.md
+++ b/docs/docs/resources/changelog.md
@@ -20,6 +20,7 @@ During the alpha period, things might break! We take breaking changes very serio
 - Fixed a bug in `<wa-select>` that caused incorrect spacing of icons
 - Fixed a bug in the Matter theme that prevented clicks on form control labels to not focus the control
 - Improved native radio alignment
+- Improved the `.wa-cloak` utility class so all FOUCE-related solutions are 100% opt-in
 
 ## 3.0.0-alpha.12
 

--- a/docs/docs/utilities/fouce.md
+++ b/docs/docs/utilities/fouce.md
@@ -7,6 +7,7 @@ snippet: .wa-cloak
 ---
 
 Often, components are shown before their logic and styles have had a chance to load, also known as a [Flash of Undefined Custom Elements](https://www.abeautifulsite.net/posts/flash-of-undefined-custom-elements/).
+
 The FOUCE style utility (which is automatically applied if you use our [style utilities](/docs/utilities/)) automatically takes care of hiding custom elements until **both they and their contents** have been registered, up to a maximum of two seconds.
 
 In many cases, this is not enough, and you may wish to hide a broader wrapper element or even the entire page until all WA elements within it have loaded.

--- a/src/styles/utilities/fouce.css
+++ b/src/styles/utilities/fouce.css
@@ -1,8 +1,6 @@
 /*
  * Utility to minimize FOUCE and show custom elements only after they're registered
  */
-:not(:defined),
-:state(wa-defined):has(:not(:defined)),
 .wa-cloak:has(:not(:defined)) {
   animation: 2s step-end wa-fouce-cloak;
 }

--- a/src/utilities/autoloader.ts
+++ b/src/utilities/autoloader.ts
@@ -55,7 +55,13 @@ export async function discover(root: Element | ShadowRoot) {
   await new Promise(requestAnimationFrame);
 
   // Dispatch an event when discovery is complete.
-  document.dispatchEvent(new CustomEvent('wa-discovery-complete'));
+  root.dispatchEvent(
+    new CustomEvent('wa-discovery-complete', {
+      bubbles: false,
+      cancelable: false,
+      composed: true,
+    }),
+  );
 }
 
 /**


### PR DESCRIPTION
- Ensures `.wa-cloak` is 100% opt-in per:
   - https://github.com/shoelace-style/webawesome-alpha/issues/221#issuecomment-2859687460
- Simplifies our cloak selectors
   - We currently suggest using `wa-cloak` on `<html>`, although it will also work for other _containers_. At this time, it doesn't work on individual custom elements, but I don't see an immediate need for that.
- Prevents the `wa-discovery-complete` event from bubbling and dispatches it from the root element, not the document.
   - This fixes a separate issue with nested root discovery causing `wa-cloak` to be removed prematurely leading to FOUCE.
