### PR TITLE
Add disabled to radio group

### DIFF
--- a/packages/webawesome/docs/docs/components/radio-group.md
+++ b/packages/webawesome/docs/docs/components/radio-group.md
@@ -44,7 +44,7 @@ Set the `appearance` attribute to `button` on all radios to render a radio butto
   <wa-radio appearance="button" value="3">Option 3</wa-radio>
 </wa-radio-group>
 
-<br>
+<br />
 
 <wa-radio-group
   label="Vertical options"
@@ -60,12 +60,22 @@ Set the `appearance` attribute to `button` on all radios to render a radio butto
 </wa-radio-group>
 ```
 
-### Disabling Options
+### Disabling
 
-Radios and radio buttons can be disabled by adding the `disabled` attribute to the respective options inside the radio group.
+To disable the entire radio group, add the `disabled` attribute to the radio group.
 
 ```html {.example}
-<wa-radio-group label="Select an option" name="a" value="1">
+<wa-radio-group label="Select an option" disabled>
+  <wa-radio value="1">Option 1</wa-radio>
+  <wa-radio value="2" disabled>Option 2</wa-radio>
+  <wa-radio value="3">Option 3</wa-radio>
+</wa-radio-group>
+```
+
+To disable individual options, add the `disabled` attribute to the respective options.
+
+```html {.example}
+<wa-radio-group label="Select an option">
   <wa-radio value="1">Option 1</wa-radio>
   <wa-radio value="2" disabled>Option 2</wa-radio>
   <wa-radio value="3">Option 3</wa-radio>

--- a/packages/webawesome/src/components/radio/radio.css
+++ b/packages/webawesome/src/components/radio/radio.css
@@ -89,7 +89,7 @@
 }
 
 /* Disabled */
-:host([disabled]) {
+:host(:state(disabled)) {
   opacity: 0.5;
   cursor: not-allowed;
 }
@@ -142,7 +142,7 @@
 }
 
 @media (hover: hover) {
-  :host([appearance='button']:hover:not([disabled], :state(checked))) {
+  :host([appearance='button']:hover:not(:state(disabled), :state(checked))) {
     background-color: color-mix(in srgb, var(--wa-color-surface-default) 95%, var(--wa-color-mix-hover));
   }
 }


### PR DESCRIPTION
Originally requested by: https://github.com/shoelace-style/webawesome-alpha/discussions/306

- Adds the ability to disable the entire radio group with `<wa-radio-group disabled>`.
- Individual items can still be disabled. The original disabled state will persist when the radio group is re-enabled.
- Removes the `@watch` decorator in favor of the `updated()` lifecycle method
