### PR TITLE
Add missing CSS part into JSDoc (Dialog, Drawer)

### DIFF
--- a/packages/webawesome/src/components/dialog/dialog.ts
+++ b/packages/webawesome/src/components/dialog/dialog.ts
@@ -37,6 +37,7 @@ import styles from './dialog.css';
  *  behavior such as data loss.
  * @event wa-after-hide - Emitted after the dialog closes and all animations are complete.
  *
+ * @csspart dialog - The dialog's internal `<dialog>` element.
  * @csspart header - The dialog's header. This element wraps the title and header actions.
  * @csspart header-actions - Optional actions to add to the header. Works best with `<wa-button>`.
  * @csspart title - The dialog's title.

--- a/packages/webawesome/src/components/drawer/drawer.ts
+++ b/packages/webawesome/src/components/drawer/drawer.ts
@@ -38,6 +38,7 @@ import styles from './drawer.css';
  *  the drawer has been closed programmatically. Avoid using this unless closing the drawer will result in destructive
  *  behavior such as data loss.
  *
+ * @csspart dialog - The drawer's internal `<dialog>` element.
  * @csspart header - The drawer's header. This element wraps the title and header actions.
  * @csspart header-actions - Optional actions to add to the header. Works best with `<wa-button>`.
  * @csspart title - The drawer's title.


### PR DESCRIPTION
#### Description

This PR adds missing CSS parts into the JSDoc of two components.

Nit: The drawer’s `<dialog>` element uses `dialog` instead of `drawer` for its CSS part name. Not sure if that makes sense, but if changed, it will be a breaking change.