### PR TITLE
Fix details focus ring

### DIFF
--- a/packages/webawesome/src/components/details/details.css
+++ b/packages/webawesome/src/components/details/details.css
@@ -6,29 +6,6 @@
   display: block;
 }
 
-:host summary {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  user-select: none;
-  -webkit-user-select: none;
-  cursor: pointer;
-
-  &::marker,
-  &::-webkit-details-marker {
-    display: none;
-  }
-
-  &:focus {
-    outline: none;
-  }
-
-  &:focus-visible {
-    outline: var(--wa-focus-ring);
-    outline-offset: calc(var(--spacing) + var(--wa-focus-ring-offset));
-  }
-}
-
 details {
   display: block;
   overflow-anchor: none;
@@ -77,15 +54,16 @@ details {
   cursor: not-allowed;
 }
 
-:host summary {
+summary {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--spacing);
+  padding: var(--spacing); /* Add padding here */
+  border-radius: calc(var(--wa-panel-border-radius) - var(--wa-panel-border-width));
   user-select: none;
   -webkit-user-select: none;
   cursor: pointer;
-  padding: var(--spacing); /* Add padding here */
 
   &::marker,
   &::-webkit-details-marker {
@@ -98,8 +76,13 @@ details {
 
   &:focus-visible {
     outline: var(--wa-focus-ring);
-    outline-offset: calc(var(--spacing) + var(--wa-focus-ring-offset));
+    outline-offset: calc(var(--wa-panel-border-width) + var(--wa-focus-ring-offset));
   }
+}
+
+:host([open]) summary {
+  border-end-start-radius: 0;
+  border-end-end-radius: 0;
 }
 
 /* 'Start' icon placement */

--- a/packages/webawesome/src/styles/native.css
+++ b/packages/webawesome/src/styles/native.css
@@ -407,6 +407,8 @@
 
       padding: var(--wa-space-m);
 
+      border-radius: calc(var(--wa-panel-border-radius) - var(--wa-panel-border-width));
+
       cursor: pointer;
       user-select: none;
       -webkit-user-select: none;
@@ -421,7 +423,7 @@
 
       &:focus-visible {
         outline: var(--wa-focus-ring);
-        outline-offset: var(--wa-focus-ring-offset);
+        outline-offset: calc(var(--wa-panel-border-width) + var(--wa-focus-ring-offset));
       }
     }
 
@@ -430,6 +432,9 @@
 
       summary {
         margin-inline: calc(-1 * var(--wa-space-m));
+
+        border-end-start-radius: 0;
+        border-end-end-radius: 0;
       }
     }
 


### PR DESCRIPTION
Closes #1456

Improves the focus styles of native `<details>` and `<wa-details>`. Consequently improves corner rounding for summaries.

#### `<wa-details>`
**Before**
<img width="350" alt="Screenshot 2025-09-17 at 6 49 40 PM" src="https://github.com/user-attachments/assets/a261cbb1-7f17-4258-9d69-91434ea0fbcb" /><img width="350" alt="Screenshot 2025-09-17 at 6 49 55 PM" src="https://github.com/user-attachments/assets/996251b5-f930-4367-ac49-2d6583aed84f" />


**After**
<img width="350" alt="Screenshot 2025-09-17 at 6 49 44 PM" src="https://github.com/user-attachments/assets/0dba424a-8f12-49d4-beb1-d0f053716b32" /><img width="350" alt="Screenshot 2025-09-17 at 6 49 59 PM" src="https://github.com/user-attachments/assets/38f88c01-b536-4a7b-a7a9-ded210b4a0f5" />


#### Native `<details>`
**Before**
<img width="350" alt="Screenshot 2025-09-17 at 6 53 27 PM" src="https://github.com/user-attachments/assets/8272f49a-aa13-48ee-8c29-5e2cd647cfb2" /><img width="350" alt="Screenshot 2025-09-17 at 6 53 30 PM" src="https://github.com/user-attachments/assets/22eb02c8-1fd9-47f9-9378-520b37bdde75" />

**After**
<img width="350" alt="Screenshot 2025-09-17 at 6 53 18 PM" src="https://github.com/user-attachments/assets/3ebec3fd-5d52-4e87-9f8e-2aea314e65d9" /><img width="350" alt="Screenshot 2025-09-17 at 6 53 23 PM" src="https://github.com/user-attachments/assets/40476102-07d1-4d56-a8c0-7dd18332664a" />