### PR TITLE
Docs: Adding CSS Selector Info to Components

### DIFF
--- a/packages/webawesome/docs/_layouts/component.njk
+++ b/packages/webawesome/docs/_layouts/component.njk
@@ -211,7 +211,12 @@
             <tr>
               <td class="table-name"><code>{{ state.name }}</code></td>
               <td class="table-description">{{ state.description | inlineMarkdown | safe }}</td>
-              <td class="table-selector"><code>:state({{ state.name }})</code></td>
+              <td class="table-selector">
+                <span class="wa-cluster wa-gap-3xs">
+                  <code>:state({{ state.name }})</code>
+                  <wa-copy-button value=":state({{ state.name }})"></wa-copy-button>
+                </span>
+              </td>
             </tr>
           {% endfor %}
         </tbody>

--- a/packages/webawesome/docs/_layouts/component.njk
+++ b/packages/webawesome/docs/_layouts/component.njk
@@ -230,6 +230,7 @@
           <tr>
             <th class="table-name">Name</th>
             <th class="table-description">Description</th>
+            <th class="table-selector">CSS selector</th>
           </tr>
         </thead>
         <tbody>
@@ -237,6 +238,12 @@
             <tr>
               <td class="table-name"><code>{{ cssPart.name }}</code></td>
               <td class="table-description">{{ cssPart.description | inlineMarkdown | safe }}</td>
+              <td class="table-selector">
+                <span class="wa-cluster wa-gap-3xs">
+                  <code>::part({{ cssPart.name }})</code>
+                  <wa-copy-button value="::part({{ cssPart.name }})"></wa-copy-button>
+                </span>
+              </td>
             </tr>
           {% endfor %}
         </tbody>

--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -665,6 +665,10 @@ wa-scroller:has(.component-table) {
     min-width: var(--line-length-xs);
   }
 
+  .table-selector .wa-cluster {
+    flex-wrap: nowrap;
+  }
+
   .table-reflect {
     text-align: center;
   }


### PR DESCRIPTION
This PR adds copy buttons to CSS selector columns in the component documentation tables for Custom States and CSS Parts sections. The changes enhance the user experience by allowing developers to easily copy selectors like `:state()` and `::part()` to their clipboard.

- Added copy buttons next to CSS selectors in Custom States and CSS Parts tables
- Added `flex-wrap: nowrap` styling to prevent the selector content from wrapping
- Added "CSS selector" column header to the CSS Parts table

---

- @claviska whatchu think?