### PR TITLE
Make the README better

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Twitter: [@webawesomer](https://twitter.com/webawesomer)
 
 Developers can use this documentation to learn how to build Web Awesome from source. You will need Node.js 14.17 or later to build and run the project locally.
 
-**You don’t need to do any of this to use Web Awesome!** This page is for people who want to contribute to the project, tinker with the source, or create a custom build of Web Awesome.
+**You don't need to do any of this to use Web Awesome!** This page is for people who want to contribute to the project, tinker with the source, or create a custom build of Web Awesome.
 
-If that’s not what you’re trying to do, the [documentation website](https://webawesome.com) is where you want to be.
+If that's not what you're trying to do, the [documentation website](https://webawesome.com) is where you want to be.
 
 ### What are you using to build Web Awesome?
 
@@ -47,11 +47,11 @@ Any dependencies intended to be used across all packages (i.e., `prettier`, `esl
 npm install -D -w prettier
 ```
 
-Any dependencies that will be used at runtime by a package should be part of the specific package’s `dependencies` such as `lit`. This is required because if that dependency is not in the `packages/*/package.json`, it will not be installed when used via npm.
+Any dependencies that will be used at runtime by a package should be part of the specific package's `dependencies` such as `lit`. This is required because if that dependency is not in the `packages/*/package.json`, it will not be installed when used via npm.
 
 Individual packages are also free to install `devDependencies` as needed as long as they are specific to that package only.
 
-To install a package specific to a Web Awesome package, change your working directory to that package’s root (i.e., `cd packages/webawesome && npm install <package-name>`).
+To install a package specific to a Web Awesome package, change your working directory to that package's root (i.e., `cd packages/webawesome && npm install <package-name>`).
 
 ### Forking the Repo
 
@@ -72,7 +72,7 @@ cd packages/webawesome
 npm start
 ```
 
-This will spin up the dev server. After the initial build, a browser will open automatically. There is currently no hot module reloading (HMR), as browsers don’t provide a way to reregister custom elements, but most changes to the source will reload the browser automatically.
+This will spin up the dev server. After the initial build, a browser will open automatically. There is currently no hot module reloading (HMR), as browsers don't provide a way to reregister custom elements, but most changes to the source will reload the browser automatically.
 
 ### Building
 
@@ -94,7 +94,7 @@ cd packages/webawesome
 npm run create wa-tag-name
 ```
 
-This will generate a source file, a stylesheet, and a docs page for you. When you start the dev server, you’ll find the new component in the “Components” section of the sidebar.
+This will generate a source file, a stylesheet, and a docs page for you. When you start the dev server, you'll find the new component in the "Components" section of the sidebar.
 
 ### Adding additional packages
 
@@ -106,7 +106,7 @@ Make sure to run `npm install` at the root of the monorepo after adding your pac
 
 ### Contributing
 
-Web Awesome is an open source project and contributions are encouraged! If you’re interesting in contributing, please review the [contribution guidelines](CONTRIBUTING.md) first.
+Web Awesome is an open source project and contributions are encouraged! If you're interesting in contributing, please review the [contribution guidelines](CONTRIBUTING.md) first.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Any dependencies that will be used at runtime by a package should be part of the
 
 Individual packages are also free to install `devDependencies` as needed as long as they are specific to that package only.
 
-To do install a package specific to a package, change your working directory to that package’s root (i.e., `cd packages/webawesome && npm install <package-name>`).
+To install a package specific to a Web Awesome package, change your working directory to that package’s root (i.e., `cd packages/webawesome && npm install <package-name>`).
 
 ### Forking the Repo
 

--- a/README.md
+++ b/README.md
@@ -21,39 +21,37 @@ Twitter: [@webawesomer](https://twitter.com/webawesomer)
 
 ## Developers ✨
 
-Developers can use this documentation to learn how to build Web Awesome from source. You will need Node >= 14.17 to build and run the project locally.
+Developers can use this documentation to learn how to build Web Awesome from source. You will need Node.js 14.17 or later to build and run the project locally.
 
-**You don't need to do any of this to use Web Awesome!** This page is for people who want to contribute to the project, tinker with the source, or create a custom build of Web Awesome.
+**You don’t need to do any of this to use Web Awesome!** This page is for people who want to contribute to the project, tinker with the source, or create a custom build of Web Awesome.
 
-If that's not what you're trying to do, the [documentation website](https://webawesome.com) is where you want to be.
+If that’s not what you’re trying to do, the [documentation website](https://webawesome.com) is where you want to be.
 
 ### What are you using to build Web Awesome?
 
-Components are built with [LitElement](https://lit-element.polymer-project.org/), a custom elements base class that provides an intuitive API and reactive data binding. The build is a custom script with bundling powered by [esbuild](https://esbuild.github.io/).
+Components are built with [Lit](https://lit.dev/), a custom elements base class that provides an intuitive API and reactive data binding. The build is a custom script with bundling powered by [esbuild](https://esbuild.github.io/).
 
 ### Understanding the Web Awesome monorepo
 
-Web Awesome uses [NPM workspaces](https://docs.npmjs.com/cli/v11/using-npm/workspaces) for its monorepo structure and is fairly minimal in what it provides.
+Web Awesome uses [npm workspaces](https://docs.npmjs.com/cli/v11/using-npm/workspaces) for its monorepo structure and is fairly minimal in what it provides.
 
-By using a NPM workspaces and a monorepo structure, we can get consistent builds, shared configurations, and reduced duplication across repositories which reduces regressions and forces consistency across `webawesome`, `webawesome-pro`, and `webawesome-app`.
+By using npm workspaces and a monorepo structure, we can get consistent builds, shared configurations, and reduced duplication across repositories which reduces regressions and forces consistency across `webawesome`, `webawesome-pro`, and `webawesome-app`.
 
 Generally, if you plan to only work with the free version of `webawesome` it is easiest to go to `packages/webawesome` and run all commands from there.
 
-### Where do NPM dependencies go?
+### Where do npm dependencies go?
 
-Any dependencies intended to be used across all packages (IE: `prettier`, `eslint`) that are _NOT_ used at runtime should be in the root `devDependencies` of `package.json`.
+Any dependencies intended to be used across all packages (i.e., `prettier`, `eslint`) that are **not** used at runtime should be in the root `devDependencies` of `package.json`.
 
 ```bash
 npm install -D -w prettier
 ```
 
-Any dependencies that will be used at runtime by a package should be part of the specific package's `"dependencies"` such as `lit`. This is required because if that dependency is not in the `packages/*/package.json`, it will not be installed when used via NPM.
+Any dependencies that will be used at runtime by a package should be part of the specific package’s `dependencies` such as `lit`. This is required because if that dependency is not in the `packages/*/package.json`, it will not be installed when used via npm.
 
-Individual packages are also free to install devDependencies as needed as long as they are specific to that package only.
+Individual packages are also free to install `devDependencies` as needed as long as they are specific to that package only.
 
-To do install a package specific to a package, change your working directory to that package's root
-
-IE: `cd packages/webawesome && npm install <package-name>`
+To do install a package specific to a package, change your working directory to that package’s root (i.e., `cd packages/webawesome && npm install <package-name>`).
 
 ### Forking the Repo
 
@@ -67,14 +65,14 @@ npm install
 
 ### Developing
 
-Once you've cloned the repo, run the following command from the respective directory within `packages/*`
+Once you’ve cloned the repo, run the following command from the respective directory within `packages/*`
 
 ```bash
 cd packages/webawesome
 npm start
 ```
 
-This will spin up the dev server. After the initial build, a browser will open automatically. There is currently no hot module reloading (HMR), as browser's don't provide a way to reregister custom elements, but most changes to the source will reload the browser automatically.
+This will spin up the dev server. After the initial build, a browser will open automatically. There is currently no hot module reloading (HMR), as browsers don’t provide a way to reregister custom elements, but most changes to the source will reload the browser automatically.
 
 ### Building
 
@@ -96,20 +94,20 @@ cd packages/webawesome
 npm run create wa-tag-name
 ```
 
-This will generate a source file, a stylesheet, and a docs page for you. When you start the dev server, you'll find the new component in the "Components" section of the sidebar.
+This will generate a source file, a stylesheet, and a docs page for you. When you start the dev server, you’ll find the new component in the “Components” section of the sidebar.
 
 ### Adding additional packages
 
 Right now the only additional packages are in private repositories.
 
-To add additional packages from other repositories, run: `git clone <url> packages/<package-name>` to clone your repo into `packages/`.
+To add additional packages from other repositories, run `git clone <url> packages/<package-name>` to clone your repo into `packages/`.
 
 Make sure to run `npm install` at the root of the monorepo after adding your package!
 
 ### Contributing
 
-Web Awesome is an open source project and contributions are encouraged! If you're interesting in contributing, please review the [contribution guidelines](CONTRIBUTING.md) first.
+Web Awesome is an open source project and contributions are encouraged! If you’re interesting in contributing, please review the [contribution guidelines](CONTRIBUTING.md) first.
 
 ## License
 
-Web Awesome is available under the terms of the MIT license.
+Web Awesome is available under the terms of the [MIT License](LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ npm install
 
 ### Developing
 
-Once you’ve cloned the repo, run the following command from the respective directory within `packages/*`
+Once you’ve cloned the repo, run the following command from the respective directory within `packages/*`.
 
 ```bash
 cd packages/webawesome


### PR DESCRIPTION
Here’s a comprehensive list of what’s changed in the README:

- Revise Node.js minimum requirement wording (to prevent line breaks)
- Replace old links to LitElement (Polymer) to Lit
- Replace mentions of “NPM” with “npm”, as per https://github.com/npm/cli?tab=readme-ov-file#is-it-npm-or-npm-or-npm
- Fix some grammar and abbreviations
- Made `dependencies` and `devDependencies` mentions unquoted to be consistent[^1]
- Correct “MIT license” with “MIT License”, as per https://opensource.org/license/mit

Also, the term “Developers” sounds a bit generic, compared to “Shoemakers” for Shoelace. I have proposed a couple of ideas to use (that aren’t applied in this PR):

- Awesomeists
- Awesomers
- Web Wizards
- Componauts
- Webonauts

You may choose any other term or any of them in this list.

[^1]: Yes, grammar isn’t correct here, but making these code fields singular doesn’t make any sense.