### PR TITLE
Use tokens for `<wa-dropdown-item>` transitions

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -10,6 +10,10 @@ Web Awesome follows [Semantic Versioning](https://semver.org/). Breaking changes
 
 Components with the <wa-badge variant="warning">Experimental</wa-badge> badge should not be used in production. They are made available as release candidates for development and testing purposes. As such, changes to experimental components will not be subject to semantic versioning.
 
+## Next
+
+- Modified the default `transition` styles of `<wa-dropdown-item>` to use design tokens [pr:1693]
+
 ## 3.0.0
 
 - 🚨 BREAKING: Changed `appearance="filled outlined"` to `appearance="filled-outlined"` in the following elements [issue:1127]

--- a/packages/webawesome/src/components/dropdown-item/dropdown-item.css
+++ b/packages/webawesome/src/components/dropdown-item/dropdown-item.css
@@ -9,8 +9,8 @@
   line-height: var(--wa-line-height-condensed);
   cursor: pointer;
   transition:
-    100ms background-color ease,
-    100ms color ease;
+    var(--wa-transition-fast) background-color var(--wa-transition-easing),
+    var(--wa-transition-fast) color var(--wa-transition-easing);
 }
 
 @media (hover: hover) {


### PR DESCRIPTION
Updates the `transition` property of `<wa-dropdown-item>` to use design tokens instead of static values.