### PR TITLE
Docs: Add Planned Features to Navigation

### DIFF
--- a/packages/webawesome/docs/_includes/planned-badge.njk
+++ b/packages/webawesome/docs/_includes/planned-badge.njk
@@ -1,0 +1,5 @@
+{% macro plannedBadge(plannedBadgeDescription, plannedBadgeId) %}
+  {% set badgeId = plannedBadgeId or ("planned-badge-" + ("" | uniqueId(8))) %}
+  <wa-badge appearance="filled" variant="neutral" pill class="planned" id="{{ badgeId }}">Planned</wa-badge>
+  <wa-tooltip for="{{ badgeId }}">{{ plannedBadgeDescription or "This is a planned feature" }}</wa-tooltip>
+{% endmacro %}

--- a/packages/webawesome/docs/_includes/pro-badge.njk
+++ b/packages/webawesome/docs/_includes/pro-badge.njk
@@ -1,5 +1,12 @@
-{% macro proBadge(proBadgeDescription, proBadgeId) %}
-  {% set badgeId = proBadgeId or ("pro-badge-" + ("" | uniqueId(8))) %}
-  <wa-badge appearance="accent" pill class="pro" id="{{ badgeId }}">Pro</wa-badge>
-  <wa-tooltip for="{{ badgeId }}">{{ proBadgeDescription or "This requires access to Web Awesome Pro" }}</wa-tooltip>
+{% macro proBadge(params) %}
+  {% set description = params.description or "This requires access to Web Awesome Pro" %}
+  {% set badgeId = params.id or ("pro-badge-" + ("" | uniqueId(8))) %}
+  {% set shrink = params.shrink or false %}
+  {% if shrink %}
+    {% set classes = "pro shrink" %}
+  {% else %}
+    {% set classes = "pro" %}
+  {% endif %}
+  <wa-badge appearance="accent" pill class="{{ classes }}" id="{{ badgeId }}">Pro</wa-badge>
+  <wa-tooltip for="{{ badgeId }}">{{ description }}</wa-tooltip>
 {% endmacro %}

--- a/packages/webawesome/docs/_includes/pro-badge.njk
+++ b/packages/webawesome/docs/_includes/pro-badge.njk
@@ -1,12 +1,6 @@
 {% macro proBadge(params) %}
   {% set description = params.description or "This requires access to Web Awesome Pro" %}
   {% set badgeId = params.id or ("pro-badge-" + ("" | uniqueId(8))) %}
-  {% set shrink = params.shrink or false %}
-  {% if shrink %}
-    {% set classes = "pro shrink" %}
-  {% else %}
-    {% set classes = "pro" %}
-  {% endif %}
-  <wa-badge appearance="accent" pill class="{{ classes }}" id="{{ badgeId }}">Pro</wa-badge>
+  <wa-badge appearance="accent" pill class="pro" id="{{ badgeId }}">Pro</wa-badge>
   <wa-tooltip for="{{ badgeId }}">{{ description }}</wa-tooltip>
 {% endmacro %}

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -43,7 +43,7 @@
         <a class="wa-cluster wa-gap-xs" href="/docs/components/page/">
           Page <wa-icon name="flask" aria-hidden="true" class="icon-shrink"></wa-icon>
         </a>
-        {{ proBadge() }}
+        {{ proBadge({ shrink: true }) }}
       </span>
     </li>
     <li><a href="/docs/components/animated-image/">Animated Image</a></li>
@@ -188,7 +188,7 @@
         <a class="wa-cluster wa-gap-xs" href="/docs/components/page/">
           Page <wa-icon name="flask" aria-hidden="true" class="icon-shrink"></wa-icon>
         </a>
-        {{ proBadge() }}
+        {{ proBadge({ shrink: true }) }}
       </span>
     </li>
   </ul>
@@ -206,7 +206,7 @@
     <li>
       <span class="wa-split">
         <a href="/docs/patterns/app/">App</a>
-        {{ proBadge() }}
+        {{ proBadge({ shrink: true }) }}
       </span>
       <ul>
         <li>
@@ -252,7 +252,7 @@
     <li>
       <span class="wa-split">
         <a href="/docs/patterns/blog-news/">Blog &amp; News</a>
-        {{ proBadge() }}
+        {{ proBadge({ shrink: true }) }}
       </span>
       <ul>
       <li>
@@ -314,7 +314,7 @@
     <li>
       <span class="wa-split">
         <a href="/docs/patterns/ecommerce/">Ecommerce</a>
-        {{ proBadge() }}
+        {{ proBadge({ shrink: true }) }}
       </span>
       <ul>
         <li>
@@ -355,7 +355,7 @@
     <li>
       <span class="wa-split">
         <a href="/docs/patterns/layouts/">Layouts</a>
-        {{ proBadge() }}
+        {{ proBadge({ shrink: true }) }}
       </span>
       <ul>
         <li>
@@ -380,7 +380,7 @@
   <li>
     <span class="wa-split">
       <a href="/themer" data-turbo="false">Theme Builder</a>
