### PR TITLE
Add Launch Sale Dialog

### DIFF
--- a/packages/webawesome/docs/_includes/_dialog-wa-launch.njk
+++ b/packages/webawesome/docs/_includes/_dialog-wa-launch.njk
@@ -1,0 +1,78 @@
+<wa-dialog id="dialog-site" light-dismiss without-header>
+
+  <div class="background-wa-pattern" style="justify-content: center; margin-inline: calc(var(--spacing) * -1); margin-block-start: calc(var(--spacing) * -1); margin-block-end: var(--spacing); background: linear-gradient(to bottom, var(--wa-color-brand), var(--wa-color-brand-50)); color: var(--wa-color-brand-on-loud); padding: var(--wa-space-3xl) var(--spacing); --background-pattern-opacity: 0.2; --background-pattern-image: url('/assets/images/bg-wa-pattern.svg');">
+
+    <div class="wa-stack wa-align-items-center" style="text-align: center;">
+      <wa-icon name="party-horn" family="duotone" variant="solid" style="font-size: var(--wa-font-size-3xl); --secondary-color: var(--wa-color-brand-on-quiet); --secondary-opacity: 1.0;"></wa-icon>
+      <h2 class="wa-heading-2xl brand-font">Get a lifetime discount on Web Awesome Pro!</h2>
+    </div>
+  </div>
+
+  <div class="wa-stack wa-gap-l">
+    <p>Celebrate our official launch with a 20% discount on a Web Awesome Pro plan&hellip;<span class="appearance-underlined variant-drawn" style="--underline-color: var(--wa-color-brand);">for life</span>! But hurry, this lifetime discount is only available for a limited time.</p>
+
+    <div class="wa-split">
+      <wa-button type="button" appearance="plain" data-dialog="close">Maybe Later</wa-button>
+      <wa-button variant="neutral" appearance="accent" href="/purchase" class="brand-font">
+        <wa-icon slot="start" variant="regular" name="rocket-launch"></wa-icon>
+        Get Pro + Save 20%
+      </wa-button>
+    </div>
+  </div>
+</wa-dialog>
+
+<script type="module">
+  (function() {
+    const SITE_DIALOG_DISMISSED_KEY = 'dialog-wa-launch-sale-dismissed';
+
+    // Early exit if user has dismissed the dialog
+    try {
+      if (localStorage.getItem(SITE_DIALOG_DISMISSED_KEY) === 'true') {
+        return;
+      }
+    } catch (e) {
+      // localStorage may be disabled or unavailable
+      return;
+    }
+
+    // Wait for DOM and dialog element
+    const dialog = document.getElementById('dialog-site');
+    if (!dialog) {
+      return;
+    }
+
+    // Initialize dialog functionality
+    let initCalled = false;
+    const initDialog = () => {
+      // Prevent double initialization
+      if (initCalled) {
+        return;
+      }
+      initCalled = true;
+
+      // Track when dialog is dismissed (via any method: overlay, escape, button, etc.)
+      dialog.addEventListener('wa-hide', () => {
+        try {
+          localStorage.setItem(SITE_DIALOG_DISMISSED_KEY, 'true');
+        } catch (e) {
+          // localStorage may be disabled
+        }
+      }, { once: true });
+
+      // Show dialog after a short delay to ensure page is loaded
+      setTimeout(() => {
+        dialog.open = true;
+      }, 500);
+    };
+
+    // Initialize when ready
+    if (customElements.get('wa-dialog')) {
+      initDialog();
+    } else {
+      document.addEventListener('wa-discovery-complete', initDialog, { once: true });
+      // Fallback timeout in case wa-discovery-complete doesn't fire
+      setTimeout(initDialog, 100);
+    }
+  })();
+</script>
+

--- a/packages/webawesome/docs/_includes/_dialog-wa-launch.njk
+++ b/packages/webawesome/docs/_includes/_dialog-wa-launch.njk
@@ -12,8 +12,8 @@
     <p>Celebrate our official launch with a 20% discount on a Web Awesome Pro plan&hellip;<span class="appearance-underlined variant-drawn" style="--underline-color: var(--wa-color-brand);">for life</span>! But hurry, this lifetime discount is only available for a limited time.</p>
 
     <div class="wa-split">
-      <wa-button type="button" appearance="plain" data-dialog="close">Maybe Later</wa-button>
-      <wa-button variant="neutral" appearance="accent" href="/purchase" class="brand-font">
+      <wa-button type="button" appearance="plain" data-dialog="close" class="plausible-event-name=launch_dialog:close_button_click">Maybe Later</wa-button>
+      <wa-button variant="neutral" appearance="accent" href="/purchase" class="brand-font plausible-event-name=launch_dialog:pro_purchase_button_click">
         <wa-icon slot="start" variant="regular" name="rocket-launch"></wa-icon>
         Get Pro + Save 20%
       </wa-button>
