### PR TITLE
Remove unsupported property; closes #1677

### DIFF
--- a/packages/webawesome/src/components/button-group/button-group.ts
+++ b/packages/webawesome/src/components/button-group/button-group.ts
@@ -3,7 +3,6 @@ import { html } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import WebAwesomeElement from '../../internal/webawesome-element.js';
-import variantStyles from '../../styles/utilities/variants.css';
 import type WaButton from '../button/button.js';
 import styles from './button-group.css';
 
@@ -19,7 +18,7 @@ import styles from './button-group.css';
  */
 @customElement('wa-button-group')
 export default class WaButtonGroup extends WebAwesomeElement {
-  static css = [variantStyles, styles];
+  static css = [styles];
 
   @query('slot') defaultSlot: HTMLSlotElement;
 
@@ -34,9 +33,6 @@ export default class WaButtonGroup extends WebAwesomeElement {
 
   /** The button group's orientation. */
   @property({ reflect: true }) orientation: 'horizontal' | 'vertical' = 'horizontal';
-
-  /** The button group's theme variant. Defaults to `neutral` if not within another element with a variant. */
-  @property({ reflect: true }) variant: 'neutral' | 'brand' | 'success' | 'warning' | 'danger' = 'neutral';
 
   updated(changedProperties: PropertyValues<this>) {
     super.updated(changedProperties);


### PR DESCRIPTION
This property wasn't removed during an alpha cleanup. It didn't get highlighted because it's public. The styles also aren't used anywhere, so those have been removed as well.