### PR TITLE
Docs: Add Links to Privacy/Refund Policies + IA Zhuzhing

### DIFF
--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -33,6 +33,7 @@
   <li><a href="/license/pro"><span class="wa-visually-hidden">Web Awesome </span>Pro License</a></li>
   <li><a href="/tos">Terms of Service</a></li>
   <li><a href="/privacy">Privacy Policy</a></li>
+  <li><a href="/refunds">Refund Policy</a></li>
   <li><a href="/docs/resources/visual-tests">Visual Tests</a></li>
 </ul>
 

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -32,6 +32,7 @@
   <li><a href="/license"><span class="wa-visually-hidden">Web Awesome </span>Free License</a></li>
   <li><a href="/license/pro"><span class="wa-visually-hidden">Web Awesome </span>Pro License</a></li>
   <li><a href="/tos">Terms of Service</a></li>
+  <li><a href="/privacy">Privacy Policy</a></li>
   <li><a href="/docs/resources/visual-tests">Visual Tests</a></li>
 </ul>
 

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -29,11 +29,6 @@
   <li><a href="/docs/resources/browser-support">Browser Support</a></li>
   <li><a href="/docs/resources/contributing">Contributing</a></li>
   <li><a href="/docs/resources/changelog">Changelog</a></li>
-  <li><a href="/license"><span class="wa-visually-hidden">Web Awesome </span>Free License</a></li>
-  <li><a href="/license/pro"><span class="wa-visually-hidden">Web Awesome </span>Pro License</a></li>
-  <li><a href="/tos">Terms of Service</a></li>
-  <li><a href="/privacy">Privacy Policy</a></li>
-  <li><a href="/refunds">Refund Policy</a></li>
   <li><a href="/docs/resources/visual-tests">Visual Tests</a></li>
 </ul>
 
@@ -406,6 +401,16 @@
     <li><a href="/docs/tokens/component-groups/">Component Groups</a></li>
   </ul>
 </wa-details>
+
+{# Policies #}
+<h2>Terms &amp; Policies</h2>
+<ul>
+  <li><a href="/license"><span class="wa-visually-hidden">Web Awesome </span>Free License</a></li>
+  <li><a href="/license/pro"><span class="wa-visually-hidden">Web Awesome </span>Pro License</a></li>
+  <li><a href="/tos">Terms of Service</a></li>
+  <li><a href="/privacy">Privacy Policy</a></li>
+  <li><a href="/refunds">Refund Policy</a></li>
+</ul>
 
 <wa-divider style="--spacing: var(--wa-space-xl);"></wa-divider>
 


### PR DESCRIPTION
This work supports the licenses being added in https://github.com/shoelace-style/webawesome-pro/pull/70 by:

- adding links to the Privacy Policy and Refund Policy in the Documentation's sidebar nav
- separating legally-minded links into a "Terms & Policies" section in the Sidebar Nav