### PR TITLE
Remove CDN URLs

### DIFF
--- a/packages/webawesome/docs/_includes/base.njk
+++ b/packages/webawesome/docs/_includes/base.njk
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-fa-kit-code="38c11e3f20" data-cdn-url="{% cdnUrl %}" class="wa-cloak">
+<html lang="en" data-fa-kit-code="38c11e3f20" data-version="{{ package.version }}" class="wa-cloak">
   <head>
     {% include 'head.njk' %}
     <meta name="theme-color" content="#f36944">

--- a/packages/webawesome/docs/_layouts/blank.njk
+++ b/packages/webawesome/docs/_layouts/blank.njk
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-fa-kit-code="38c11e3f20" data-cdn-url="{% cdnUrl %}">
+<html lang="en" data-fa-kit-code="38c11e3f20" data-version="{{ package.version }}">
   <head>
     {% include 'head.njk' %}
     {% block head %}{% endblock %}

--- a/packages/webawesome/docs/_layouts/component.njk
+++ b/packages/webawesome/docs/_layouts/component.njk
@@ -273,10 +273,8 @@
     <wa-tab panel="react">React</wa-tab>
     <wa-tab-panel name="cdn">
       <p>
-        To manually import this component from the CDN, use the following code.
+        Let the autoloader do the work! [Sign up for a free account](/signup) to get access to the Web Awesome CDN — the easiest way to use Web Awesome!
       </p>
-
-      <pre><code class="language-js">import '{% cdnUrl componentPath %}';</code></pre>
     </wa-tab-panel>
     <wa-tab-panel name="npm">
       <p>

