### PR TITLE
Fixes <wa-details> toggling when interacting with nested <wa-select> elements

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -11,6 +11,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 ## Next
 
 - Fixed incorrectly named exported tooltip parts in `<wa-slider>` [pr:1277]
+- Fixed a bug where clicks inside `<wa-select>` caused parent `<wa-details>` to toggle; clicks within the select now stop propagation. [issue:1252]
 
 ## 3.0.0-beta.4
 

--- a/packages/webawesome/src/components/details/details.ts
+++ b/packages/webawesome/src/components/details/details.ts
@@ -114,7 +114,7 @@ export default class WaDetails extends WebAwesomeElement {
   private handleSummaryClick(event: MouseEvent) {
     let targetElement = getTargetElement(event);
 
-    if (targetElement?.closest('a, button, wa-button, input, wa-input, textarea, wa-textarea, select, wa-select')) {
+    if (targetElement?.closest('a, button, wa-button, input, wa-input, textarea, wa-textarea')) {
       // Let interactive elements handle their own clicks, fixes #309
       return;
     }

--- a/packages/webawesome/src/components/option/option.ts
+++ b/packages/webawesome/src/components/option/option.ts
@@ -94,6 +94,7 @@ export default class WaOption extends WebAwesomeElement {
 
     this.addEventListener('mouseenter', this.handleHover);
     this.addEventListener('mouseleave', this.handleHover);
+    this.addEventListener('click', this.handleClickStopPropagation);
     this.updateDefaultLabel();
   }
 
@@ -102,7 +103,13 @@ export default class WaOption extends WebAwesomeElement {
 
     this.removeEventListener('mouseenter', this.handleHover);
     this.removeEventListener('mouseleave', this.handleHover);
+    this.removeEventListener('click', this.handleClickStopPropagation);
   }
+
+  private handleClickStopPropagation = (event: MouseEvent) => {
+    event.stopPropagation();
+    event.preventDefault();
+  };
 
   private handleDefaultSlotChange() {
     // Tell the controller to update the label

--- a/packages/webawesome/src/components/select/select.ts
+++ b/packages/webawesome/src/components/select/select.ts
@@ -501,8 +501,20 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
     }
 
     event.preventDefault();
+    event.stopPropagation();
     this.displayInput.focus({ preventScroll: true });
     this.open = !this.open;
+  }
+
+  private handleComboboxClick(event: MouseEvent) {
+    // Prevent bubbling clicks from toggling ancestor components such as <wa-details>
+    event.stopPropagation();
+    event.preventDefault();
+  }
+
+  private handleListboxClick(event: MouseEvent) {
+    event.stopPropagation();
+    event.preventDefault();
   }
 
   private handleComboboxKeyDown(event: KeyboardEvent) {
@@ -533,6 +545,8 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
   }
 
   private handleOptionClick(event: MouseEvent) {
+    event.stopPropagation();
+    event.preventDefault();
     const target = event.target as HTMLElement;
     const option = target.closest('wa-option');
 
@@ -942,6 +956,7 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
               slot="anchor"
               @keydown=${this.handleComboboxKeyDown}
               @mousedown=${this.handleComboboxMouseDown}
+              @click=${this.handleComboboxClick}
             >
               <slot part="start" name="start" class="start"></slot>
 
@@ -1022,6 +1037,7 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
               class="listbox"
               tabindex="-1"
               @mouseup=${this.handleOptionClick}
+              @click=${this.handleListboxClick}
             >
               <slot @slotchange=${this.handleDefaultSlotChange}></slot>
             </div>


### PR DESCRIPTION
## Description

Fixes an issue where clicking on a `<wa-select>` inside the `<summary>` of a `<wa-details>` component would incorrectly toggle the details section, even when the click event was stopped..

https://github.com/user-attachments/assets/b4caab24-12cb-4f94-abd8-49e2ff729ac3


## Related Issues

- Fixes #1252
- Related to #309, #1249

## Next Steps

- **Remove hardcoded element checks from `<wa-details>`** #1250 to eliminate the element whitelist and rely solely on event handling (`event.stopPropagation()`) for preventing unintended toggles.