### PR TITLE
Add `resize: vertical` to native `<textarea>`

### DIFF
--- a/packages/webawesome/src/styles/native.css
+++ b/packages/webawesome/src/styles/native.css
@@ -924,6 +924,10 @@
     }
   }
 
+  textarea {
+    resize: vertical;
+  }
+
   input.wa-pill,
   textarea.wa-pill {
     border-radius: var(--wa-border-radius-pill) !important;


### PR DESCRIPTION
- Adds `resize: vertical` as the default style for native textareas, which is common in CSS resets
- This "fixes" #392 as the issue occurs due to the label's display being `inline-block` and wrapping, but textareas are 100% by default so the user can already customize this behavior as desired