### PR TITLE
Fix home page icons

### DIFF
--- a/packages/webawesome/docs/index.md
+++ b/packages/webawesome/docs/index.md
@@ -141,10 +141,11 @@ layout: page
       display: flex;
       align-items: center;
       justify-content: center;
+      block-size: 2em;
+      inline-size: 2em;
       background-color: var(--wa-color-neutral-fill-loud);
       color: var(--wa-color-neutral-on-loud);
       border-radius: 0.25rem;
-      aspect-ratio: 1;
       padding: 0.5em;
 
       &.brand-orange {


### PR DESCRIPTION
Adds `inline-size` and `block-size` to the decorative icons on the home page to fix their squashed appearance.

Before:
<img width="862" height="146" alt="Screenshot 2025-08-21 at 11 41 36 AM" src="https://github.com/user-attachments/assets/99f66c6e-0acd-49c7-ba77-944f2de83ff4" />


After:
<img width="862" height="158" alt="Screenshot 2025-08-21 at 11 41 30 AM" src="https://github.com/user-attachments/assets/4ab50363-a07e-48cf-afbe-e301312da2a5" />
