### PR TITLE
Allow Setting `data-no-anchor` at the View-Level

### DIFF
--- a/packages/webawesome/docs/_includes/base.njk
+++ b/packages/webawesome/docs/_includes/base.njk
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" data-fa-kit-code="38c11e3f20" data-version="{{ package.version }}" class="wa-cloak">
+<html lang="en" data-fa-kit-code="38c11e3f20" data-version="{{ package.version }}" class="wa-cloak"{% if hasAnchors == false %} data-no-anchor{% endif %}>
   <head>
     {% include 'head.njk' %}
     <meta name="theme-color" content="#f36944">
@@ -29,6 +29,7 @@
   <body class="layout-{{ layout | stripExtension }} page-{{ pageClass or page.fileSlug or 'home' }}{{ ' page-wide' if wide }}">
     {% if hasBanner == undefined %}{% set hasBanner = true %}{% endif %}
     {% if hasGeneratedTitle == undefined %}{% set hasGeneratedTitle = true %}{% endif %}
+    {% if hasAnchors == undefined %}{% set hasAnchors = true %}{% endif %}
 
     {% set defaultWaPageAttributes = defaultWaPageAttributes or { view: 'desktop', 'disable-navigation-toggle': true, 'mobile-breakpoint': 1180, 'disable-sticky': 'banner' } %}
     {% set waPageAttributes = waPageAttributes or {} %}

--- a/packages/webawesome/docs/_includes/base.njk
+++ b/packages/webawesome/docs/_includes/base.njk
@@ -1,4 +1,7 @@
 <!DOCTYPE html>
+{% if hasAnchors == undefined %}{% set hasAnchors = true %}{% endif %}
+{% if hasBanner == undefined %}{% set hasBanner = true %}{% endif %}
+{% if hasGeneratedTitle == undefined %}{% set hasGeneratedTitle = true %}{% endif %}
 <html lang="en" data-fa-kit-code="38c11e3f20" data-version="{{ package.version }}" class="wa-cloak"{% if hasAnchors == false %} data-no-anchor{% endif %}>
   <head>
     {% include 'head.njk' %}
@@ -27,9 +30,6 @@
     </script>
   </head>
   <body class="layout-{{ layout | stripExtension }} page-{{ pageClass or page.fileSlug or 'home' }}{{ ' page-wide' if wide }}">
-    {% if hasBanner == undefined %}{% set hasBanner = true %}{% endif %}
-    {% if hasGeneratedTitle == undefined %}{% set hasGeneratedTitle = true %}{% endif %}
-    {% if hasAnchors == undefined %}{% set hasAnchors = true %}{% endif %}
 
     {% set defaultWaPageAttributes = defaultWaPageAttributes or { view: 'desktop', 'disable-navigation-toggle': true, 'mobile-breakpoint': 1180, 'disable-sticky': 'banner' } %}
     {% set waPageAttributes = waPageAttributes or {} %}

--- a/packages/webawesome/docs/_transformers/anchor-headings.js
+++ b/packages/webawesome/docs/_transformers/anchor-headings.js
@@ -35,9 +35,23 @@ export function anchorHeadingsTransformer(options = {}) {
       return doc;
     }
 
-    // Look for headings
-    let selector = `:is(${options.headingSelector}):not([data-no-anchor], [data-no-anchor] *)`;
+    // Check if the document or container has data-no-anchor (view-level)
+    const hasNoAnchorOnDocument = doc.querySelector('html')?.hasAttribute('data-no-anchor') || false;
+    const hasNoAnchorOnContainer = container.closest('[data-no-anchor]') !== null;
+
+    // If view-level data-no-anchor is set, skip processing all headings
+    if (hasNoAnchorOnDocument || hasNoAnchorOnContainer) {
+      return doc;
+    }
+
+    // Look for headings (selector excludes headings with data-no-anchor attribute)
+    let selector = `:is(${options.headingSelector}):not([data-no-anchor])`;
     container.querySelectorAll(selector).forEach(heading => {
+      // Skip if heading is a descendant of an element with data-no-anchor
+      // (selector already excludes headings with the attribute directly)
+      if (heading.closest('[data-no-anchor]') !== null) {
+        return;
+      }
       const hasAnchor = heading.querySelector('a');
       const existingId = heading.getAttribute('id');
       const clone = parse(heading.outerHTML);


### PR DESCRIPTION
This PR adds support for globally disabling heading anchors on pages through a `hasAnchors` flag. Pages can now set `hasAnchors: false` in their front matter to suppress anchor link generation for all headings on that page.

- Added a `hasAnchors` variable with a default value of `true` in the template
- Modified the `<html>` tag to conditionally add the `data-no-anchor` attribute when `hasAnchors` is set to `false`

One can still generate anchors for a view and then surgically chose to not via the `data-no-anchor` being set on a DOM element.

---

- @lindsaym-fa, similar to https://github.com/shoelace-style/webawesome/pull/1715, mind making sure this approach feels right and is helpful to managing when we want to disable anchor generation at a view level?