### PR TITLE
CSS: Remove duplicate width property from select component

### DIFF
--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -38,7 +38,7 @@ wa-page > [slot='banner'] {
   }
 
   &.banner-wa-launch {
-    /* custom brand colors carrried over from theme-site for the banner */
+    /* custom brand colors carried over from theme-site for the banner */
     --wa-color-brand-95: #fef0ec;
     --wa-color-brand-90: #fce0d8;
     --wa-color-brand-80: #f8bcac;

--- a/packages/webawesome/src/components/select/select.css
+++ b/packages/webawesome/src/components/select/select.css
@@ -74,7 +74,6 @@
   padding: 0 var(--wa-form-control-padding-inline);
   position: relative;
   vertical-align: middle;
-  width: 100%;
   transition:
     background-color var(--wa-transition-normal),
     border var(--wa-transition-normal),


### PR DESCRIPTION
Deleted the duplicate 'width: 100%' style from the select component (already defined on line 56).

Also fixed a typo in a comment in the docs CSS.

You should setup Stylelint to prevent these issues :-)