### PR TITLE
Replace invisible BOM marker in Dialog/Drawer with a zero‐width space

### DIFF
--- a/packages/webawesome/src/components/dialog/dialog.ts
+++ b/packages/webawesome/src/components/dialog/dialog.ts
@@ -224,7 +224,7 @@ export default class WaDialog extends WebAwesomeElement {
               <header part="header" class="header">
                 <h2 part="title" class="title" id="title">
                   <!-- If there's no label, use an invisible character to prevent the header from collapsing -->
-                  <slot name="label"> ${this.label.length > 0 ? this.label : String.fromCharCode(65279)} </slot>
+                  <slot name="label"> ${this.label.length > 0 ? this.label : String.fromCharCode(8203)} </slot>
                 </h2>
                 <div part="header-actions" class="header-actions">
                   <slot name="header-actions"></slot>

--- a/packages/webawesome/src/components/drawer/drawer.ts
+++ b/packages/webawesome/src/components/drawer/drawer.ts
@@ -241,7 +241,7 @@ export default class WaDrawer extends WebAwesomeElement {
               <header part="header" class="header">
                 <h2 part="title" class="title" id="title">
                   <!-- If there's no label, use an invisible character to prevent the header from collapsing -->
-                  <slot name="label"> ${this.label.length > 0 ? this.label : String.fromCharCode(65279)} </slot>
+                  <slot name="label"> ${this.label.length > 0 ? this.label : String.fromCharCode(8203)} </slot>
                 </h2>
                 <div part="header-actions" class="header-actions">
                   <slot name="header-actions"></slot>


### PR DESCRIPTION
#### Description

This PR replaces the invisible BOM marker (`String.fromCharCode(65279)`) with the zero‐width space (`String.fromCharCode(8203)`). This helps prevent any weird rendering quirks in text editors or any other application that might happen if people copy the contents of the dialog/drawer.