### PR TITLE
Relative links to `cluster` and `stack` fixed

### DIFF
--- a/packages/webawesome/docs/docs/utilities/align-items.md
+++ b/packages/webawesome/docs/docs/utilities/align-items.md
@@ -20,7 +20,7 @@ tags: layoutUtilities
   }
 </style>
 
-Web Awesome includes classes to set the `align-items` property of flex and grid containers. They can be used alongside other Web Awesome layout utilities, like [cluster](/docs/layout/cluster) and [stack](/docs/layout/stack), to align children in container on the container's cross axis.
+Web Awesome includes classes to set the `align-items` property of flex and grid containers. They can be used alongside other Web Awesome layout utilities, like [cluster](/docs/utilities/cluster) and [stack](/docs/utilities/stack), to align children in container on the container's cross axis.
 
 | Class Name                | `align-items` Value | Preview                                                                                                                                  |
 | ------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Fixed some internal links from `/docs/layout/` to `docs/utilities/`