### PR TITLE
Fix <wa-tree>: restore spinner visibility during lazy loading

### DIFF
--- a/packages/webawesome/src/components/tree-item/tree-item.ts
+++ b/packages/webawesome/src/components/tree-item/tree-item.ts
@@ -252,6 +252,7 @@ export default class WaTreeItem extends WebAwesomeElement {
         class="${classMap({
           'tree-item': true,
           'tree-item-expanded': this.expanded,
+          'tree-item-loading': this.loading,
           'tree-item-selected': this.selected,
           'tree-item-leaf': this.isLeaf,
           'tree-item-has-expand-button': showExpandButton,
@@ -268,11 +269,13 @@ export default class WaTreeItem extends WebAwesomeElement {
             })}
             aria-hidden="true"
           >
+            ${when(
+              this.loading,
+              () => html`<slot class="spinner-slot" name="spinner">
+                <wa-spinner part="spinner" exportparts="base:spinner__base"></wa-spinner>
+              </slot>`,
+            )}
             <slot class="expand-icon-slot" name="expand-icon">
-              ${when(
-                this.loading,
-                () => html` <wa-spinner part="spinner" exportparts="base:spinner__base"></wa-spinner> `,
-              )}
               <wa-icon name=${isRtl ? 'chevron-left' : 'chevron-right'} library="system" variant="solid"></wa-icon>
             </slot>
             <slot class="expand-icon-slot" name="collapse-icon">


### PR DESCRIPTION
Fixes: https://github.com/shoelace-style/webawesome/issues/1678

This PR restores the loading spinner that appears while a tree item is fetching its children during lazy loading.
Previously, the spinner wasn’t rendered because it was placed inside the existing expand-icon slot, which was being hidden by the expand/collapse CSS selectors.

The spinner is now rendered through a dedicated spinner slot, ensuring it displays correctly without interfering with expand or collapse icons.

Preview:
<img width="937" height="478" alt="image" src="https://github.com/user-attachments/assets/0499493c-b020-42e0-894d-d87a0e94186e" />