-      {{ proBadge("This requires an active Web Awesome Pro subscription") }}
+      {{ proBadge({ description: "This requires an active Web Awesome Pro subscription", shrink: true }) }}
     </span>
   </li>
 </ul>

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -43,7 +43,7 @@
         <a class="wa-cluster wa-gap-xs" href="/docs/components/page/">
           Page <wa-icon name="flask" aria-hidden="true" class="icon-shrink"></wa-icon>
         </a>
-        {{ proBadge({ shrink: true }) }}
+        {{ proBadge() }}
       </span>
     </li>
     <li><a href="/docs/components/animated-image/">Animated Image</a></li>
@@ -188,7 +188,7 @@
         <a class="wa-cluster wa-gap-xs" href="/docs/components/page/">
           Page <wa-icon name="flask" aria-hidden="true" class="icon-shrink"></wa-icon>
         </a>
-        {{ proBadge({ shrink: true }) }}
+        {{ proBadge() }}
       </span>
     </li>
   </ul>
@@ -206,7 +206,7 @@
     <li>
       <span class="wa-split">
         <a href="/docs/patterns/app/">App</a>
-        {{ proBadge({ shrink: true }) }}
+        {{ proBadge() }}
       </span>
       <ul>
         <li>
@@ -252,7 +252,7 @@
     <li>
       <span class="wa-split">
         <a href="/docs/patterns/blog-news/">Blog &amp; News</a>
-        {{ proBadge({ shrink: true }) }}
+        {{ proBadge() }}
       </span>
       <ul>
       <li>
@@ -314,7 +314,7 @@
     <li>
       <span class="wa-split">
         <a href="/docs/patterns/ecommerce/">Ecommerce</a>
-        {{ proBadge({ shrink: true }) }}
+        {{ proBadge() }}
       </span>
       <ul>
         <li>
@@ -355,7 +355,7 @@
     <li>
       <span class="wa-split">
         <a href="/docs/patterns/layouts/">Layouts</a>
-        {{ proBadge({ shrink: true }) }}
+        {{ proBadge() }}
       </span>
       <ul>
         <li>

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -1,6 +1,7 @@
 {# Search #}
 {% include "search-trigger-button.njk" %}
 {% from "pro-badge.njk" import proBadge %}
+{% from "planned-badge.njk" import plannedBadge %}
 
 {# Getting started #}
 <h2>Getting Started</h2>
@@ -73,8 +74,10 @@
         </li>
       </ul>
     </li>
+    <li><span class="is-planned wa-split">Charts <a href="https://github.com/shoelace-style/webawesome/issues/1073" target="_blank">{{ plannedBadge("A Web Awesome Kickstarter stretch goal!") }}</a></span></li>
     <li><a href="/docs/components/checkbox/">Checkbox</a></li>
     <li><a href="/docs/components/color-picker/">Color Picker</a></li>
+    <li><span class="is-planned wa-split">Combobox <a href="https://github.com/shoelace-style/webawesome/issues/1074" target="_blank">{{ plannedBadge("A Web Awesome Kickstarter stretch goal!") }}</a></span></li>
     <li><a href="/docs/components/comparison/">Comparison</a></li>
     <li>
       <a class="wa-cluster wa-gap-xs" href="/docs/components/copy-button/">
@@ -82,6 +85,8 @@
         <wa-icon name="flask" aria-hidden="true"></wa-icon>
       </a>
     </li>
+    <li><span class="is-planned wa-split">Data Grid <a href="https://github.com/shoelace-style/webawesome/issues/1072" target="_blank">{{ plannedBadge("A Web Awesome Kickstarter stretch goal!") }}</a></span></li>
+    <li><span class="is-planned wa-split">Datepicker <a href="https://github.com/shoelace-style/webawesome/issues/1075" target="_blank">{{ plannedBadge("A Web Awesome Kickstarter stretch goal!") }}</a></span></li>
     <li><a href="/docs/components/details/">Details</a></li>
     <li><a href="/docs/components/dialog/">Dialog</a></li>
     <li><a href="/docs/components/divider/">Divider</a></li>

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -41,7 +41,7 @@
     <li>
       <span class="wa-split">
         <a class="wa-cluster wa-gap-xs" href="/docs/components/page/">
-          Page <wa-icon name="flask" aria-hidden="true"></wa-icon>
+          Page <wa-icon name="flask" aria-hidden="true" class="icon-shrink"></wa-icon>
         </a>
         {{ proBadge() }}
       </span>
@@ -63,13 +63,13 @@
     <li>
       <a class="wa-cluster wa-gap-xs" href="/docs/components/carousel/">
         Carousel
-        <wa-icon name="flask" aria-hidden="true"></wa-icon>
+        <wa-icon name="flask" aria-hidden="true" class="icon-shrink"></wa-icon>
       </a>
       <ul>
         <li>
           <a class="wa-cluster wa-gap-xs" href="/docs/components/carousel-item/">
             Carousel Item
-            <wa-icon name="flask" aria-hidden="true"></wa-icon>
+            <wa-icon name="flask" aria-hidden="true" class="icon-shrink"></wa-icon>
           </a>
         </li>
       </ul>
@@ -82,7 +82,7 @@
     <li>
       <a class="wa-cluster wa-gap-xs" href="/docs/components/copy-button/">
         Copy Button
-        <wa-icon name="flask" aria-hidden="true"></wa-icon>
+        <wa-icon name="flask" aria-hidden="true" class="icon-shrink"></wa-icon>
       </a>
     </li>
     <li><span class="is-planned wa-split">Data Grid <a href="https://github.com/shoelace-style/webawesome/issues/1072" target="_blank">{{ plannedBadge("A Web Awesome Kickstarter stretch goal!") }}</a></span></li>
@@ -186,7 +186,7 @@
     <li>
       <span class="wa-split">
         <a class="wa-cluster wa-gap-xs" href="/docs/components/page/">
-          Page <wa-icon name="flask" aria-hidden="true"></wa-icon>
+          Page <wa-icon name="flask" aria-hidden="true" class="icon-shrink"></wa-icon>
         </a>
         {{ proBadge() }}
       </span>

--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -218,6 +218,11 @@ wa-button.delete {
   }
 }
 
+/* planned sidebar item */
+.is-planned {
+  color: var(--wa-color-neutral-50);
+}
+
 #sidebar-close-button {
   display: none;
 }

