### PR TITLE
Apply `position: relative` only to buttons that contain badges

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -28,6 +28,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug in JSX typings that generated the incorrect component imports [issue:1303]
 - Fixed a bug in `<wa-slider>` that prevented the thumb from receiving focus when clicking/tapping [issue:1312]
 - Fixed a bug in `<wa-scroller>` that caused the shadow to appear below relatively-positioned elements [issue:1326]
+- Fixed `<wa-button>` to have `static` positioning by default and `relative` positioning only when used with `<wa-badge>` [pr:1346]
 
 ## 3.0.0-beta.4
 

--- a/packages/webawesome/src/components/button/button.css
+++ b/packages/webawesome/src/components/button/button.css
@@ -1,6 +1,9 @@
 @layer wa-component {
   :host {
     display: inline-block;
+  }
+
+  :host(:has(wa-badge)) {
     position: relative;
   }
 }


### PR DESCRIPTION
Partially addresses #1226.

Relative positioning is only necessary on buttons when they contain badges in order to support positioning the badge at the top right corner of buttons, shown here: https://webawesome.com/docs/components/badge/#with-buttons 
This change applies `position: relative` under this condition rather than by default.