### PR TITLE
Docs: Add Theme-based Scripts + Styles Templating Blocks

### DIFF
--- a/packages/webawesome/docs/_includes/base.njk
+++ b/packages/webawesome/docs/_includes/base.njk
@@ -26,20 +26,22 @@
       document.documentElement.classList.toggle('wa-dark', isDark);
     </script>
 
-    <script type="module">
-      // Set the initial theme before the page renders to prevent flashing
-      const savedTheme = localStorage.getItem('theme') || 'default';
+    {% block themeScript %}
+      <script type="module">
+        // Set the initial theme before the page renders to prevent flashing
+        const savedTheme = localStorage.getItem('theme') || 'default';
 
-      // Update the theme stylesheet link first
-      const themeStylesheet = document.getElementById('theme-stylesheet');
-      if (themeStylesheet) {
-        themeStylesheet.href = `/dist/styles/themes/${savedTheme}.css`;
-      }
+        // Update the theme stylesheet link first
+        const themeStylesheet = document.getElementById('theme-stylesheet');
+        if (themeStylesheet) {
+          themeStylesheet.href = `/dist/styles/themes/${savedTheme}.css`;
+        }
 
-      if (savedTheme !== 'default') {
-        document.documentElement.classList.add(`wa-theme-${savedTheme}`);
-      }
-    </script>
+        if (savedTheme !== 'default') {
+          document.documentElement.classList.add(`wa-theme-${savedTheme}`);
+        }
+      </script>
+    {% endblock %}
   </head>
   <body class="layout-{{ layout | stripExtension }} page-{{ pageClass or page.fileSlug or 'home' }}{{ ' page-wide' if wide }}">
     {% set defaultWaPageAttributes = defaultWaPageAttributes or { view: 'desktop', 'disable-navigation-toggle': true, 'mobile-breakpoint': 1180 } %}

--- a/packages/webawesome/docs/_includes/head.njk
+++ b/packages/webawesome/docs/_includes/head.njk
@@ -20,7 +20,9 @@
 <link rel="preconnect" href="https://cdn.jsdelivr.net">
 <script type="module" src="/dist/webawesome.loader.js"></script>
 
-<link id="theme-stylesheet" rel="stylesheet" href="/dist/styles/themes/default.css" render="blocking" fetchpriority="high" />
+{% block themeStylesheet %}
+  <link id="theme-stylesheet" rel="stylesheet" href="/dist/styles/themes/default.css" render="blocking" fetchpriority="high" />
+{% endblock %}
 
 <link rel="stylesheet" href="/dist/styles/webawesome.css" />
 


### PR DESCRIPTION
This work adds a couple of new nunjucks [blocks](https://mozilla.github.io/nunjucks/templating.html#block) into our `base.njk` layout and `header.njk`.

The purpose of these is to allow for easy and safe overriding of the current theme as set by the Docs' theme-switching logic, including:
- setting the current theme
- loading the current theme's CSS/assets
- adding the current theme's classes to the `<html>` element.