### PR TITLE
💅 Docs: Sidebar Visual + UI Polish

### DIFF
--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -31,15 +31,15 @@
 <!-- Components -->
 <wa-details appearance="outlined">
   <h2 slot="summary">
-    <a class="wa-cluster wa-align-items-center wa-gap-xs" href="/docs/components/" title="Overview">
+    <a class="wa-cluster wa-gap-xs" href="/docs/components/" title="Overview">
       <wa-icon name="grid-2" aria-hidden="true"></wa-icon>
       Components
     </a>
   </h2>
   <ul>
     <li>
-      <span class="wa-split wa-align-items-center wa-gap-m">
-        <a class="wa-cluster wa-align-items-center wa-gap-xs" href="/docs/components/page/">
+      <span class="wa-split">
+        <a class="wa-cluster wa-gap-xs" href="/docs/components/page/">
           Page <wa-icon name="flask" aria-hidden="true"></wa-icon>
         </a>
         <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
@@ -60,13 +60,13 @@
     <li><a href="/docs/components/callout/">Callout</a></li>
     <li><a href="/docs/components/card/">Card</a></li>
     <li>
-      <a class="wa-cluster wa-align-items-center wa-gap-xs" href="/docs/components/carousel/">
+      <a class="wa-cluster wa-gap-xs" href="/docs/components/carousel/">
         Carousel
         <wa-icon name="flask" aria-hidden="true"></wa-icon>
       </a>
       <ul>
         <li>
-          <a class="wa-cluster wa-align-items-center wa-gap-xs" href="/docs/components/carousel-item/">
+          <a class="wa-cluster wa-gap-xs" href="/docs/components/carousel-item/">
             Carousel Item
             <wa-icon name="flask" aria-hidden="true"></wa-icon>
           </a>
@@ -77,7 +77,7 @@
     <li><a href="/docs/components/color-picker/">Color Picker</a></li>
     <li><a href="/docs/components/comparison/">Comparison</a></li>
     <li>
-      <a class="wa-cluster wa-align-items-center wa-gap-xs" href="/docs/components/copy-button/">
+      <a class="wa-cluster wa-gap-xs" href="/docs/components/copy-button/">
         Copy Button
         <wa-icon name="flask" aria-hidden="true"></wa-icon>
       </a>
@@ -145,7 +145,7 @@
 <!-- Style utilities -->
 <wa-details appearance="outlined">
   <h2 slot="summary">
-    <a class="wa-cluster wa-align-items-center wa-gap-xs" href="/docs/utilities/" title="Overview">
+    <a class="wa-cluster wa-gap-xs" href="/docs/utilities/" title="Overview">
       <wa-icon name="grid-2" aria-hidden="true"></wa-icon>
       Style Utilities
     </a>
@@ -163,7 +163,7 @@
 <!-- Layout -->
 <wa-details appearance="outlined">
   <h2 slot="summary">
-    <a class="wa-cluster wa-align-items-center wa-gap-xs" href="/docs/layout/" title="Overview">
+    <a class="wa-cluster wa-gap-xs" href="/docs/layout/" title="Overview">
       <wa-icon name="grid-2" aria-hidden="true"></wa-icon>
       Layout
     </a>
@@ -178,8 +178,8 @@
     <li><a href="/docs/utilities/split/">Split</a></li>
     <li><a href="/docs/utilities/stack/">Stack</a></li>
     <li>
-      <span class="wa-split wa-align-items-center wa-gap-m">
-        <a class="wa-cluster wa-align-items-center wa-gap-xs" href="/docs/components/page/">
+      <span class="wa-split">
+        <a class="wa-cluster wa-gap-xs" href="/docs/components/page/">
           Page <wa-icon name="flask" aria-hidden="true"></wa-icon>
         </a>
         <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
@@ -191,14 +191,14 @@
 <!-- Patterns -->
 <wa-details appearance="outlined">
   <h2 slot="summary">
-    <a class="wa-cluster wa-align-items-center wa-gap-xs" href="/docs/patterns/" title="Overview">
+    <a class="wa-cluster wa-gap-xs" href="/docs/patterns/" title="Overview">
       <wa-icon name="grid-2" aria-hidden="true"></wa-icon>
       Patterns
     </a>
   </h2>
   <ul>
     <li>
-      <span class="wa-split wa-align-items-center wa-gap-m">
+      <span class="wa-split">
         <a href="/docs/patterns/app/">App</a>
         <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
       </span>
@@ -244,7 +244,7 @@
       </ul>
     </li>
     <li>
