### PR TITLE
make event cancelable

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -8,6 +8,10 @@ Web Awesome follows [Semantic Versioning](https://semver.org/). Breaking changes
 
 Components with the <wa-badge variant="warning">Experimental</wa-badge> badge should not be used in production. They are made available as release candidates for development and testing purposes. As such, changes to experimental components will not be subject to semantic versioning.
 
+## Next
+
+- Fixed a bug in `<wa-dropdown>` that closed the dropdown event when preventing `wa-select` [issue:1432]
+
 ## 3.0.0-beta.5
 
 ### Bug Fixes and Improvements {data-no-outline}

--- a/packages/webawesome/src/events/select.ts
+++ b/packages/webawesome/src/events/select.ts
@@ -2,7 +2,7 @@ export class WaSelectEvent extends Event {
   readonly detail;
 
   constructor(detail: WaSelectEventDetail) {
-    super('wa-select', { bubbles: true, cancelable: false, composed: true });
+    super('wa-select', { bubbles: true, cancelable: true, composed: true });
     this.detail = detail;
   }
 }


### PR DESCRIPTION
Fixes #1432


Test fixture:

```html
<wa-dropdown id="keep-open">
  <wa-button slot="trigger" with-caret>View</wa-button>
  <wa-dropdown-item type="checkbox" value="full-screen">Enter full screen</wa-dropdown-item>
  <wa-dropdown-item type="checkbox" value="actual">Actual size</wa-dropdown-item>
  <wa-dropdown-item type="checkbox" value="zoom-in">Zoom in</wa-dropdown-item>
  <wa-dropdown-item type="checkbox" value="zoom-out">Zoom out</wa-dropdown-item>
</wa-dropdown>

<script>
  const dropdown = document.querySelector('#keep-open');

  dropdown.addEventListener('wa-select', event => {
    event.preventDefault();
  });
</script>
```