### PR TITLE
Fix slider on devices that support touch and mouse; fixes #1703

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -10,6 +10,10 @@ Web Awesome follows [Semantic Versioning](https://semver.org/). Breaking changes
 
 Components with the <wa-badge variant="warning">Experimental</wa-badge> badge should not be used in production. They are made available as release candidates for development and testing purposes. As such, changes to experimental components will not be subject to semantic versioning.
 
+## Next
+
+- Fixed a bug in `<wa-slider>` that caused some touch devices to end up with the incorrect value [issue:1703]
+
 ## 3.0.0
 
 - 🚨 BREAKING: Changed `appearance="filled outlined"` to `appearance="filled-outlined"` in the following elements [issue:1127]

--- a/packages/webawesome/src/internal/drag.ts
+++ b/packages/webawesome/src/internal/drag.ts
@@ -84,8 +84,8 @@ export class DraggableElement {
   }
 
   private handleDragStart = (event: PointerEvent | TouchEvent) => {
-    const clientX = supportsTouch && 'touches' in event ? event.touches[0].clientX : (event as PointerEvent).clientX;
-    const clientY = supportsTouch && 'touches' in event ? event.touches[0].clientY : (event as PointerEvent).clientY;
+    const clientX = 'touches' in event ? event.touches[0].clientX : (event as PointerEvent).clientX;
+    const clientY = 'touches' in event ? event.touches[0].clientY : (event as PointerEvent).clientY;
 
     if (
       this.isDragging ||
@@ -105,8 +105,8 @@ export class DraggableElement {
   };
 
   private handleDragStop = (event: PointerEvent | TouchEvent) => {
-    const clientX = supportsTouch && 'touches' in event ? event.touches[0].clientX : (event as PointerEvent).clientX;
-    const clientY = supportsTouch && 'touches' in event ? event.touches[0].clientY : (event as PointerEvent).clientY;
+    const clientX = 'touches' in event ? event.touches[0].clientX : (event as PointerEvent).clientX;
+    const clientY = 'touches' in event ? event.touches[0].clientY : (event as PointerEvent).clientY;
 
     this.isDragging = false;
     document.removeEventListener('pointerup', this.handleDragStop);
@@ -117,8 +117,8 @@ export class DraggableElement {
   };
 
   private handleDragMove = (event: PointerEvent | TouchEvent) => {
-    const clientX = supportsTouch && 'touches' in event ? event.touches[0].clientX : (event as PointerEvent).clientX;
-    const clientY = supportsTouch && 'touches' in event ? event.touches[0].clientY : (event as PointerEvent).clientY;
+    const clientX = 'touches' in event ? event.touches[0].clientX : (event as PointerEvent).clientX;
+    const clientY = 'touches' in event ? event.touches[0].clientY : (event as PointerEvent).clientY;
 
     // Prevent text selection while dragging
     window.getSelection()?.removeAllRanges();


### PR DESCRIPTION
The `supportsTouch` check isn't useful here, as a device can support touch + mouse at the same time which causes #1703. This solution looks for a touch event first, then falls back to mouse.