### PR TITLE
Remove non‐existent Plain appearance in the Badge visual tests (Color tab)

### DIFF
--- a/packages/webawesome/docs/_includes/visual-tests/color.njk
+++ b/packages/webawesome/docs/_includes/visual-tests/color.njk
@@ -16,7 +16,6 @@
           <wa-badge variant="brand" appearance="filled outlined">Filled + Outlined</wa-badge>
           <wa-badge variant="brand" appearance="filled">Filled</wa-badge>
           <wa-badge variant="brand" appearance="outlined">Outlined</wa-badge>
-          <wa-badge variant="brand" appearance="plain">Plain</wa-badge>
         </div>
       </td>
       <td>
@@ -25,7 +24,6 @@
           <wa-badge class="wa-brand" appearance="filled outlined">Filled + Outlined</wa-badge>
           <wa-badge class="wa-brand" appearance="filled">Filled</wa-badge>
           <wa-badge class="wa-brand" appearance="outlined">Outlined</wa-badge>
-          <wa-badge class="wa-brand" appearance="plain">Plain</wa-badge>
         </div>
       </td>
     </tr>
@@ -37,7 +35,6 @@
           <wa-badge variant="neutral" appearance="filled outlined">Filled + Outlined</wa-badge>
           <wa-badge variant="neutral" appearance="filled">Filled</wa-badge>
           <wa-badge variant="neutral" appearance="outlined">Outlined</wa-badge>
-          <wa-badge variant="neutral" appearance="plain">Plain</wa-badge>
         </div>
       </td>
       <td>
@@ -46,7 +43,6 @@
           <wa-badge class="wa-neutral" appearance="filled outlined">Filled + Outlined</wa-badge>
           <wa-badge class="wa-neutral" appearance="filled">Filled</wa-badge>
           <wa-badge class="wa-neutral" appearance="outlined">Outlined</wa-badge>
-          <wa-badge class="wa-neutral" appearance="plain">Plain</wa-badge>
         </div>
       </td>
     </tr>
@@ -58,7 +54,6 @@
           <wa-badge variant="success" appearance="filled outlined">Filled + Outlined</wa-badge>
           <wa-badge variant="success" appearance="filled">Filled</wa-badge>
           <wa-badge variant="success" appearance="outlined">Outlined</wa-badge>
-          <wa-badge variant="success" appearance="plain">Plain</wa-badge>
         </div>
       </td>
       <td>
@@ -67,7 +62,6 @@
           <wa-badge class="wa-success" appearance="filled outlined">Filled + Outlined</wa-badge>
           <wa-badge class="wa-success" appearance="filled">Filled</wa-badge>
           <wa-badge class="wa-success" appearance="outlined">Outlined</wa-badge>
-          <wa-badge class="wa-success" appearance="plain">Plain</wa-badge>
         </div>
       </td>
     </tr>
@@ -79,7 +73,6 @@
           <wa-badge variant="warning" appearance="filled outlined">Filled + Outlined</wa-badge>
           <wa-badge variant="warning" appearance="filled">Filled</wa-badge>
           <wa-badge variant="warning" appearance="outlined">Outlined</wa-badge>
-          <wa-badge variant="warning" appearance="plain">Plain</wa-badge>
         </div>
       </td>
       <td>
@@ -88,7 +81,6 @@
           <wa-badge class="wa-warning" appearance="filled outlined">Filled + Outlined</wa-badge>
           <wa-badge class="wa-warning" appearance="filled">Filled</wa-badge>
           <wa-badge class="wa-warning" appearance="outlined">Outlined</wa-badge>
-          <wa-badge class="wa-warning" appearance="plain">Plain</wa-badge>
         </div>
       </td>
     </tr>
@@ -100,7 +92,6 @@
           <wa-badge variant="danger" appearance="filled outlined">Filled + Outlined</wa-badge>
           <wa-badge variant="danger" appearance="filled">Filled</wa-badge>
           <wa-badge variant="danger" appearance="outlined">Outlined</wa-badge>
-          <wa-badge variant="danger" appearance="plain">Plain</wa-badge>
         </div>
       </td>
       <td>
@@ -109,7 +100,6 @@
           <wa-badge class="wa-danger" appearance="filled outlined">Filled + Outlined</wa-badge>
           <wa-badge class="wa-danger" appearance="filled">Filled</wa-badge>
           <wa-badge class="wa-danger" appearance="outlined">Outlined</wa-badge>
-          <wa-badge class="wa-danger" appearance="plain">Plain</wa-badge>
         </div>
       </td>
     </tr>


### PR DESCRIPTION
#### Description

This PR removes a non‐existent Plain appearance used in the Badge component in the Visual Tests under the Color tab.