### PR TITLE
update to the button  if it has an icon in it's default slot

### DIFF
--- a/packages/webawesome/docs/docs/components/button.md
+++ b/packages/webawesome/docs/docs/components/button.md
@@ -183,6 +183,9 @@ Use the `start` and `end` slots to add presentational elements like `<wa-icon>` 
 Use the `with-caret` attribute to add a dropdown indicator when a button will trigger a dropdown, menu, or popover.
 
 ```html {.example}
+<wa-button size="small" with-caret>
+  <wa-icon name="gear" label="Settings"></wa-icon>
+</wa-button>
 <wa-button size="small" with-caret>Small</wa-button>
 <wa-button size="medium" with-caret>Medium</wa-button>
 <wa-button size="large" with-caret>Large</wa-button>

--- a/packages/webawesome/src/components/button/button.css
+++ b/packages/webawesome/src/components/button/button.css
@@ -178,6 +178,10 @@
   aspect-ratio: 1;
 }
 
+.button.is-icon-button:has(wa-icon) {
+  width: auto;
+}
+
 /* Pill modifier */
 :host([pill]) .button {
   border-radius: var(--wa-border-radius-pill);


### PR DESCRIPTION
This is a PR for #1447 that should fix the issue the user was having when adding an icon to the default slot of a button with the `with-caret` attribute.  
<img width="627" height="322" alt="Screenshot 2025-09-17 at 2 53 59 PM" src="https://github.com/user-attachments/assets/c5307fe6-5add-415d-b515-aff72e6e1d8d" />
