### PR TITLE
Improve autofill background

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -34,6 +34,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed an overflow style that was causing tab group content to be unnecessarily truncated [issue:1401]
 - Fixed a bug in `<wa-icon>` that caused icon buttons to render when non-text nodes were slotted in [issue:1475]
 - Fixed a bug in `<wa-tooltip>` that prevented tooltips from showing when disconnecting and then reconnecting to the DOM [issue:1595]
+- Improved autofill styles in `<wa-input>` so they span the entire width of the visual input [issue:1439]
 - Modified `<wa-slider>` to only show the tooltip on the handle being dragged when in range mode [issue:1320]
 
 ## 3.0.0-beta.6

--- a/packages/webawesome/src/components/input/input.css
+++ b/packages/webawesome/src/components/input/input.css
@@ -63,8 +63,15 @@
   border-radius: var(--wa-border-radius-pill) !important;
 }
 
-.text-field input,
-.text-field textarea {
+.text-field {
+  /* Show autofill styles over the entire text field, not just the native <input> */
+  &:has(:autofill),
+  &:has(:-webkit-autofill) {
+    background-color: var(--wa-color-brand-fill-quiet) !important;
+  }
+
+  input,
+  textarea {
   /*
     Fixes an alignment issue with placeholders.
     https://github.com/shoelace-style/webawesome/issues/342
@@ -79,6 +86,16 @@
   cursor: inherit;
   -webkit-appearance: none;
   font: inherit;
+
+  /* Turn off Safari's autofill styles */
+  &:-webkit-autofill,
+  &:-webkit-autofill:hover,
+  &:-webkit-autofill:focus,
+  &:-webkit-autofill:active {
+    -webkit-background-clip: text;
+    background-color: transparent;
+    -webkit-text-fill-color: inherit;
+  }
 }
 
 input {

--- a/packages/webawesome/src/components/input/input.css
+++ b/packages/webawesome/src/components/input/input.css
@@ -72,29 +72,30 @@
 
   input,
   textarea {
-  /*
+    /*
     Fixes an alignment issue with placeholders.
     https://github.com/shoelace-style/webawesome/issues/342
   */
-  height: 100%;
+    height: 100%;
 
-  padding: 0;
-  border: none;
-  outline: none;
-  box-shadow: none;
-  margin: 0;
-  cursor: inherit;
-  -webkit-appearance: none;
-  font: inherit;
+    padding: 0;
+    border: none;
+    outline: none;
+    box-shadow: none;
+    margin: 0;
+    cursor: inherit;
+    -webkit-appearance: none;
+    font: inherit;
 
-  /* Turn off Safari's autofill styles */
-  &:-webkit-autofill,
-  &:-webkit-autofill:hover,
-  &:-webkit-autofill:focus,
-  &:-webkit-autofill:active {
-    -webkit-background-clip: text;
-    background-color: transparent;
-    -webkit-text-fill-color: inherit;
+    /* Turn off Safari's autofill styles */
+    &:-webkit-autofill,
+    &:-webkit-autofill:hover,
+    &:-webkit-autofill:focus,
+    &:-webkit-autofill:active {
+      -webkit-background-clip: text;
+      background-color: transparent;
+      -webkit-text-fill-color: inherit;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #1439

This one is tricky to test, so here's a screenshot. I used `--wa-color-brand-fill-quiet` for the background. @lindsaym-fa let me know if you want to adjust any styles before merging.

Before without focus
<img width="1288" height="368" alt="before-without-focus" src="https://github.com/user-attachments/assets/b0763239-914d-4698-8b62-3de5c43d0a05" />

Before with focus
<img width="1274" height="364" alt="before-with-focus" src="https://github.com/user-attachments/assets/664abe05-7aa4-428f-a198-a8cdebf5fb5e" />

After without focus
<img width="1280" height="370" alt="after-without-focus" src="https://github.com/user-attachments/assets/36ac84d1-2a6f-41e9-b465-47f880294c5d" />

After with focus
<img width="1278" height="356" alt="after-with-focus" src="https://github.com/user-attachments/assets/649e9c17-9340-4fef-921e-1d014a591ea4" />

