### PR TITLE
Fix extra whitespace in `<wa-textarea>` with `resize="auto"`

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -8,6 +8,12 @@ Web Awesome follows [Semantic Versioning](https://semver.org/). Breaking changes
 
 Components with the <wa-badge variant="warning">Experimental</wa-badge> badge should not be used in production. They are made available as release candidates for development and testing purposes. As such, changes to experimental components will not be subject to semantic versioning.
 
+## Next
+
+### Bug Fixes and Improvements {data-no-outline}
+
+- Fixed a bug in `<wa-textarea>` where setting `resize="auto"` caused the height of the textarea to double [issue:1155]
+
 ## 3.0.0-beta.2
 
 ### New Features {data-no-outline}

--- a/packages/webawesome/src/components/textarea/textarea.css
+++ b/packages/webawesome/src/components/textarea/textarea.css
@@ -2,10 +2,9 @@
   border-width: 0;
 }
 
-/* Shared textarea and size-adjuster positioning */
-.textarea,
-.size-adjuster {
-  grid-area: 1 / 1 / 2 / 2;
+.textarea {
+  display: grid;
+  align-items: center;
   margin: 0;
   border: none;
   outline: none;
@@ -72,13 +71,14 @@ textarea {
   }
 }
 
-.textarea {
-  position: relative;
+/* Shared textarea and size-adjuster positioning */
+.control,
+.size-adjuster {
+  grid-area: 1 / 1 / 2 / 2;
 }
 
 .size-adjuster {
   visibility: hidden;
-  position: absolute;
   pointer-events: none;
   opacity: 0;
   padding: 0;

--- a/packages/webawesome/src/components/textarea/textarea.css
+++ b/packages/webawesome/src/components/textarea/textarea.css
@@ -72,8 +72,13 @@ textarea {
   }
 }
 
+.textarea {
+  position: relative;
+}
+
 .size-adjuster {
   visibility: hidden;
+  position: absolute;
   pointer-events: none;
   opacity: 0;
   padding: 0;


### PR DESCRIPTION
Closes #1155

The size adjuster was no longer positioned properly relative to the `.textarea` wrapper, causing `<wa-textarea>` to double in height.