### PR TITLE
Add missing and allow passing of aria attributes for dialogs

### DIFF
--- a/packages/webawesome/src/components/dialog/dialog.ts
+++ b/packages/webawesome/src/components/dialog/dialog.ts
@@ -1,6 +1,7 @@
 import { html, isServer } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { WaAfterHideEvent } from '../../events/after-hide.js';
 import { WaAfterShowEvent } from '../../events/after-show.js';
 import { WaHideEvent } from '../../events/hide.js';
@@ -75,6 +76,13 @@ export default class WaDialog extends WebAwesomeElement {
 
   /** When enabled, the dialog will be closed when the user clicks outside of it. */
   @property({ attribute: 'light-dismiss', type: Boolean }) lightDismiss = false;
+
+  /** The ID of the element that labels the dialog.
+   *  Overrides the default `aria-labelledby="title"`. */
+  @property({ attribute: 'aria-labelledby' }) ariaLabelledby?: string;
+
+  /** The ID of the element that describes the dialog. */
+  @property({ attribute: 'aria-describedby' }) ariaDescribedby?: string;
 
   firstUpdated() {
     if (this.open) {
@@ -213,6 +221,8 @@ export default class WaDialog extends WebAwesomeElement {
 
     return html`
       <dialog
+        aria-labelledby=${this.ariaLabelledby ?? 'title'}
+        aria-describedby=${ifDefined(this.ariaDescribedby)}
         part="dialog"
         class=${classMap({
           dialog: true,

--- a/packages/webawesome/src/components/drawer/drawer.ts
+++ b/packages/webawesome/src/components/drawer/drawer.ts
@@ -1,6 +1,7 @@
 import { html, isServer } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { WaAfterHideEvent } from '../../events/after-hide.js';
 import { WaAfterShowEvent } from '../../events/after-show.js';
 import { WaHideEvent } from '../../events/hide.js';
@@ -84,6 +85,13 @@ export default class WaDrawer extends WebAwesomeElement {
 
   /** When enabled, the drawer will be closed when the user clicks outside of it. */
   @property({ attribute: 'light-dismiss', type: Boolean }) lightDismiss = true;
+
+  /** The ID of the element that labels the drawer dialog.
+   *  Overrides the default `aria-labelledby="title"`. */
+  @property({ attribute: 'aria-labelledby' }) ariaLabelledby?: string;
+
+  /** The ID of the element that describes the drawer dialog. */
+  @property({ attribute: 'aria-describedby' }) ariaDescribedby?: string;
 
   firstUpdated() {
     if (isServer) {
@@ -226,7 +234,9 @@ export default class WaDrawer extends WebAwesomeElement {
 
     return html`
       <dialog
-        part="dialog"
+        aria-labelledby=${this.ariaLabelledby ?? 'title'}
+        aria-describedby=${ifDefined(this.ariaDescribedby)}
+        part="drawer"
         class=${classMap({
           drawer: true,
           open: this.open,

--- a/packages/webawesome/src/components/popover/popover.ts
+++ b/packages/webawesome/src/components/popover/popover.ts
@@ -2,6 +2,7 @@ import type { PropertyValues } from 'lit';
 import { html } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { WaAfterHideEvent } from '../../events/after-hide.js';
 import { WaAfterShowEvent } from '../../events/after-show.js';
 import { WaHideEvent } from '../../events/hide.js';
@@ -87,6 +88,12 @@ export default class WaPopover extends WebAwesomeElement {
 
   /** Removes the arrow from the popover. */
   @property({ attribute: 'without-arrow', type: Boolean, reflect: true }) withoutArrow = false;
+
+  /** The ID of the element that labels the popover dialog. */
+  @property({ attribute: 'aria-labelledby' }) ariaLabelledby?: string;
+
+  /** The ID of the element that describes the popover dialog. */
+  @property({ attribute: 'aria-describedby' }) ariaDescribedby?: string;
 
   private eventController = new AbortController();
 
@@ -287,7 +294,12 @@ export default class WaPopover extends WebAwesomeElement {
 
   render() {
     return html`
-      <dialog part="dialog" class="dialog">
+      <dialog
+        aria-labelledby=${ifDefined(this.ariaLabelledby)}
+        aria-describedby=${ifDefined(this.ariaDescribedby)}
+        part="dialog"
+        class="dialog"
+      >
         <wa-popup
           part="popup"
           exportparts="


### PR DESCRIPTION
Fixes: #1722

Adds `aria-labelledby` and `aria-describedby` attributes to:

- wa-dialog
- wa-drawer 
- wa-popover

`wa-dialog` and `wa-drawer` have a default label from the title id, which has been added unless overridden by the caller.