### PR TITLE
Add missing `nanoid` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13984,6 +13984,7 @@
         "@shoelace-style/localize": "^3.2.1",
         "composed-offset-position": "^0.0.6",
         "lit": "^3.2.1",
+        "nanoid": "^5.1.5",
         "qr-creator": "^1.0.0",
         "style-observer": "^0.0.7"
       },
@@ -14009,6 +14010,23 @@
       "devDependencies": {},
       "engines": {
         "node": ">=14.17.0"
+      }
+    },
+    "packages/webawesome/node_modules/nanoid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+      "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
       }
     }
   }

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -10,7 +10,8 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 
 ## Next
 
-- Fixed a bug in `<wa-slider>` that prevented the hint from showing up
+- Fixed the missing `nanoid` dependency in `package.json` [discuss:1139]
+- Fixed a bug in `<wa-slider>` that prevented the hint from showing up [discuss:1172]
 
 ## 3.0.0-beta.2
 

--- a/packages/webawesome/package.json
+++ b/packages/webawesome/package.json
@@ -77,10 +77,10 @@
     "@shoelace-style/localize": "^3.2.1",
     "composed-offset-position": "^0.0.6",
     "lit": "^3.2.1",
+    "nanoid": "^5.1.5",
     "qr-creator": "^1.0.0",
     "style-observer": "^0.0.7"
   },
-  "devDependencies": {},
   "lint-staged": {
     "*.{ts,js}": [
       "prettier --write"


### PR DESCRIPTION
As discussed here: https://github.com/shoelace-style/webawesome/discussions/1139#discussioncomment-13665338

This is a [124-byte library](https://github.com/ai/nanoid) we use to generate random IDs with. It just wasn't properly listed as a dependency.