### PR TITLE
Fix: Home View's Page + Open Graph Titles

### DIFF
--- a/packages/webawesome/docs/.eleventy.js
+++ b/packages/webawesome/docs/.eleventy.js
@@ -182,8 +182,16 @@ export default async function (eleventyConfig) {
   // Attach lastUpdatedISO to page data so templates can use {{ lastUpdatedISO }} directly
   eleventyConfig.addGlobalData('eleventyComputed', {
     lastUpdatedISO: data => getLastModifiedISO(data.page?.inputPath, data.lastUpdated),
-    // Open Graph metadata with smart defaults
-    ogTitle: data => data.ogTitle || data.title,
+    // Page title with smart + default site name formatting
+    pageTitle: data => {
+      const title = data.title || siteMetadata.name;
+      return title !== siteMetadata.name ? `${title} | ${siteMetadata.name}` : title;
+    },
+    // Open Graph title with smart + default site name formatting
+    ogTitle: data => {
+      const ogTitle = data.ogTitle || data.title || siteMetadata.name;
+      return ogTitle !== siteMetadata.name ? `${ogTitle} | ${siteMetadata.name}` : ogTitle;
+    },
     ogDescription: data => data.ogDescription || data.description,
     ogImage: data => data.ogImage || siteMetadata.image,
     ogUrl: data => {

--- a/packages/webawesome/docs/_includes/head.njk
+++ b/packages/webawesome/docs/_includes/head.njk
@@ -3,13 +3,13 @@
 <meta name="description" content="{{ description }}">
 {% if noindex or unlisted %}<meta name="robots" content="noindex">{% endif %}
 
-<title>{{ title }} | {{ siteMetadata.name }}</title>
+<title>{{ pageTitle }}</title>
 
 {# Skip OG tags for unlisted/noindex pages to prevent social sharing #}
 {% if not (noindex or unlisted) %}
   <meta property="og:type" content="{{ ogType }}" />
   <meta property="og:url" content="{{ ogUrl }}" />
-  <meta property="og:title" content="{{ ogTitle }} | {{ siteMetadata.name }}" />
+  <meta property="og:title" content="{{ ogTitle }}" />
   <meta property="og:description" content="{{ ogDescription }}" />
   <meta property="og:image" content="{{ ogImage }}" />
   <meta property="og:site_name" content="{{ siteMetadata.name }}" />


### PR DESCRIPTION
This PR fixes title rendering for the home page by introducing smart formatting that avoids redundant site name duplication. When the page title matches the site name, it now displays only once instead of appearing as "Site Name | Site Name".