### PR TITLE
Improve step icon color visibility

### DIFF
--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -112,10 +112,15 @@
 
   /* step icons for ordered instructions */
   .step-icon {
-    --primary-color: var(--wa-color-neutral-on-normal);
-    --secondary-color: var(--wa-color-neutral-fill-normal);
+    --primary-color: var(--wa-color-neutral-20);
+    --secondary-color: var(--wa-color-neutral-80);
     --secondary-opacity: 1;
     font-size: 2em;
+
+    .wa-dark & {
+      --primary-color: var(--wa-color-neutral-90);
+      --secondary-color: var(--wa-color-neutral-30);
+    }
   }
 
   /* #endregion */


### PR DESCRIPTION
The secondary color of our step icons was feeling a bit light. This change styles step icons with different neutral tints in light and dark mode for bespoke contrast.

@talbs please let me know if you have any concerns or other suggestions!