### PR TITLE
Adds `--show-duration` and `--hide-duration` to `<wa-select>`

### DIFF
--- a/packages/webawesome/docs/docs/components/select.md
+++ b/packages/webawesome/docs/docs/components/select.md
@@ -366,7 +366,7 @@ Here's a comprehensive example showing different lazy loading scenarios:
 
     const option = document.createElement('wa-option');
     option.setAttribute('value', 'foo');
-    option.selected = true
+    option.selected = true;
     option.innerText = 'Foo';
 
     // For the multiple select with existing selected options, make the new option selected

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -17,6 +17,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
   - Improved support for duotone icons in `<wa-icon>`, including custom colors, custom opacity, and opacity swapping
   - Removed the `fixed-width` attribute as it's now the default behavior
 - Added the Hindi translation [pr:1307]
+- Added `--show-duration` and `--hide-duration` to `<wa-select>` [issue:1281]
 - Fixed incorrectly named exported tooltip parts in `<wa-slider>` [pr:1277]
 - Fixed a bug in `<wa-dropdown>` that caused menus to overflow the viewport instead of resizing [issue:1267]
 - Fixed a bug in `<wa-dropdown>` that prevented keyboard selection of items when nested in shadow roots [issue:1270]

--- a/packages/webawesome/src/components/select/select.css
+++ b/packages/webawesome/src/components/select/select.css
@@ -1,5 +1,7 @@
 :host {
   --tag-max-size: 10ch;
+  --show-duration: 100ms;
+  --hide-duration: 100ms;
 }
 
 /* Add ellipses to multi select options */
@@ -29,6 +31,10 @@
   width: 100%;
   position: relative;
   vertical-align: middle;
+
+  /* Pass through from select to the popup */
+  --show-duration: inherit;
+  --hide-duration: inherit;
 
   &::part(popup) {
     z-index: 900;

--- a/packages/webawesome/src/components/select/select.ts
+++ b/packages/webawesome/src/components/select/select.ts
@@ -74,6 +74,8 @@ import styles from './select.css';
  * @csspart clear-button - The clear button.
  * @csspart expand-icon - The container that wraps the expand icon.
  *
+ * @cssproperty [--show-duration=100ms] - The duration of the show animation.
+ * @cssproperty [--hide-duration=100ms] - The duration of the hide animation.
  * @cssproperty [--tag-max-size=10ch] - When using `multiple`, the max size of tags before their content is truncated.
  *
  * @cssstate blank - The select is empty.


### PR DESCRIPTION
Per #1281, this PR maps `--show-duration` and `--hide-duration` to the underlying `<wa-popup>` component so you can set the animation durations on the select directly.