### PR TITLE
Fix domain in documentation links

### DIFF
--- a/packages/webawesome/docs/docs/components/zoomable-frame.md
+++ b/packages/webawesome/docs/docs/components/zoomable-frame.md
@@ -6,7 +6,7 @@ category: Imagery
 ---
 
 ```html {.example}
-<wa-zoomable-frame src="https://backers.webawesome.com/" zoom="0.5"> </wa-zoomable-frame>
+<wa-zoomable-frame src="https://webawesome.com/" zoom="0.5"> </wa-zoomable-frame>
 ```
 
 ## Examples
@@ -43,7 +43,7 @@ Set the `zoom` attribute to control the frame's zoom level. Use `1` for 100%, `2
 Define specific zoom increments with the `zoom-levels` attribute using space-separated percentages and decimal values like `zoom-levels="0.25 0.5 75% 100%"`.
 
 ```html {.example}
-<wa-zoomable-frame src="https://backers.webawesome.com/" zoom="0.5" zoom-levels="50% 0.75 100%"> </wa-zoomable-frame>
+<wa-zoomable-frame src="https://webawesome.com/" zoom="0.5" zoom-levels="50% 0.75 100%"> </wa-zoomable-frame>
 ```
 
 ### Hiding zoom controls
@@ -51,7 +51,7 @@ Define specific zoom increments with the `zoom-levels` attribute using space-sep
 Add the `without-controls` attribute to hide the zoom control interface from the frame.
 
 ```html {.example}
-<wa-zoomable-frame src="https://backers.webawesome.com/" without-controls zoom="0.5"> </wa-zoomable-frame>
+<wa-zoomable-frame src="https://webawesome.com/" without-controls zoom="0.5"> </wa-zoomable-frame>
 ```
 
 ### Preventing user interaction
@@ -59,5 +59,5 @@ Add the `without-controls` attribute to hide the zoom control interface from the
 Apply the `without-interaction` attribute to make the frame non-interactive. Note that this prevents keyboard navigation into the frame, which may impact accessibility for some users.
 
 ```html {.example}
-<wa-zoomable-frame src="https://backers.webawesome.com/" zoom="0.5" without-interaction> </wa-zoomable-frame>
+<wa-zoomable-frame src="https://webawesome.com/" zoom="0.5" without-interaction> </wa-zoomable-frame>
 ```

