### PR TITLE
Refactor copy button documentation layout for improved alignment with input

### DIFF
--- a/packages/webawesome/docs/docs/components/copy-button.md
+++ b/packages/webawesome/docs/docs/components/copy-button.md
@@ -56,10 +56,12 @@ To copy data from an attribute, use `from="id[attr]"` where `id` is the id of th
 <br /><br />
 
 <!-- Copies the input's "value" property -->
-<wa-input id="my-input" type="text" value="User input" style="display: inline-block; max-width: 300px;"></wa-input>
-<wa-copy-button from="my-input.value"></wa-copy-button>
+<span class="wa-align-items-center wa-gap-2xs">
+  <wa-input id="my-input" type="text" value="User input" style="display: inline-block; max-width: 300px;"></wa-input>
+  <wa-copy-button from="my-input.value"></wa-copy-button>
+</span>
 
-<br /><br />
+<br />
 
 <!-- Copies the link's "href" attribute -->
 <a id="my-link" href="https://shoelace.style/">Web Awesome Website</a>


### PR DESCRIPTION
### Problem

In one of the [copy button examples](https://webawesome.com/docs/components/copy-button#copying-values-from-other-elements) `wa-copy-button` and `wa-input` were not aligned properly. This also caused an uneven spacing between the examples. Same for the CodePen example.

<img width="250" alt="screenshot 1" src="https://github.com/user-attachments/assets/09ad26c1-94d4-4eae-9e6b-29197b935e13" />

### Solution

Adding 2 alignment classes from webawesome solved the problem

<img width="250" alt="screenshot 2" src="https://github.com/user-attachments/assets/feefd566-ceb5-43a0-9bd7-9620b3c8610e" />