### PR TITLE
🧼 Anchor Link Clean Up

### DIFF
--- a/packages/webawesome/docs/_transformers/anchor-headings.js
+++ b/packages/webawesome/docs/_transformers/anchor-headings.js
@@ -79,7 +79,7 @@ export function anchorHeadingsTransformer(options = {}) {
       const anchor = parse(`
         <a href="#${encodeURIComponent(id)}">
           <span class="wa-visually-hidden"></span>
-          <span aria-hidden="true">#</span>
+          <wa-icon variant="regular" name="hashtag" class="icon-shrink"></wa-icon>
         </a>
       `);
       anchor.querySelector('.wa-visually-hidden').textContent = options.anchorLabel;

--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -351,26 +351,6 @@ h1.title {
   }
 }
 
-/* Anchor headings */
-.anchor-heading a {
-  visibility: hidden;
-  text-decoration: none;
-}
-
-@media (hover: hover) {
-  .anchor-heading:hover a {
-    visibility: visible;
-    padding: 0 0.125em;
-  }
-}
-
-@media print {
-  /* Show URLs for printed links */
-  a:not(.anchor-heading)[href]::after {
-    content: ' (' attr(href) ')';
-  }
-}
-
 /* Callouts */
 .callout {
   display: flex;

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -122,6 +122,26 @@
       --secondary-color: var(--wa-color-neutral-30);
     }
   }
+
+  /* anchor headings */
+  .anchor-heading a {
+    visibility: hidden;
+    text-decoration: none;
+  }
+
+  @media (hover: hover) {
+    .anchor-heading:hover a {
+      visibility: visible;
+      padding: 0 0.125em;
+    }
+  }
+
+  @media print {
+    /* show URLs for printed links */
+    a:not(.anchor-heading)[href]::after {
+      content: ' (' attr(href) ')';
+    }
+  }
   /* #endregion */
 
   /* #region funsies + cosmetics */

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -123,16 +123,19 @@
     }
   }
 
-  /* anchor headings */
+  /* anchor headings  */
   .anchor-heading a {
+    opacity: 0;
     visibility: hidden;
     text-decoration: none;
+    transition: opacity var(--wa-transition-normal) var(--wa-transition-easing);
   }
 
   @media (hover: hover) {
     .anchor-heading:hover a {
+      opacity: 1;
       visibility: visible;
-      padding: 0 0.125em;
+      padding: var(--wa-space-3xs);
     }
   }
 


### PR DESCRIPTION
This PR refactors anchor heading styles by consolidating them from `docs.css` into `utils.css` and enhances the visual behavior. The changes replace the plain text "#" symbol with a `wa-icon` component for a more polished appearance.

**Key Changes:**
- Moved anchor heading styles from `docs.css` to `utils.css` for better organization
- Replaced the plain "#" character with a `wa-icon` component using the "hashtag" icon
- Enhanced hover animation with opacity transition and updated spacing using design tokens