### PR TITLE
Fix `<wa-radio appearance="button">` focus styles

### DIFF
--- a/packages/webawesome/src/components/radio/radio.css
+++ b/packages/webawesome/src/components/radio/radio.css
@@ -174,7 +174,7 @@
 }
 
 :host([appearance='button']:state(checked):focus-visible) {
-  outline: var(--wa-focus-ring-style) var(--wa-focus-ring-width) var(--wa-color-brand-border-loud);
+  outline: var(--wa-focus-ring);
   outline-offset: var(--wa-focus-ring-offset);
 }
 


### PR DESCRIPTION
Fixes `<wa-radio>`s with `appearance="button"` to use our standard `--wa-focus-ring` token for focus styles.