### PR TITLE
Fix nav toggle behavior in `<wa-page>`

### DIFF
--- a/docs/_includes/page-demo.njk
+++ b/docs/_includes/page-demo.njk
@@ -22,5 +22,5 @@
 
 <script type="module">
   const cacheBust = new Date().toString()
-  import(`./demo.js?${cacheBust}`)
+  import(`/docs/components/page/demo.js?${cacheBust}`)
 </script>

--- a/docs/docs/resources/changelog.md
+++ b/docs/docs/resources/changelog.md
@@ -21,6 +21,7 @@ During the alpha period, things might break! We take breaking changes very serio
 - Fixed a bug in `<wa-select>` that caused incorrect spacing of icons
 - Fixed a bug in `<wa-select>` that caused the listbox to now show after being disabled
 - Fixed a bug in `<wa-radio-group>` that prevented radio buttons from validating
+- Fixed a bug in `<wa-page>` that caused the nav toggle to show even when using `disable-navigation-toggle` 
 - Improved native radio alignment
 - Improved the `.wa-cloak` utility class so all FOUCE-related solutions are 100% opt-in
 

--- a/src/components/page/page.ts
+++ b/src/components/page/page.ts
@@ -201,8 +201,9 @@ export default class WaPage extends WebAwesomeElement {
     super.connectedCallback();
     this.pageResizeObserver.observe(this);
 
-    // Wait a cycle for the initial update to complete
-    requestAnimationFrame(() => {
+    // Wait a cycle for the initial update to complete. We use `setTimeout` intentionally to ensure DOM children also
+    // have a chance to update.
+    setTimeout(() => {
       this.headerResizeObserver.observe(this.header);
       this.subheaderResizeObserver.observe(this.subheader);
       this.bannerResizeObserver.observe(this.banner);

--- a/src/components/page/page.ts
+++ b/src/components/page/page.ts
@@ -199,24 +199,22 @@ export default class WaPage extends WebAwesomeElement {
 
   connectedCallback() {
     super.connectedCallback();
-
     this.pageResizeObserver.observe(this);
 
-    const navQuery = ":not([slot='toggle-navigation']) [data-toggle-nav]";
-
-    // check once on initial connect
-    // eslint-disable-next-line
-    this.disableNavigationToggle = Boolean(this.querySelector(navQuery));
-
-    setTimeout(() => {
+    // Wait a cycle for the initial update to complete
+    requestAnimationFrame(() => {
       this.headerResizeObserver.observe(this.header);
       this.subheaderResizeObserver.observe(this.subheader);
       this.bannerResizeObserver.observe(this.banner);
       this.footerResizeObserver.observe(this.footer);
 
-      // Check again when the element updates
-      // eslint-disable-next-line
-      this.disableNavigationToggle = Boolean(this.querySelector(navQuery));
+      if (this.hasAttribute('disable-navigation-toggle')) {
+        this.disableNavigationToggle = true;
+      } else {
+        // Otherwise, use auto-detection again
+        const navQuery = ":not([slot='toggle-navigation']) [data-toggle-nav]";
+        this.disableNavigationToggle = Boolean(this.querySelector(navQuery));
+      }
     });
   }
 


### PR DESCRIPTION
[Reported by a backer:](https://github.com/shoelace-style/webawesome-alpha/issues/268#issuecomment-2877392854)

@KonnorRogers I'm not as familiar with the internals of `<wa-page>` as I'd like to be, so give this a good review. I didn't notice any side effects :)

<details>
<summary>Fixture to reproduce and test</summary>

```html
<wa-page disable-navigation-toggle style="outline: dashed 2px gray;">
  <header slot="header" class="wa-split">
    <div class="wa-cluster wa-gap-xs">
      <wa-icon src="/img/logo-play.svg" style="font-size: 2.5em;"></wa-icon>
      <span id="brand-name" class="wa-heading-s wa-desktop-only">{{ metadata.author.name }}</span>
    </div>
    <div class="wa-cluster wa-gap-xs">
      <wa-button href="#" size="small" variant="brand" appearance="outlined">
        <wa-icon slot="prefix" name="calendar-days" variant="solid"></wa-icon>
        Prossimi Eventi
      </wa-button>
      <wa-button href="#" size="small" variant="brand">
        <wa-icon slot="prefix" name="crown" variant="solid"></wa-icon>
        VIP
      </wa-button>
    </div>
  </header>
  <main>
    {{ content | safe }}
  </main>
</wa-page>
```

</details>