### PR TITLE
Round `--content-width-*` and use in the docs

### DIFF
--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -249,7 +249,7 @@ wa-page[view='mobile'] :is([slot='navigation-header'], [slot='navigation']) {
 
 /* Main content */
 wa-page > main {
-  max-width: 80ch;
+  max-width: var(--content-width-s);
   padding: var(--wa-space-xl);
   margin-inline: auto;
 }
@@ -357,7 +357,7 @@ h1.title {
 
 /* Search list pages */
 wa-page > main:has(> .search-list) {
-  max-width: 120ch;
+  max-width: var(--content-width-l);
   margin-inline: auto;
 }
 
@@ -572,7 +572,7 @@ wa-scroller:has(.component-table) {
 
   .table-arguments,
   .table-description {
-    min-width: 40ch;
+    min-width: var(--line-length-xs);
   }
 
   .table-reflect {
@@ -621,10 +621,10 @@ wa-scroller:has(.component-table) {
 
 .page-wide {
   wa-page > main {
-    max-width: 140ch;
+    max-width: var(--content-width-l);
 
     .max-line-length {
-      max-width: 80ch;
+      max-width: var(--line-length-l);
     }
   }
 }

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -4,11 +4,12 @@
 
 @layer wa-utils {
   :root {
-    /* max-width for fixed width app-based pages */
-    --content-width-l: 132ch;
-    --content-width-m: 110ch;
-    --content-width-s: 80ch;
-    --content-width-xs: 50ch;
+    /* max-width for fixed width app-based pages
+     * We round() these to avoid obscure component rendering bugs caused by widths with fractional pixels */
+    --content-width-l: round(up, 132ch, 1px);
+    --content-width-m: round(up, 110ch, 1px);
+    --content-width-s: round(up, 80ch, 1px);
+    --content-width-xs: round(up, 50ch, 1px);
     --content-padding-inline: 4ch;
     --content-flow-spacing: 8ch;
 


### PR DESCRIPTION
- Updates our `--content-width-*` properties to use `round()` so that resulting values are always whole pixels to prevent the odd rendering bug like we previously had for `<wa-scroller>` (see https://github.com/shoelace-style/webawesome/pull/907#pullrequestreview-2841640899 and #1525 for context)
- Use `--content-width-*` and `--line-length-*` for our docs pages