### PR TITLE
Fix focus ring in `<wa-scroller>`, `<wa-dialog>`, and `<wa-drawer>`

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -13,6 +13,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Added the Kazakh translation [pr:1496]
 - Fixed a bug in `<wa-button>` where slotted badges weren't properly positioned in buttons with an `href` [issue:1377]
 - Fixed focus outline styles in `<wa-details>` and native `<details>` [issue:1456]
+- Fixed focus outline styles in `<wa-scroller>`, `<wa-dialog>`, and `<wa-drawer>` [issue:1484]
 
 ## 3.0.0-beta.6
 

--- a/packages/webawesome/src/components/dialog/dialog.css
+++ b/packages/webawesome/src/components/dialog/dialog.css
@@ -111,6 +111,15 @@
   padding: var(--spacing);
   overflow: auto;
   -webkit-overflow-scrolling: touch;
+
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
+    outline: var(--wa-focus-ring);
+    outline-offset: var(--wa-focus-ring-offset);
+  }
 }
 
 .footer {

--- a/packages/webawesome/src/components/drawer/drawer.css
+++ b/packages/webawesome/src/components/drawer/drawer.css
@@ -175,6 +175,15 @@
   padding: var(--spacing);
   overflow: auto;
   -webkit-overflow-scrolling: touch;
+
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
+    outline: var(--wa-focus-ring);
+    outline-offset: var(--wa-focus-ring-offset);
+  }
 }
 
 .footer {

--- a/packages/webawesome/src/components/scroller/scroller.css
+++ b/packages/webawesome/src/components/scroller/scroller.css
@@ -10,7 +10,6 @@
   position: relative;
   max-width: 100%;
   isolation: isolate;
-  overflow: hidden;
 }
 
 :host([orientation='vertical']) {


### PR DESCRIPTION
Closes #1484 

- Adds themed focus rings to `<wa-dialog>` and `<wa-drawer>`
- Removes `overflow: hidden;` from `<wa-scroller>`, which prevented the existing focus ring from being displayed

---

**Note:** This re-introduces an exceptionally minor issue mentioned in #907 where Safari renders a single pixel of content outside of the starting shadow of `<wa-scroller>`, which was initially the reason for `overflow: hidden;` on the host element.

Upon closer inspection, this rendering issue is only limited to containers whose width is fractional and further depends on browser + OS rendering behaviors. For example, the issue occurs in our docs because we're sizing the main content based on `ch` units, which results a width of 599.25px. I'll create a separate PR to address this content width issue in the docs so that we (...mostly me 😅) aren't snagged by similar issues in the future.

**Edit:** This is addressed in #1526