### PR TITLE
Make sure essential CSS is always imported

### DIFF
--- a/packages/webawesome/docs/_includes/head.njk
+++ b/packages/webawesome/docs/_includes/head.njk
@@ -21,9 +21,7 @@
 <script type="module" src="/dist/webawesome.loader.js"></script>
 
 <link id="theme-stylesheet" rel="stylesheet" href="/dist/styles/themes/default.css" render="blocking" fetchpriority="high" />
-{% for palette in themer.palettes %}
-	<link rel="stylesheet" href="/dist/styles/color/palettes/{{palette.filename}}" />
-{% endfor %}
+
 <link rel="stylesheet" href="/dist/styles/webawesome.css" />
 
 <script type="module">

--- a/packages/webawesome/src/styles/color/palettes/bright.css
+++ b/packages/webawesome/src/styles/color/palettes/bright.css
@@ -1,4 +1,5 @@
 @import url('base.css');
+@import url('../variants.css');
 
 @layer wa-color-palette {
   .wa-palette-bright {

--- a/packages/webawesome/src/styles/color/palettes/default.css
+++ b/packages/webawesome/src/styles/color/palettes/default.css
@@ -1,4 +1,5 @@
 @import url('base.css');
+@import url('../variants.css');
 
 @layer wa-color-palette {
   :where(:root),

--- a/packages/webawesome/src/styles/color/palettes/shoelace.css
+++ b/packages/webawesome/src/styles/color/palettes/shoelace.css
@@ -1,4 +1,5 @@
 @import url('base.css');
+@import url('../variants.css');
 
 @layer wa-color-palette {
   .wa-palette-shoelace,

--- a/packages/webawesome/src/styles/native.css
+++ b/packages/webawesome/src/styles/native.css
@@ -1,3 +1,6 @@
+@import url('utilities/size.css');
+@import url('utilities/variants.css');
+
 @layer wa-native {
   /* #region General ~~~~~~~~~~~~~~~~~~~~~~~~~ */
   html {

--- a/packages/webawesome/src/styles/themes/awesome.css
+++ b/packages/webawesome/src/styles/themes/awesome.css
@@ -1,3 +1,4 @@
+@import url('../color/palettes/bright.css'); /* To use this palette, add class="wa-palette-bright" to the <html> element */
 @import url('https://fonts.bunny.net/css2?family=Crimson+Pro:ital,wght@0,200..900;1,200..900&family=Quicksand:wght@300..700&display=swap');
 
 @layer wa-theme {

--- a/packages/webawesome/src/styles/themes/default.css
+++ b/packages/webawesome/src/styles/themes/default.css
@@ -1,3 +1,5 @@
+@import url('../color/palettes/default.css');
+
 @layer wa-theme {
   :where(:root),
   .wa-theme-default,

--- a/packages/webawesome/src/styles/themes/default.css
+++ b/packages/webawesome/src/styles/themes/default.css
@@ -1,6 +1,3 @@
-@import url('../color/palettes/default.css');
-@import url('../color/variants.css');
-
 @layer wa-theme {
   :where(:root),
   .wa-theme-default,

--- a/packages/webawesome/src/styles/themes/shoelace.css
+++ b/packages/webawesome/src/styles/themes/shoelace.css
@@ -1,3 +1,5 @@
+@import url('../color/palettes/shoelace.css'); /* To use this palette, add class="wa-palette-shoelace" to the <html> element */
+
 @layer wa-theme {
   .wa-theme-shoelace,
   .wa-theme-shoelace.wa-light,

--- a/packages/webawesome/src/styles/webawesome.css
+++ b/packages/webawesome/src/styles/webawesome.css
@@ -6,5 +6,6 @@
 /* CSS Utilities */
 @import url('utilities.css');
 
-/* Theme */
+/* Palette & Theme */
+@import url('palettes/default.css');
 @import url('themes/default.css');

--- a/packages/webawesome/src/styles/webawesome.css
+++ b/packages/webawesome/src/styles/webawesome.css
@@ -7,5 +7,5 @@
 @import url('utilities.css');
 
 /* Palette & Theme */
-@import url('palettes/default.css');
+@import url('color/palettes/default.css');
 @import url('themes/default.css');

--- a/packages/webawesome/src/styles/webawesome.css
+++ b/packages/webawesome/src/styles/webawesome.css
@@ -6,6 +6,5 @@
 /* CSS Utilities */
 @import url('utilities.css');
 
-/* Palette & Theme */
-@import url('color/palettes/default.css');
+/* Theme */
 @import url('themes/default.css');


### PR DESCRIPTION
Updates style imports to better match what code is actually necessary to use the intended styles. As such:
- **Native styles (`native.css`) imports `/utilities/variants.css` and `/utilities/size.css`**
  - Native styles rely on these shared utilities to support parity with components' `size=""` and `variant=""` attributes. This change ensures that, even if a user opts out of other WA utility classes, `.wa-size-[s|m|l]` and `.wa-[brand|success|warning|danger|neutral]` continue to work with native elements.
- **Each palette stylesheet (`/color/palettes/[palette-name].css`) imports `/color/variants.css`**
  - `/color/variants.css` controls the color of component variants (brand, neutral, etc.) and was originally imported in the Default theme. This means that variants only worked when either the Default theme or our kitchen sink styles (webawesome.css) were used.
  - Because `/color/variants.css` relies on the literal color tokens (e.g. `--wa-color-blue-50`) defined in our palettes to function, this stylesheet is shipped alongside each palette stylesheet.
- **Each theme stylesheet (`/themes/[theme-name].css`) imports the theme's intended palette**
  - Our themes don't have a visible effect without a palette. This ensures that a palette is shipped alongside each theme.
  - This aligns with the guidance we already provide on /docs/color-palettes/, in which we instruct users to add the class for the theme's intended palette but don't actually provide a second `<link>` to reference the palette.