### PR TITLE
Do not crush labels with nested tags

### DIFF
--- a/packages/webawesome/src/components/button/button.css
+++ b/packages/webawesome/src/components/button/button.css
@@ -184,6 +184,10 @@
 }
 
 .label {
+  display: inline-block;
+}
+
+.is-icon-button .label {
   display: flex;
 }
 

--- a/packages/webawesome/src/components/button/button.css
+++ b/packages/webawesome/src/components/button/button.css
@@ -186,6 +186,9 @@
 .label {
   display: flex;
 }
+:not(.is-icon-button) .label {
+  display: inline-block;
+}
 
 .label::slotted(wa-icon) {
   align-self: center;

--- a/packages/webawesome/src/components/checkbox/checkbox.css
+++ b/packages/webawesome/src/components/checkbox/checkbox.css
@@ -45,6 +45,9 @@
   vertical-align: middle;
   cursor: pointer;
 }
+[part~='label'] {
+  display: inline-block;
+}
 
 /* Checked */
 [part~='control']:has(:checked, :indeterminate) {

--- a/packages/webawesome/src/components/checkbox/checkbox.css
+++ b/packages/webawesome/src/components/checkbox/checkbox.css
@@ -45,6 +45,7 @@
   vertical-align: middle;
   cursor: pointer;
 }
+
 [part~='label'] {
   display: inline;
 }

--- a/packages/webawesome/src/components/checkbox/checkbox.css
+++ b/packages/webawesome/src/components/checkbox/checkbox.css
@@ -45,6 +45,9 @@
   vertical-align: middle;
   cursor: pointer;
 }
+[part~='label'] {
+  display: inline;
+}
 
 /* Checked */
 [part~='control']:has(:checked, :indeterminate) {


### PR DESCRIPTION
fixes https://github.com/shoelace-style/webawesome/issues/1272
This pull request makes small but important improvements to the layout and styling of the `button` and `checkbox` components in the UI library. The changes ensure better alignment and consistent display of labels for these components.

Styling improvements for label display:

* Updated `.label` styling in `button.css` to use `inline-block` display for button labels except when the button is an icon button, improving label alignment.
* Added a rule to `checkbox.css` to set `[part~='label']` as `inline-block`, ensuring proper label display for checkboxes.