### PR TITLE
Add `stroke-width` style based on `--track-width` to `<wa-spinner>`

### DIFF
--- a/packages/webawesome/src/components/spinner/spinner.css
+++ b/packages/webawesome/src/components/spinner/spinner.css
@@ -24,12 +24,14 @@ svg {
 
 .track {
   stroke: var(--track-color);
+  stroke-width: var(--track-width);
 }
 
 .indicator {
   stroke: var(--indicator-color);
   stroke-dasharray: 75, 100;
   stroke-dashoffset: -5;
+  stroke-width: var(--track-width);
   animation: dash 1.5s ease-in-out infinite;
   stroke-linecap: round;
 }


### PR DESCRIPTION
Update spinner to respect track width property. Issue https://github.com/shoelace-style/webawesome/issues/1317