### PR TITLE
Fix badge positioning for link buttons

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -10,6 +10,9 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 
 ## Next
 
+- Fixed a bug in `<wa-button>` where slotted badges weren't properly positioned in buttons with an `href` [issue:1377]
+- Fixed focus outline styles in `<wa-details>` and native `<details>` [issue:1456]
+
 ## 3.0.0-beta.6
 
 - Fixed a bug in `<wa-dropdown>` that closed the dropdown event when preventing `wa-select` [issue:1432]

--- a/packages/webawesome/src/components/button/button.css
+++ b/packages/webawesome/src/components/button/button.css
@@ -258,7 +258,7 @@ wa-icon[part~='caret'] {
  * Badges
  */
 
-button ::slotted(wa-badge) {
+.button ::slotted(wa-badge) {
   border-color: var(--wa-color-surface-default);
   position: absolute;
   inset-block-start: 0;


### PR DESCRIPTION
Closes #1377 

Updates `<wa-button>` styles to target `.button` for badge positioning. The `.button` class is used internally for both standard and link buttons.