### PR TITLE
Fix code example resizer in dark mode

### DIFF
--- a/docs/assets/styles/code-examples.css
+++ b/docs/assets/styles/code-examples.css
@@ -50,7 +50,7 @@
   width: 1.75rem;
   font-size: 20px;
   color: var(--wa-color-text-quiet);
-  background-color: var(--wa-color-neutral-0, white);
+  background-color: var(--wa-color-neutral--wa-color-surface-default);
   border-left: var(--wa-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
   border-top-right-radius: var(--wa-border-radius-l);
   cursor: ew-resize;


### PR DESCRIPTION
Wrong token.

Before
![before](https://github.com/user-attachments/assets/df4d7ef9-076d-45aa-aab5-ce8cb088ab12)

After
![after](https://github.com/user-attachments/assets/0e78da9f-836d-4e93-ba3e-02b93c034486)
