### PR TITLE
Update Layouts to Prep for Site Assets

### DIFF
--- a/packages/webawesome/docs/.eleventy.js
+++ b/packages/webawesome/docs/.eleventy.js
@@ -93,6 +93,17 @@ export default async function (eleventyConfig) {
     return typeof content === 'string' ? content.replace(/^(\s|\|)/g, '').replace(/(\s|\|)$/g, '') : content;
   });
 
+  /**
+   * @example
+    {% set foo = {foo: "bar"} %}
+    {% set bar = {bar: "baz"} %}
+    {% set merged = foo | merge(bar) %}
+    {{ merged | dump }}
+   */
+  eleventyConfig.addFilter('merge', function (obj1, obj2) {
+    return Object.assign({}, obj1, obj2);
+  });
+
   // Custom filter to sort with a priority item first, e.g.
   // {{ collection | sortWithFirst('fileSlug', 'default') }} => the item with the fileSlug of 'default' will be first
   eleventyConfig.addFilter('sortWithFirst', function (collection, property, firstValue) {

--- a/packages/webawesome/docs/.eleventy.js
+++ b/packages/webawesome/docs/.eleventy.js
@@ -76,7 +76,6 @@ export default async function (eleventyConfig) {
   //
   eleventyConfig.addGlobalData('package', packageData);
   eleventyConfig.addGlobalData('layout', 'page.njk');
-  eleventyConfig.addGlobalData('pageType', 'docs'); // Default page type
   eleventyConfig.addGlobalData('server', {
     head: '',
     loginOrAvatar: '',

--- a/packages/webawesome/docs/_includes/base.njk
+++ b/packages/webawesome/docs/_includes/base.njk
@@ -41,7 +41,7 @@
       }
     </script>
   </head>
-  <body class="layout-{{ layout | stripExtension }} page-{{ page.fileSlug or 'home' }}{{ ' page-wide' if wide }} page-{{ pageType or 'docs' }}">
+  <body class="layout-{{ layout | stripExtension }} page-{{ page.fileSlug or 'home' }}{{ ' page-wide' if wide }}">
     <!-- use view="desktop" as default to reduce layout jank on desktop site. -->
     <wa-page
       view="desktop"

--- a/packages/webawesome/docs/_includes/base.njk
+++ b/packages/webawesome/docs/_includes/base.njk
@@ -41,7 +41,7 @@
       }
     </script>
   </head>
-  <body class="layout-{{ layout | stripExtension }} page-{{ page.fileSlug or 'home' }}{{ ' page-wide' if wide }}">
+  <body class="layout-{{ layout | stripExtension }} page-{{ pageClass or page.fileSlug or 'home' }}{{ ' page-wide' if wide }}">
     {% set defaultWaPageAttributes = defaultWaPageAttributes or { view: 'desktop', 'disable-navigation-toggle': true, 'mobile-breakpoint': 1180 } %}
     {% set waPageAttributes = waPageAttributes or {} %}
     {% set mergedWaPageAttributes = defaultWaPageAttributes | merge(waPageAttributes) %}

--- a/packages/webawesome/docs/_includes/base.njk
+++ b/packages/webawesome/docs/_includes/base.njk
@@ -15,15 +15,9 @@
     {% if hasSidebar %}<script type="module" src="/assets/scripts/sidebar.js"></script>{% endif %}
     <script defer data-domain="webawesome.com" src="https://plausible.io/js/script.js"></script>
 
-    {% if pageType == 'marketing' %}
-      {# Marketing styles #}
-      <link rel="stylesheet" href="/assets/styles/marketing.css" />
-    {% else %}
-      {# Docs styles (default) #}
+    {% block head %}
       <link rel="stylesheet" href="/assets/styles/docs.css" />
-    {% endif %}
-
-    {% block head %}{% endblock %}
+    {% endblock %}
 
     <script type="module">
       // Set the initial color scheme before the page renders to prevent flashing

--- a/packages/webawesome/docs/_includes/base.njk
+++ b/packages/webawesome/docs/_includes/base.njk
@@ -42,13 +42,15 @@
     </script>
   </head>
   <body class="layout-{{ layout | stripExtension }} page-{{ page.fileSlug or 'home' }}{{ ' page-wide' if wide }}">
-    <!-- use view="desktop" as default to reduce layout jank on desktop site. -->
+    {% set defaultWaPageAttributes = defaultWaPageAttributes or { view: 'desktop', 'disable-navigation-toggle': true, 'mobile-breakpoint': 1180 } %}
+    {% set waPageAttributes = waPageAttributes or {} %}
+    {% set mergedWaPageAttributes = defaultWaPageAttributes | merge(waPageAttributes) %}
     <wa-page
-      view="desktop"
-      {% block wa_page_attributes %}
-        disable-navigation-toggle
-        mobile-breakpoint="1180"
-      {% endblock %}
+      {% for key, value in mergedWaPageAttributes %}
+        {% if value != null and value != false %}
+          {{ key }}="{{ value }}"
+        {% endif %}
+      {% endfor %}
     >
         {% block pageHeader %}
           <header slot="header" class="wa-split">

--- a/packages/webawesome/docs/_includes/base.njk
+++ b/packages/webawesome/docs/_includes/base.njk
@@ -23,7 +23,6 @@
       <link rel="stylesheet" href="/assets/styles/docs.css" />
     {% endif %}
 
-
     {% block head %}{% endblock %}
 
     <script type="module">
@@ -50,7 +49,13 @@
   </head>
   <body class="layout-{{ layout | stripExtension }} page-{{ page.fileSlug or 'home' }}{{ ' page-wide' if wide }} page-{{ pageType or 'docs' }}">
     <!-- use view="desktop" as default to reduce layout jank on desktop site. -->
-    <wa-page view="desktop" disable-navigation-toggle {% if pageType == 'marketing' %}disable-sticky="header"{% endif %} mobile-breakpoint="1180">
+    <wa-page
+      view="desktop"
+      {% block wa_page_attributes %}
+        disable-navigation-toggle
+        mobile-breakpoint="1180"
+      {% endblock %}
+    >
         {% block pageHeader %}
           <header slot="header" class="wa-split">
             {# Logo #}

--- a/packages/webawesome/docs/_includes/color-scheme-selector.njk
+++ b/packages/webawesome/docs/_includes/color-scheme-selector.njk
@@ -1,18 +1,18 @@
-<wa-select class="color-scheme-selector" appearance="filled" size="small" value="auto" title="Press \ to toggle">
-  <wa-icon class="only-light" slot="start" name="sun" variant="regular"></wa-icon>
-  <wa-icon class="only-dark" slot="start" name="moon" variant="regular"></wa-icon>
+<wa-select class="color-scheme-selector" appearance="filled" value="auto" title="Press \ to toggle">
+  <wa-icon class="only-light" slot="start" name="sun-bright" variant="regular"></wa-icon>
+  <wa-icon class="only-dark" slot="start" name="moon-stars" variant="regular"></wa-icon>
   <wa-option value="light">
-    <wa-icon slot="start" name="sun" variant="regular"></wa-icon>
+    <wa-icon slot="start" name="sun-bright" variant="regular"></wa-icon>
     Light
   </wa-option>
   <wa-option value="dark">
-    <wa-icon slot="start" name="moon" variant="regular"></wa-icon>
+    <wa-icon slot="start" name="moon-stars" variant="regular"></wa-icon>
     Dark
   </wa-option>
   <wa-divider></wa-divider>
   <wa-option value="auto">
-    <wa-icon class="only-light" slot="start" name="sun" variant="regular"></wa-icon>
-    <wa-icon class="only-dark" slot="start" name="moon" variant="regular"></wa-icon>
+    <wa-icon class="only-light" slot="start" name="sun-bright" variant="regular"></wa-icon>
+    <wa-icon class="only-dark" slot="start" name="moon-stars" variant="regular"></wa-icon>
     System
   </wa-option>
 </wa-select>

--- a/packages/webawesome/docs/_layouts/blank.njk
+++ b/packages/webawesome/docs/_layouts/blank.njk
@@ -4,7 +4,7 @@
     {% include 'head.njk' %}
     {% block head %}{% endblock %}
   </head>
-  <body class="layout-{{ layout | stripExtension }}">
+  <body class="layout-{{ layout | stripExtension }} page-{{ page.fileSlug or 'home' }}">
     {% block content %}
       {{ content | safe }}
     {% endblock %}

--- a/packages/webawesome/docs/_layouts/blank.njk
+++ b/packages/webawesome/docs/_layouts/blank.njk
@@ -4,7 +4,7 @@
     {% include 'head.njk' %}
     {% block head %}{% endblock %}
   </head>
-  <body class="layout-{{ layout | stripExtension }} page-{{ page.fileSlug or 'home' }}">
+  <body class="layout-{{ layout | stripExtension }} page-{{ pageClass or page.fileSlug or 'home' }}">
     {% block content %}
       {{ content | safe }}
     {% endblock %}


### PR DESCRIPTION
This PR updates site layouts to prepare for new asset organization, removing marketing-specific styling logic and streamlining the template structure.

- Removed the conditional marketing/docs CSS loading and unified on docs.css
- Updated icon names from generic "sun/moon" to more specific "sun-bright/moon-stars"
- Simplified layout structure by removing pageType variable and making template blocks more flexible