### PR TITLE
Remove duplicated declaration

### DIFF
--- a/packages/webawesome/src/components/split-panel/split-panel.ts
+++ b/packages/webawesome/src/components/split-panel/split-panel.ts
@@ -317,9 +317,3 @@ declare global {
     'wa-split-panel': WaSplitPanel;
   }
 }
-
-declare global {
-  interface HTMLElementTagNameMap {
-    'wa-split-panel': WaSplitPanel;
-  }
-}


### PR DESCRIPTION
A trivial change to remove a duplicated declaration in the `<wa-split-panel>` component.