--- a/packages/webawesome/scripts/plop/templates/component/component.hbs
+++ b/packages/webawesome/scripts/plop/templates/component/component.hbs
@@ -1,43 +1,14 @@
-import { html } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
-import { watch } from '../../internal/watch.js';
-import WebAwesomeElement from '../../internal/webawesome-element.js';
-import styles from './{{ tagWithoutPrefix tag }}.css';
-
-/**
- * @summary Short summary of the component's intended use.
- * @documentation https://backers.webawesome.com/docs/components/{{ tagWithoutPrefix tag }}
- * @status experimental
- * @since 3.0
- *
- * @dependency wa-example
- *
- * @slot - The default slot.
- * @slot example - An example slot.
- *
- * @csspart base - The component's base wrapper.
- *
- * @cssproperty --example - An example CSS custom property.
- */
- @customElement("{{ tag }}")
-export default class {{ properCase tag }} extends WebAwesomeElement {
-  static css = styles;
-
-  /** An example attribute. */
-  @property() attr = 'example';
-
-  @watch('example')
-  handleExampleChange() {
-    // do something
-  }
-
-  render() {
-    return html` <slot></slot> `;
-  }
-}
-
-declare global {
-  interface HTMLElementTagNameMap {
-    '{{ tag }}': {{ properCase tag }};
-  }
-}
+import { html } from 'lit'; import { customElement, property } from 'lit/decorators.js'; import { watch } from
+'../../internal/watch.js'; import WebAwesomeElement from '../../internal/webawesome-element.js'; import styles from './{{tagWithoutPrefix
+  tag
+}}.css'; /** * @summary Short summary of the component's intended use. * @documentation
+https://webawesome.com/docs/components/{{tagWithoutPrefix tag}}
+* @status experimental * @since 3.0 * * @dependency wa-example * * @slot - The default slot. * @slot example - An
+example slot. * * @csspart base - The component's base wrapper. * * @cssproperty --example - An example CSS custom
+property. */ @customElement("{{tag}}") export default class
+{{properCase tag}}
+extends WebAwesomeElement { static css = styles; /** An example attribute. */ @property() attr = 'example';
+@watch('example') handleExampleChange() { // do something } render() { return html`
+<slot></slot>
+`; } } declare global { interface HTMLElementTagNameMap { '{{tag}}':
+{{properCase tag}}; } }

--- a/packages/webawesome/scripts/plop/templates/component/component.hbs
+++ b/packages/webawesome/scripts/plop/templates/component/component.hbs
@@ -1,14 +1,43 @@
-import { html } from 'lit'; import { customElement, property } from 'lit/decorators.js'; import { watch } from
-'../../internal/watch.js'; import WebAwesomeElement from '../../internal/webawesome-element.js'; import styles from './{{tagWithoutPrefix
-  tag
-}}.css'; /** * @summary Short summary of the component's intended use. * @documentation
-https://webawesome.com/docs/components/{{tagWithoutPrefix tag}}
-* @status experimental * @since 3.0 * * @dependency wa-example * * @slot - The default slot. * @slot example - An
-example slot. * * @csspart base - The component's base wrapper. * * @cssproperty --example - An example CSS custom
-property. */ @customElement("{{tag}}") export default class
-{{properCase tag}}
-extends WebAwesomeElement { static css = styles; /** An example attribute. */ @property() attr = 'example';
-@watch('example') handleExampleChange() { // do something } render() { return html`
-<slot></slot>
-`; } } declare global { interface HTMLElementTagNameMap { '{{tag}}':
-{{properCase tag}}; } }
+import { html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { watch } from '../../internal/watch.js';
+import WebAwesomeElement from '../../internal/webawesome-element.js';
+import styles from './{{ tagWithoutPrefix tag }}.css';
+
+/**
+ * @summary Short summary of the component's intended use.
+ * @documentation https://webawesome.com/docs/components/{{ tagWithoutPrefix tag }}
+ * @status experimental
+ * @since 3.0
+ *
+ * @dependency wa-example
+ *
+ * @slot - The default slot.
+ * @slot example - An example slot.
+ *
+ * @csspart base - The component's base wrapper.
+ *
+ * @cssproperty --example - An example CSS custom property.
+ */
+ @customElement("{{ tag }}")
+export default class {{ properCase tag }} extends WebAwesomeElement {
+  static css = styles;
+
+  /** An example attribute. */
+  @property() attr = 'example';
+
+  @watch('example')
+  handleExampleChange() {
+    // do something
+  }
+
+  render() {
+    return html` <slot></slot> `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    '{{ tag }}': {{ properCase tag }};
+  }
+}

--- a/packages/webawesome/src/components/animated-image/animated-image.ts
+++ b/packages/webawesome/src/components/animated-image/animated-image.ts
@@ -9,7 +9,7 @@ import styles from './animated-image.css';
 
 /**
  * @summary A component for displaying animated GIFs and WEBPs that play and pause on interaction.
- * @documentation https://backers.webawesome.com/docs/components/animated-image
+ * @documentation https://webawesome.com/docs/components/animated-image
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/animation/animation.ts
+++ b/packages/webawesome/src/components/animation/animation.ts
@@ -10,7 +10,7 @@ import { animations } from './animations.js';
 
 /**
  * @summary Animate elements declaratively with nearly 100 baked-in presets, or roll your own with custom keyframes. Powered by the [Web Animations API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API).
- * @documentation https://backers.webawesome.com/docs/components/animation
+ * @documentation https://webawesome.com/docs/components/animation
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/avatar/avatar.ts
+++ b/packages/webawesome/src/components/avatar/avatar.ts
@@ -8,7 +8,7 @@ import styles from './avatar.css';
 
 /**
  * @summary Avatars are used to represent a person or object.
- * @documentation https://backers.webawesome.com/docs/components/avatar
+ * @documentation https://webawesome.com/docs/components/avatar
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/badge/badge.ts
+++ b/packages/webawesome/src/components/badge/badge.ts
@@ -6,7 +6,7 @@ import styles from './badge.css';
 
 /**
  * @summary Badges are used to draw attention and display statuses or counts.
- * @documentation https://backers.webawesome.com/docs/components/badge
+ * @documentation https://webawesome.com/docs/components/badge
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/breadcrumb-item/breadcrumb-item.ts
+++ b/packages/webawesome/src/components/breadcrumb-item/breadcrumb-item.ts
@@ -7,7 +7,7 @@ import styles from './breadcrumb-item.css';
 
 /**
  * @summary Breadcrumb Items are used inside breadcrumbs to represent different links.
- * @documentation https://backers.webawesome.com/docs/components/breadcrumb-item
+ * @documentation https://webawesome.com/docs/components/breadcrumb-item
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/webawesome/src/components/breadcrumb/breadcrumb.ts
@@ -8,7 +8,7 @@ import styles from './breadcrumb.css';
 
 /**
  * @summary Breadcrumbs provide a group of links so users can easily navigate a website's hierarchy.
- * @documentation https://backers.webawesome.com/docs/components/breadcrumb
+ * @documentation https://webawesome.com/docs/components/breadcrumb
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/button-group/button-group.ts
+++ b/packages/webawesome/src/components/button-group/button-group.ts
@@ -10,7 +10,7 @@ import styles from './button-group.css';
 
 /**
  * @summary Button groups can be used to group related buttons into sections.
- * @documentation https://backers.webawesome.com/docs/components/button-group
+ * @documentation https://webawesome.com/docs/components/button-group
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/button/button.ts
+++ b/packages/webawesome/src/components/button/button.ts
@@ -16,7 +16,7 @@ import styles from './button.css';
 
 /**
  * @summary Buttons represent actions that are available to the user.
- * @documentation https://backers.webawesome.com/docs/components/button
+ * @documentation https://webawesome.com/docs/components/button
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/callout/callout.ts
+++ b/packages/webawesome/src/components/callout/callout.ts
@@ -7,7 +7,7 @@ import styles from './callout.css';
 
 /**
  * @summary Callouts are used to display important messages inline.
- * @documentation https://backers.webawesome.com/docs/components/callout
+ * @documentation https://webawesome.com/docs/components/callout
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/card/card.ts
+++ b/packages/webawesome/src/components/card/card.ts
@@ -7,7 +7,7 @@ import styles from './card.css';
 
 /**
  * @summary Cards can be used to group related subjects in a container.
- * @documentation https://backers.webawesome.com/docs/components/card
+ * @documentation https://webawesome.com/docs/components/card
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/checkbox/checkbox.ts
+++ b/packages/webawesome/src/components/checkbox/checkbox.ts
@@ -15,7 +15,7 @@ import styles from './checkbox.css';
 
 /**
  * @summary Checkboxes allow the user to toggle an option on or off.
- * @documentation https://backers.webawesome.com/docs/components/checkbox
+ * @documentation https://webawesome.com/docs/components/checkbox
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/color-picker/color-picker.ts
+++ b/packages/webawesome/src/components/color-picker/color-picker.ts
@@ -39,7 +39,7 @@ declare const EyeDropper: EyeDropperConstructor;
 
 /**
  * @summary Color pickers allow the user to select a color.
- * @documentation https://backers.webawesome.com/docs/components/color-picker
+ * @documentation https://webawesome.com/docs/components/color-picker
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/comparison/comparison.ts
+++ b/packages/webawesome/src/components/comparison/comparison.ts
@@ -11,7 +11,7 @@ import styles from './comparison.css';
 
 /**
  * @summary Compare visual differences between similar content with a sliding panel.
- * @documentation https://backers.webawesome.com/docs/components/comparison
+ * @documentation https://webawesome.com/docs/components/comparison
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/copy-button/copy-button.ts
+++ b/packages/webawesome/src/components/copy-button/copy-button.ts
@@ -14,7 +14,7 @@ import styles from './copy-button.css';
 
 /**
  * @summary Copies text data to the clipboard when the user clicks the trigger.
- * @documentation https://backers.webawesome.com/docs/components/copy
+ * @documentation https://webawesome.com/docs/components/copy
  * @status experimental
  * @since 2.7
  *

--- a/packages/webawesome/src/components/details/details.ts
+++ b/packages/webawesome/src/components/details/details.ts
@@ -14,7 +14,7 @@ import styles from './details.css';
 
 /**
  * @summary Details show a brief summary and expand to show additional content.
- * @documentation https://backers.webawesome.com/docs/components/details
+ * @documentation https://webawesome.com/docs/components/details
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/dialog/dialog.ts
+++ b/packages/webawesome/src/components/dialog/dialog.ts
@@ -17,7 +17,7 @@ import styles from './dialog.css';
 
 /**
  * @summary Dialogs, sometimes called "modals", appear above the page and require the user's immediate attention.
- * @documentation https://backers.webawesome.com/docs/components/dialog
+ * @documentation https://webawesome.com/docs/components/dialog
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/divider/divider.ts
+++ b/packages/webawesome/src/components/divider/divider.ts
@@ -5,7 +5,7 @@ import styles from './divider.css';
 
 /**
  * @summary Dividers are used to visually separate or group elements.
- * @documentation https://backers.webawesome.com/docs/components/divider
+ * @documentation https://webawesome.com/docs/components/divider
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/drawer/drawer.ts
+++ b/packages/webawesome/src/components/drawer/drawer.ts
@@ -17,7 +17,7 @@ import styles from './drawer.css';
 
 /**
  * @summary Drawers slide in from a container to expose additional options and information.
- * @documentation https://backers.webawesome.com/docs/components/drawer
+ * @documentation https://webawesome.com/docs/components/drawer
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/dropdown-item/dropdown-item.ts
+++ b/packages/webawesome/src/components/dropdown-item/dropdown-item.ts
@@ -8,7 +8,7 @@ import styles from './dropdown-item.css';
 
 /**
  * @summary Represents an individual item within a dropdown menu, supporting standard items, checkboxes, and submenus.
- * @documentation https://backers.webawesome.com/docs/components/dropdown-item
+ * @documentation https://webawesome.com/docs/components/dropdown-item
  * @status experimental
  * @since 3.0
  *

--- a/packages/webawesome/src/components/dropdown/dropdown.ts
+++ b/packages/webawesome/src/components/dropdown/dropdown.ts
@@ -24,7 +24,7 @@ const openDropdowns = new Set<WaDropdown>();
 /**
  * @summary Dropdowns display a list of options that can be triggered by a button or other element. They support
  *  keyboard navigation, submenus, and various customization options.
- * @documentation https://backers.webawesome.com/docs/components/dropdown
+ * @documentation https://webawesome.com/docs/components/dropdown
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/format-bytes/format-bytes.ts
+++ b/packages/webawesome/src/components/format-bytes/format-bytes.ts
@@ -4,7 +4,7 @@ import { LocalizeController } from '../../utilities/localize.js';
 
 /**
  * @summary Formats a number as a human readable bytes value.
- * @documentation https://backers.webawesome.com/docs/components/format-bytes
+ * @documentation https://webawesome.com/docs/components/format-bytes
  * @status stable
  * @since 2.0
  */

--- a/packages/webawesome/src/components/format-date/format-date.ts
+++ b/packages/webawesome/src/components/format-date/format-date.ts
@@ -5,7 +5,7 @@ import { LocalizeController } from '../../utilities/localize.js';
 
 /**
  * @summary Formats a date/time using the specified locale and options.
- * @documentation https://backers.webawesome.com/docs/components/format-date
+ * @documentation https://webawesome.com/docs/components/format-date
  * @status stable
  * @since 2.0
  */

--- a/packages/webawesome/src/components/format-number/format-number.ts
+++ b/packages/webawesome/src/components/format-number/format-number.ts
@@ -4,7 +4,7 @@ import { LocalizeController } from '../../utilities/localize.js';
 
 /**
  * @summary Formats a number using the specified locale and options.
- * @documentation https://backers.webawesome.com/docs/components/format-number
+ * @documentation https://webawesome.com/docs/components/format-number
  * @status stable
  * @since 2.0
  */

--- a/packages/webawesome/src/components/icon/icon.ts
+++ b/packages/webawesome/src/components/icon/icon.ts
@@ -24,7 +24,7 @@ interface IconSource {
 
 /**
  * @summary Icons are symbols that can be used to represent various options within an application.
- * @documentation https://backers.webawesome.com/docs/components/icon
+ * @documentation https://webawesome.com/docs/components/icon
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/include/include.ts
+++ b/packages/webawesome/src/components/include/include.ts
@@ -9,7 +9,7 @@ import { requestInclude } from './request.js';
 
 /**
  * @summary Includes give you the power to embed external HTML files into the page.
- * @documentation https://backers.webawesome.com/docs/components/include
+ * @documentation https://webawesome.com/docs/components/include
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/input/input.ts
+++ b/packages/webawesome/src/components/input/input.ts
@@ -17,7 +17,7 @@ import styles from './input.css';
 
 /**
  * @summary Inputs collect data from the user.
- * @documentation https://backers.webawesome.com/docs/components/input
+ * @documentation https://webawesome.com/docs/components/input
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/mutation-observer/mutation-observer.ts
+++ b/packages/webawesome/src/components/mutation-observer/mutation-observer.ts
@@ -7,7 +7,7 @@ import styles from './mutation-observer.css';
 
 /**
  * @summary The Mutation Observer component offers a thin, declarative interface to the [`MutationObserver API`](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver).
- * @documentation https://backers.webawesome.com/docs/components/mutation-observer
+ * @documentation https://webawesome.com/docs/components/mutation-observer
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/option/option.ts
+++ b/packages/webawesome/src/components/option/option.ts
@@ -9,7 +9,7 @@ import styles from './option.css';
 
 /**
  * @summary Options define the selectable items within a select component.
- * @documentation https://backers.webawesome.com/docs/components/option
+ * @documentation https://webawesome.com/docs/components/option
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/page/page.ts
+++ b/packages/webawesome/src/components/page/page.ts
@@ -79,7 +79,7 @@ function toLength(px: number | string): string {
 
 /**
  * @summary Pages offer an easy way to scaffold entire page layouts using minimal markup.
- * @documentation https://backers.webawesome.com/docs/components/page
+ * @documentation https://webawesome.com/docs/components/page
  * @status experimental
  * @since 3.0
  *

--- a/packages/webawesome/src/components/popover/popover.ts
+++ b/packages/webawesome/src/components/popover/popover.ts
@@ -18,7 +18,7 @@ const openPopovers = new Set<WaPopover>();
 
 /**
  * @summary Popovers display contextual content and interactive elements in a floating panel.
- * @documentation https://backers.webawesome.com/docs/components/popover
+ * @documentation https://webawesome.com/docs/components/popover
  * @status stable
  * @since 3.0
  *

--- a/packages/webawesome/src/components/popup/popup.ts
+++ b/packages/webawesome/src/components/popup/popup.ts
@@ -37,7 +37,7 @@ const SUPPORTS_POPOVER = globalThis?.HTMLElement?.prototype.hasOwnProperty('popo
 
 /**
  * @summary Popup is a utility that lets you declaratively anchor "popup" containers to another element.
- * @documentation https://backers.webawesome.com/docs/components/popup
+ * @documentation https://webawesome.com/docs/components/popup
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/progress-bar/progress-bar.ts
+++ b/packages/webawesome/src/components/progress-bar/progress-bar.ts
@@ -9,7 +9,7 @@ import styles from './progress-bar.css';
 
 /**
  * @summary Progress bars are used to show the status of an ongoing operation.
- * @documentation https://backers.webawesome.com/docs/components/progress-bar
+ * @documentation https://webawesome.com/docs/components/progress-bar
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/progress-ring/progress-ring.ts
+++ b/packages/webawesome/src/components/progress-ring/progress-ring.ts
@@ -7,7 +7,7 @@ import styles from './progress-ring.css';
 
 /**
  * @summary Progress rings are used to show the progress of a determinate operation in a circular fashion.
- * @documentation https://backers.webawesome.com/docs/components/progress-ring
+ * @documentation https://webawesome.com/docs/components/progress-ring
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/qr-code/qr-code.ts
+++ b/packages/webawesome/src/components/qr-code/qr-code.ts
@@ -10,7 +10,7 @@ let QrCreator: _QrCreator.default;
 
 /**
  * @summary Generates a [QR code](https://www.qrcode.com/) and renders it using the [Canvas API](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API).
- * @documentation https://backers.webawesome.com/docs/components/qr-code
+ * @documentation https://webawesome.com/docs/components/qr-code
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/radio-group/radio-group.ts
+++ b/packages/webawesome/src/components/radio-group/radio-group.ts
@@ -14,7 +14,7 @@ import styles from './radio-group.css';
 
 /**
  * @summary Radio groups are used to group multiple [radios](/docs/components/radio) so they function as a single form control.
- * @documentation https://backers.webawesome.com/docs/components/radio-group
+ * @documentation https://webawesome.com/docs/components/radio-group
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/radio/radio.ts
+++ b/packages/webawesome/src/components/radio/radio.ts
@@ -9,7 +9,7 @@ import styles from './radio.css';
 
 /**
  * @summary Radios allow the user to select a single option from a group.
- * @documentation https://backers.webawesome.com/docs/components/radio
+ * @documentation https://webawesome.com/docs/components/radio
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/rating/rating.ts
+++ b/packages/webawesome/src/components/rating/rating.ts
@@ -14,7 +14,7 @@ import styles from './rating.css';
 
 /**
  * @summary Ratings give users a way to quickly view and provide feedback.
- * @documentation https://backers.webawesome.com/docs/components/rating
+ * @documentation https://webawesome.com/docs/components/rating
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/relative-time/relative-time.ts
+++ b/packages/webawesome/src/components/relative-time/relative-time.ts
@@ -20,7 +20,7 @@ const availableUnits: UnitConfig[] = [
 
 /**
  * @summary Outputs a localized time phrase relative to the current date and time.
- * @documentation https://backers.webawesome.com/docs/components/relative-time
+ * @documentation https://webawesome.com/docs/components/relative-time
  * @status stable
  * @since 2.0
  */

--- a/packages/webawesome/src/components/resize-observer/resize-observer.ts
+++ b/packages/webawesome/src/components/resize-observer/resize-observer.ts
@@ -7,7 +7,7 @@ import styles from './resize-observer.css';
 
 /**
  * @summary The Resize Observer component offers a thin, declarative interface to the [`ResizeObserver API`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver).
- * @documentation https://backers.webawesome.com/docs/components/resize-observer
+ * @documentation https://webawesome.com/docs/components/resize-observer
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/scroller/scroller.ts
+++ b/packages/webawesome/src/components/scroller/scroller.ts
@@ -7,7 +7,7 @@ import styles from './scroller.css';
 /**
  * @summary Scrollers create an accessible container while providing visual cues that help users identify and navigate
  *  through content that scrolls.
- * @documentation https://backers.webawesome.com/docs/components/card
+ * @documentation https://webawesome.com/docs/components/card
  * @status stable
  * @since 3.0
  *

--- a/packages/webawesome/src/components/select/select.ts
+++ b/packages/webawesome/src/components/select/select.ts
@@ -29,7 +29,7 @@ import styles from './select.css';
 
 /**
  * @summary Selects allow you to choose items from a menu of predefined options.
- * @documentation https://backers.webawesome.com/docs/components/select
+ * @documentation https://webawesome.com/docs/components/select
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/skeleton/skeleton.ts
+++ b/packages/webawesome/src/components/skeleton/skeleton.ts
@@ -5,7 +5,7 @@ import styles from './skeleton.css';
 
 /**
  * @summary Skeletons are used to provide a visual representation of where content will eventually be drawn.
- * @documentation https://backers.webawesome.com/docs/components/skeleton
+ * @documentation https://webawesome.com/docs/components/skeleton
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/slider/slider.ts
+++ b/packages/webawesome/src/components/slider/slider.ts
@@ -19,7 +19,7 @@ import styles from './slider.css';
  * <wa-slider>
  *
  * @summary Ranges allow the user to select a single value within a given range using a slider.
- * @documentation https://backers.webawesome.com/docs/components/range
+ * @documentation https://webawesome.com/docs/components/range
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/spinner/spinner.ts
+++ b/packages/webawesome/src/components/spinner/spinner.ts
@@ -6,7 +6,7 @@ import styles from './spinner.css';
 
 /**
  * @summary Spinners are used to show the progress of an indeterminate operation.
- * @documentation https://backers.webawesome.com/docs/components/spinner
+ * @documentation https://webawesome.com/docs/components/spinner
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/split-panel/split-panel.ts
+++ b/packages/webawesome/src/components/split-panel/split-panel.ts
@@ -11,7 +11,7 @@ import styles from './split-panel.css';
 
 /**
  * @summary Split panels display two adjacent panels, allowing the user to reposition them.
- * @documentation https://backers.webawesome.com/docs/components/split-panel
+ * @documentation https://webawesome.com/docs/components/split-panel
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/switch/switch.ts
+++ b/packages/webawesome/src/components/switch/switch.ts
@@ -14,7 +14,7 @@ import styles from './switch.css';
 
 /**
  * @summary Switches allow the user to toggle an option on or off.
- * @documentation https://backers.webawesome.com/docs/components/switch
+ * @documentation https://webawesome.com/docs/components/switch
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/tab-group/tab-group.ts
+++ b/packages/webawesome/src/components/tab-group/tab-group.ts
@@ -16,7 +16,7 @@ import styles from './tab-group.css';
 
 /**
  * @summary Tab groups organize content into a container that shows one section at a time.
- * @documentation https://backers.webawesome.com/docs/components/tab-group
+ * @documentation https://webawesome.com/docs/components/tab-group
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/tab-panel/tab-panel.ts
+++ b/packages/webawesome/src/components/tab-panel/tab-panel.ts
@@ -9,7 +9,7 @@ let id = 0;
 
 /**
  * @summary Tab panels are used inside [tab groups](/docs/components/tab-group) to display tabbed content.
- * @documentation https://backers.webawesome.com/docs/components/tab-panel
+ * @documentation https://webawesome.com/docs/components/tab-panel
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/tab/tab.ts
+++ b/packages/webawesome/src/components/tab/tab.ts
@@ -9,7 +9,7 @@ let id = 0;
 
 /**
  * @summary Tabs are used inside [tab groups](/docs/components/tab-group) to represent and activate [tab panels](/docs/components/tab-panel).
- * @documentation https://backers.webawesome.com/docs/components/tab
+ * @documentation https://webawesome.com/docs/components/tab
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/tag/tag.ts
+++ b/packages/webawesome/src/components/tag/tag.ts
@@ -10,7 +10,7 @@ import styles from './tag.css';
 
 /**
  * @summary Tags are used as labels to organize things or to indicate a selection.
- * @documentation https://backers.webawesome.com/docs/components/tag
+ * @documentation https://webawesome.com/docs/components/tag
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/textarea/textarea.ts
+++ b/packages/webawesome/src/components/textarea/textarea.ts
@@ -14,7 +14,7 @@ import styles from './textarea.css';
 
 /**
  * @summary Textareas collect data from the user and allow multiple lines of text.
- * @documentation https://backers.webawesome.com/docs/components/textarea
+ * @documentation https://webawesome.com/docs/components/textarea
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/tooltip/tooltip.ts
+++ b/packages/webawesome/src/components/tooltip/tooltip.ts
@@ -15,7 +15,7 @@ import styles from './tooltip.css';
 
 /**
  * @summary Tooltips display additional information based on a specific action.
- * @documentation https://backers.webawesome.com/docs/components/tooltip
+ * @documentation https://webawesome.com/docs/components/tooltip
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/tree-item/tree-item.ts
+++ b/packages/webawesome/src/components/tree-item/tree-item.ts
@@ -21,7 +21,7 @@ import styles from './tree-item.css';
 
 /**
  * @summary A tree item serves as a hierarchical node that lives inside a [tree](/docs/components/tree).
- * @documentation https://backers.webawesome.com/docs/components/tree-item
+ * @documentation https://webawesome.com/docs/components/tree-item
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/tree/tree.ts
+++ b/packages/webawesome/src/components/tree/tree.ts
@@ -50,7 +50,7 @@ function syncCheckboxes(changedTreeItem: WaTreeItem, initialSync = false) {
 
 /**
  * @summary Trees allow you to display a hierarchical list of selectable [tree items](/docs/components/tree-item). Items with children can be expanded and collapsed as desired by the user.
- * @documentation https://backers.webawesome.com/docs/components/tree
+ * @documentation https://webawesome.com/docs/components/tree
  * @status stable
  * @since 2.0
  *

--- a/packages/webawesome/src/components/zoomable-frame/zoomable-frame.ts
+++ b/packages/webawesome/src/components/zoomable-frame/zoomable-frame.ts
@@ -9,7 +9,7 @@ import styles from './zoomable-frame.css';
 
 /**
  * @summary Zoomable frames render iframe content with zoom and interaction controls.
- * @documentation https://backers.webawesome.com/docs/components/zoomable-frame
+ * @documentation https://webawesome.com/docs/components/zoomable-frame
  * @status stable
  * @since 3.0
  *


### PR DESCRIPTION
This changes `backers.webawesome.com` to `webawesome.com`. I don't think we need a changelog for this one since they're just comments and they redirected properly to the correct location.