### PR TITLE
Docs: Icon Component - Update Default Width

### DIFF
--- a/packages/webawesome/docs/docs/components/icon.md
+++ b/packages/webawesome/docs/docs/components/icon.md
@@ -100,7 +100,7 @@ Icons are sized relative to the current font size. To change their size, set the
 
 ### Auto Width
 
-By default, icons have a 1em height and a fixed 1em width. Use the `auto-width` attribute to allow the icon to use its natural variable width.
+By default, icons have a `1em` height and a fixed `1.25em` width. Use the `auto-width` attribute to allow the icon to use its natural variable width.
 
 ```html {.example}
 Without auto-width<br />

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -21,6 +21,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 
 - 🚨 BREAKING: Updated `<wa-icon>` to use Font Awesome 7 [pr:1222]
   - Added the `auto-width` attribute to automatically size icons, since FA7 is fixed-width by default now
+  - Changed the default width of icons to `1.25em` to match FA7's fixed-width proportions
   - Improved support for duotone icons in `<wa-icon>`, including custom colors, custom opacity, and opacity swapping
   - Removed the `fixed-width` attribute as it's now the default behavior
 - 🚨 BREAKING: Renamed the `icon-position` attribute to `icon-placement` in `<wa-details>` [discuss:1340]


### PR DESCRIPTION
Per the good catch in https://github.com/shoelace-style/webawesome/discussions/1451, this work updates the following:

* The default width noted in the Icon component docs. It should now reflect the `1.25em` proportions of Font Awesome 7's fixed-width.
* The 3.0.0-beta.5 changelog to reflect when this default width change was made.