### PR TITLE
Fix cancel event from within drawer or dialog triggering them to close

### DIFF
--- a/packages/webawesome/src/components/dialog/dialog.test.ts
+++ b/packages/webawesome/src/components/dialog/dialog.test.ts
@@ -119,6 +119,19 @@ describe('<wa-dialog>', () => {
         expect(el.open).to.be.true;
       });
 
+      it('should not close when bubbled cancel event originates from within the drawer', async () => {
+        const el = await fixture<WaDialog>(html` <wa-dialog open><input type="file" /></wa-dialog> `);
+        const input = el.querySelector('input')!;
+
+        await clickOnElement(el); // Chromium wants the page to have been clicked prior to closing the dialog.
+        const cancelEvent = new Event('cancel', { bubbles: true });
+        input.dispatchEvent(cancelEvent);
+
+        await aTimeout(250);
+
+        expect(el.open).to.be.true;
+      });
+
       it('should allow initial focus to be set', async () => {
         const el = await fixture<WaDialog>(html` <wa-dialog><wa-input autofocus></wa-input></wa-dialog> `);
         const input = el.querySelector('wa-input')!;

--- a/packages/webawesome/src/components/dialog/dialog.ts
+++ b/packages/webawesome/src/components/dialog/dialog.ts
@@ -129,7 +129,7 @@ export default class WaDialog extends WebAwesomeElement {
   private handleDialogCancel(event: Event) {
     event.preventDefault();
 
-    if (!this.dialog.classList.contains('hide')) {
+    if (!this.dialog.classList.contains('hide') && event.target === this.dialog) {
       this.requestClose(this.dialog);
     }
   }

--- a/packages/webawesome/src/components/drawer/drawer.test.ts
+++ b/packages/webawesome/src/components/drawer/drawer.test.ts
@@ -115,6 +115,18 @@ describe('<wa-drawer>', () => {
         expect(el.open).to.be.true;
       });
 
+      it('should not close when bubbled cancel event originates from within the drawer', async () => {
+        const el = await fixture<WaDrawer>(html`<wa-drawer open><input type="file" /></wa-drawer>`);
+        const input = el.querySelector('input')!;
+
+        const cancelEvent = new Event('cancel', { bubbles: true });
+        input.dispatchEvent(cancelEvent);
+
+        await aTimeout(250);
+
+        expect(el.open).to.be.true;
+      });
+
       it('should allow initial focus to be set', async () => {
         const el = await fixture<WaDrawer>(html` <wa-drawer><wa-input autofocus></wa-input></wa-drawer> `);
         const input = el.querySelector('wa-input')!;

--- a/packages/webawesome/src/components/drawer/drawer.ts
+++ b/packages/webawesome/src/components/drawer/drawer.ts
@@ -141,7 +141,7 @@ export default class WaDrawer extends WebAwesomeElement {
   private handleDialogCancel(event: Event) {
     event.preventDefault();
 
-    if (!this.drawer.classList.contains('hide')) {
+    if (!this.drawer.classList.contains('hide') && event.target === this.drawer) {
       this.requestClose(this.drawer);
     }
   }


### PR DESCRIPTION
# Problem

Fixes #1585 

File inputs within dialog or drawer emit a cancel event when closed which bubbles up to the dialog where it is captured and then re-emitted as a `sl-hide` which causes the drawer or dialog to be closed even though the dialog was not the element emitting the event.

## Before

<table border="0">
 <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/d39be6d6-0e91-490d-a3fe-e1bfb6749edb" alt='demo1'>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/0d8d10a7-832b-49c3-8a81-a4223d779293" alt='demo2'>
    </td>
 </tr>
</table>

## After

<table border="0">
 <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/163cb911-7965-4b4f-a6dc-8e44e5d9037d" alt='demo3'>
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/4863c629-bebb-4ba0-84b3-23584ce4fd74" alt='demo4'>
    </td>
 </tr>
</table>
