### PR TITLE
Fix details animation by preventing overflow during animation

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -12,6 +12,8 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 
 ### New Features {data-no-outline}
 
+- Added the `animating` custom state to `<wa-details>`
+
 ### Bug Fixes and Improvements {data-no-outline}
 
 - Fixed a bug in `<wa-details>` that caused the content to overflow the container when animating [issue:1149]

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -8,6 +8,14 @@ Web Awesome follows [Semantic Versioning](https://semver.org/). Breaking changes
 
 Components with the <wa-badge variant="warning">Experimental</wa-badge> badge should not be used in production. They are made available as release candidates for development and testing purposes. As such, changes to experimental components will not be subject to semantic versioning.
 
+## Next
+
+### New Features {data-no-outline}
+
+### Bug Fixes and Improvements {data-no-outline}
+
+- Fixed a bug in `<wa-details>` that caused the content to overflow the container when animating [issue:1149]
+
 ## 3.0.0-beta.3
 
 ### New Features {data-no-outline}

--- a/packages/webawesome/src/components/details/details.css
+++ b/packages/webawesome/src/components/details/details.css
@@ -122,7 +122,7 @@ details {
   display: none;
 }
 
-.body {
+.body.animating {
   overflow: hidden;
 }
 

--- a/packages/webawesome/src/components/details/details.css
+++ b/packages/webawesome/src/components/details/details.css
@@ -122,8 +122,7 @@ details {
   display: none;
 }
 
-/* Overflows get clipped during the closing animation if we don't wait until the close is gone. */
-:host(:not([open])) .body {
+.body {
   overflow: hidden;
 }
 
@@ -132,11 +131,4 @@ details {
   padding-block-start: var(--spacing);
   padding-inline: var(--spacing); /* Add horizontal padding */
   padding-block-end: var(--spacing); /* Add bottom padding */
-}
-
-@keyframes show {
-  from {
-  }
-  to {
-  }
 }

--- a/packages/webawesome/src/components/details/details.ts
+++ b/packages/webawesome/src/components/details/details.ts
@@ -1,5 +1,7 @@
+import type { PropertyValues } from 'lit';
 import { html } from 'lit';
-import { customElement, property, query } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 import { WaAfterHideEvent } from '../../events/after-hide.js';
 import { WaAfterShowEvent } from '../../events/after-show.js';
 import { WaHideEvent } from '../../events/hide.js';
@@ -40,6 +42,8 @@ import styles from './details.css';
  * @cssproperty --spacing - The amount of space around and between the details' content. Expects a single value.
  * @cssproperty [--show-duration=200ms] - The show duration to use when applying built-in animation classes.
  * @cssproperty [--hide-duration=200ms] - The hide duration to use when applying built-in animation classes.
+ *
+ * @cssstate animating - Applied when the details is animating expand/collapse.
  */
 @customElement('wa-details')
 export default class WaDetails extends WebAwesomeElement {
@@ -52,6 +56,8 @@ export default class WaDetails extends WebAwesomeElement {
   @query('summary') header: HTMLElement;
   @query('.body') body: HTMLElement;
   @query('.expand-icon-slot') expandIconSlot: HTMLSlotElement;
+
+  @state() isAnimating = false;
 
   /**
    * Indicates whether or not the details is open. You can toggle this attribute to show and hide the details, or you
@@ -70,6 +76,11 @@ export default class WaDetails extends WebAwesomeElement {
 
   /** The element's visual appearance. */
   @property({ reflect: true }) appearance: 'filled' | 'outlined' | 'plain' = 'outlined';
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.detailsObserver?.disconnect();
+  }
 
   firstUpdated() {
     this.body.style.height = this.open ? 'auto' : '0';
@@ -91,9 +102,10 @@ export default class WaDetails extends WebAwesomeElement {
     this.detailsObserver.observe(this.details, { attributes: true });
   }
 
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this.detailsObserver?.disconnect();
+  updated(changedProperties: PropertyValues<this>) {
+    if (changedProperties.has('isAnimating')) {
+      this.customStates.set('animating', this.isAnimating);
+    }
   }
 
   private handleSummaryClick(event: MouseEvent) {
@@ -168,6 +180,7 @@ export default class WaDetails extends WebAwesomeElement {
       // Close other details with the same name
       this.closeOthersWithSameName();
 
+      this.isAnimating = true;
       const duration = parseDuration(getComputedStyle(this.body).getPropertyValue('--show-duration'));
       // We can't animate to 'auto', so use the scroll height for now
       await animate(
@@ -182,6 +195,7 @@ export default class WaDetails extends WebAwesomeElement {
         },
       );
       this.body.style.height = 'auto';
+      this.isAnimating = false;
 
       this.dispatchEvent(new WaAfterShowEvent());
     } else {
@@ -194,6 +208,7 @@ export default class WaDetails extends WebAwesomeElement {
         return;
       }
 
+      this.isAnimating = true;
       const duration = parseDuration(getComputedStyle(this.body).getPropertyValue('--hide-duration'));
       // We can't animate from 'auto', so use the scroll height for now
       await animate(
@@ -205,7 +220,7 @@ export default class WaDetails extends WebAwesomeElement {
         { duration, easing: 'linear' },
       );
       this.body.style.height = 'auto';
-
+      this.isAnimating = false;
       this.details.open = false;
       this.dispatchEvent(new WaAfterHideEvent());
     }
@@ -268,7 +283,14 @@ export default class WaDetails extends WebAwesomeElement {
           </span>
         </summary>
 
-        <div class="body" role="region" aria-labelledby="header">
+        <div
+          class=${classMap({
+            body: true,
+            animating: this.isAnimating,
+          })}
+          role="region"
+          aria-labelledby="header"
+        >
           <slot part="content" id="content" class="content"></slot>
         </div>
       </details>


### PR DESCRIPTION
@lindsaym-fa apologies, I stole this one from you because the overflow should only be hidden during animation and it's probably a good idea to add a custom state for users to override it.

- Fixes #1149
- Adds the `animating` custom state to details (this is necessary for anyone wanting to override the body part's overflow during animation)