### PR TITLE
Align native styles with `<wa-slider>`

### DIFF
--- a/packages/webawesome/src/styles/native.css
+++ b/packages/webawesome/src/styles/native.css
@@ -991,43 +991,20 @@
 
   /* Slider */
   input[type='range'] {
-    --thumb-color: var(--wa-form-control-activated-color);
-    --thumb-gap: calc(var(--thumb-size) * 0.125);
-    --thumb-shadow: initial;
     --thumb-size: calc(1rem * var(--wa-form-control-value-line-height));
-
-    --track-color-active: var(--wa-color-neutral-fill-normal);
-    --track-color-inactive: var(--wa-color-neutral-fill-normal);
-    --track-active-offset: 0%;
     --track-height: calc(var(--thumb-size) * 0.25);
 
     display: flex;
     flex-direction: column;
     position: relative;
-  }
-
-  input[type='range'] {
-    --percent: 0%;
-    -webkit-appearance: none;
     border-radius: calc(var(--track-height) / 2);
     width: 100%;
     height: var(--track-height);
     line-height: var(--wa-form-control-height);
     vertical-align: middle;
     margin: 0;
-    --dir: right;
-
-    background-image: linear-gradient(
-      to var(--dir),
-      var(--track-color-inactive) min(var(--percent), var(--track-active-offset)),
-      var(--track-color-active) min(var(--percent), var(--track-active-offset)),
-      var(--track-color-active) max(var(--percent), var(--track-active-offset)),
-      var(--track-color-inactive) max(var(--percent), var(--track-active-offset))
-    );
-
-    &:dir(rtl) {
-      --dir: left;
-    }
+    background-color: var(--wa-color-neutral-fill-normal);
+    -webkit-appearance: none;
 
     &::-webkit-slider-runnable-track {
       width: 100%;
@@ -1040,14 +1017,12 @@
       width: var(--thumb-size);
       height: var(--thumb-size);
       border-radius: 50%;
-      background-color: var(--thumb-color);
-      box-shadow:
-        var(--thumb-shadow, 0 0 transparent),
-        0 0 0 var(--thumb-gap) var(--wa-color-surface-default);
-      -webkit-appearance: none;
+      background-color: var(--wa-form-control-activated-color);
+      box-shadow: 0 0 0 calc(var(--thumb-size) * 0.125) var(--wa-color-surface-default);
       margin-top: calc(var(--thumb-size) / -2 + var(--track-height) / 2);
       transition: var(--wa-transition-fast);
       transition-property: width, height;
+      -webkit-appearance: none;
     }
 
     &:enabled {
@@ -1070,7 +1045,7 @@
     }
 
     &::-moz-range-progress {
-      background-color: var(--track-color-active);
+      background-color: var(--wa-color-neutral-fill-normal);
       border-radius: 3px;
       height: var(--track-height);
     }
@@ -1078,7 +1053,7 @@
     &::-moz-range-track {
       width: 100%;
       height: var(--track-height);
-      background-color: var(--track-color-inactive);
+      background-color: var(--wa-color-neutral-fill-normal);
       border-radius: 3px;
       border: none;
     }
@@ -1087,10 +1062,8 @@
       height: var(--thumb-size);
       width: var(--thumb-size);
       border-radius: 50%;
-      background-color: var(--thumb-color);
-      box-shadow:
-        var(--thumb-shadow, 0 0 transparent),
-        0 0 0 var(--thumb-gap) var(--wa-color-surface-default);
+      background-color: var(--wa-form-control-activated-color);
+      box-shadow: 0 0 0 calc(var(--thumb-size) * 0.125) var(--wa-color-surface-default);
       transition-property: background-color, border-color, box-shadow, color;
       transition-duration: var(--wa-transition-normal);
       transition-timing-function: var(--wa-transition-easing);
@@ -1110,6 +1083,10 @@
         cursor: grabbing;
       }
     }
+  }
+
+  label > input[type='range'] {
+    margin-block-start: var(--wa-space-l);
   }
 
   /* States */


### PR DESCRIPTION
- Makes native styles more consistent with `<wa-slider>`
- Removes unused custom properties leftover from shared styles (only two are left because they are reused)
- Fixes #627 

Before
![CleanShot 2025-06-03 at 08 09 47@2x](https://github.com/user-attachments/assets/8aec3b71-310f-461b-969f-cd8ba9e66e63)

After
![CleanShot 2025-06-03 at 08 08 57@2x](https://github.com/user-attachments/assets/2bd67228-7f74-4553-aaa3-bfb553d697e9)
