### PR TITLE
Fix plop templates

### DIFF
--- a/packages/webawesome/scripts/plop/plopfile.js
+++ b/packages/webawesome/scripts/plop/plopfile.js
@@ -37,7 +37,7 @@ export default function (plop) {
       },
       {
         type: 'add',
-        path: '../../src/components/{{ tagWithoutPrefix tag }}/{{ tagWithoutPrefix tag }}.styles.ts',
+        path: '../../src/components/{{ tagWithoutPrefix tag }}/{{ tagWithoutPrefix tag }}.css',
         templateFile: 'templates/component/styles.hbs',
       },
       {

--- a/packages/webawesome/scripts/plop/templates/component/component.hbs
+++ b/packages/webawesome/scripts/plop/templates/component/component.hbs
@@ -3,7 +3,6 @@ import { customElement, property } from 'lit/decorators.js';
 import { watch } from '../../internal/watch.js';
 import WebAwesomeElement from '../../internal/webawesome-element.js';
 import componentStyles from '../../styles/component/host.css';
-import { LocalizeController } from '../../utilities/localize.js';
 import styles from './{{ tagWithoutPrefix tag }}.css';
 
 /**
@@ -13,8 +12,6 @@ import styles from './{{ tagWithoutPrefix tag }}.css';
  * @since 3.0
  *
  * @dependency wa-example
- *
- * @event wa-event-name - Emitted as an example.
  *
  * @slot - The default slot.
  * @slot example - An example slot.
@@ -26,8 +23,6 @@ import styles from './{{ tagWithoutPrefix tag }}.css';
  @customElement("{{ tag }}")
 export default class {{ properCase tag }} extends WebAwesomeElement {
   static shadowStyle = [componentStyles, styles];
-
-  private readonly localize = new LocalizeController(this);
 
   /** An example attribute. */
   @property() attr = 'example';

--- a/packages/webawesome/scripts/plop/templates/component/component.hbs
+++ b/packages/webawesome/scripts/plop/templates/component/component.hbs
@@ -26,7 +26,7 @@ import type { CSSResultGroup } from 'lit';
  */
  @customElement("{{ tag }}")
 export default class {{ properCase tag }} extends WebAwesomeElement {
-  static styles: CSSResultGroup = [componentStyles, styles];
+  static shadowStyle = styles;
 
   private readonly localize = new LocalizeController(this);
 

--- a/packages/webawesome/scripts/plop/templates/component/component.hbs
+++ b/packages/webawesome/scripts/plop/templates/component/component.hbs
@@ -1,11 +1,10 @@
-import { customElement, property } from 'lit/decorators.js';
 import { html } from 'lit';
-import { LocalizeController } from '../../utilities/localize.js';
+import { customElement, property } from 'lit/decorators.js';
 import { watch } from '../../internal/watch.js';
-import componentStyles from '../../styles/component.styles.js';
-import styles from './test-element.styles.js';
 import WebAwesomeElement from '../../internal/webawesome-element.js';
-import type { CSSResultGroup } from 'lit';
+import componentStyles from '../../styles/component/host.css';
+import { LocalizeController } from '../../utilities/localize.js';
+import styles from './{{ tagWithoutPrefix tag }}.css';
 
 /**
  * @summary Short summary of the component's intended use.
@@ -26,7 +25,7 @@ import type { CSSResultGroup } from 'lit';
  */
  @customElement("{{ tag }}")
 export default class {{ properCase tag }} extends WebAwesomeElement {
-  static shadowStyle = styles;
+  static shadowStyle = [componentStyles, styles];
 
   private readonly localize = new LocalizeController(this);
 

--- a/packages/webawesome/scripts/plop/templates/component/styles.hbs
+++ b/packages/webawesome/scripts/plop/templates/component/styles.hbs
@@ -1,7 +1,3 @@
-import { css } from 'lit';
-
-export default css`
-  :host {
-    display: block;
-  }
-`;
+:host {
+  display: block;
+}

--- a/packages/webawesome/scripts/plop/templates/component/tests.hbs
+++ b/packages/webawesome/scripts/plop/templates/component/tests.hbs
@@ -1,4 +1,3 @@
-import '../../../dist/webawesome.js';
 import { expect, fixture, html } from '@open-wc/testing';
 
 describe('<{{ tag }}>', () => {


### PR DESCRIPTION
Ignore the branch name. This PR fixes the plop templates used when running `npm run create` so they work again.