### PR TITLE
(l10n: it): Fix language name in `it.ts`

### DIFF
--- a/packages/webawesome/src/translations/it.ts
+++ b/packages/webawesome/src/translations/it.ts
@@ -3,7 +3,7 @@ import type { Translation } from '../utilities/localize.js';
 
 const translation: Translation = {
   $code: 'it',
-  $name: 'Italian',
+  $name: 'Italiano',
   $dir: 'ltr',
 
   carousel: 'Carosello',


### PR DESCRIPTION
#### Description

This fixes the language name used in `it.ts`, a localisation file.