### PR TITLE
Adding a `reflect` property option to the `name` property

### DIFF
--- a/packages/webawesome/src/components/select/select.ts
+++ b/packages/webawesome/src/components/select/select.ts
@@ -119,7 +119,7 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
   @state() optionValues: Set<string | null> | undefined;
 
   /** The name of the select, submitted as a name/value pair with form data. */
-  @property() name = '';
+  @property({ reflect: true }) name = '';
 
   private _defaultValue: null | string | string[] = null;
 


### PR DESCRIPTION
This PR is a fix for issue #1711 

The `{ reflect: true }` option for the `name` property of `<wa-select>` is missing, and causes React to remove the `name` property in certain situations, breaking any form that uses such a component.