### PR TITLE
Prep for Pro + Product Marketing

### DIFF
--- a/packages/webawesome/docs/.eleventy.js
+++ b/packages/webawesome/docs/.eleventy.js
@@ -76,6 +76,7 @@ export default async function (eleventyConfig) {
   //
   eleventyConfig.addGlobalData('package', packageData);
   eleventyConfig.addGlobalData('layout', 'page.njk');
+  eleventyConfig.addGlobalData('pageType', 'docs'); // Default page type
   eleventyConfig.addGlobalData('server', {
     head: '',
     loginOrAvatar: '',

--- a/packages/webawesome/docs/_includes/base.njk
+++ b/packages/webawesome/docs/_includes/base.njk
@@ -50,7 +50,7 @@
   </head>
   <body class="layout-{{ layout | stripExtension }} page-{{ page.fileSlug or 'home' }}{{ ' page-wide' if wide }} page-{{ pageType or 'docs' }}">
     <!-- use view="desktop" as default to reduce layout jank on desktop site. -->
-    <wa-page view="desktop" disable-navigation-toggle mobile-breakpoint="1180">
+    <wa-page view="desktop" disable-navigation-toggle {% if pageType == 'marketing' %}disable-sticky="header"{% endif %} mobile-breakpoint="1180">
       {% if pageHeader %}
         {% include pageHeader %}
       {% else %}

--- a/packages/webawesome/docs/_includes/base.njk
+++ b/packages/webawesome/docs/_includes/base.njk
@@ -42,7 +42,7 @@
       }
     </script>
   </head>
-  <body class="layout-{{ layout | stripExtension }}{{ ' page-wide' if wide }}">
+  <body class="layout-{{ layout | stripExtension }} page-{{ page.fileSlug or 'home' }}{{ ' page-wide' if wide }} page-{{ pageType or 'docs' }}">
     <!-- use view="desktop" as default to reduce layout jank on desktop site. -->
     <wa-page view="desktop" disable-navigation-toggle mobile-breakpoint="1180">
       {% if pageHeader %}

--- a/packages/webawesome/docs/_includes/base.njk
+++ b/packages/webawesome/docs/_includes/base.njk
@@ -15,8 +15,14 @@
     {% if hasSidebar %}<script type="module" src="/assets/scripts/sidebar.js"></script>{% endif %}
     <script defer data-domain="webawesome.com" src="https://plausible.io/js/script.js"></script>
 
-    {# Docs styles #}
-    <link rel="stylesheet" href="/assets/styles/docs.css" />
+    {% if pageType == 'marketing' %}
+      {# Marketing styles #}
+      <link rel="stylesheet" href="/assets/styles/marketing.css" />
+    {% else %}
+      {# Docs styles (default) #}
+      <link rel="stylesheet" href="/assets/styles/docs.css" />
+    {% endif %}
+
 
     {% block head %}{% endblock %}
 

--- a/packages/webawesome/docs/_includes/base.njk
+++ b/packages/webawesome/docs/_includes/base.njk
@@ -45,48 +45,52 @@
   <body class="layout-{{ layout | stripExtension }}{{ ' page-wide' if wide }}">
     <!-- use view="desktop" as default to reduce layout jank on desktop site. -->
     <wa-page view="desktop" disable-navigation-toggle mobile-breakpoint="1180">
-      <header slot="header" class="wa-split">
-        {# Logo #}
-        <div id="docs-branding">
-          {# Nav toggle #}
-          <wa-button appearance="plain" size="small" data-toggle-nav>
-            <wa-icon name="bars" label="Toggle navigation"></wa-icon>
-          </wa-button>
+      {% if pageHeader %}
+        {% include pageHeader %}
+      {% else %}
+        <header slot="header" class="wa-split">
+          {# Logo #}
+          <div id="docs-branding">
+            {# Nav toggle #}
+            <wa-button appearance="plain" size="small" data-toggle-nav>
+              <wa-icon name="bars" label="Toggle navigation"></wa-icon>
+            </wa-button>
 
-          <a href="/" aria-label="Web Awesome">
-            <span class="wa-desktop-only">{% include "logo.njk" %}</span>
-            <span class="wa-mobile-only">{% include "logo-simple.njk" %}</span>
-          </a>
-          <small id="version-number" class="wa-desktop-only">{{ package.version }}</small>
-          <wa-badge variant="brand" appearance="filled" class="wa-desktop-only">Beta</wa-badge>
-        </div>
-
-        <div id="docs-toolbar" class="wa-cluster">
-          {# Desktop selectors #}
-          <div class="wa-desktop-only wa-cluster wa-gap-xs">
-            {% include "theme-selector.njk" %}
-            {% include "color-scheme-selector.njk" %}
+            <a href="/" aria-label="Web Awesome">
+              <span class="wa-desktop-only">{% include "logo.njk" %}</span>
+              <span class="wa-mobile-only">{% include "logo-simple.njk" %}</span>
+            </a>
+            <small id="version-number" class="wa-desktop-only">{{ package.version }}</small>
+            <wa-badge variant="brand" appearance="filled" class="wa-desktop-only">Beta</wa-badge>
           </div>
 
-          <wa-divider orientation="vertical" class="wa-desktop-only"></wa-divider>
+          <div id="docs-toolbar" class="wa-cluster">
+            {# Desktop selectors #}
+            <div class="wa-desktop-only wa-cluster wa-gap-xs">
+              {% include "theme-selector.njk" %}
+              {% include "color-scheme-selector.njk" %}
+            </div>
 
-          <div id="github-buttons" class="wa-cluster wa-gap-xs">
-            <wa-button id="github-repo-button" href="https://github.com/shoelace-style/webawesome" rel="noopener noreferrer" target="_blank" appearance="filled" size="small">
-              <wa-icon family="brands" name="github" label="GitHub"></wa-icon>
-            </wa-button>
-            <wa-tooltip for="github-repo-button" distance="2">GitHub</wa-tooltip>
-            <wa-button id="github-star-button" href="https://github.com/shoelace-style/webawesome/stargazers" rel="noopener noreferrer" target="_blank" appearance="filled" size="small">
-              <wa-icon name="star" variant="regular" label="Star this repository"></wa-icon>
-            </wa-button>
-            <wa-tooltip for="github-star-button" distance="2">Star this repository</wa-tooltip>
+            <wa-divider orientation="vertical" class="wa-desktop-only"></wa-divider>
+
+            <div id="github-buttons" class="wa-cluster wa-gap-xs">
+              <wa-button id="github-repo-button" href="https://github.com/shoelace-style/webawesome" rel="noopener noreferrer" target="_blank" appearance="filled" size="small">
+                <wa-icon family="brands" name="github" label="GitHub"></wa-icon>
+              </wa-button>
+              <wa-tooltip for="github-repo-button" distance="2">GitHub</wa-tooltip>
+              <wa-button id="github-star-button" href="https://github.com/shoelace-style/webawesome/stargazers" rel="noopener noreferrer" target="_blank" appearance="filled" size="small">
+                <wa-icon name="star" variant="regular" label="Star this repository"></wa-icon>
+              </wa-button>
+              <wa-tooltip for="github-star-button" distance="2">Star this repository</wa-tooltip>
+            </div>
+
+            <wa-divider orientation="vertical"></wa-divider>
+
+            {# Login #}
+            {% server "loginOrAvatar" %}
           </div>
-
-          <wa-divider orientation="vertical"></wa-divider>
-
-          {# Login #}
-          {% server "loginOrAvatar" %}
-        </div>
-      </header>
+        </header>
+      {% endif %}
 
       {# Sidebar #}
       {% if hasSidebar %}
@@ -138,6 +142,11 @@
       </main>
 
       {% include 'search.njk' %}
+
+      {# Footer #}
+      {% if pageFooter %}
+        {% include pageFooter %}
+      {% endif %}
     </wa-page>
 
   </body>


### PR DESCRIPTION
This work helps prep `base.njk` prep for Pro and Product Marketing-based views that live alongside this repo's docs, templates, and components. 

In short, it does the following:
- adds conditional logic to override a page's header and footer through custom front matter (`pageHeader` and `pageFooter` respectively). Ideally, this could be done using Nunjucks' [block](https://mozilla.github.io/nunjucks/templating.html#block), but there's an issue doing so in our current set up.
- revises the classes we add to our pages' `<body>` element - adding `pageType` and `pageSlug`-based classes.
- adds conditional logic to load Marketing-based CSS based on `pageType` and by default continuing to load Docs-based CSS.

---

@KonnorRogers, how do these changes look to you? Happy to revert or try another path on anything that seems off.