### PR TITLE
Add size example to `<wa-badge>`

### DIFF
--- a/docs/docs/components/badge.md
+++ b/docs/docs/components/badge.md
@@ -70,7 +70,7 @@ Use the `appearance` attribute to change the badge's visual appearance.
 Badges are sized relative to the current font size. You can set `font-size` on any badge (or an ancestor element) to change it.
 
 ```html {.example}
-<wa-badge variant="brand" style="font-size: .75rem;">Brand</wa-badge>
+<wa-badge variant="brand" style="font-size: var(--wa-font-size-xs);">Brand</wa-badge>
 <wa-badge variant="brand" style="font-size: 1rem;">Brand</wa-badge>
 <wa-badge variant="brand" style="font-size: 1.5rem;">Brand</wa-badge>
 ```

--- a/docs/docs/components/badge.md
+++ b/docs/docs/components/badge.md
@@ -71,7 +71,8 @@ Badges are sized relative to the current font size. You can set `font-size` on a
 
 ```html {.example}
 <wa-badge variant="brand" style="font-size: var(--wa-font-size-xs);">Brand</wa-badge>
-<wa-badge variant="brand" style="font-size: 1rem;">Brand</wa-badge>
+<wa-badge variant="brand" style="font-size: var(--wa-font-size-s);">Brand</wa-badge>
+<wa-badge variant="brand" style="font-size: var(--wa-font-size-m);">Brand</wa-badge>
 <wa-badge variant="brand" style="font-size: 1.5rem;">Brand</wa-badge>
 ```
 

--- a/docs/docs/components/badge.md
+++ b/docs/docs/components/badge.md
@@ -73,7 +73,8 @@ Badges are sized relative to the current font size. You can set `font-size` on a
 <wa-badge variant="brand" style="font-size: var(--wa-font-size-xs);">Brand</wa-badge>
 <wa-badge variant="brand" style="font-size: var(--wa-font-size-s);">Brand</wa-badge>
 <wa-badge variant="brand" style="font-size: var(--wa-font-size-m);">Brand</wa-badge>
-<wa-badge variant="brand" style="font-size: 1.5rem;">Brand</wa-badge>
+<wa-badge variant="brand" style="font-size: var(--wa-font-size-l);">Brand</wa-badge>
+<wa-badge variant="brand" style="font-size: var(--wa-font-size-xl);">Brand</wa-badge>
 ```
 
 ### Pill Badges

--- a/docs/docs/components/badge.md
+++ b/docs/docs/components/badge.md
@@ -65,6 +65,16 @@ Use the `appearance` attribute to change the badge's visual appearance.
 </div>
 ```
 
+### Size
+
+Badges are sized relative to the current font size. You can set `font-size` on any badge (or an ancestor element) to change it.
+
+```html {.example}
+<wa-badge variant="brand" style="font-size: .75rem;">Brand</wa-badge>
+<wa-badge variant="brand" style="font-size: 1rem;">Brand</wa-badge>
+<wa-badge variant="brand" style="font-size: 1.5rem;">Brand</wa-badge>
+```
+
 ### Pill Badges
 
 Use the `pill` attribute to give badges rounded edges.


### PR DESCRIPTION
This was missing and [at least one user](https://github.com/shoelace-style/webawesome-alpha/discussions/202) didn't know how to size things, so seemed like an easy win.