-      <span class="wa-split wa-align-items-center wa-gap-m">
+      <span class="wa-split">
         <a href="/docs/patterns/blog-news/">Blog &amp; News</a>
         <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
       </span>
@@ -306,7 +306,7 @@
       </ul>
     </li>
     <li>
-      <span class="wa-split wa-align-items-center wa-gap-m">
+      <span class="wa-split">
         <a href="/docs/patterns/ecommerce/">Ecommerce</a>
         <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
       </span>
@@ -347,7 +347,7 @@
       </ul>
     </li>
     <li>
-      <span class="wa-split wa-align-items-center wa-gap-m">
+      <span class="wa-split">
         <a href="/docs/patterns/layouts/">Layouts</a>
         <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
       </span>
@@ -372,7 +372,7 @@
   <li><a href="/docs/color-palettes">Color Palettes</a></li>
   <li><a href="/docs/themes">Themes</a></li>
   <li>
-    <span class="wa-split wa-align-items-center wa-gap-m">
+    <span class="wa-split">
       <a href="/themer" data-turbo="false">Theme Builder</a>
       <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
     </span>
@@ -382,7 +382,7 @@
 <!-- Design tokens -->
 <wa-details appearance="outlined">
   <h2 slot="summary">
-    <a class="wa-cluster wa-align-items-center wa-gap-xs" href="/docs/tokens/" title="Overview">
+    <a class="wa-cluster wa-gap-xs" href="/docs/tokens/" title="Overview">
       <wa-icon name="grid-2" aria-hidden="true"></wa-icon>
       Design Tokens
     </a>

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -291,7 +291,7 @@
         <li>
           <a href="/docs/patterns/blog-news/login/">Sign Up &amp; Login</a>
         </li>
-         <li>
+        <li>
           <a href="/docs/patterns/blog-news/numbers/">Numbers</a>
         </li>
         <li>
@@ -300,7 +300,7 @@
         <li>
           <a href="/docs/patterns/blog-news/teams/">Teams</a>
         </li>
-         <li>
+        <li>
           <a href="/docs/patterns/blog-news/testimonials/">Testimonials</a>
         </li>
       </ul>

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -38,9 +38,12 @@
   </h2>
   <ul>
     <li>
-      <a href="/docs/components/page/">Page</a>
-      <wa-icon name="flask" aria-hidden="true"></wa-icon>
-      <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
+      <span class="wa-split wa-align-items-center wa-gap-m">
+        <a class="wa-cluster wa-align-items-center wa-gap-xs" href="/docs/components/page/">
+          Page <wa-icon name="flask" aria-hidden="true"></wa-icon>
+        </a>
+        <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
+      </span>
     </li>
     <li><a href="/docs/components/animated-image/">Animated Image</a></li>
     <li><a href="/docs/components/animation/">Animation</a></li>
@@ -57,12 +60,16 @@
     <li><a href="/docs/components/callout/">Callout</a></li>
     <li><a href="/docs/components/card/">Card</a></li>
     <li>
-      <a href="/docs/components/carousel/">Carousel</a>
-      <wa-icon name="flask" aria-hidden="true"></wa-icon>
+      <a class="wa-cluster wa-align-items-center wa-gap-xs" href="/docs/components/carousel/">
+        Carousel
+        <wa-icon name="flask" aria-hidden="true"></wa-icon>
+      </a>
       <ul>
         <li>
-          <a href="/docs/components/carousel-item/">Carousel Item</a>
-          <wa-icon name="flask" aria-hidden="true"></wa-icon>
+          <a class="wa-cluster wa-align-items-center wa-gap-xs" href="/docs/components/carousel-item/">
+            Carousel Item
+            <wa-icon name="flask" aria-hidden="true"></wa-icon>
+          </a>
         </li>
       </ul>
     </li>
@@ -70,8 +77,10 @@
     <li><a href="/docs/components/color-picker/">Color Picker</a></li>
     <li><a href="/docs/components/comparison/">Comparison</a></li>
     <li>
-      <a href="/docs/components/copy-button/">Copy Button</a>
-      <wa-icon name="flask" aria-hidden="true"></wa-icon>
+      <a class="wa-cluster wa-align-items-center wa-gap-xs" href="/docs/components/copy-button/">
+        Copy Button
+        <wa-icon name="flask" aria-hidden="true"></wa-icon>
+      </a>
     </li>
     <li><a href="/docs/components/details/">Details</a></li>
     <li><a href="/docs/components/dialog/">Dialog</a></li>
@@ -169,9 +178,12 @@
     <li><a href="/docs/utilities/split/">Split</a></li>
     <li><a href="/docs/utilities/stack/">Stack</a></li>
     <li>
