### PR TITLE
(component: scroller): Fix incorrect documentation link used in Scroller’s `@documentation` JSDoc tag

### DIFF
--- a/packages/webawesome/src/components/scroller/scroller.ts
+++ b/packages/webawesome/src/components/scroller/scroller.ts
@@ -7,7 +7,7 @@ import styles from './scroller.css';
 /**
  * @summary Scrollers create an accessible container while providing visual cues that help users identify and navigate
  *  through content that scrolls.
- * @documentation https://webawesome.com/docs/components/card
+ * @documentation https://webawesome.com/docs/components/scroller
  * @status stable
  * @since 3.0
  *


### PR DESCRIPTION
#### Description

This PR fixes an incorrect documentation link used in Scroller’s `@documentation` JSDoc tag.