### PR TITLE
Remove whitespace from `<wa-format-date>` and `<wa-relative-time>`

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -36,6 +36,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug in `<wa-input>` that prevented the value from changing when assigning non-string values to `value` [issue:1323]
 - Fixed a bug in `<wa-color-picker>` that prevent the picker from staying in the viewport
 - Fixed a bug that in `<wa-icon>` that caused `library`, `family`, `variant` and `name` to not reflect [pr:#1395]
+- Fixed a bug in `<wa-format-date>` and `<wa-relative-wa-relative-time>` that caused spaces to appear before and after the output [#1417]
 
 ## 3.0.0-beta.4
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -36,7 +36,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug in `<wa-input>` that prevented the value from changing when assigning non-string values to `value` [issue:1323]
 - Fixed a bug in `<wa-color-picker>` that prevent the picker from staying in the viewport
 - Fixed a bug that in `<wa-icon>` that caused `library`, `family`, `variant` and `name` to not reflect [pr:#1395]
-- Fixed a bug in `<wa-format-date>` and `<wa-relative-wa-relative-time>` that caused spaces to appear before and after the output [#1417]
+- Fixed a bug in `<wa-format-date>` and `<wa-relative-time>` that caused spaces to appear before and after the output [#1417]
 
 ## 3.0.0-beta.4
 

--- a/packages/webawesome/src/components/format-date/format-date.ts
+++ b/packages/webawesome/src/components/format-date/format-date.ts
@@ -66,23 +66,22 @@ export default class WaFormatDate extends WebAwesomeElement {
       return undefined;
     }
 
-    return html`
-      <time datetime=${date.toISOString()}>
-        ${this.localize.date(date, {
-          weekday: this.weekday,
-          era: this.era,
-          year: this.year,
-          month: this.month,
-          day: this.day,
-          hour: this.hour,
-          minute: this.minute,
-          second: this.second,
-          timeZoneName: this.timeZoneName,
-          timeZone: this.timeZone,
-          hour12: hour12,
-        })}
-      </time>
-    `;
+    const displayDate = this.localize.date(date, {
+      weekday: this.weekday,
+      era: this.era,
+      year: this.year,
+      month: this.month,
+      day: this.day,
+      hour: this.hour,
+      minute: this.minute,
+      second: this.second,
+      timeZoneName: this.timeZoneName,
+      timeZone: this.timeZone,
+      hour12: hour12,
+    });
+
+    // No whitespace before or after
+    return html`<time datetime=${date.toISOString()}>${displayDate}</time>`;
   }
 }
 

--- a/packages/webawesome/src/components/relative-time/relative-time.ts
+++ b/packages/webawesome/src/components/relative-time/relative-time.ts
@@ -99,7 +99,8 @@ export default class WaRelativeTime extends WebAwesomeElement {
       this.updateTimeout = setTimeout(() => this.requestUpdate(), nextInterval);
     }
 
-    return html` <time datetime=${this.isoTime}>${this.relativeTime}</time> `;
+    // No whitespace before or after
+    return html`<time datetime=${this.isoTime}>${this.relativeTime}</time>`;
   }
 }
 


### PR DESCRIPTION
This PR removes the spaces added before/after the output due to whitespace in the component's template. Other formatters aren't affected.

Closes #1417