### PR TITLE
Fix theme and palette option spacing

### DIFF
--- a/packages/webawesome/docs/docs/color-palettes.njk
+++ b/packages/webawesome/docs/docs/color-palettes.njk
@@ -178,6 +178,7 @@ Then apply the following class to the `<html>` element:
       display: flex;
       flex-direction: row;
       flex-wrap: wrap;
+      gap: var(--wa-space-s);
     }
 
     &::part(form-control-label) {
@@ -201,6 +202,7 @@ Then apply the following class to the `<html>` element:
     align-items: center;
     justify-content: center;
     min-height: var(--wa-space-3xl);
+    margin: 0;
     padding: var(--spacing);
     background-color: var(--wa-color-surface-default);
     border: 1px solid var(--wa-color-surface-border);

--- a/packages/webawesome/docs/docs/themes.njk
+++ b/packages/webawesome/docs/docs/themes.njk
@@ -287,6 +287,7 @@ Then apply the following classes to the `<html>` element:
         display: flex;
         flex-direction: row;
         flex-wrap: wrap;
+        gap: var(--wa-space-s);
       }
 
       &::part(form-control-label) {
@@ -310,6 +311,7 @@ Then apply the following classes to the `<html>` element:
       align-items: center;
       justify-content: center;
       min-height: var(--wa-space-3xl);
+      margin: 0;
       padding: var(--spacing);
       border: 1px solid var(--wa-color-surface-border);
       border-radius: var(--border-radius);


### PR DESCRIPTION
Fixes the spacing between options at `/docs/themes` and `/docs/color-palettes`.

Before
<img width="2246" height="692" alt="image" src="https://github.com/user-attachments/assets/ede8b292-0695-435f-84a9-414f892251ff" />


After
<img width="1111" height="355" alt="Screenshot 2025-10-27 at 11 01 24 PM" src="https://github.com/user-attachments/assets/b4df4357-e882-483f-b22b-0515f556f4e2" />
