### PR TITLE
Docs: Add Planned Features to Navigation (Part Deux)

### DIFF
--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -29,7 +29,7 @@
   <li><a href="/docs/resources/contributing">Contributing</a></li>
   <li><a href="/docs/resources/changelog">Changelog</a></li>
   <li><a href="/docs/resources/visual-tests">Visual Tests</a></li>
-  
+
 
 </ul>
 
@@ -101,6 +101,7 @@
         <li><a href="/docs/components/dropdown-item">Dropdown Item</a></li>
       </ul>
     </li>
+    <li><span class="is-planned wa-split">File Input <a href="https://github.com/shoelace-style/webawesome/issues/1240" target="_blank">{{ plannedBadge("A Web Awesome Kickstarter stretch goal!") }}</a></span></li>
     <li><a href="/docs/components/format-bytes/">Format Bytes</a></li>
     <li><a href="/docs/components/format-date/">Format Date</a></li>
     <li><a href="/docs/components/format-number/">Format Number</a></li>
@@ -109,6 +110,7 @@
     <li><a href="/docs/components/input/">Input</a></li>
     <li><a href="/docs/components/intersection-observer">Intersection Observer</a></li>
     <li><a href="/docs/components/mutation-observer/">Mutation Observer</a></li>
+    <li><span class="is-planned wa-split">Number Input <a href="https://github.com/shoelace-style/webawesome/issues/1688" target="_blank">{{ plannedBadge("A Web Awesome Kickstarter stretch goal!") }}</a></span></li>
     <li><a href="/docs/components/popover/">Popover</a></li>
     <li><a href="/docs/components/popup/">Popup</a></li>
     <li><a href="/docs/components/progress-bar/">Progress Bar</a></li>
@@ -144,9 +146,15 @@
     </li>
     <li><a href="/docs/components/tag/">Tag</a></li>
     <li><a href="/docs/components/textarea/">Textarea</a></li>
+    <li><span class="is-planned wa-split">Toast <a href="https://github.com/shoelace-style/webawesome/issues/105" target="_blank">{{ plannedBadge("A Web Awesome Kickstarter stretch goal!") }}</a></span></li>
     <li><a href="/docs/components/tooltip/">Tooltip</a></li>
-    <li><a href="/docs/components/tree/">Tree</a></li>
-    <li><a href="/docs/components/tree-item/">Tree Item</a></li>
+    <li>
+      <a href="/docs/components/tree/">Tree</a>
+      <ul>
+        <li><a href="/docs/components/tree-item/">Tree Item</a></li>
+      </ul>
+    </li>
+    <li><span class="is-planned wa-split">Video <a href="https://github.com/shoelace-style/webawesome/issues/985" target="_blank">{{ plannedBadge("A Web Awesome Kickstarter stretch goal!") }}</a></span></li>
     <li><a href="/docs/components/zoomable-frame">Zoomable Frame</a></li>
     {# PLOP_NEW_COMPONENT_PLACEHOLDER #}
   </ul>


### PR DESCRIPTION
Following up on https://github.com/shoelace-style/webawesome/pull/1539, this work adds the additional and known stretch goal-based components we plan on building to our Docs navigation. 

It also links the "planned" badge to the corresponding GitHub issue to help folks follow along.