### PR TITLE
Allow bundlers access to package.json

### DIFF
--- a/packages/webawesome/package.json
+++ b/packages/webawesome/package.json
@@ -29,7 +29,8 @@
     "./dist/react": "./dist/react/index.js",
     "./dist/react/*": "./dist/react/*",
     "./dist/translations": "./dist/translations",
-    "./dist/translations/*": "./dist/translations/*"
+    "./dist/translations/*": "./dist/translations/*",
+    "./package.json": "./package.json"
   },
   "files": [
     "README.md",


### PR DESCRIPTION
There are cases where tooling extending Web Awesome can get important information from the `package.json` (i.e. version). Exporting the file will given bundlers access to the file.