### PR TITLE
increase breakpoint on wa-page

### DIFF
--- a/packages/webawesome/docs/_includes/base.njk
+++ b/packages/webawesome/docs/_includes/base.njk
@@ -20,7 +20,7 @@
   </head>
   <body class="layout-{{ layout | stripExtension }}{{ ' page-wide' if wide }}">
     <!-- use view="desktop" as default to reduce layout jank on desktop site. -->
-    <wa-page view="desktop" disable-navigation-toggle="" mobile-breakpoint="1140">
+    <wa-page view="desktop" disable-navigation-toggle="" mobile-breakpoint="1180">
       <header slot="header" class="wa-split">
         {# Logo #}
         <div id="docs-branding">


### PR DESCRIPTION
Right now between 1140->1170 theres some ugly wrapping, so to be safe, I bumped it to 1180.


<img width="1163" alt="Screenshot 2025-06-16 at 1 56 48 PM" src="https://github.com/user-attachments/assets/4060da1d-8f9d-4a6e-a774-fe2d5612de29" />
