### PR TITLE
Add jsx types to package.json exports

### DIFF
--- a/packages/webawesome/package.json
+++ b/packages/webawesome/package.json
@@ -19,6 +19,7 @@
       "import": "./dist/webawesome.js"
     },
     "./dist/custom-elements.json": "./dist/custom-elements.json",
+    "./dist/custom-elements-jsx.d.ts": "./dist/custom-elements-jsx.d.ts",
     "./dist/webawesome.js": "./dist/webawesome.js",
     "./dist/webawesome.loader.js": "./dist/webawesome.loader.js",
     "./dist/styles": "./dist/styles",


### PR DESCRIPTION
Noticed this was missing while trying out the new JSX types and attempting to extend JSX's IntrinsicElements.