### PR TITLE
Fix dialog and drawer header

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -8,6 +8,14 @@ Web Awesome follows [Semantic Versioning](https://semver.org/). Breaking changes
 
 Components with the <wa-badge variant="warning">Experimental</wa-badge> badge should not be used in production. They are made available as release candidates for development and testing purposes. As such, changes to experimental components will not be subject to semantic versioning.
 
+## Next
+
+### New Features {data-no-outline}
+
+### Bug Fixes and Improvements {data-no-outline}
+
+- Fixed a bug in `<wa-dialog>` and `<wa-drawer>` that prevented the header from showing when the label was missing [issue:1209]
+
 ## 3.0.0-beta.3
 
 ### New Features {data-no-outline}

--- a/packages/webawesome/src/components/dialog/dialog.ts
+++ b/packages/webawesome/src/components/dialog/dialog.ts
@@ -205,9 +205,7 @@ export default class WaDialog extends WebAwesomeElement {
   }
 
   render() {
-    const hasHeader =
-      !this.withoutHeader &&
-      (this.label.length > 0 || this.hasSlotController.test('label') || this.hasSlotController.test('header-actions'));
+    const hasHeader = !this.withoutHeader;
     const hasFooter = this.hasSlotController.test('footer');
 
     return html`

--- a/packages/webawesome/src/components/drawer/drawer.ts
+++ b/packages/webawesome/src/components/drawer/drawer.ts
@@ -218,9 +218,7 @@ export default class WaDrawer extends WebAwesomeElement {
   }
 
   render() {
-    const hasHeader =
-      !this.withoutHeader &&
-      (this.label.length > 0 || this.hasSlotController.test('label') || this.hasSlotController.test('header-actions'));
+    const hasHeader = !this.withoutHeader;
     const hasFooter = this.hasSlotController.test('footer');
 
     return html`


### PR DESCRIPTION
Fixes #1209 by ensuring the header is always shown based on the `without-header` attribute, not the detection of a label.