### PR TITLE
[Comparer] Expose wrapper as part, fix choppy dragging

### DIFF
--- a/src/components/comparer/comparer.css
+++ b/src/components/comparer/comparer.css
@@ -11,6 +11,15 @@
   overflow: hidden;
 }
 
+/* Make content inert when dragging.
+   Otherwise, for <iframe> and <object> dragging is very choppy. */
+:host(:active) {
+  .before,
+  .after {
+    pointer-events: none;
+  }
+}
+
 .before,
 .after {
   display: block;

--- a/src/components/comparer/comparer.ts
+++ b/src/components/comparer/comparer.ts
@@ -23,6 +23,7 @@ import styles from './comparer.css';
  *
  * @event change - Emitted when the position changes.
  *
+ * @csspart base - The container that wraps the before and after content.
  * @csspart before - The container that wraps the before content.
  * @csspart after - The container that wraps the after content.
  * @csspart divider - The divider that separates the before and after content.
@@ -96,7 +97,7 @@ export default class WaComparer extends WebAwesomeElement {
     const isRtl = this.hasUpdated ? this.localize.dir() === 'rtl' : this.dir === 'rtl';
 
     return html`
-      <div class="image">
+      <div class="image" part="base">
         <div part="before" class="before">
           <slot name="before"></slot>
         </div>


### PR DESCRIPTION
This PR fixes 2 `<wa-comparer>` issues that came up while implementing the dark mode preview in the themer:
1. The wrapper was not exposed as a part. I exposed it as `base`.
2. When the elements being compared were iframes (I suspect the same issue would exist with `<object>` too) dragging was incredibly choppy as the iframe kept capturing it. With this, both compared elements get `pointer-events: none` while dragging is happening.