### PR TITLE
Add 'lorem' to the language list in cspell.json

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -236,5 +236,6 @@
   "ignoreRegExpList": [
     "(^|[^a-z])sl[a-z]*(^|[^a-z])"
   ],
+  "language": "en, en-US, lorem",
   "useGitignore": true
 }


### PR DESCRIPTION
Lorem ipsum text is used in examples and as such is flagged as typos in VS Code / Cursor. The change in this PR fixes that.