### PR TITLE
Use button-group variant in child buttons

### DIFF
--- a/packages/webawesome/docs/docs/components/button-group.md
+++ b/packages/webawesome/docs/docs/components/button-group.md
@@ -119,16 +119,6 @@ Theme buttons are supported through the button group's `variant` attribute.
 </wa-button-group>
 ```
 
-You can still use the buttons’ own `variant` attribute to override the inherited variant.
-
-```html {.example}
-<wa-button-group label="Alignment" variant="brand">
-  <wa-button>Left</wa-button>
-  <wa-button>Center</wa-button>
-  <wa-button variant="neutral">Right</wa-button>
-</wa-button-group>
-```
-
 ### Pill Buttons
 
 Pill buttons are supported through the button's `pill` attribute.

--- a/packages/webawesome/src/components/button-group/button-group.ts
+++ b/packages/webawesome/src/components/button-group/button-group.ts
@@ -86,6 +86,7 @@ export default class WaButtonGroup extends WebAwesomeElement {
       if (button) {
         if ((button as WaButton).appearance === 'outlined') this.hasOutlined = true;
         if (this.size) button.setAttribute('size', this.size);
+        if (this.variant) button.setAttribute('variant', this.variant);
         button.classList.add('wa-button-group__button');
         button.classList.toggle('wa-button-group__horizontal', this.orientation === 'horizontal');
         button.classList.toggle('wa-button-group__vertical', this.orientation === 'vertical');


### PR DESCRIPTION
fix #1298

- I wasn't able to let the `wa-button` overwrite the groups variant, so I removed this docs for now.