### PR TITLE
Use `margin` for `<wa-icon>` spacing in native buttons

### DIFF
--- a/packages/webawesome/docs/docs/utilities/native.md
+++ b/packages/webawesome/docs/docs/utilities/native.md
@@ -380,6 +380,19 @@ Add the `wa-pill` class to give buttons rounded edges.
 <button class="wa-pill">Pill button</button>
 ```
 
+When using `<wa-icon>` within a button, wrap adjacent label text in `<span>` or similar to automatically add margin between the icon and the label, just like the `start` and `end` slots of `<wa-button>`.
+
+```html {.example}
+<button>
+  <wa-icon name="plane-departure"></wa-icon>
+  <span>Start Icon</span>
+</button>
+<button>
+  <span>End Icon</span>
+  <wa-icon name="plane-arrival"></wa-icon>
+</button>
+```
+
 ### Form controls
 
 Create a variety of form controls with `<input type="">`, `<select>`, and `<textarea>`. Each control closely matches the appearance of the corresponding Web Awesome component.

--- a/packages/webawesome/src/styles/native.css
+++ b/packages/webawesome/src/styles/native.css
@@ -564,7 +564,6 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 0.5em;
 
     height: var(--wa-form-control-height);
     padding: 0 var(--wa-form-control-padding-inline);
@@ -708,6 +707,16 @@
 
     &.wa-pill {
       border-radius: var(--wa-border-radius-pill);
+    }
+
+    /* Adds space between icons and adjacent elements
+     * Prefer sibling selectors over :first-child/:last-child to avoid extra space when an icon is used alone */
+    & > wa-icon:has(+ *) {
+      margin-inline-end: 0.75em;
+    }
+
+    & > * + wa-icon {
+      margin-inline-start: 0.75em;
     }
   }
   /* #endregion */


### PR DESCRIPTION
Addresses #1184. 

Swaps native button's `gap` property in favor of applying `margin` only to `<wa-icon>` to prevent unexpected spacing as described in the discussion.

Some notes on the approach:
- I've opted for sibling selectors (`wa-icon:has(+ *)` and `* + wa-icon`) rather than `wa-icon:first-child` and `wa-icon:last-child`. `:first-child`/`:last-child` matches icons that are used alone within buttons AND icons used alongside unwrapped inner text, which leads to extra space in both of those situations. imo, it's preferable for there to be _no_ space added in either case, which the sibling selectors accomplish.
- Adjacent label text must be wrapped in `<span>` or similar for the spacing to take effect. Without this, we have no way to detect the presence of the label text in CSS. (We'd also have this limitation with the `:first-child`/`:last-child` approach.)

Docs have been added to /docs/utilities/native/#buttons in addition to a clarifying comment in `native.css` accordingly!