### PR TITLE
Remove the unsupported button group `size` attribute

### DIFF
--- a/packages/webawesome/docs/_includes/visual-tests/size.njk
+++ b/packages/webawesome/docs/_includes/visual-tests/size.njk
@@ -40,66 +40,6 @@
 </div>
 <wa-divider></wa-divider>
 
-<h3>Button Group</h3>
-
-<div class="table-scroll">
-<table>
-  <thead>
-    <th></th>
-    <th><code>size=""</code></th>
-    <th><code>.wa-size-[s|m|l]</code></th>
-  </thead>
-  <tbody>
-    <tr>
-      <th><code>small</code>/<code>s</code></th>
-      <td>
-        <wa-button-group orientation="horizontal" size="small">
-          <wa-button value="1">Button L</wa-button>
-          <wa-button value="2">Button R</wa-button>
-        </wa-button-group>
-      </td>
-      <td>
-        <wa-button-group orientation="horizontal" class="wa-size-s">
-          <wa-button value="1">Button L</wa-button>
-          <wa-button value="2">Button R</wa-button>
-        </wa-button-group>
-      </td>
-    </tr>
-    <tr>
-      <th><code>medium</code>/<code>m</code></th>
-      <td>
-        <wa-button-group orientation="horizontal" size="medium">
-          <wa-button value="1">Button L</wa-button>
-          <wa-button value="2">Button R</wa-button>
-        </wa-button-group>
-      </td>
-      <td>
-        <wa-button-group orientation="horizontal" class="wa-size-m">
-          <wa-button value="1">Button L</wa-button>
-          <wa-button value="2">Button R</wa-button>
-        </wa-button-group>
-      </td>
-    </tr>
-    <tr>
-      <th><code>large</code>/<code>l</code></th>
-      <td>
-        <wa-button-group orientation="horizontal" size="large">
-          <wa-button value="1">Button L</wa-button>
-          <wa-button value="2">Button R</wa-button>
-        </wa-button-group>
-      </td>
-      <td>
-        <wa-button-group orientation="horizontal" class="wa-size-l">
-          <wa-button value="1">Button L</wa-button>
-          <wa-button value="2">Button R</wa-button>
-        </wa-button-group>
-      </td>
-    </tr>
-  </tbody>
-</table>
-</div>
-<wa-divider></wa-divider>
-
 <h3>Callout</h3>
 
 <div class="table-scroll">

--- a/packages/webawesome/docs/docs/components/button-group.md
+++ b/packages/webawesome/docs/docs/components/button-group.md
@@ -15,41 +15,6 @@ category: Actions
 
 ## Examples
 
-### Button Sizes
-
-Unless otherwise specified,
-the size of [buttons](/docs/components/button) will be determined by the Button Group's `size` attribute.
-
-```html {.example}
-<wa-button-group size="small" label="Alignment">
-  <wa-button>Left</wa-button>
-  <wa-button>Center</wa-button>
-  <wa-button>Right</wa-button>
-</wa-button-group>
-
-<br /><br />
-
-<wa-button-group size="medium" label="Alignment">
-  <wa-button>Left</wa-button>
-  <wa-button>Center</wa-button>
-  <wa-button>Right</wa-button>
-</wa-button-group>
-
-<br /><br />
-
-<wa-button-group size="large" label="Alignment">
-  <wa-button>Left</wa-button>
-  <wa-button>Center</wa-button>
-  <wa-button>Right</wa-button>
-</wa-button-group>
-```
-
-:::info
-While you can still set the size of [buttons](/docs/components/button) individually,
-and it will override the inherited size,
-it is rarely a good idea to mix sizes within the same button group.
-:::
-
 ### Vertical Button Groups
 
 Set the `orientation` attribute to `vertical` to make a vertical button group.

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -16,6 +16,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
   - Added the `auto-width` attribute to automatically size icons, since FA7 is fixed-width by default now
   - Improved support for duotone icons in `<wa-icon>`, including custom colors, custom opacity, and opacity swapping
   - Removed the `fixed-width` attribute as it's now the default behavior
+- 🚨 BREAKING: Removed the `size` attribute from `<wa-button-group>` as it only set the initial size and gets out of sync when buttons are updated (apply a `size` to each button instead)
 - Added the Hindi translation [pr:1307]
 - Fixed incorrectly named exported tooltip parts in `<wa-slider>` [pr:1277]
 - Fixed a bug in `<wa-dropdown>` that caused menus to overflow the viewport instead of resizing [issue:1267]

--- a/packages/webawesome/src/components/button-group/button-group.ts
+++ b/packages/webawesome/src/components/button-group/button-group.ts
@@ -3,7 +3,6 @@ import { html } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import WebAwesomeElement from '../../internal/webawesome-element.js';
-import sizeStyles from '../../styles/utilities/size.css';
 import variantStyles from '../../styles/utilities/variants.css';
 import type WaButton from '../button/button.js';
 import styles from './button-group.css';
@@ -20,7 +19,7 @@ import styles from './button-group.css';
  */
 @customElement('wa-button-group')
 export default class WaButtonGroup extends WebAwesomeElement {
-  static css = [sizeStyles, variantStyles, styles];
+  static css = [variantStyles, styles];
 
   @query('slot') defaultSlot: HTMLSlotElement;
 
@@ -35,9 +34,6 @@ export default class WaButtonGroup extends WebAwesomeElement {
 
   /** The button group's orientation. */
   @property({ reflect: true }) orientation: 'horizontal' | 'vertical' = 'horizontal';
-
-  /** The component's size. */
-  @property({ reflect: true }) size: 'small' | 'medium' | 'large'; // unset by default to not override child elements
 
   /** The button group's theme variant. Defaults to `neutral` if not within another element with a variant. */
   @property({ reflect: true }) variant: 'neutral' | 'brand' | 'success' | 'warning' | 'danger' = 'neutral';
@@ -85,7 +81,6 @@ export default class WaButtonGroup extends WebAwesomeElement {
 
       if (button) {
         if ((button as WaButton).appearance === 'outlined') this.hasOutlined = true;
-        if (this.size) button.setAttribute('size', this.size);
         button.classList.add('wa-button-group__button');
         button.classList.toggle('wa-button-group__horizontal', this.orientation === 'horizontal');
         button.classList.toggle('wa-button-group__vertical', this.orientation === 'vertical');


### PR DESCRIPTION
During cleanup, we missed the `size` attribute in `<wa-button-group>`. It is currently applying its size to all child buttons, but only when slotted initially. It will not update properly if button sizes change dynamically, for instance, as that would require a mutation observer.

For the same reason we chose not to implement #1298, I have removed `size`. The size should be placed directly on buttons, as previously required.