### PR TITLE
Remove extra stylesheets from CodePen editing

### DIFF
--- a/packages/webawesome/docs/assets/scripts/code-examples.js
+++ b/packages/webawesome/docs/assets/scripts/code-examples.js
@@ -57,9 +57,7 @@ document.addEventListener('click', event => {
     const cdnUrl = document.documentElement.dataset.cdnUrl;
     const html =
       `<script data-fa-kit-code="b10bfbde90" type="module" src="${cdnUrl}webawesome.loader.js"></script>\n` +
-      `<link rel="stylesheet" href="${cdnUrl}styles/themes/default.css">\n` +
-      `<link rel="stylesheet" href="${cdnUrl}styles/webawesome.css">\n` +
-      `<link rel="stylesheet" href="${cdnUrl}styles/utilities.css">\n\n` +
+      `<link rel="stylesheet" href="${cdnUrl}styles/webawesome.css">\n\n` +
       `${code.textContent}`;
     const css = 'html > body {\n  padding: 2rem !important;\n}';
     const js = '';


### PR DESCRIPTION
Following #1113, we only need to include `webawesome.css` when editing in CodePen. This stylesheet automatically imports all WA styles, including `themes/default.css` and `utilities.css`.