### PR TITLE
Fix tag sizes

### DIFF
--- a/packages/webawesome/src/components/tag/tag.css
+++ b/packages/webawesome/src/components/tag/tag.css
@@ -1,21 +1,23 @@
-:host {
-  display: inline-flex;
-  gap: 0.5em;
-  border-radius: var(--wa-border-radius-m);
-  align-items: center;
-  background-color: var(--background-color, var(--wa-color-fill-quiet));
-  border-color: var(--border-color, transparent);
-  border-style: var(--wa-border-style);
-  border-width: var(--wa-border-width-s);
-  color: var(--text-color, var(--wa-color-on-normal));
-  font-size: inherit;
-  line-height: 1;
-  white-space: nowrap;
-  user-select: none;
-  -webkit-user-select: none;
-  height: calc(var(--wa-form-control-height) * 0.8);
-  line-height: calc(var(--wa-form-control-height) - var(--wa-form-control-border-width) * 2);
-  padding: 0 0.75em;
+@layer wa-component {
+  :host {
+    display: inline-flex;
+    gap: 0.5em;
+    border-radius: var(--wa-border-radius-m);
+    align-items: center;
+    background-color: var(--background-color, var(--wa-color-fill-quiet));
+    border-color: var(--border-color, transparent);
+    border-style: var(--wa-border-style);
+    border-width: var(--wa-border-width-s);
+    color: var(--text-color, var(--wa-color-on-normal));
+    font-size: inherit;
+    line-height: 1;
+    white-space: nowrap;
+    user-select: none;
+    -webkit-user-select: none;
+    height: calc(var(--wa-form-control-height) * 0.8);
+    line-height: calc(var(--wa-form-control-height) - var(--wa-form-control-border-width) * 2);
+    padding: 0 0.75em;
+  }
 }
 
 .content {

--- a/packages/webawesome/src/components/tag/tag.ts
+++ b/packages/webawesome/src/components/tag/tag.ts
@@ -28,7 +28,7 @@ import styles from './tag.css';
  */
 @customElement('wa-tag')
 export default class WaTag extends WebAwesomeElement {
-  static css = [sizeStyles, variantStyles, appearanceStyles, styles];
+  static css = [styles, variantStyles, sizeStyles, appearanceStyles];
 
   private readonly localize = new LocalizeController(this);
 


### PR DESCRIPTION
Closes #1059

We previously encountered a similar issue in #993 where the `appearance` attribute wasn't working for `<wa-button>` until [this fix](https://github.com/shoelace-style/webawesome/pull/993/commits/e99fe2adff1e541fea24d904fc76d57b11bb09ac) was implemented.

Because `<wa-tag>`'s `:host` styles specify `font-size: inherit`, and these styles are unlayered, `font-size: inherit` takes precedence over the layered `font-size` styles in `size.css`. We fix this by wrapping `<wa-tag>`'s `:host` styles in its own layer and changing the order of internal styles so that the `wa-component` layer is lower in the cascade order than any of the styles in the `wa-utilities` layer.