### PR TITLE
Fix theme + palette radio styles

### DIFF
--- a/packages/webawesome/docs/docs/color-palettes.njk
+++ b/packages/webawesome/docs/docs/color-palettes.njk
@@ -178,6 +178,7 @@ Then apply the following class to the `<html>` element:
       display: flex;
       flex-direction: row;
       flex-wrap: wrap;
+      gap: var(--wa-space-m);
     }
 
     &::part(form-control-label) {
@@ -190,7 +191,11 @@ Then apply the following class to the `<html>` element:
       overflow: hidden;
       white-space: nowrap;
       padding: 0;
-   }
+    }
+
+    wa-radio {
+      margin-inline: 0;
+    }
   }
 
   .palette-card {

--- a/packages/webawesome/docs/docs/themes.njk
+++ b/packages/webawesome/docs/docs/themes.njk
@@ -279,14 +279,13 @@ Then apply the following classes to the `<html>` element:
   }
 
   #theme-viewer {
-    margin-block-start: 2rem;
-
     #theme-picker {
 
       &::part(form-control-input) {
         display: flex;
         flex-direction: row;
         flex-wrap: wrap;
+        gap: var(--wa-space-m);
       }
 
       &::part(form-control-label) {
@@ -299,6 +298,10 @@ Then apply the following classes to the `<html>` element:
         overflow: hidden;
         white-space: nowrap;
         padding: 0;
+      }
+
+      wa-radio {
+        margin-inline: 0;
       }
     }
 


### PR DESCRIPTION
Ensures theme and palette radios aren't borked when wrapping.

<img width="2246" height="692" alt="image" src="https://github.com/user-attachments/assets/5ec2347d-2dc9-40b8-a661-c1647076a3de" />
