### PR TITLE
Fix `<wa-radio-button>` overrides in themes

### DIFF
--- a/src/components/radio-button/radio-button.ts
+++ b/src/components/radio-button/radio-button.ts
@@ -25,21 +25,8 @@ import styles from './radio-button.css';
  * @event blur - Emitted when the button loses focus.
  * @event focus - Emitted when the button gains focus.
  *
- * @cssproperty --background-color - The button's background color.
- * @cssproperty --background-color-active - The button's background color when active.
- * @cssproperty --background-color-hover - The button's background color on hover.
- * @cssproperty --border-color - The color of the button's border.
- * @cssproperty --border-color-active - The color of the button's border when active.
- * @cssproperty --border-color-hover - The color of the button's border on hover.
- * @cssproperty --border-radius - The radius of the button's corners.
- * @cssproperty --border-style - The style of the button's border.
- * @cssproperty --border-width - The width of the button's border. Expects a single value.
- * @cssproperty --box-shadow - The shadow effects around the edges of the button.
  * @cssproperty --indicator-color - The color of the checked button indicator.
  * @cssproperty --indicator-width - The width of the checked button indicator.
- * @cssproperty --text-color - The color of the button's label.
- * @cssproperty --text-color-active - The color of the button's label when active.
- * @cssproperty --text-color-hover - The color of the button's label on hover.
  *
  * @csspart base - The internal `<button>` element.
  * @csspart checked - The internal button element when the radio button is checked.

--- a/src/styles/themes/awesome/overrides.css
+++ b/src/styles/themes/awesome/overrides.css
@@ -74,12 +74,17 @@
   }
 
   wa-radio-group > wa-radio-button {
-    &::part(base):active,
+    &::part(base) {
+      --background-color-active: var(--border-color-active);
+      --border-color-active: var(--wa-color-neutral-border-loud);
+      --text-color-active: var(--wa-color-surface-default);
+    }
     &::part(checked) {
       --background-color: var(--border-color);
       --background-color-hover: var(--border-color);
       --border-color: var(--wa-color-neutral-border-loud);
       --text-color: var(--wa-color-surface-default);
+      --text-color-hover: var(--text-color);
     }
   }
 

--- a/src/styles/themes/classic/overrides.css
+++ b/src/styles/themes/classic/overrides.css
@@ -15,16 +15,18 @@
   }
 
   wa-radio-button {
-    --background-color-active: color-mix(in oklab, var(--background-color-hover), var(--wa-color-mix-active));
-    --background-color-hover: var(--wa-form-control-activated-color);
-    --border-color: var(--wa-form-control-border-color);
-    --border-color-active: var(--background-color-active);
-    --border-color-hover: var(--background-color-hover);
-    --text-color-active: var(--text-color-hover);
-    --text-color-hover: var(--wa-color-brand-on-loud);
-    --indicator-color: var(--wa-background-color);
+    &::part(base) {
+      --background-color-active: color-mix(in oklab, var(--background-color-hover), var(--wa-color-mix-active));
+      --background-color-hover: var(--wa-form-control-activated-color);
+      --border-color: var(--wa-form-control-border-color);
+      --border-color-active: var(--background-color-active);
+      --border-color-hover: var(--background-color-hover);
+      --text-color-active: var(--text-color-hover);
+      --text-color-hover: var(--wa-color-brand-on-loud);
+      --indicator-color: var(--wa-form-control-activated-color);
+    }
 
-    &[checked] {
+    &::part(checked) {
       --background-color: var(--wa-form-control-activated-color);
       --border-color: var(--background-color);
       --text-color: var(--wa-color-brand-on-loud);


### PR DESCRIPTION
Fixes the selectors used in our Classic and Awesome themes to style radio buttons.

Additionally removes a bunch of CSS properties from the radio button docs. Because we're using a `<button>` element with our utility classes (e.g. `.wa-filled`) under the hood, specifying properties like `--background-color` on `<wa-radio-button>` doesn't have any effect; instead, we need to specify these on `::part()`. This is something that could be improved, but given we've discussed retiring `<wa-radio-button>` anyway, I didn't spend any effort on it here.

### Classic
**Before**
<img width="301" alt="Screenshot 2025-05-08 at 11 48 51 AM" src="https://github.com/user-attachments/assets/55f45cd8-7aaa-4cea-a36a-a07ab618e9cc" />

**After**
<img width="301" alt="Screenshot 2025-05-08 at 11 49 24 AM" src="https://github.com/user-attachments/assets/048e3da8-0964-4e83-bb8c-4ff193933676" />


### Awesome
**Before**
Poor contrast when hovering on checked:
<img width="363" alt="Screenshot 2025-05-08 at 11 48 11 AM" src="https://github.com/user-attachments/assets/436975f4-a495-455f-b606-8eccbdf19cc3" />

Poor contrast when active:
<img width="363" alt="Screenshot 2025-05-08 at 11 48 17 AM" src="https://github.com/user-attachments/assets/a19c5b74-6ea2-4779-90e4-c8451137c7da" />


**After**
Hovering on checked and active buttons have the same, high contrast appearance:
<img width="363" alt="Screenshot 2025-05-08 at 11 46 47 AM" src="https://github.com/user-attachments/assets/38c66961-8d14-4c96-943e-06c00ea9fbfa" />
