### PR TITLE
Add `without-arrow` to popover and tooltip to hide arrows without artifacts

### DIFF
--- a/packages/webawesome/docs/docs/components/popover.md
+++ b/packages/webawesome/docs/docs/components/popover.md
@@ -91,7 +91,7 @@ Use the `distance` attribute to control how far the popover appears from its anc
 
 ### Arrow Size
 
-Use the `--arrow-size` custom property to change the size of the popover's arrow. Set it to `0` to remove the arrow entirely.
+Use the `--arrow-size` custom property to change the size of the popover's arrow. To remove it, use the `without-arrow` attribute.
 
 ```html {.example}
 <div style="display: flex; gap: 1rem; align-items: center;">
@@ -99,7 +99,7 @@ Use the `--arrow-size` custom property to change the size of the popover's arrow
   <wa-popover for="popover__big-arrow" style="--arrow-size: 8px;">I have a big arrow</wa-popover>
 
   <wa-button id="popover__no-arrow">No arrow</wa-button>
-  <wa-popover for="popover__no-arrow" style="--arrow-size: 0;">I don't have an arrow</wa-popover>
+  <wa-popover for="popover__no-arrow" without-arrow>I don't have an arrow</wa-popover>
 </div>
 ```
 

--- a/packages/webawesome/docs/docs/components/tooltip.md
+++ b/packages/webawesome/docs/docs/components/tooltip.md
@@ -113,11 +113,11 @@ Tooltips can be controller programmatically by setting the `trigger` attribute t
 
 ### Removing Arrows
 
-You can control the size of tooltip arrows by overriding the `--wa-tooltip-arrow-size` design token. To remove them, set the value to `0` as shown below.
+You can control the size of tooltip arrows by overriding the `--wa-tooltip-arrow-size` design token. To remove the arrow, use the `without-arrow` attribute.
 
 ```html {.example}
 <wa-button id="no-arrow">No Arrow</wa-button>
-<wa-tooltip for="no-arrow" style="--wa-tooltip-arrow-size: 0;">This is a tooltip with no arrow</wa-tooltip>
+<wa-tooltip for="no-arrow" without-arrow>This is a tooltip with no arrow</wa-tooltip>
 ```
 
 To override it globally, set it in a root block in your stylesheet after the Web Awesome stylesheet is loaded.

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -13,8 +13,9 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 ### New Features {data-no-outline}
 
 - Added the `icon-position` attribute to `<wa-details>` [discuss:1099]
-- Added the `animating` custom state to `<wa-details>`
+- Added the `animating` custom state to `<wa-details>` [pr:1214]
 - Added `--wa-tooltip-border-color`, `--wa-tooltip-border-style`, and `--wa-tooltip-border-width` tokens [issue:1224]
+- Added the `without-arrow` attribute to `<wa-popover>` and `<wa-tooltip>` to hide arrows without artifacts
 
 ### Bug Fixes and Improvements {data-no-outline}
 

--- a/packages/webawesome/src/components/popover/popover.ts
+++ b/packages/webawesome/src/components/popover/popover.ts
@@ -85,6 +85,9 @@ export default class WaPopover extends WebAwesomeElement {
   /** The ID of the popover's anchor element. This must be an interactive/focusable element such as a button. */
   @property() for: string | null = null;
 
+  /** Removes the arrow from the popover. */
+  @property({ attribute: 'without-arrow', type: Boolean, reflect: true }) withoutArrow = false;
+
   private eventController = new AbortController();
 
   connectedCallback() {
@@ -300,7 +303,7 @@ export default class WaPopover extends WebAwesomeElement {
           skidding=${this.skidding}
           flip
           shift
-          arrow
+          ?arrow=${!this.withoutArrow}
           .anchor=${this.anchor}
         >
           <div part="body" class="body" @click=${this.handleBodyClick}>

--- a/packages/webawesome/src/components/tooltip/tooltip.ts
+++ b/packages/webawesome/src/components/tooltip/tooltip.ts
@@ -89,6 +89,9 @@ export default class WaTooltip extends WebAwesomeElement {
    */
   @property() trigger = 'hover focus';
 
+  /** Removes the arrow from the tooltip. */
+  @property({ attribute: 'without-arrow', type: Boolean, reflect: true }) withoutArrow = false;
+
   @property() for: string | null = null;
 
   @state() anchor: null | Element = null;
@@ -332,7 +335,7 @@ export default class WaTooltip extends WebAwesomeElement {
         skidding=${this.skidding}
         flip
         shift
-        arrow
+        ?arrow=${!this.withoutArrow}
         hover-bridge
         .anchor=${this.anchor}
       >


### PR DESCRIPTION
Fixes the issue described in: https://x.com/realsamuelcook/status/1950585557857309102

The current advice to users who want to remove arrows is to set `--arrow-size: 0` but that leaves tiny but visible artifacts. This introduced `without-arrow` to hide them instead, which follows existing conventions for hiding/showing optional content in the library.

I couldn't find a CSS-only way to do this when the arrows have borders. This only affected popover, but tooltips with styled borders will be affected to so I preemptively updated it.