### PR TITLE
Allow required indicator to be targetable

### DIFF
--- a/packages/webawesome/src/styles/component/form-control.css
+++ b/packages/webawesome/src/styles/component/form-control.css
@@ -5,14 +5,14 @@
 
 /* Label */
 :is([part~='form-control-label'], [part~='label']):has(*:not(:empty)) {
-  display: inline-block;
+  display: inline-flex;
   color: var(--wa-form-control-label-color);
   font-weight: var(--wa-form-control-label-font-weight);
   line-height: var(--wa-form-control-label-line-height);
   margin-block-end: 0.5em;
 }
 
-:host([required]) slot:is([name='label'], [part='label'])::after {
+:host([required]) :is([part~='form-control-label'], [part~='label'])::after {
   content: var(--wa-form-control-required-content);
   margin-inline-start: var(--wa-form-control-required-content-offset);
   color: var(--wa-form-control-required-content-color);


### PR DESCRIPTION
In #1486, we updated our internal form control styles so that the value of `--wa-form-control-required-content-offset` had expected results across all form control components. This involved changing our selector to applied required content from `part`s to `slot`s.

However, slots in the shadow DOM aren't inherently style-able from the light DOM. This means that there was no way to target the `::after` pseudo-selector generating the required indicator. (see @talbs for the resulting pain and suffering)

This change does two things:

1. Returns to using `part` selectors for the required indicator so that it's targetable in light DOM styles via `::part(form-control-label)::after` or `::part(label)::after`, depending on the component
2. Uses `display: inline-flex;` for labels to avoid the heinous, enigmatic extra whitespace inherent to `inline-block`, which was bloating the space between the label text and required indicator for some components 

I accept all warranted shunning for [suggesting the last fix](https://github.com/shoelace-style/webawesome/pull/1486#pullrequestreview-3269178635) that in turn caused this issue.