### PR TITLE
Fixes spacing between clear and password toggle icons in `<wa-input>`

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -29,6 +29,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug in `<wa-slider>` that prevented the thumb from receiving focus when clicking/tapping [issue:1312]
 - Fixed a bug in `<wa-scroller>` that caused the shadow to appear below relatively-positioned elements [issue:1326]
 - Fixed `<wa-button>` to have `static` positioning by default and `relative` positioning only when used with `<wa-badge>` [pr:1346]
+- Fixed spacing in `<wa-input>` when both clear and password toggle icons are present [issue:1325]
 
 ## 3.0.0-beta.4
 

--- a/packages/webawesome/src/components/input/input.css
+++ b/packages/webawesome/src/components/input/input.css
@@ -190,6 +190,10 @@ textarea {
   }
 }
 
+.clear + .password-toggle {
+  margin-inline-start: var(--wa-space-2xs);
+}
+
 /* Don't show the browser's password toggle in Edge */
 ::-ms-reveal {
   display: none;

--- a/packages/webawesome/src/components/input/input.css
+++ b/packages/webawesome/src/components/input/input.css
@@ -174,6 +174,7 @@ textarea {
   padding: 0;
   transition: var(--wa-transition-normal) color;
   cursor: pointer;
+  margin-inline-start: var(--wa-form-control-padding-inline);
 
   @media (hover: hover) {
     &:hover {
@@ -188,10 +189,6 @@ textarea {
   &:focus {
     outline: none;
   }
-}
-
-.clear + .password-toggle {
-  margin-inline-start: var(--wa-space-2xs);
 }
 
 /* Don't show the browser's password toggle in Edge */


### PR DESCRIPTION
I went with 2xs spacing, but feel free to adjust.

<img width="842" height="160" alt="CleanShot 2025-08-20 at 17 30 11@2x" src="https://github.com/user-attachments/assets/778b38cb-650e-49c0-a101-fe1e7bd8562f" />

Closes #1325 