-      <a href="/docs/components/page/">Page</a>
-      <wa-icon name="flask" aria-hidden="true"></wa-icon>
-      <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
+      <span class="wa-split wa-align-items-center wa-gap-m">
+        <a class="wa-cluster wa-align-items-center wa-gap-xs" href="/docs/components/page/">
+          Page <wa-icon name="flask" aria-hidden="true"></wa-icon>
+        </a>
+        <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
+      </span>
     </li>
   </ul>
 </wa-details>
@@ -186,8 +198,10 @@
   </h2>
   <ul>
     <li>
-      <a href="/docs/patterns/app/">App</a>
-      <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
+      <span class="wa-split wa-align-items-center wa-gap-m">
+        <a href="/docs/patterns/app/">App</a>
+        <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
+      </span>
       <ul>
         <li>
           <a href="/docs/patterns/app/action-panel/">Action Panel</a>
@@ -230,8 +244,10 @@
       </ul>
     </li>
     <li>
-      <a href="/docs/patterns/blog-news/">Blog &amp; News</a>
-      <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
+      <span class="wa-split wa-align-items-center wa-gap-m">
+        <a href="/docs/patterns/blog-news/">Blog &amp; News</a>
+        <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
+      </span>
       <ul>
       <li>
           <a href="/docs/patterns/blog-news/banners/">Banners</a>
@@ -290,8 +306,10 @@
       </ul>
     </li>
     <li>
-      <a href="/docs/patterns/ecommerce/">Ecommerce</a>
-      <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
+      <span class="wa-split wa-align-items-center wa-gap-m">
+        <a href="/docs/patterns/ecommerce/">Ecommerce</a>
+        <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
+      </span>
       <ul>
         <li>
           <a href="/docs/patterns/ecommerce/category-filter/">Category Filter</a>
@@ -329,8 +347,10 @@
       </ul>
     </li>
     <li>
-      <a href="/docs/patterns/layouts/">Layouts</a>
-      <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
+      <span class="wa-split wa-align-items-center wa-gap-m">
+        <a href="/docs/patterns/layouts/">Layouts</a>
+        <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
+      </span>
       <ul>
         <li>
           <a href="/docs/patterns/layouts/ecommerce/">Ecommerce</a>
@@ -352,8 +372,10 @@
   <li><a href="/docs/color-palettes">Color Palettes</a></li>
   <li><a href="/docs/themes">Themes</a></li>
   <li>
-    <a href="/themer" data-turbo="false">Theme Builder</a>
-    <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
+    <span class="wa-split wa-align-items-center wa-gap-m">
+      <a href="/themer" data-turbo="false">Theme Builder</a>
+      <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
+    </span>
   </li>
 </ul>
 

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -31,7 +31,7 @@
 <!-- Components -->
 <wa-details appearance="outlined">
   <h2 slot="summary">
-    <a href="/docs/components/" title="Overview">
+    <a class="wa-cluster wa-align-items-center wa-gap-xs" href="/docs/components/" title="Overview">
       Components
       <wa-icon name="grid-2" aria-hidden="true"></wa-icon>
     </a>
@@ -136,7 +136,7 @@
 <!-- Style utilities -->
 <wa-details appearance="outlined">
   <h2 slot="summary">
-    <a href="/docs/utilities/" title="Overview">
+    <a class="wa-cluster wa-align-items-center wa-gap-xs" href="/docs/utilities/" title="Overview">
       Style Utilities
       <wa-icon name="grid-2" aria-hidden="true"></wa-icon>
     </a>
@@ -154,7 +154,7 @@
 <!-- Layout -->
 <wa-details appearance="outlined">
   <h2 slot="summary">
-    <a href="/docs/layout/" title="Overview">
+    <a class="wa-cluster wa-align-items-center wa-gap-xs" href="/docs/layout/" title="Overview">
       Layout
       <wa-icon name="grid-2" aria-hidden="true"></wa-icon>
     </a>
@@ -179,7 +179,7 @@
 <!-- Patterns -->
 <wa-details appearance="outlined">
   <h2 slot="summary">
-    <a href="/docs/patterns/" title="Overview">
+    <a class="wa-cluster wa-align-items-center wa-gap-xs" href="/docs/patterns/" title="Overview">
       Patterns
       <wa-icon name="grid-2" aria-hidden="true"></wa-icon>
     </a>
@@ -360,7 +360,7 @@
 <!-- Design tokens -->
 <wa-details appearance="outlined">
   <h2 slot="summary">
