### PR TITLE
Abstract Code Highlighter Syntax Coloring

### DIFF
--- a/packages/webawesome/docs/assets/styles/code-highlighter.css
+++ b/packages/webawesome/docs/assets/styles/code-highlighter.css
@@ -2,22 +2,25 @@
 pre[id*='code-block-'] {
   color-scheme: dark;
   color: white;
-  background-color: var(--wa-color-neutral-20);
+  background-color: var(--wa-code-background, var(--wa-color-neutral-20));
 
   /* Ensures a discernible background color in dark mode
    * Useful for themes that use gray-20 as --wa-color-surface-default  */
   .wa-dark & {
-    background-color: var(--wa-color-surface-lowered);
+    background-color: var(--wa-code-background-dark, var(--wa-color-surface-lowered));
   }
 }
 
 .code-comment,
 .code-prolog,
 .code-doctype,
-.code-cdata,
+.code-cdata {
+  color: var(--wa-code-comment, var(--wa-color-gray-70));
+}
+
 .code-operator,
 .code-punctuation {
-  color: var(--wa-color-gray-70);
+  color: var(--wa-code-operator, var(--wa-color-gray-70));
 }
 
 .code-namespace {
@@ -28,24 +31,27 @@ pre[id*='code-block-'] {
 .code-keyword,
 .code-tag,
 .code-url {
-  color: var(--wa-color-indigo-70);
+  color: var(--wa-code-keyword, var(--wa-color-indigo-70));
 }
 
 .code-symbol,
 .code-deleted,
 .code-important {
-  color: var(--wa-color-red-70);
+  color: var(--wa-code-error, var(--wa-color-red-70));
+}
+
+.code-string,
+.code-char,
+.code-constant {
+  color: var(--wa-code-string, var(--wa-color-green-70));
 }
 
 .code-boolean,
-.code-constant,
 .code-selector,
 .code-attr-name,
-.code-string,
-.code-char,
 .code-builtin,
 .code-inserted {
-  color: var(--wa-color-green-70);
+  color: var(--wa-code-literal, var(--wa-color-green-70));
 }
 
 .code-atrule,
@@ -55,7 +61,7 @@ pre[id*='code-block-'] {
 .code-function,
 .code-class-name,
 .code-regex {
-  color: var(--wa-color-blue-70);
+  color: var(--wa-code-value, var(--wa-color-blue-70));
 }
 
 .code-important,

--- a/packages/webawesome/docs/assets/styles/code-highlighter.css
+++ b/packages/webawesome/docs/assets/styles/code-highlighter.css
@@ -2,12 +2,12 @@
 pre[id*='code-block-'] {
   color-scheme: dark;
   color: white;
-  background-color: var(--wa-code-background, var(--wa-color-neutral-20));
+  background-color: var(--code-background, var(--wa-color-neutral-20));
 
   /* Ensures a discernible background color in dark mode
    * Useful for themes that use gray-20 as --wa-color-surface-default  */
   .wa-dark & {
-    background-color: var(--wa-code-background-dark, var(--wa-color-surface-lowered));
+    background-color: var(--code-background-dark, var(--wa-color-surface-lowered));
   }
 }
 
@@ -15,12 +15,12 @@ pre[id*='code-block-'] {
 .code-prolog,
 .code-doctype,
 .code-cdata {
-  color: var(--wa-code-comment, var(--wa-color-gray-70));
+  color: var(--code-comment, var(--wa-color-gray-70));
 }
 
 .code-operator,
 .code-punctuation {
-  color: var(--wa-code-operator, var(--wa-color-gray-70));
+  color: var(--code-operator, var(--wa-color-gray-70));
 }
 
 .code-namespace {
@@ -31,19 +31,19 @@ pre[id*='code-block-'] {
 .code-keyword,
 .code-tag,
 .code-url {
-  color: var(--wa-code-keyword, var(--wa-color-indigo-70));
+  color: var(--code-keyword, var(--wa-color-indigo-70));
 }
 
 .code-symbol,
 .code-deleted,
 .code-important {
-  color: var(--wa-code-error, var(--wa-color-red-70));
+  color: var(--code-error, var(--wa-color-red-70));
 }
 
 .code-string,
 .code-char,
 .code-constant {
-  color: var(--wa-code-string, var(--wa-color-green-70));
+  color: var(--code-string, var(--wa-color-green-70));
 }
 
 .code-boolean,
@@ -51,7 +51,7 @@ pre[id*='code-block-'] {
 .code-attr-name,
 .code-builtin,
 .code-inserted {
-  color: var(--wa-code-literal, var(--wa-color-green-70));
+  color: var(--code-literal, var(--wa-color-green-70));
 }
 
 .code-atrule,
@@ -61,7 +61,7 @@ pre[id*='code-block-'] {
 .code-function,
 .code-class-name,
 .code-regex {
-  color: var(--wa-code-value, var(--wa-color-blue-70));
+  color: var(--code-value, var(--wa-color-blue-70));
 }
 
 .code-important,


### PR DESCRIPTION
This PR abstracts the code highlighter syntax coloring by introducing CSS custom properties (variables) with fallback values, making the color scheme more customizable and themeable.

**Key Changes:**
- Introduced CSS custom properties for code syntax highlighting colors with existing color values as fallbacks
- Separated comment, string, and literal token styles into distinct rulesets for better organization
- Added a dark mode background color custom property

---

@lindsaym-fa, mind reviewing this and confirming its a good idea?