### PR TITLE
Fix react imports to include a class name

### DIFF
--- a/packages/webawesome/docs/_layouts/component.njk
+++ b/packages/webawesome/docs/_layouts/component.njk
@@ -288,7 +288,7 @@
       <p>
         To manually import this component from React, use the following code.
       </p>
-      <pre><code class="language-js">import '@awesome.me/webawesome/dist/react/{{ componentName }}';</code></pre>
+      <pre><code class="language-js">import {{ component.name }} from '@awesome.me/webawesome/dist/react/{{ componentName }}';</code></pre>
     </wa-tab-panel>
   </wa-tab-group>
 


### PR DESCRIPTION
changes from `import "@awesome.me/webawesome/dist/react/button"` to `import WaButton from "@awesome.me/webawesome/dist/react/button"`