@@ -41,6 +41,13 @@
       return;
     }
 
+    // Helper function to safely track Plausible events
+    const trackEvent = (eventName) => {
+      if (typeof plausible !== 'undefined') {
+        plausible(eventName);
+      }
+    };
+
     // Initialize dialog functionality
     let initCalled = false;
     const initDialog = () => {
@@ -50,12 +57,24 @@
       }
       initCalled = true;
 
-      // Track when dialog is dismissed (via any method: overlay, escape, button, etc.)
-      dialog.addEventListener('wa-hide', () => {
+      // Track when dialog is shown
+      dialog.addEventListener('wa-show', () => {
+        trackEvent('launch_dialog:view');
+      }, { once: true });
+
+      // Track when dialog is dismissed
+      dialog.addEventListener('wa-hide', (event) => {
+        // Track overlay click or Escape key dismissal
+        // Button clicks are tracked via CSS classes, so we only track non-button dismissals
+        if (event.detail?.source === dialog) {
+          trackEvent('launch_dialog:overlay_click');
+        }
+
+        // Save dismissal state to localStorage
         try {
           localStorage.setItem(SITE_DIALOG_DISMISSED_KEY, 'true');
         } catch (e) {
-          // localStorage may be disabled
+          // localStorage may be disabled or unavailable
         }
       }, { once: true });
 

--- a/packages/webawesome/docs/_includes/base.njk
+++ b/packages/webawesome/docs/_includes/base.njk
@@ -139,6 +139,11 @@
 
       {#- Site-Wide Dialog -#}
       {% if hasSiteDialog %}
+        {% raw %}
+          {%- if not currentUser.hasPro -%}
+            {% include "_dialog-wa-launch.njk" ignore missing %}
+          {%- endif -%}
+        {% endraw %}
       {% endif %}
 
       {# Footer #}

--- a/packages/webawesome/docs/_includes/base.njk
+++ b/packages/webawesome/docs/_includes/base.njk
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 {% if hasAnchors == undefined %}{% set hasAnchors = true %}{% endif %}
 {% if hasBanner == undefined %}{% set hasBanner = true %}{% endif %}
+{% if hasSiteDialog == undefined %}{% set hasSiteDialog = true %}{% endif %}
 {% if hasGeneratedTitle == undefined %}{% set hasGeneratedTitle = true %}{% endif %}
 <html lang="en" data-fa-kit-code="38c11e3f20" data-version="{{ package.version }}" class="wa-cloak"{% if hasAnchors == false %} data-no-anchor{% endif %}>
   <head>
@@ -135,6 +136,10 @@
       </main>
 
       {% include 'search.njk' %}
+
+      {#- Site-Wide Dialog -#}
+      {% if hasSiteDialog %}
+      {% endif %}
 
       {# Footer #}
       {% block pageFooter %}{% endblock %}

--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -64,6 +64,24 @@ wa-page > [slot='banner'] {
   }
 }
 
+/* Site-Wide Dialog */
+#dialog-site {
+  /* custom brand colors carrried over from theme-site for the banner */
+  --wa-color-brand-95: #fef0ec;
+  --wa-color-brand-90: #fce0d8;
+  --wa-color-brand-80: #f8bcac;
+  --wa-color-brand-70: #fa9378;
+  --wa-color-brand-60: #f46a45;
+  --wa-color-brand-50: #cb4b27;
+  --wa-color-brand-40: #9d371a;
+  --wa-color-brand-30: #7c2a13;
+  --wa-color-brand-20: #5d1d0b;
+  --wa-color-brand-10: #3b0f05;
+  --wa-color-brand-05: #270802;
+  --wa-color-brand: var(--wa-color-brand-60);
+  --wa-color-brand-on: var(--wa-color-brand-10);
+}
+
 /* Header */
 wa-page::part(header) {
   background-color: var(--wa-color-surface-default);


### PR DESCRIPTION
This PR adds a site-wide promotional dialog for the Web Awesome launch sale, offering a 20% lifetime discount on Pro plans. The dialog is shown to non-Pro users and can be dismissed, with the dismissal state stored in localStorage to prevent showing it again.

- Adds a new `hasSiteDialog` flag to control dialog visibility (defaults to `true`)
- Creates a new reusable dialog component with promotional content and CTA buttons
- Implements dialog logic with localStorage persistence and customizable force-show mode for testing

---

<img width="2832" height="1540" alt="image" src="https://github.com/user-attachments/assets/769f2cda-3613-432e-a3e3-de5d08dea872" />

---

- @claviska, not sure if this needed, but I recall you mentioning this may be wanted to help promote the very limited sale on Web Awesome Pro. Feel free to review if that's the case.