### PR TITLE
Fix popup arrow to avoid overlays

### DIFF
--- a/packages/webawesome/src/components/popup/popup.css
+++ b/packages/webawesome/src/components/popup/popup.css
@@ -49,6 +49,7 @@
   rotate: 45deg;
   background: var(--arrow-color);
   z-index: 3;
+  clip-path: polygon(0 100%, 100% 0, 100% 100%);
 }
 
 :host([data-current-placement~='left']) .arrow {


### PR DESCRIPTION
- Add a clip-path to the popup arrow
  - this avoids overlay with the container when padding is reduced or the arrow size is increased.
-  original PR: home-assistant/webawesome#8