### PR TITLE
improve tag spacing; fixes #677

### DIFF
--- a/docs/docs/resources/changelog.md
+++ b/docs/docs/resources/changelog.md
@@ -20,6 +20,7 @@ During the alpha period, things might break! We take breaking changes very serio
 - Added a new Blog & News pattern category
 - Added a new free component: `<wa-scroller>` (#1 of 14 per stretch goals)
 - Added support for Duotone Thin, Light, and Regular styles and the Sharp Duotone family of styles to `<wa-icon>`
+- Added a default `gap` to `<wa-tag>` for better default spacing when used with icons [issue:677]
 - Fixed a bug that caused `<wa-radio-group>` to have an undesired margin below it
 - Fixed a bug in the Matter theme that prevented clicks on form control labels to not focus the control
 - Fixed a bug in `<wa-select>` that caused incorrect spacing of icons

--- a/src/components/tag/tag.css
+++ b/src/components/tag/tag.css
@@ -4,6 +4,7 @@
   --size-l: var(--wa-font-size-m);
 
   display: inline-flex;
+  gap: 0.33em;
   border-radius: var(--wa-border-radius-m);
   align-items: center;
   background-color: var(--background-color, var(--wa-color-fill-quiet));
@@ -41,7 +42,6 @@
 /*
  * Pill modifier
  */
-
 :host([pill]) {
   border-radius: var(--wa-border-radius-pill);
 }

--- a/src/components/tag/tag.css
+++ b/src/components/tag/tag.css
@@ -4,7 +4,7 @@
   --size-l: var(--wa-font-size-m);
 
   display: inline-flex;
-  gap: 0.33em;
+  gap: var(--wa-space-xs);
   border-radius: var(--wa-border-radius-m);
   align-items: center;
   background-color: var(--background-color, var(--wa-color-fill-quiet));

--- a/src/components/tag/tag.css
+++ b/src/components/tag/tag.css
@@ -4,7 +4,7 @@
   --size-l: var(--wa-font-size-m);
 
   display: inline-flex;
-  gap: var(--wa-space-xs);
+  gap: 0.33em;
   border-radius: var(--wa-border-radius-m);
   align-items: center;
   background-color: var(--background-color, var(--wa-color-fill-quiet));


### PR DESCRIPTION
See #677. I went with `gap` because we don't know if slotted icons are at the start or end. I used `em` over a spacing tokens for consistent spacing in all three sizes.

HTML

```html
<wa-tag variant="brand"><wa-icon name="house"></wa-icon> Brand</wa-tag>
<wa-tag variant="success"><wa-icon name="heart"></wa-icon> Success</wa-tag>
```


Before

![tag-before](https://github.com/user-attachments/assets/7b2cc38e-f696-42c4-8d95-05b5a420c6d7)

After

![CleanShot 2025-05-21 at 08 33 11@2x](https://github.com/user-attachments/assets/8518db86-bbe5-4540-a488-10283190e1b1)