--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -220,7 +220,7 @@ wa-button.delete {
 
 /* planned sidebar item */
 .is-planned {
-  color: var(--wa-color-neutral-50);
+  color: var(--wa-color-text-quiet);
 }
 
 #sidebar-close-button {

--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -181,6 +181,12 @@ wa-page > header {
     }
   }
 
+  li wa-badge {
+    /* adding 1 scale below --wa-font-size-2xs to handle badge proportions in sidebar nav */
+    --font-size-3xs: round(calc(var(--wa-font-size-2xs) / 1.125), 1px); /* 10px */
+    font-size: var(--font-size-3xs);
+  }
+
   wa-details {
     --show-duration: 0;
     --hide-duration: 0;

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -88,6 +88,7 @@
   /* planned badge */
   wa-badge.planned {
     background-color: var(--wa-color-neutral-fill-quiet);
+    color: var(--wa-color-neutral-on-quiet);
 
     + wa-tooltip {
       font-size: var(--wa-font-size-xs);

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -79,10 +79,6 @@
       font-size: var(--wa-font-size-xs);
       --max-width: unset;
     }
-
-    &.shrink {
-      font-size: round(calc(var(--wa-font-size-2xs) / 1.125), 1px); /* ~10px */
-    }
   }
 
   /* planned badge */

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -73,7 +73,6 @@
     color: white;
     background-color: var(--wa-brand-orange);
     border-color: var(--wa-brand-orange);
-    text-transform: uppercase;
 
     + wa-tooltip {
       font-size: var(--wa-font-size-xs);

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -155,5 +155,10 @@
   wa-icon.icon-embiggen {
     font-size: round(1.125em, 1px);
   }
+
+  /* decreasing visual size of icons in certain contexts (such as in sidebar nav) */
+  wa-icon.icon-shrink {
+    font-size: round(0.875em, 1px);
+  }
   /* #endregion */
 }

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -79,6 +79,10 @@
       font-size: var(--wa-font-size-xs);
       --max-width: unset;
     }
+
+    &.shrink {
+      font-size: round(calc(var(--wa-font-size-2xs) / 1.125), 1px); /* ~10px */
+    }
   }
 
   /* planned badge */

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -81,6 +81,16 @@
     }
   }
 
+  /* planned badge */
+  wa-badge.planned {
+    background-color: var(--wa-color-neutral-fill-quiet);
+
+    + wa-tooltip {
+      font-size: var(--wa-font-size-xs);
+      --max-width: unset;
+    }
+  }
+
   /* search trigger */
   wa-button#search-trigger {
     &::part(base) {


### PR DESCRIPTION
This work adds planned features to the documentation navigation with visual badges and styling. This enhancement helps users identify which components are planned but not yet implemented, linking to relevant GitHub issues for more information.

* Adds specific planned features (Charts, Combobox, Data Grid, Datepicker) to the sidebar with appropriate styling
* Introduces a new "planned" badge component for marking planned features


This work also tackles a few minor Sidebar UI improvements...
* Adds the opposite of `.icon-embiggen` -> `.icon-shrink` to contextually reduce the visual size of icons slightly. 
* Applies `.icon-shrink` to experimental feature iconography in the docs Sidebar
* ~Updates the pro badge component to support a shrink parameter for a more appropriately scaled size in some places (DRYing out cases like https://github.com/shoelace-style/webawesome-app/pull/131#discussion_r2392453502).~

---

| Preview |
|--------|
| <img width="812" height="882" alt="CleanShot 2025-10-02 at 21 15 58@2x" src="https://github.com/user-attachments/assets/08237a7b-f1dd-4bb0-8366-7fcf409dc424" /> |
| Planned Features don't have links on their label, but have a "planned" badge linking to the GH Issue | 