### PR TITLE
Fix checked switch styles in Shoelace theme

### DIFF
--- a/packages/webawesome/src/styles/themes/shoelace.css
+++ b/packages/webawesome/src/styles/themes/shoelace.css
@@ -457,7 +457,7 @@
         border-color: var(--wa-color-gray-50);
       }
 
-      &[checked]::part(control) {
+      &:state(checked)::part(control) {
         background-color: var(--wa-form-control-activated-color);
         border-color: var(--wa-form-control-activated-color);
       }
@@ -466,7 +466,7 @@
         background-color: var(--wa-color-surface-default);
         border: var(--wa-border-width-s) var(--wa-border-style) var(--wa-color-gray-50);
       }
-      &[checked]::part(thumb) {
+      &:state(checked)::part(thumb) {
         border-color: var(--wa-form-control-activated-color);
       }
     }


### PR DESCRIPTION
Closes #1487 

Fixes Shoelace theme custom `wa-switch` styles to target `:state(checked)` instead of `[checked]`