### PR TITLE
Docs: Polish Pro Badge

### DIFF
--- a/packages/webawesome/docs/.eleventy.js
+++ b/packages/webawesome/docs/.eleventy.js
@@ -1,3 +1,4 @@
+import { nanoid } from 'nanoid';
 import { parse as HTMLParse } from 'node-html-parser';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -87,6 +88,7 @@ export default async function (eleventyConfig) {
   eleventyConfig.addFilter('markdown', content => markdown.render(content || ''));
   eleventyConfig.addFilter('stripExtension', string => path.parse(string + '').name);
   eleventyConfig.addFilter('stripPrefix', content => content.replace(/^wa-/, ''));
+  eleventyConfig.addFilter('uniqueId', (_value, length = 8) => nanoid(length));
   // Trims whitespace and pipes from the start and end of a string. Useful for CEM types, which can be pipe-delimited.
   // With Prettier 3, this means a leading pipe will exist be present when the line wraps.
   eleventyConfig.addFilter('trimPipes', content => {

--- a/packages/webawesome/docs/_includes/pro-badge.njk
+++ b/packages/webawesome/docs/_includes/pro-badge.njk
@@ -1,0 +1,1 @@
+<wa-badge appearance="accent" pill class="pro">Pro</wa-badge>

--- a/packages/webawesome/docs/_includes/pro-badge.njk
+++ b/packages/webawesome/docs/_includes/pro-badge.njk
@@ -1,3 +1,5 @@
-{% set badgeId = proBadgeId or ("pro-badge-" + ("" | uniqueId(8))) %}
-<wa-badge appearance="accent" pill class="pro" id="{{ badgeId }}">Pro</wa-badge>
-<wa-tooltip for="{{ badgeId }}">{{ proBadgeDescription or "This requires access to Web Awesome Pro" }}</wa-tooltip>
+{% macro proBadge(proBadgeDescription, proBadgeId) %}
+  {% set badgeId = proBadgeId or ("pro-badge-" + ("" | uniqueId(8))) %}
+  <wa-badge appearance="accent" pill class="pro" id="{{ badgeId }}">Pro</wa-badge>
+  <wa-tooltip for="{{ badgeId }}">{{ proBadgeDescription or "This requires access to Web Awesome Pro" }}</wa-tooltip>
+{% endmacro %}

--- a/packages/webawesome/docs/_includes/pro-badge.njk
+++ b/packages/webawesome/docs/_includes/pro-badge.njk
@@ -1,1 +1,3 @@
-<wa-badge appearance="accent" pill class="pro">Pro</wa-badge>
+{% set badgeId = proBadgeId or ("pro-badge-" + ("" | uniqueId(8))) %}
+<wa-badge appearance="accent" pill class="pro" id="{{ badgeId }}">Pro</wa-badge>
+<wa-tooltip for="{{ badgeId }}">{{ proBadgeDescription or "This requires access to Web Awesome Pro" }}</wa-tooltip>

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -1,5 +1,6 @@
 {# Search #}
 {% include "search-trigger-button.njk" %}
+{% from "pro-badge.njk" import proBadge %}
 
 {# Getting started #}
 <h2>Getting Started</h2>
@@ -38,7 +39,7 @@
         <a class="wa-cluster wa-gap-xs" href="/docs/components/page/">
           Page <wa-icon name="flask" aria-hidden="true"></wa-icon>
         </a>
-        {% include "pro-badge.njk" %}
+        {{ proBadge() }}
       </span>
     </li>
     <li><a href="/docs/components/animated-image/">Animated Image</a></li>
@@ -179,7 +180,7 @@
         <a class="wa-cluster wa-gap-xs" href="/docs/components/page/">
           Page <wa-icon name="flask" aria-hidden="true"></wa-icon>
         </a>
-        {% include "pro-badge.njk" %}
+        {{ proBadge() }}
       </span>
     </li>
   </ul>
@@ -197,7 +198,7 @@
     <li>
       <span class="wa-split">
         <a href="/docs/patterns/app/">App</a>
-        {% include "pro-badge.njk" %}
+        {{ proBadge() }}
       </span>
       <ul>
         <li>
@@ -243,7 +244,7 @@
     <li>
       <span class="wa-split">
         <a href="/docs/patterns/blog-news/">Blog &amp; News</a>
-        {% include "pro-badge.njk" %}
+        {{ proBadge() }}
       </span>
       <ul>
       <li>
@@ -305,7 +306,7 @@
     <li>
       <span class="wa-split">
         <a href="/docs/patterns/ecommerce/">Ecommerce</a>
-        {% include "pro-badge.njk" %}
+        {{ proBadge() }}
       </span>
       <ul>
         <li>
@@ -346,7 +347,7 @@
     <li>
       <span class="wa-split">
         <a href="/docs/patterns/layouts/">Layouts</a>
-        {% include "pro-badge.njk" %}
+        {{ proBadge() }}
       </span>
       <ul>
         <li>
@@ -371,7 +372,7 @@
   <li>
     <span class="wa-split">
       <a href="/themer" data-turbo="false">Theme Builder</a>
-      {% include "pro-badge.njk" %}
+      {{ proBadge("This requires an active Web Awesome Pro subscription") }}
     </span>
   </li>
 </ul>

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -38,7 +38,7 @@
         <a class="wa-cluster wa-gap-xs" href="/docs/components/page/">
           Page <wa-icon name="flask" aria-hidden="true"></wa-icon>
         </a>
-        <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
+        <wa-badge pill class="pro" appearance="accent" aria-label="This requires access to Pro">Pro</wa-badge>
       </span>
     </li>
     <li><a href="/docs/components/animated-image/">Animated Image</a></li>
@@ -179,7 +179,7 @@
         <a class="wa-cluster wa-gap-xs" href="/docs/components/page/">
           Page <wa-icon name="flask" aria-hidden="true"></wa-icon>
         </a>
-        <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
+        <wa-badge pill class="pro" appearance="accent" aria-label="This requires access to Pro">Pro</wa-badge>
       </span>
     </li>
   </ul>
@@ -197,7 +197,7 @@
     <li>
       <span class="wa-split">
         <a href="/docs/patterns/app/">App</a>
-        <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
+        <wa-badge pill class="pro" appearance="accent" aria-label="This requires access to Pro">Pro</wa-badge>
       </span>
       <ul>
         <li>
@@ -243,7 +243,7 @@
     <li>
       <span class="wa-split">
         <a href="/docs/patterns/blog-news/">Blog &amp; News</a>
-        <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
+        <wa-badge pill class="pro" appearance="accent" aria-label="This requires access to Pro">Pro</wa-badge>
       </span>
       <ul>
       <li>
@@ -305,7 +305,7 @@
     <li>
       <span class="wa-split">
         <a href="/docs/patterns/ecommerce/">Ecommerce</a>
-        <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
+        <wa-badge pill class="pro" appearance="accent" aria-label="This requires access to Pro">Pro</wa-badge>
       </span>
       <ul>
         <li>
@@ -346,7 +346,7 @@
     <li>
       <span class="wa-split">
         <a href="/docs/patterns/layouts/">Layouts</a>
-        <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
+        <wa-badge pill class="pro" appearance="accent" aria-label="This requires access to Pro">Pro</wa-badge>
       </span>
       <ul>
         <li>
@@ -371,7 +371,7 @@
   <li>
     <span class="wa-split">
       <a href="/themer" data-turbo="false">Theme Builder</a>
-      <wa-badge class="pro" appearance="accent" attention="none">PRO</wa-badge>
+      <wa-badge pill class="pro" appearance="accent" aria-label="This requires access to Pro">Pro</wa-badge>
     </span>
   </li>
 </ul>

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -38,7 +38,7 @@
         <a class="wa-cluster wa-gap-xs" href="/docs/components/page/">
           Page <wa-icon name="flask" aria-hidden="true"></wa-icon>
         </a>
-        <wa-badge pill class="pro" appearance="accent" aria-label="This requires access to Pro">Pro</wa-badge>
+        {% include "pro-badge.njk" %}
       </span>
     </li>
     <li><a href="/docs/components/animated-image/">Animated Image</a></li>
@@ -179,7 +179,7 @@
         <a class="wa-cluster wa-gap-xs" href="/docs/components/page/">
           Page <wa-icon name="flask" aria-hidden="true"></wa-icon>
         </a>
-        <wa-badge pill class="pro" appearance="accent" aria-label="This requires access to Pro">Pro</wa-badge>
+        {% include "pro-badge.njk" %}
       </span>
     </li>
   </ul>
@@ -197,7 +197,7 @@
     <li>
       <span class="wa-split">
         <a href="/docs/patterns/app/">App</a>
-        <wa-badge pill class="pro" appearance="accent" aria-label="This requires access to Pro">Pro</wa-badge>
+        {% include "pro-badge.njk" %}
       </span>
       <ul>
         <li>
@@ -243,7 +243,7 @@
     <li>
       <span class="wa-split">
         <a href="/docs/patterns/blog-news/">Blog &amp; News</a>
-        <wa-badge pill class="pro" appearance="accent" aria-label="This requires access to Pro">Pro</wa-badge>
+        {% include "pro-badge.njk" %}
       </span>
       <ul>
       <li>
@@ -305,7 +305,7 @@
     <li>
       <span class="wa-split">
         <a href="/docs/patterns/ecommerce/">Ecommerce</a>
-        <wa-badge pill class="pro" appearance="accent" aria-label="This requires access to Pro">Pro</wa-badge>
+        {% include "pro-badge.njk" %}
       </span>
       <ul>
         <li>
@@ -346,7 +346,7 @@
     <li>
       <span class="wa-split">
         <a href="/docs/patterns/layouts/">Layouts</a>
-        <wa-badge pill class="pro" appearance="accent" aria-label="This requires access to Pro">Pro</wa-badge>
+        {% include "pro-badge.njk" %}
       </span>
       <ul>
         <li>
@@ -371,7 +371,7 @@
   <li>
     <span class="wa-split">
       <a href="/themer" data-turbo="false">Theme Builder</a>
-      <wa-badge pill class="pro" appearance="accent" aria-label="This requires access to Pro">Pro</wa-badge>
+      {% include "pro-badge.njk" %}
     </span>
   </li>
 </ul>

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -73,6 +73,11 @@
     background-color: var(--wa-brand-orange);
     border-color: var(--wa-brand-orange);
     text-transform: uppercase;
+
+    + wa-tooltip {
+      font-size: var(--wa-font-size-xs);
+      --max-width: unset;
+    }
   }
 
   /* search trigger */

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -72,6 +72,7 @@
     color: white;
     background-color: var(--wa-brand-orange);
     border-color: var(--wa-brand-orange);
+    text-transform: uppercase;
   }
 
   /* search trigger */


### PR DESCRIPTION
This PR polishes the Pro badge component by creating a reusable Nunjucks macro and improving its visual styling with tooltips and uppercase text formatting.

- Creates a reusable `proBadge` macro to standardize Pro badge rendering across the documentation
- Adds tooltip functionality to provide contextual information about Pro features
- Enhances visual styling with `pill` shape, uppercase text transformation, and tooltip sizing

One of the goals is that we now have a consistent Pro Marker we can use when needed for upcoming features/UI.

| Before | After |
|--------|--------|
| <img width="1460" height="1596" alt="CleanShot 2025-09-26 at 16 37 47" src="https://github.com/user-attachments/assets/22e4706e-a406-46ad-a0dd-398548c1a29c" /> | <img width="1460" height="1596" alt="CleanShot 2025-09-26 at 16 36 03" src="https://github.com/user-attachments/assets/2b5bdbcd-52e1-4ccc-a929-4fdc9609bd18" /> | 