### PR TITLE
component(callout): Update `@since` JSDoc tag from 2.0 to 3.0

### DIFF
--- a/packages/webawesome/src/components/callout/callout.ts
+++ b/packages/webawesome/src/components/callout/callout.ts
@@ -9,7 +9,7 @@ import styles from './callout.css';
  * @summary Callouts are used to display important messages inline.
  * @documentation https://webawesome.com/docs/components/callout
  * @status stable
- * @since 2.0
+ * @since 3.0
  *
  * @slot - The callout's main content.
  * @slot icon - An icon to show in the callout. Works best with `<wa-icon>`.


### PR DESCRIPTION
#### Description

Web Awesome introduced the Callout component, as an effort to separate the “all‐in‐one” Alert component in Shoelace. In Shoelace, you cannot really find the Callout component, and in <https://shoelace.style/components/alert#variants>, the example is basically identical to <https://webawesome.com/docs/components/callout/#variants>, so it probably was copied over.

To prove this even more (if even necessary at this point), <https://shoelace.style/components/callout> points to a 404, so a Callout page wasn’t even hidden in Shoelace, it just never existed.