### PR TITLE
Fix wa-button tap highlight

### DIFF
--- a/packages/webawesome/src/components/button/button.css
+++ b/packages/webawesome/src/components/button/button.css
@@ -1,9 +1,11 @@
 @layer wa-component {
   :host {
     display: inline-block;
+    border-radius: var(--wa-form-control-border-radius);
+    overflow: hidden;
 
     /* Workaround because Chrome doesn't like :host(:has()) below
-     * https://issues.chromium.org/issues/40062355 
+     * https://issues.chromium.org/issues/40062355
      * Firefox doesn't like this nested rule, so both are needed */
     &:has(wa-badge) {
       position: relative;


### PR DESCRIPTION
Android Chrome shows a tap highlight, when you tap a button.
This PR fixes the shape of this highlight by adding the border radius to the host and hide the overflow.

before:
<img width="248" height="168" alt="grafik" src="https://github.com/user-attachments/assets/8cdfa224-0e27-40be-8863-5b91701273c6" />

after:
<img width="219" height="140" alt="grafik" src="https://github.com/user-attachments/assets/af27a480-0186-4eea-b945-24f46813c729" />