--- a/packages/webawesome/docs/_layouts/component.njk
+++ b/packages/webawesome/docs/_layouts/component.njk
@@ -261,7 +261,7 @@
   {# Importing #}
   <h2>Importing</h2>
   <p>
-    The <a href="/docs/#quick-start-autoloading-via-cdn">autoloader</a> is the recommended way to import components. If you prefer to do it manually, use one of the following code snippets.
+    Autoloading components via <a href="/docs/#using-a-project">projects</a> is the recommended way to import components. If you prefer to do it manually, use one of the following code snippets.
   </p>
 
 
@@ -273,7 +273,7 @@
     <wa-tab panel="react">React</wa-tab>
     <wa-tab-panel name="cdn">
       <p>
-        Let the autoloader do the work! [Sign up for a free account](/signup) to get access to the Web Awesome CDN — the easiest way to use Web Awesome!
+        Let your project code do the work! <a href="/signup">Sign up for free</a> to use a project with your very own CDN &mdash; it's the fastest and easiest way to use Web Awesome.
       </p>
     </wa-tab-panel>
     <wa-tab-panel name="npm">

--- a/packages/webawesome/docs/assets/scripts/code-examples.js
+++ b/packages/webawesome/docs/assets/scripts/code-examples.js
@@ -1,3 +1,6 @@
+const version = document.documentElement.getAttribute('data-version') || '';
+const CDN_URL = `https://cdn.jsdelivr.net/npm/@awesome.me/webawesome@${version}/dist-cdn/`;
+
 //
 // Resizing previews
 //
@@ -54,10 +57,9 @@ document.addEventListener('click', event => {
   if (pen) {
     const codeExample = pen.closest('.code-example');
     const code = codeExample.querySelector('code');
-    const cdnUrl = document.documentElement.dataset.cdnUrl;
     const html =
-      `<script data-fa-kit-code="38c11e3f20" type="module" src="${cdnUrl}webawesome.loader.js"></script>\n` +
-      `<link rel="stylesheet" href="${cdnUrl}styles/webawesome.css">\n\n` +
+      `<script data-fa-kit-code="38c11e3f20" type="module" src="${CDN_URL}webawesome.loader.js"></script>\n` +
+      `<link rel="stylesheet" href="${CDN_URL}styles/webawesome.css">\n\n` +
       `${code.textContent}`;
     const css = 'html > body {\n  padding: 2rem !important;\n}';
     const js = '';

--- a/packages/webawesome/docs/assets/scripts/search.js
+++ b/packages/webawesome/docs/assets/scripts/search.js
@@ -1,5 +1,6 @@
 // Search data
-const res = await Promise.all([import('https://cdn.jsdelivr.net/npm/lunr/+esm'), fetch('/search.json')]);
+const version = document.documentElement.getAttribute('data-version') || '';
+const res = await Promise.all([import('https://cdn.jsdelivr.net/npm/lunr/+esm'), fetch(`/search.json?v=${version}`)]);
 const lunr = res[0].default;
 const searchData = await res[1].json();
 const searchIndex = lunr.Index.load(searchData.searchIndex);

--- a/packages/webawesome/docs/docs/color-palettes.njk
+++ b/packages/webawesome/docs/docs/color-palettes.njk
@@ -66,14 +66,50 @@ layout: page
 </div>
 
 <h2>Using This Palette</h2>
+
 <div id="import-code">
   {% for palette in themer.palettes %}
-  <div class="palette-instructions" data-palette="{{ palette.name | lower }}" {% if not loop.first %}hidden{% endif %}>
-    <p>
-      To import this palette, set <code>&lt;html class=&quot;wa-palette-{{ palette.name | lower }}&quot;&gt;</code> and import the following stylesheet:
-    </p>
-    <pre><code class="language-html">&lt;link rel=&quot;stylesheet&quot; href=&quot;/dist/styles/color/palettes/{{ palette.filename }}&quot; /&gt;</code></pre>
-  </div>
+    <div class="palette-instructions" data-palette="{{ palette.name | lower }}" {% if not loop.first %}hidden{% endif %}>
+      <wa-tab-group>
+        <wa-tab panel="projects"><wa-icon name="briefcase" variant="regular"></wa-icon> Projects</wa-tab>
+        <wa-tab panel="npm"><wa-icon name="box-open" variant="regular"></wa-icon> npm</wa-tab>
+        <wa-tab panel="self-hosted"><wa-icon name="file-zipper" variant="regular"></wa-icon> Self-Hosted</wa-tab>
+
+        <wa-tab-panel name="projects">
+          <h3 class="wa-heading-m">For Pro Projects:</h3>
+          <p>
+              In your project's <wa-icon name="gear" variant="regular"></wa-icon> Settings, <wa-icon name="paintbrush" variant="regular"></wa-icon> Edit Your Theme to open the Theme Builder. Select <strong>{{ palette.name | capitalize }}</strong> as your Color Palette.
+          </p>
+          <h3 class="wa-heading-m">For Free Projects:</h3>
+          <p>
+              In your project's <wa-icon name="gear" variant="regular"></wa-icon> Settings, set your Color Palette to <wa-icon name="swatchbook" variant="regular"></wa-icon> <strong>{{ palette.name | capitalize }}</strong>.
+          </p>
+          <p>Save your palette and watch it come to life anywhere you're using your project.</p>
+        </wa-tab-panel>
+
+        <wa-tab-panel name="npm">
+          <p>
+            To use this theme, import the theme's stylesheet:
+          </p>
+          <pre><code class="language-js">import &apos;@awesome.me/webawesome/dist/styles/themes/{{ palette.filename }}&apos;;</code></pre>
+          <p>
+            Then apply the following class to the <code>&lt;html&gt;</code> element:
+          </p>
+          <pre><code class="language-html">&lt;html class=&quot;wa-palette-{{ palette.name | lower }}&quot;&gt;</code></pre>
+        </wa-tab-panel>
+
+        <wa-tab-panel name="self-hosted">
+          <p>
+            To use this theme, import the theme's stylesheet:
+          </p>
+          <pre><code class="language-html">&lt;link rel=&quot;stylesheet&quot; href=&quot;/dist/styles/themes/{{ palette.filename }}&quot; /&gt;</code></pre>
+          <p>
+            Then apply the following class to the <code>&lt;html&gt;</code> element:
+          </p>
+          <pre><code class="language-html">&lt;html class=&quot;wa-palette-{{ palette.name | lower }}&quot;&gt;</code></pre>
+        </wa-tab-panel>
+      </wa-tab-group>
+    </div>
   {% endfor %}
 </div>
 

--- a/packages/webawesome/docs/docs/color-palettes.njk
+++ b/packages/webawesome/docs/docs/color-palettes.njk
@@ -72,7 +72,7 @@ layout: page
     <p>
       To import this palette, set <code>&lt;html class=&quot;wa-palette-{{ palette.name | lower }}&quot;&gt;</code> and import the following stylesheet:
     </p>
-    <pre><code class="language-html">&lt;link rel=&quot;stylesheet&quot; href=&quot;{% cdnUrl %}styles/color/palettes/{{ palette.filename }}&quot; /&gt;</code></pre>
+    <pre><code class="language-html">&lt;link rel=&quot;stylesheet&quot; href=&quot;/dist/styles/color/palettes/{{ palette.filename }}&quot; /&gt;</code></pre>
   </div>
   {% endfor %}
 </div>

--- a/packages/webawesome/docs/docs/customizing.md
+++ b/packages/webawesome/docs/docs/customizing.md
@@ -10,27 +10,32 @@ You can customize the look and feel of Web Awesome at a high level with themes. 
 
 Web Awesome uses [themes](/docs/themes) to apply a cohesive look and feel across the entire library. Themes are built with a collection of predefined CSS custom properties, which we call [design tokens](/docs/tokens), and there are many premade themes you can choose from.
 
-To use a theme, simply add a link to the theme's stylesheet to the `<head>` of your page. For example, you can add this snippet alongside th [installation code](/docs/#quick-start-autoloading-via-cdn) to use the _Awesome_ theme:
+{% raw %}
+  <p>
+    To use a pre-built theme {%- if currentUser.hasPro -%}&nbsp;or build your own{%- endif -%},&nbsp;
+    {%- if not session.isLoggedIn -%}
+      <a href="/signup">sign up</a> or <a href="/login">log in</a> to create a project.&nbsp;
+    {%- else -%}
+      head over to <a href="/teams">your teams</a> and open up the project you'd like to use.&nbsp;
+    {%- endif -%}
+    In your project's <wa-icon name="gear" variant="regular"></wa-icon> <strong>Settings</strong>,&nbsp;
+    {%- if not currentUser.hasPro -%}
+      select a <wa-icon name="paintbrush" variant="regular"></wa-icon> <strong>Theme</strong> and a <wa-icon name="swatchbook" variant="regular"></wa-icon> <strong>Color Palette</strong> to use, save your changes, and bask in the glory of your new theme.
+    {%- else -%}
+      <wa-icon name="paintbrush" variant="regular"></wa-icon> <strong>Edit Your Theme</strong> to open the Theme Builder and select a pre-built theme or customize your colors, fonts, icons, and more.
+    {%- endif -%}
+  </p>
+{% endraw %}
 
-```html
-<link rel="stylesheet" href="/dist/styles/themes/awesome.css" />
-```
-
-You can customize any theme just with CSS — no preprocessor required. All design tokens are prefixed with `--wa-` to avoid collisions with other libraries and your own custom properties. Simply override any design token in your own stylesheet by scoping your styles to `:root`, the class for the specific theme you want to override (if needed), and the class for the relevant color scheme (if needed). Here's an example that changes the default brand color to purple in light mode:
+For even more customizations, you can off-road and override any theme just with CSS — no preprocessor required. All design tokens are prefixed with `--wa-` to avoid collisions with other libraries and your own custom properties. Simply style any design token in your own stylesheet by scoping your styles to `:root` and the class for the relevant color scheme (if needed). Here's an example that uses tinted surface colors in light mode:
 
 ```css
 :root,
 .wa-light,
 .wa-dark .wa-invert {
-  --wa-color-brand-fill-quiet: var(--wa-color-purple-95);
-  --wa-color-brand-fill-normal: var(--wa-color-purple-90);
-  --wa-color-brand-fill-loud: var(--wa-color-purple-50);
-  --wa-color-brand-border-quiet: var(--wa-color-purple-90);
-  --wa-color-brand-border-normal: var(--wa-color-purple-80);
-  --wa-color-brand-border-loud: var(--wa-color-purple-60);
-  --wa-color-brand-on-quiet: var(--wa-color-purple-40);
-  --wa-color-brand-on-normal: var(--wa-color-purple-30);
-  --wa-color-brand-on-loud: white;
+  --wa-color-surface-raised: var(--wa-color-neutral-95);
+  --wa-color-surface-default: var(--wa-color-neutral-90);
+  --wa-color-surface-lowered: var(--wa-color-neutral-80);
 }
 ```
 

--- a/packages/webawesome/docs/docs/customizing.md
+++ b/packages/webawesome/docs/docs/customizing.md
@@ -13,7 +13,7 @@ Web Awesome uses [themes](/docs/themes) to apply a cohesive look and feel across
 To use a theme, simply add a link to the theme's stylesheet to the `<head>` of your page. For example, you can add this snippet alongside th [installation code](/docs/#quick-start-autoloading-via-cdn) to use the _Awesome_ theme:
 
 ```html
-<link rel="stylesheet" href="{% cdnUrl 'styles/themes/awesome.css' %}" />
+<link rel="stylesheet" href="/dist/styles/themes/awesome.css" />
 ```
 
 You can customize any theme just with CSS — no preprocessor required. All design tokens are prefixed with `--wa-` to avoid collisions with other libraries and your own custom properties. Simply override any design token in your own stylesheet by scoping your styles to `:root`, the class for the specific theme you want to override (if needed), and the class for the relevant color scheme (if needed). Here's an example that changes the default brand color to purple in light mode:

--- a/packages/webawesome/docs/docs/index.md
+++ b/packages/webawesome/docs/docs/index.md
@@ -12,42 +12,27 @@ Welcome to Web Awesome! [Learn more](https://webawesome.com/) about this project
 
 ---
 
-## Quick Start (Autoloading via CDN)
+## 🚀 Using a Project
 
-To get everything included in Web Awesome, add the following code to the `<head>` of your site:
+A project gives you your own, personal CDN to use Web Awesome on your site. Each project uses a single line of code to install your preferred version, theme, Font Awesome kit...the works! And, when you update your project's settings, your project code pulls in all of the right stuff automatically — no need to update your own code or redeploy your site.
 
-```html
-<link rel="stylesheet" href="/dist/styles/webawesome.css" />
-<script type="module" src="/dist/webawesome.loader.js"></script>
-```
+One line of code from us. The entire Web Awesome library for you.
 
-This snippet adds:
+To use a project:
 
-- **Web Awesome styles**, a collection of stylesheets including essential default theme styles, optional [styles for native elements](/docs/utilities/native) and optional [utility classes](/docs/utilities)
-- **The autoloader**, a lightweight script watches the DOM for unregistered Web Awesome elements and lazy loads them for you — even if they're added dynamically
-
-Now you can [start using Web Awesome!](/docs/usage)
-
----
-
-## Using Font Awesome Kit Codes
-
-Font Awesome users can provide their kit code to unlock premium icon packs. You can provide yours by adding the `data-fa-kit-code` attribute to any element on the page, or by calling the `setKitCode()` method.
-
-```html
-<!-- Option 1: the data-fa-kit-code attribute -->
-<script src="bundle.js" data-fa-kit-code="abc123"></script>
-
-<!-- Option 2: the setKitCode() method -->
-<script type="module">
-  import { setKitCode } from '/dist/webawesome.loader.js';
-  setKitCode('YOUR_KIT_CODE_HERE');
-</script>
-```
-
-:::info
-Not a Font Awesome user yet? [Learn more about premium icon packs](https://fontawesome.com/) and sign up for an account to unlock them!
-:::
+{% raw %}
+<ol>
+  <li>
+    {% if not session.isLoggedIn %}
+      <a href="/signup">Sign up</a> or <a href="/login">log in</a> to create a project.
+    {% else %}
+      Head over to <a href="/teams">your favorite team</a> and open up the project you'd like to use.
+    {% endif %}
+  </li>
+  <li>Copy and paste your unique project code into the <code>&lt;head&gt;</code> of each page on your site.</li>
+  <li><a href="/docs/usage">Start using Web Awesome!</a></li>
+</ol>
+{% endraw %}
 
 ---
 
@@ -63,31 +48,9 @@ Not a Font Awesome user yet? [Learn more about premium icon packs](https://fonta
 {% endraw %}
 </div>
 
-## Advanced Setup
+## 🛠️ Advanced Setup
 
-The autoloader is the easiest way to use Web Awesome, but different projects (or your own preferences!) may require different installation methods.
-
-### Cherry Picking from CDN
-
-Cherry picking will only load the components you need up front, while limiting the number of files the browser has to download. The disadvantage is that you need to import each individual component on each page it's used. Additionally, you must include the default theme (`styles/themes/default.css`) to style any imported components. To use a different theme, include your preferred theme _in addition to_ the default theme.
-
-Here's an example that loads only the button component.
-
-```html
-<link rel="stylesheet" href="/dist/styles/themes/default.css" />
-
-<script type="module">
-  import '/dist/components/button/button.js';
-
-  // <wa-button> is ready to use!
-</script>
-```
-
-You can copy and paste the code to import a component from the "Importing" section of the component's documentation. Note that some components have dependencies that are automatically imported when you cherry pick. If a component has dependencies, they will be listed in the "Dependencies" section of its docs.
-
-:::warning
-You will see files named `chunk.[hash].js` in the `chunks` directory. Never import these files directly, as they are generated and change from version to version.
-:::
+Projects are our favorite way to use Web Awesome, but different environments (or your own preferences!) may require different installation methods. If you're self-hosting Web Awesome or using npm, refer to the instructions in this section.
 
 ### Installing via npm
 
@@ -116,11 +79,48 @@ import '@awesome.me/webawesome/dist/components/input/input.js';
 
 Once they've been imported, you can use them in your HTML normally. Component imports are located in the "Importing" section of each component's documentation.
 
+
+### The Difference Between `/dist` & `/dist-cdn`
+
+If you have Web Awesome installed locally via npm, you'll notice the following directories in the project's root:
+
+```
+dist/
+dist-cdn/
+```
+
+The `dist-cdn` files come with everything bundled together, so you can use them directly without a build tool. The dist files keep dependencies separate, which lets your bundler optimize and share code more efficiently.
+
+Use `dist-cdn` if you're loading directly in the browser or from a CDN. Use `dist` if you're using a bundler like Webpack or Vite.
+
+### Referencing Necessary Styles
+
+If you're self-hosting Web Awesome, you'll need to set up your pages to reference any necessary styles. You can do so by referencing `webawesome.css`, or you can pick and choose specific stylesheets you'd like to use.
+
+```html
+<!-- Option 1: use all Web Awesome styles -->
+<link rel="stylesheet" href="/dist/styles/webawesome.css" />
+
+
+<!-- Option 2: pick and choose styles -->
+
+<!-- theme (required) -->
+<link rel="stylesheet" href="/dist/styles/themes/default.css" />
+
+<!-- native styles (optional) -->
+<link rel="stylesheet" href="/dist/styles/native.css" />
+
+<!-- CSS utilities (optional) -->
+<link rel="stylesheet" href="/dist/styles/utilities.css" />
+```
+
+If you choose to use a theme other than the default theme, be sure to add the corresponding class (e.g. `.wa-theme-awesome`) to your `<html>` element so that the class is applied.
+
 ### Setting the Base Path
 
 Some components rely on assets (icons, images, etc.) and Web Awesome needs to know where they're located. For convenience, Web Awesome will try to auto-detect the correct location based on the script you've loaded it from. This assumes assets are colocated with `webawesome.loader.js` and will "just work" for most users.
 
-==If you're using the CDN, you can skip this section.== However, if you're [cherry picking](#cherry-picking-from-cdn) or bundling Web Awesome, you'll need to set the base path. You can do this one of two ways.
+==If you're using a Web Awesome project, you can skip this section.== However, if you're [cherry picking](#cherry-picking-from-cdn) or bundling Web Awesome, you'll need to set the base path. You can do this one of two ways.
 
 ```html
 <!-- Option 1: the data-webawesome attribute -->
@@ -153,18 +153,26 @@ Most of the magic behind assets is handled internally by Web Awesome, but if you
 </script>
 ```
 
-### The Difference Between `/dist` & `/dist-cdn`
+### Using Font Awesome Pro and Pro+
 
-If you have Web Awesome installed locally via npm, you'll notice the following directories in the project's root:
+Font Awesome users can provide their kit code to unlock Pro and Pro+ icon packs. If you're using a project, simply add your Font Awesome Kit Code in your project's settings, and boom! Done.
 
+If you're using Web Awesome through other methods like npm, you can provide yours by adding the `data-fa-kit-code` attribute to any element on the page, or by calling the `setKitCode()` method.
+
+```html
+<!-- Option 1: the data-fa-kit-code attribute -->
+<script src="bundle.js" data-fa-kit-code="abc123"></script>
+
+<!-- Option 2: the setKitCode() method -->
+<script type="module">
+  import { setKitCode } from '{% cdnUrl 'webawesome.loader.js' %}';
+  setKitCode('YOUR_KIT_CODE_HERE');
+</script>
 ```
-dist/
-dist-cdn/
-```
 
-The `dist-cdn` files come with everything bundled together, so you can use them directly without a build tool. The dist files keep dependencies separate, which lets your bundler optimize and share code more efficiently.
-
-Use `dist-cdn` if you're loading directly in the browser or from a CDN. Use `dist` if you're using a bundler like Webpack or Vite.
+:::info
+Not a Font Awesome user yet? [Learn more about Font Awesome icon packs](https://fontawesome.com/) and sign up for an account to unlock them!
+:::
 
 ## React Users
 

--- a/packages/webawesome/docs/docs/index.md
+++ b/packages/webawesome/docs/docs/index.md
@@ -17,8 +17,8 @@ Welcome to Web Awesome! [Learn more](https://webawesome.com/) about this project
 To get everything included in Web Awesome, add the following code to the `<head>` of your site:
 
 ```html
-<link rel="stylesheet" href="{% cdnUrl 'styles/webawesome.css' %}" />
-<script type="module" src="{% cdnUrl 'webawesome.loader.js' %}"></script>
+<link rel="stylesheet" href="/dist/styles/webawesome.css" />
+<script type="module" src="/dist/webawesome.loader.js"></script>
 ```
 
 This snippet adds:
@@ -40,7 +40,7 @@ Font Awesome users can provide their kit code to unlock premium icon packs. You 
 
 <!-- Option 2: the setKitCode() method -->
 <script type="module">
-  import { setKitCode } from '{% cdnUrl 'webawesome.loader.js' %}';
+  import { setKitCode } from '/dist/webawesome.loader.js';
   setKitCode('YOUR_KIT_CODE_HERE');
 </script>
 ```
@@ -74,10 +74,10 @@ Cherry picking will only load the components you need up front, while limiting t
 Here's an example that loads only the button component.
 
 ```html
-<link rel="stylesheet" href="{% cdnUrl 'styles/themes/default.css' %}" />
+<link rel="stylesheet" href="/dist/styles/themes/default.css" />
 
 <script type="module">
-  import '{% cdnUrl 'components/button/button.js' %}';
+  import '/dist/components/button/button.js';
 
   // <wa-button> is ready to use!
 </script>

--- a/packages/webawesome/docs/docs/layout.njk
+++ b/packages/webawesome/docs/docs/layout.njk
@@ -52,13 +52,13 @@ Layout components are included in Web Awesome's [autoloader](/docs/#quick-start-
 Layout utilities are bundled with all [style utilities](/docs/utilities). You can import all Web Awesome page styles (including [native styles](/docs/utilities/native/)) by including the following stylesheet in your project:
 
 ```html
-<link rel="stylesheet" href="{% cdnUrl 'styles/webawesome.css' %}" />
+<link rel="stylesheet" href="/dist/styles/webawesome.css" />
 ```
 
 Or, you can choose to import _only_ the utilities:
 
 ```html
-<link rel="stylesheet" href="{% cdnUrl 'styles/utilities.css' %}" />
+<link rel="stylesheet" href="/dist/styles/utilities.css" />
 ```
 {% endmarkdown %}
 </div>

--- a/packages/webawesome/docs/docs/localization.md
+++ b/packages/webawesome/docs/docs/localization.md
@@ -27,7 +27,7 @@ Web Awesome ships with [a number of translations](https://github.com/shoelace-st
 You can import translations using the following syntax, where `<code>` is replaced with any language code shown above.
 
 ```js
-import '{% cdnUrl "translations/<code>.js" %}';
+import '/dist/translations/<code>.js';
 ```
 
 You do not need to load translations up front. You can import them dynamically even after updating the `lang` attribute. Once a translation is registered, localized components will update automatically.
@@ -37,7 +37,7 @@ You do not need to load translations up front. You can import them dynamically e
 document.documentElement.lang = 'de';
 
 // Import the translation
-import('{% cdnUrl "translations/<code>.js" %}');
+import('/translations/<code>.js');
 ```
 
 ### Translation Resolution

--- a/packages/webawesome/docs/docs/themes.njk
+++ b/packages/webawesome/docs/docs/themes.njk
@@ -87,47 +87,51 @@ to create a project with any one of these themes.
 
 <h2>Using This Theme</h2>
 
-{% for theme in themer.themes %}
-<wa-tab-group class="theme-instructions" data-theme="{{ theme.filename | stripExtension }}" {% if not loop.first %}hidden{% endif %}>
-  <wa-tab panel="projects"><wa-icon name="briefcase" variant="regular"></wa-icon> Projects</wa-tab>
-  <wa-tab panel="npm"><wa-icon name="box-open" variant="regular"></wa-icon> npm</wa-tab>
-  <wa-tab panel="self-hosted"><wa-icon name="file-zipper" variant="regular"></wa-icon> Self-Hosted</wa-tab>
+<div id="import-code">
+  {% for theme in themer.themes %}
+    <div class="theme-instructions" data-theme="{{ theme.filename | stripExtension }}" {% if not loop.first %}hidden{% endif %}>
+      <wa-tab-group>
+        <wa-tab panel="projects"><wa-icon name="briefcase" variant="regular"></wa-icon> Projects</wa-tab>
+        <wa-tab panel="npm"><wa-icon name="box-open" variant="regular"></wa-icon> npm</wa-tab>
+        <wa-tab panel="self-hosted"><wa-icon name="file-zipper" variant="regular"></wa-icon> Self-Hosted</wa-tab>
 
-  <wa-tab-panel name="projects">
-    <h3 class="wa-heading-m">For Pro Projects:</h3>
-    <p>
-        In your project's <wa-icon name="gear" variant="regular"></wa-icon> Settings, <wa-icon name="paintbrush" variant="regular"></wa-icon> Edit Your Theme to open the Theme Builder. Select <strong>{{ theme.filename | stripExtension | capitalize }}</strong> as your Starting Theme.
-    </p>
-    <h3 class="wa-heading-m">For Free Projects:</h3>
-    <p>
-        In your project's <wa-icon name="gear" variant="regular"></wa-icon> Settings, set your Theme to <wa-icon name="paintbrush" variant="regular"></wa-icon> <strong>{{ theme.filename | stripExtension | capitalize }}</strong> and your Color Palette to <wa-icon name="swatchbook" variant="regular"></wa-icon> <strong>{{ theme.palette.filename | stripExtension | capitalize }}</strong>.
-    </p>
-    <p>Save your theme and watch it come to life anywhere you're using your project.</p>
-  </wa-tab-panel>
+        <wa-tab-panel name="projects">
+          <h3 class="wa-heading-m">For Pro Projects:</h3>
+          <p>
+              In your project's <wa-icon name="gear" variant="regular"></wa-icon> Settings, <wa-icon name="paintbrush" variant="regular"></wa-icon> Edit Your Theme to open the Theme Builder. Select <strong>{{ theme.filename | stripExtension | capitalize }}</strong> as your Starting Theme.
+          </p>
+          <h3 class="wa-heading-m">For Free Projects:</h3>
+          <p>
+              In your project's <wa-icon name="gear" variant="regular"></wa-icon> Settings, set your Theme to <wa-icon name="paintbrush" variant="regular"></wa-icon> <strong>{{ theme.filename | stripExtension | capitalize }}</strong> and your Color Palette to <wa-icon name="swatchbook" variant="regular"></wa-icon> <strong>{{ theme.palette.filename | stripExtension | capitalize }}</strong>.
+          </p>
+          <p>Save your theme and watch it come to life anywhere you're using your project.</p>
+        </wa-tab-panel>
 
-  <wa-tab-panel name="npm">
-    <p>
-      To use this theme, import the theme's stylesheet:
-    </p>
-    <pre><code class="language-js">import &apos;@awesome.me/webawesome/dist/styles/themes/{{ theme.filename }}&apos;;</code></pre>
-    <p>
-      Then apply the following classes to the <code>&lt;html&gt;</code> element:
-    </p>
-    <pre><code class="language-html">&lt;html class=&quot;wa-theme-{{ theme.filename | stripExtension }} wa-palette-{{ theme.palette.filename | stripExtension }} wa-brand-{{ theme.colorBrand.color}}&quot;&gt;</code></pre>
-  </wa-tab-panel>
+        <wa-tab-panel name="npm">
+          <p>
+            To use this theme, import the theme's stylesheet:
+          </p>
+          <pre><code class="language-js">import &apos;@awesome.me/webawesome/dist/styles/themes/{{ theme.filename }}&apos;;</code></pre>
+          <p>
+            Then apply the following classes to the <code>&lt;html&gt;</code> element:
+          </p>
+          <pre><code class="language-html">&lt;html class=&quot;wa-theme-{{ theme.filename | stripExtension }} wa-palette-{{ theme.palette.filename | stripExtension }} wa-brand-{{ theme.colorBrand.color}}&quot;&gt;</code></pre>
+        </wa-tab-panel>
 
-  <wa-tab-panel name="self-hosted">
-    <p>
-      To use this theme, import the theme's stylesheet:
-    </p>
-    <pre><code class="language-html">&lt;link rel=&quot;stylesheet&quot; href=&quot;/dist/styles/themes/{{ theme.filename }}&quot; /&gt;</code></pre>
-    <p>
-      Then apply the following classes to the <code>&lt;html&gt;</code> element:
-    </p>
-    <pre><code class="language-html">&lt;html class=&quot;wa-theme-{{ theme.filename | stripExtension }} wa-palette-{{ theme.palette.filename | stripExtension }} wa-brand-{{ theme.colorBrand.color}}&quot;&gt;</code></pre>
-  </wa-tab-panel>
-</wa-tab-group>
-{% endfor %}
+        <wa-tab-panel name="self-hosted">
+          <p>
+            To use this theme, import the theme's stylesheet:
+          </p>
+          <pre><code class="language-html">&lt;link rel=&quot;stylesheet&quot; href=&quot;/dist/styles/themes/{{ theme.filename }}&quot; /&gt;</code></pre>
+          <p>
+            Then apply the following classes to the <code>&lt;html&gt;</code> element:
+          </p>
+          <pre><code class="language-html">&lt;html class=&quot;wa-theme-{{ theme.filename | stripExtension }} wa-palette-{{ theme.palette.filename | stripExtension }} wa-brand-{{ theme.colorBrand.color}}&quot;&gt;</code></pre>
+        </wa-tab-panel>
+      </wa-tab-group>
+    </div>
+  {% endfor %}
+</div>
 
 
 <script type="module">

--- a/packages/webawesome/docs/docs/themes.njk
+++ b/packages/webawesome/docs/docs/themes.njk
@@ -94,7 +94,7 @@ to create a project with any one of these themes.
     </p>
 <pre><code class="language-html">&lt;html class=&quot;wa-theme-{{ theme.filename | stripExtension }} wa-palette-{{ theme.palette.filename | stripExtension }} wa-brand-{{ theme.colorBrand.color}}&quot;&gt;
 ...
-&lt;link rel=&quot;stylesheet&quot; href=&quot;{% cdnUrl %}styles/themes/{{ theme.filename }}&quot; /&gt;</code></pre>
+&lt;link rel=&quot;stylesheet&quot; href=&quot;/dist/styles/themes/{{ theme.filename }}&quot; /&gt;</code></pre>
   </div>
   {% endfor %}
 </div>

--- a/packages/webawesome/docs/docs/themes.njk
+++ b/packages/webawesome/docs/docs/themes.njk
@@ -86,18 +86,48 @@ to create a project with any one of these themes.
 </div>
 
 <h2>Using This Theme</h2>
-<div id="import-code">
-  {% for theme in themer.themes %}
-  <div class="theme-instructions" data-theme="{{ theme.filename | stripExtension }}" {% if not loop.first %}hidden{% endif %}>
+
+{% for theme in themer.themes %}
+<wa-tab-group class="theme-instructions" data-theme="{{ theme.filename | stripExtension }}" {% if not loop.first %}hidden{% endif %}>
+  <wa-tab panel="projects"><wa-icon name="briefcase" variant="regular"></wa-icon> Projects</wa-tab>
+  <wa-tab panel="npm"><wa-icon name="box-open" variant="regular"></wa-icon> npm</wa-tab>
+  <wa-tab panel="self-hosted"><wa-icon name="file-zipper" variant="regular"></wa-icon> Self-Hosted</wa-tab>
+
+  <wa-tab-panel name="projects">
+    <h3 class="wa-heading-m">For Pro Projects:</h3>
     <p>
-      To import this theme, apply the following classes to the <code>&lt;html&gt;</code> element and import the theme's stylesheet.
+        In your project's <wa-icon name="gear" variant="regular"></wa-icon> Settings, <wa-icon name="paintbrush" variant="regular"></wa-icon> Edit Your Theme to open the Theme Builder. Select <strong>{{ theme.filename | stripExtension | capitalize }}</strong> as your Starting Theme.
     </p>
-<pre><code class="language-html">&lt;html class=&quot;wa-theme-{{ theme.filename | stripExtension }} wa-palette-{{ theme.palette.filename | stripExtension }} wa-brand-{{ theme.colorBrand.color}}&quot;&gt;
-...
-&lt;link rel=&quot;stylesheet&quot; href=&quot;/dist/styles/themes/{{ theme.filename }}&quot; /&gt;</code></pre>
-  </div>
-  {% endfor %}
-</div>
+    <h3 class="wa-heading-m">For Free Projects:</h3>
+    <p>
+        In your project's <wa-icon name="gear" variant="regular"></wa-icon> Settings, set your Theme to <wa-icon name="paintbrush" variant="regular"></wa-icon> <strong>{{ theme.filename | stripExtension | capitalize }}</strong> and your Color Palette to <wa-icon name="swatchbook" variant="regular"></wa-icon> <strong>{{ theme.palette.filename | stripExtension | capitalize }}</strong>.
+    </p>
+    <p>Save your theme and watch it come to life anywhere you're using your project.</p>
+  </wa-tab-panel>
+
+  <wa-tab-panel name="npm">
+    <p>
+      To use this theme, import the theme's stylesheet:
+    </p>
+    <pre><code class="language-js">import &apos;@awesome.me/webawesome/dist/styles/themes/{{ theme.filename }}&apos;;</code></pre>
+    <p>
+      Then apply the following classes to the <code>&lt;html&gt;</code> element:
+    </p>
+    <pre><code class="language-html">&lt;html class=&quot;wa-theme-{{ theme.filename | stripExtension }} wa-palette-{{ theme.palette.filename | stripExtension }} wa-brand-{{ theme.colorBrand.color}}&quot;&gt;</code></pre>
+  </wa-tab-panel>
+
+  <wa-tab-panel name="self-hosted">
+    <p>
+      To use this theme, import the theme's stylesheet:
+    </p>
+    <pre><code class="language-html">&lt;link rel=&quot;stylesheet&quot; href=&quot;/dist/styles/themes/{{ theme.filename }}&quot; /&gt;</code></pre>
+    <p>
+      Then apply the following classes to the <code>&lt;html&gt;</code> element:
+    </p>
+    <pre><code class="language-html">&lt;html class=&quot;wa-theme-{{ theme.filename | stripExtension }} wa-palette-{{ theme.palette.filename | stripExtension }} wa-brand-{{ theme.colorBrand.color}}&quot;&gt;</code></pre>
+  </wa-tab-panel>
+</wa-tab-group>
+{% endfor %}
 
 
 <script type="module">

--- a/packages/webawesome/docs/docs/usage.md
+++ b/packages/webawesome/docs/docs/usage.md
@@ -40,6 +40,7 @@ await allDefined();
 
 By default, `allDefined()` will wait for all `wa-` prefixed custom elements within the current `document` to be registered.
 You can customize this behavior by passing in options:
+
 - `root` allows you to pass in a different element to search within, or a different document entirely (defaults to `document`).
 - `match` allows you to specify a custom function to determine which elements to wait for. This function should return `true` for elements you want to wait for and `false` for those you don't.
 - `additionalElements` allows you to wait for custom elements to be defined that may not be present in the DOM at the time `allDefined()` is called. This can be useful for elements that are loaded dynamically via JS.
@@ -52,7 +53,7 @@ import { allDefined } from '/dist/webawesome.js';
 await allDefined({
   match: tagName => tagName.startsWith('wa-') || tagName === 'my-component',
   root: document.getElementById('sidebar'),
-  additionalElements: ['wa-slider', 'other-slider']
+  additionalElements: ['wa-slider', 'other-slider'],
 });
 ```
 
@@ -194,12 +195,11 @@ Web Awesome ships with a file called `vscode.html-custom-data.json` that can be 
 
 If `settings.json` already exists, simply add the above line to the root of the object. Note that you may need to restart VS Code for the changes to take effect.
 
-If you are using WebAwesome through the [CDN](/docs/#quick-start-autoloading-via-cdn) you can manually [download the file]({% cdnUrl 'vscode.html-custom-data.json' %}]({% cdnUrl 'vscode.html-custom-data.json' %}) instead.
-
 ### JetBrains IDEs
-If you are using a [JetBrains IDE](https://www.jetbrains.com/) and you are installing Web Awesome from NPM, the editor will automatically detect the web-types.json file from the package and you should immediately see component information in your editor.
 
-If you are installing from the CDN, you can [download a local copy]({% cdnUrl 'web-types.json' %}) and add it to the root of your project. Be sure to add a reference to the web-types.json file in your package.json in order for your editor to properly detect it.
+If you are using a [JetBrains IDE](https://www.jetbrains.com/) and you are installing Web Awesome from NPM, the editor will automatically detect the `web-types.json` file from the package and you should immediately see component information in your editor.
+
+Be sure to add a reference to the `web-types.json` file in your `package.json` in order for your editor to properly detect it.
 
 ```json
 {

--- a/packages/webawesome/docs/docs/utilities/index.njk
+++ b/packages/webawesome/docs/docs/utilities/index.njk
@@ -52,13 +52,13 @@ layout: docs
 To use all Web Awesome page styles (including [native styles](/docs/utilities/native/)), include the following stylesheet in your project:
 
 ```html
-<link rel="stylesheet" href="{% cdnUrl 'styles/webawesome.css' %}" />
+<link rel="stylesheet" href="/dist/styles/webawesome.css" />
 ```
 
 Or, to _only_ include utilities:
 
 ```html
-<link rel="stylesheet" href="{% cdnUrl 'styles/utilities.css' %}" />
+<link rel="stylesheet" href="/dist/styles/utilities.css" />
 ```
 
 {% endmarkdown %}

--- a/packages/webawesome/docs/docs/utilities/native.md
+++ b/packages/webawesome/docs/docs/utilities/native.md
@@ -12,14 +12,14 @@ Native styles use design tokens to spruce up native HTML elements so that they m
 To use all Web Awesome styles (including [utilities](/docs/utilities/)), include the following stylesheet in your project:
 
 ```html
-<link rel="stylesheet" href="{% cdnUrl 'styles/webawesome.css' %}" />
+<link rel="stylesheet" href="/dist/styles/webawesome.css" />
 ```
 
 Or, if you only want styles for native elements, include the default theme and native styles individually:
 
 ```html
-<link rel="stylesheet" href="{% cdnUrl 'styles/themes/default.css' %}" />
-<link rel="stylesheet" href="{% cdnUrl 'styles/native.css' %}" />
+<link rel="stylesheet" href="/dist/styles/themes/default.css" />
+<link rel="stylesheet" href="/dist/styles/native.css" />
 ```
 
 You can additionally include any pre-made [theme](/docs/themes/) or [color palette](/docs/color-palettes/) to change the look of native elements.
@@ -30,10 +30,18 @@ Native styles set default space between many block-level HTML elements using the
 
 ```html {.example}
 <h3>Curabitur odio ligula</h3>
-<p>Fusce mollis quam lorem, et gravida arcu laoreet ut. Pellentesque et malesuada mi. Morbi faucibus nisl nec nulla porta, ac scelerisque elit finibus.</p>
-<blockquote>The Road goes ever on and on<br />
-Out from the door where it began.</blockquote>
-<p>Donec varius, ipsum sit amet lobortis tristique, quam arcu pellentesque turpis, non porta lacus arcu non arcu. Morbi luctus at nisl sit amet faucibus.</p>
+<p>
+  Fusce mollis quam lorem, et gravida arcu laoreet ut. Pellentesque et malesuada mi. Morbi faucibus nisl nec nulla
+  porta, ac scelerisque elit finibus.
+</p>
+<blockquote>
+  The Road goes ever on and on<br />
+  Out from the door where it began.
+</blockquote>
+<p>
+  Donec varius, ipsum sit amet lobortis tristique, quam arcu pellentesque turpis, non porta lacus arcu non arcu. Morbi
+  luctus at nisl sit amet faucibus.
+</p>
 <hr />
 <ul>
   <li>Aenean imperdiet</li>
@@ -191,8 +199,8 @@ Use any inline text element like `<strong>`, `<em>`, `<a>`, `<kbd>`, and others 
 Add responsive media with `<img>`, `<svg>`, `<video>`, `<iframe>`, and others. Media takes up 100% width by default and scales according to its container's width.
 
 ```html {.example}
-<img 
-  src="https://images.unsplash.com/photo-1620196244888-d31ff5bbf163?q=80&w=1000&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D" 
+<img
+  src="https://images.unsplash.com/photo-1620196244888-d31ff5bbf163?q=80&w=1000&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
   alt="A gray kitten lays next to a toy"
 />
 ```
@@ -204,7 +212,9 @@ Structure tabular data with `<table>` and related elements like `<caption>`, `<t
 ```html {.example}
 <table>
   <caption>
-    This <code>&lt;caption&gt;</code> describes the table
+    This
+    <code>&lt;caption&gt;</code>
+    describes the table
   </caption>
   <thead>
     <tr>
@@ -347,7 +357,6 @@ Create buttons with `<button>` or `<input type="button | submit | reset">`. Butt
 
 Add the `wa-brand`, `wa-neutral`, `wa-success`, `wa-warning`, or `wa-danger` class to specify the button's [color variant](/docs/utilities/color/).
 
-
 ```html {.example}
 <button class="wa-neutral">Neutral</button>
 <button class="wa-brand">Brand</button>
@@ -406,7 +415,8 @@ Create a variety of form controls with `<input type="">`, `<select>`, and `<text
   <label>Color <input type="color" value="#f36944" /></label>
   <label>File <input type="file" multiple /></label>
   <label>Range <input type="range" /></label>
-  <label>Select
+  <label
+    >Select
     <select>
       <option value="option-1">Option 1</option>
       <option value="option-2">Option 2</option>
@@ -432,6 +442,7 @@ Create a variety of form controls with `<input type="">`, `<select>`, and `<text
 ```
 
 Add the `wa-size-s`, `wa-size-m`, or `wa-size-l` class to any form control or its parent `<label>` to specify its size.
+
 ```html {.example}
 <div class="wa-stack">
   <input type="text" placeholder="Small input" class="wa-size-s" />
@@ -510,7 +521,8 @@ Wrap form controls in a flex container to arrange them horizontally or verticall
 
 <form class="wa-stack">
   <label>Number of pancakes <input type="number" value="5" /></label>
-  <label>Syrup flavor
+  <label
+    >Syrup flavor
     <select>
       <option value="maple">Maple</option>
       <option value="strawberry">Strawberry</option>


### PR DESCRIPTION
- Removes the 11ty `cdnUrl` function since we only support projects/kits via CDN
- Removes `<html data-cdn-url="...">`
- Adds `<html data-version="...">`
- Updates search to use `?v={version}` to support long term caching in the app