### PR TITLE
Fix exportparts of tooltip inside wa-slider component

### DIFF
--- a/packages/webawesome/src/components/slider/slider.ts
+++ b/packages/webawesome/src/components/slider/slider.ts
@@ -841,8 +841,8 @@ export default class WaSlider extends WebAwesomeFormAssociatedElement {
               id=${`tooltip${thumbId !== 'thumb' ? '-' + thumbId : ''}`}
               part="tooltip"
               exportparts="
-                tooltip:tooltip__tooltip,
-                content:tooltip__content,
+                base:tooltip__base,
+                body:tooltip__body,
                 arrow:tooltip__arrow
               "
               trigger="manual"


### PR DESCRIPTION
This fix is a follow-up to https://github.com/shoelace-style/webawesome/issues/1224

Fix the `exportparts` of tooltip which seems incorrect.

❌ Incorrect:

```css
wa-slider::part(tooltip__content) {
  /* customize tooltip body */
}
```


✅ Expected:

```css
wa-slider::part(tooltip__body) {
  /* customize tooltip body */
}
```