### PR TITLE
Allow <wa-input type="file">

### DIFF
--- a/packages/webawesome/docs/_includes/visual-tests/native.njk
+++ b/packages/webawesome/docs/_includes/visual-tests/native.njk
@@ -312,6 +312,15 @@
       </td>
     </tr>
     <tr>
+      <th><code>type="file"</code></th>
+      <td>
+        <wa-input label="Input (file)" type="file"></wa-input>
+      </td>
+      <td>
+        <label>Input (file) <input type="file"></input></label>
+      </td>
+    </tr>
+    <tr>
       <th><code>filled</code></th>
       <td>
         <wa-input label="Input (filled)" placeholder="Placeholder" appearance="filled"></wa-input>

--- a/packages/webawesome/src/components/input/input.css
+++ b/packages/webawesome/src/components/input/input.css
@@ -29,7 +29,9 @@
   transition-timing-function: var(--wa-transition-easing);
   background-color: var(--wa-form-control-background-color);
   box-shadow: var(--box-shadow);
-  padding: 0 var(--wa-form-control-padding-inline);
+  &:not(:has(input[type="file"])) {
+    padding: 0 var(--wa-form-control-padding-inline);
+  }
 
   &:focus-within {
     outline: var(--wa-focus-ring);
@@ -102,6 +104,13 @@ input {
     }
   }
 
+  &::file-selector-button {
+      height: 100%;
+      margin-inline-end: var(--wa-form-control-padding-inline);
+      box-sizing: border-box;
+      font: inherit;
+    } 
+  
   &::placeholder {
     color: var(--wa-form-control-placeholder-color);
     user-select: none;

--- a/packages/webawesome/src/components/input/input.ts
+++ b/packages/webawesome/src/components/input/input.ts
@@ -75,6 +75,7 @@ export default class WaInput extends WebAwesomeFormAssociatedElement {
     | 'date'
     | 'datetime-local'
     | 'email'
+    | 'file'
     | 'number'
     | 'password'
     | 'search'
@@ -204,7 +205,7 @@ export default class WaInput extends WebAwesomeFormAssociatedElement {
    * Tells the browser what type of data will be entered by the user, allowing it to display the appropriate virtual
    * keyboard on supportive devices.
    */
-  @property() inputmode: 'none' | 'text' | 'decimal' | 'numeric' | 'tel' | 'search' | 'email' | 'url';
+  @property() inputmode: 'none' | 'text' | 'decimal' | 'numeric' | 'tel' | 'search' | 'email' | 'url' | 'file';
 
   /**
    * Used for SSR. Will determine if the SSRed component will have the label slot rendered on initial paint.

--- a/packages/webawesome/src/styles/native.css
+++ b/packages/webawesome/src/styles/native.css
@@ -519,7 +519,6 @@
             [type='button'],
             [type='checkbox'],
             [type='color'],
-            [type='file'],
             [type='hidden'],
             [type='image'],
             [type='radio'],
@@ -860,7 +859,6 @@
     [type='button'],
     [type='checkbox'],
     [type='color'],
-    [type='file'],
     [type='hidden'],
     [type='image'],
     [type='radio'],
@@ -898,6 +896,14 @@
 
       user-select: none;
       -webkit-user-select: none;
+    }
+
+    &::file-selector-button {
+      height: 100%;
+      margin-inline-start: calc(-1 * var(--wa-form-control-padding-inline));
+      margin-inline-end: var(--wa-form-control-padding-inline);
+      box-sizing: border-box;
+      font: inherit;
     }
 
     &:focus {


### PR DESCRIPTION
Following the proposition in #1238.

I have added a visual test with some css to handle `input type="file"` and is `wa` counterpart.

<img width="1847" height="177" alt="image" src="https://github.com/user-attachments/assets/0fede3f2-1ab4-45f2-939b-afa82e43bdbf" />
