### PR TITLE
Apply `position: relative` only to buttons that contain badges *for real*

### DIFF
--- a/packages/webawesome/src/components/button/button.css
+++ b/packages/webawesome/src/components/button/button.css
@@ -1,8 +1,17 @@
 @layer wa-component {
   :host {
     display: inline-block;
+
+    /* Workaround because Chrome doesn't like :host(:has()) below
+     * https://issues.chromium.org/issues/40062355 
+     * Firefox doesn't like this nested rule, so both are needed */
+    &:has(wa-badge) {
+      position: relative;
+    }
   }
 
+  /* Apply relative positioning only when needed to position wa-badge
+   * This avoids creating a new stacking context for every button */
   :host(:has(wa-badge)) {
     position: relative;
   }


### PR DESCRIPTION
Turns out #1346 was only a partial fix. `:host(:has(wa-badge))` works in Firefox and Safari, but not in Chrome.

This change adds a nested selector that Chrome gets along with and some comments to (hopefully) clarify the redundant styles.