### PR TITLE
Control 11ty-Generated Headings' Display via Front Matter

### DIFF
--- a/packages/webawesome/docs/_includes/base.njk
+++ b/packages/webawesome/docs/_includes/base.njk
@@ -28,7 +28,7 @@
   </head>
   <body class="layout-{{ layout | stripExtension }} page-{{ pageClass or page.fileSlug or 'home' }}{{ ' page-wide' if wide }}">
     {% if hasBanner == undefined %}{% set hasBanner = true %}{% endif %}
-    {% if hasHiddenGeneratedTitle == undefined %}{% set hasHiddenGeneratedTitle = false %}{% endif %}
+    {% if hasGeneratedTitle == undefined %}{% set hasGeneratedTitle = true %}{% endif %}
 
     {% set defaultWaPageAttributes = defaultWaPageAttributes or { view: 'desktop', 'disable-navigation-toggle': true, 'mobile-breakpoint': 1180, 'disable-sticky': 'banner' } %}
     {% set waPageAttributes = waPageAttributes or {} %}
@@ -119,7 +119,7 @@
         <div id="flashes">{% server "flashes" %}</div>
 
         {% block header %}
-          <h1 class="title title-generated{{ ' is-hidden' if hasHiddenGeneratedTitle }}">{{ title }}</h1>
+          <h1 class="title title-generated{{ ' hidden' if not hasGeneratedTitle }}">{{ title }}</h1>
         {% endblock %}
 
         {% block beforeContent %}{% endblock %}

--- a/packages/webawesome/docs/_includes/base.njk
+++ b/packages/webawesome/docs/_includes/base.njk
@@ -27,9 +27,8 @@
     </script>
   </head>
   <body class="layout-{{ layout | stripExtension }} page-{{ pageClass or page.fileSlug or 'home' }}{{ ' page-wide' if wide }}">
-    {% if hasBanner == undefined %}
-      {% set hasBanner = true %}
-    {% endif %}
+    {% if hasBanner == undefined %}{% set hasBanner = true %}{% endif %}
+    {% if hasHiddenGeneratedTitle == undefined %}{% set hasHiddenGeneratedTitle = false %}{% endif %}
 
     {% set defaultWaPageAttributes = defaultWaPageAttributes or { view: 'desktop', 'disable-navigation-toggle': true, 'mobile-breakpoint': 1180, 'disable-sticky': 'banner' } %}
     {% set waPageAttributes = waPageAttributes or {} %}
@@ -120,7 +119,7 @@
         <div id="flashes">{% server "flashes" %}</div>
 
         {% block header %}
-          <h1 class="title">{{ title }}</h1>
+          <h1 class="title title-generated{{ ' is-hidden' if hasHiddenGeneratedTitle }}">{{ title }}</h1>
         {% endblock %}
 
         {% block beforeContent %}{% endblock %}

--- a/packages/webawesome/docs/_includes/base.njk
+++ b/packages/webawesome/docs/_includes/base.njk
@@ -119,7 +119,9 @@
         <div id="flashes">{% server "flashes" %}</div>
 
         {% block header %}
-          <h1 class="title title-generated{{ ' hidden' if not hasGeneratedTitle }}">{{ title }}</h1>
+          {% if hasGeneratedTitle %}
+            <h1 class="title">{{ title }}</h1>
+          {% endif %}
         {% endblock %}
 
         {% block beforeContent %}{% endblock %}

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -68,8 +68,8 @@
   /* #endregion */
 
   /* #region shared UI */
-  /* hide 11ty generated titles (set hasHiddenGeneratedTitle front matter to true to hide the title) */
-  .title-generated.is-hidden {
+  /* hide 11ty generated titles (set hasGeneratedTitle: false in front matter to hide the title) */
+  .title-generated.hidden {
     display: none;
   }
   /* pro badge */

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -68,6 +68,10 @@
   /* #endregion */
 
   /* #region shared UI */
+  /* hide 11ty generated titles (set hasHiddenGeneratedTitle front matter to true to hide the title) */
+  .title-generated.is-hidden {
+    display: none;
+  }
   /* pro badge */
   wa-badge.pro {
     color: white;
@@ -122,7 +126,6 @@
       --secondary-color: var(--wa-color-neutral-30);
     }
   }
-
   /* #endregion */
 
   /* #region funsies + cosmetics */

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -68,10 +68,6 @@
   /* #endregion */
 
   /* #region shared UI */
-  /* hide 11ty generated titles (set hasGeneratedTitle: false in front matter to hide the title) */
-  .title-generated.hidden {
-    display: none;
-  }
   /* pro badge */
   wa-badge.pro {
     color: white;


### PR DESCRIPTION
This PR adds functionality to hide 11ty-generated page titles through front matter configuration conditionally. When `hasGeneratedTitle` is set to `false` in a page's front matter, the generated title will be hidden using CSS.

- Added `hasGeneratedTitle` front matter variable with default value of `true`

---

@lindsaym-fa mind checking my choices here and making sure this is a better way to go than per-view custom CSS?