### PR TITLE
(l10n: de): Fix a German translation to make it sound more natural

### DIFF
--- a/packages/webawesome/src/translations/de.ts
+++ b/packages/webawesome/src/translations/de.ts
@@ -34,7 +34,7 @@ const translation: Translation = {
   selectAColorFromTheScreen: 'Farbe vom Bildschirm auswählen',
   showPassword: 'Passwort anzeigen',
   slideNum: slide => `Folie ${slide}`,
-  toggleColorFormat: 'Farbformat umschalten',
+  toggleColorFormat: 'Farbformat wechseln',
   zoomIn: 'Hineinzoomen',
   zoomOut: 'Herauszoomen',
 };


### PR DESCRIPTION
#### Description

This PR changes the previous translation of the key `toggleColorFormat` from “Farbformat umschalten” to “Farbformat wechseln” as it sounds more natural after this change.

<details>
    <summary>🇩🇪 In Deutsch übersetzt</summary>
    Dieser Pull‐Request ändert die vorherige Übersetzung des Schlüssels <code>toggleColorFormat</code> von „Farbformat umschalten“ in „Farbformat wechseln“, da es nach dieser Änderung sich besser anhört.
</details>