### PR TITLE
Add `z-index` to scroller's content and shadows

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -24,6 +24,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug in JSX typings that prevented the types file from being exported [pr:1295]
 - Fixed a bug in JSX typings that generated the incorrect component imports [issue:1303]
 - Fixed a bug in `<wa-slider>` that prevented the thumb from receiving focus when clicking/tapping [issue:1312]
+- Fixed a bug in `<wa-scroller>` that caused the shadow to appear below relatively-positioned elements [issue:1326]
 
 ## 3.0.0-beta.4
 

--- a/packages/webawesome/src/components/scroller/scroller.css
+++ b/packages/webawesome/src/components/scroller/scroller.css
@@ -20,8 +20,10 @@
 }
 
 #content {
+  z-index: 1; /* below shadows */
   border-radius: inherit;
   scroll-behavior: smooth;
+  scrollbar-color: var(--thumb-color) var(--track-color);
   scrollbar-width: thin;
 
   /* Prevent text in mobile Safari from being larger when the container width larger than the viewport */
@@ -102,6 +104,7 @@
   #start-shadow,
   #end-shadow {
     position: absolute;
+    z-index: 2;
     right: 0;
     left: 0;
     height: var(--shadow-size);

--- a/packages/webawesome/src/components/scroller/scroller.css
+++ b/packages/webawesome/src/components/scroller/scroller.css
@@ -23,7 +23,6 @@
   z-index: 1; /* below shadows */
   border-radius: inherit;
   scroll-behavior: smooth;
-  scrollbar-color: var(--thumb-color) var(--track-color);
   scrollbar-width: thin;
 
   /* Prevent text in mobile Safari from being larger when the container width larger than the viewport */


### PR DESCRIPTION
Fixes #1326

To verify the fix, refer to the reproduction in #1326. Essentially, add some form controls into a scroller and observe the shadows. They should appear ABOVE the form controls, not below as in the repro.