-    <a href="/docs/tokens/" title="Overview">
+    <a class="wa-cluster wa-align-items-center wa-gap-xs" href="/docs/tokens/" title="Overview">
       Design Tokens
       <wa-icon name="grid-2" aria-hidden="true"></wa-icon>
     </a>

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -32,8 +32,8 @@
 <wa-details appearance="outlined">
   <h2 slot="summary">
     <a class="wa-cluster wa-align-items-center wa-gap-xs" href="/docs/components/" title="Overview">
-      Components
       <wa-icon name="grid-2" aria-hidden="true"></wa-icon>
+      Components
     </a>
   </h2>
   <ul>
@@ -137,8 +137,8 @@
 <wa-details appearance="outlined">
   <h2 slot="summary">
     <a class="wa-cluster wa-align-items-center wa-gap-xs" href="/docs/utilities/" title="Overview">
-      Style Utilities
       <wa-icon name="grid-2" aria-hidden="true"></wa-icon>
+      Style Utilities
     </a>
   </h2>
   <ul>
@@ -155,8 +155,8 @@
 <wa-details appearance="outlined">
   <h2 slot="summary">
     <a class="wa-cluster wa-align-items-center wa-gap-xs" href="/docs/layout/" title="Overview">
-      Layout
       <wa-icon name="grid-2" aria-hidden="true"></wa-icon>
+      Layout
     </a>
   </h2>
   <ul>
@@ -180,8 +180,8 @@
 <wa-details appearance="outlined">
   <h2 slot="summary">
     <a class="wa-cluster wa-align-items-center wa-gap-xs" href="/docs/patterns/" title="Overview">
-      Patterns
       <wa-icon name="grid-2" aria-hidden="true"></wa-icon>
+      Patterns
     </a>
   </h2>
   <ul>
@@ -361,8 +361,8 @@
 <wa-details appearance="outlined">
   <h2 slot="summary">
     <a class="wa-cluster wa-align-items-center wa-gap-xs" href="/docs/tokens/" title="Overview">
-      Design Tokens
       <wa-icon name="grid-2" aria-hidden="true"></wa-icon>
+      Design Tokens
     </a>
   </h2>
   <ul>

--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -401,6 +401,7 @@ wa-button#search-trigger {
 #search-trigger kbd {
   font-size: var(--wa-font-size-2xs);
   line-height: var(--wa-form-control-value-line-height);
+  padding-inline: 0.33em;
 }
 
 /* Search list pages */

--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -205,14 +205,10 @@ wa-badge.pro {
     color: var(--wa-color-text-quiet);
 
     a {
-      display: flex;
-      align-items: center;
-      gap: 0.4em;
       color: var(--wa-color-text-normal);
       text-decoration: none;
 
       wa-icon {
-        margin-block-end: -0.15em;
         font-size: var(--wa-font-size-s);
         font-weight: var(--wa-font-weight-action);
         color: var(--wa-color-gray-70);

--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -211,15 +211,10 @@ wa-badge.pro {
       wa-icon {
         font-size: var(--wa-font-size-s);
         font-weight: var(--wa-font-weight-action);
-        color: var(--wa-color-gray-70);
       }
 
       &:hover {
         text-decoration: underline;
-
-        wa-icon {
-          color: var(--wa-color-text-normal);
-        }
       }
     }
   }

--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -215,10 +215,10 @@ wa-badge.pro {
       }
 
       &:hover {
-        color: var(--wa-color-brand-on-normal);
+        text-decoration: underline;
 
         wa-icon {
-          color: var(--wa-color-brand-on-quiet);
+          color: var(--wa-color-text-normal);
         }
       }
     }

--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -181,11 +181,6 @@ wa-page > header {
 
   li wa-icon {
     color: var(--wa-color-text-quiet);
-    vertical-align: middle;
-
-    &[name='flask'] {
-      margin-inline: 0.125em;
-    }
   }
 }
 


### PR DESCRIPTION
This work touches up some minutiae in the Web Awesome Docs' Sidebar UI, including:

* using layout utilities for heading + complex link alignment
* syncing up the visual style of heading links to match conventions elsewhere in the sidebar nav
* updating alignment of icons and text in heading + complex links (experimental or Pro)
* increasing visual padding of `<kbd>` element in Search Trigger button.

### Comparison Screenie
| Before | After |
|--------|--------|
| <img width="604" height="1466" alt="image" src="https://github.com/user-attachments/assets/692bc641-67b1-46f1-8419-d38c6cab1ea0" /> | <img width="604" height="1450" alt="image" src="https://github.com/user-attachments/assets/317c209e-2cb7-4a5f-8233-e0a52f013f2a" /> |

---

- @lindsaym-fa, mind reviewing my markup, CSS, and UI changes?