### PR TITLE
Fix: Allow wa-hide to be cancelled in WaDropdown

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -16,6 +16,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - 🚨 BREAKING: Changed `appearance="filled outlined"` to `appearance="filled-outlined"` in `<wa-card>` [issue:1671]
 - Fixed a bug in `<wa-slider>` that caused some touch devices to end up with the incorrect value [issue:1703]
 - Fixed a bug in `<wa-card>` that prevented some slots from being detected correctly [discuss:1450]
+- Fixed a bug in `<wa-dropdown>` that caused the browser to hang when cancelling the `wa-hide` event [issue:1483]
 - Improved performance of `<wa-icon>` so initial rendering occurs faster, especially with multiple icons on the page [issue:1729]
 
 ## 3.0.0

--- a/packages/webawesome/src/components/dropdown/dropdown.test.ts
+++ b/packages/webawesome/src/components/dropdown/dropdown.test.ts
@@ -1,9 +1,119 @@
-import { expect, fixture, html } from '@open-wc/testing';
+import { aTimeout, expect, fixture, html, waitUntil } from '@open-wc/testing';
+import sinon from 'sinon';
+import type WaDropdown from './dropdown.js';
 
 describe('<wa-dropdown>', () => {
   it('should render a component', async () => {
     const el = await fixture(html` <wa-dropdown></wa-dropdown> `);
 
     expect(el).to.exist;
+  });
+
+  it('should not be open by default', async () => {
+    const el = await fixture<WaDropdown>(html`
+      <wa-dropdown>
+        <wa-button slot="trigger">Dropdown</wa-button>
+        <wa-dropdown-item>One</wa-dropdown-item>
+      </wa-dropdown>
+    `);
+
+    await el.updateComplete;
+    await aTimeout(200);
+
+    expect(el.open).to.be.false;
+  });
+
+  it('should fire a single show/after-show and hide/after-hide in normal open/close flow', async () => {
+    const el = await fixture<WaDropdown>(html`
+      <wa-dropdown>
+        <wa-button slot="trigger">Dropdown</wa-button>
+        <wa-dropdown-item>One</wa-dropdown-item>
+        <wa-dropdown-item>Two</wa-dropdown-item>
+      </wa-dropdown>
+    `);
+
+    // setup spies to track how often we see different show/hide events
+    const showSpy = sinon.spy();
+    const afterShowSpy = sinon.spy();
+    const hideSpy = sinon.spy();
+    const afterHideSpy = sinon.spy();
+
+    el.addEventListener('wa-show', showSpy);
+    el.addEventListener('wa-after-show', afterShowSpy);
+    el.addEventListener('wa-hide', hideSpy);
+    el.addEventListener('wa-after-hide', afterHideSpy);
+
+    // open the dropdown by triggering a click on the trigger
+    const trigger = el.querySelector<HTMLElement>('[slot="trigger"]')!;
+    trigger.click();
+
+    await waitUntil(() => showSpy.calledOnce);
+    await waitUntil(() => afterShowSpy.calledOnce);
+
+    expect(showSpy.callCount).to.equal(1);
+    expect(afterShowSpy.callCount).to.equal(1);
+
+    expect(el.open).to.be.true;
+
+    // close the dropdown by clicking the trigger again
+    trigger.click();
+
+    await waitUntil(() => hideSpy.calledOnce);
+    await waitUntil(() => afterHideSpy.calledOnce);
+
+    expect(hideSpy.callCount).to.equal(1);
+    expect(afterHideSpy.callCount).to.equal(1);
+
+    expect(el.open).to.be.false;
+  });
+
+  it('should fire a single show/after-show and hide/after-hide when wa-hide event is cancelled', async () => {
+    const el = await fixture<WaDropdown>(html`
+      <wa-dropdown>
+        <wa-button slot="trigger">Dropdown</wa-button>
+        <wa-dropdown-item>One</wa-dropdown-item>
+        <wa-dropdown-item>Two</wa-dropdown-item>
+      </wa-dropdown>
+    `);
+
+    // setup spies to track how often we see different show/hide events
+    const showSpy = sinon.spy();
+    const afterShowSpy = sinon.spy();
+    const hideSpy = sinon.spy();
+    const afterHideSpy = sinon.spy();
+
+    el.addEventListener('wa-show', showSpy);
+    el.addEventListener('wa-after-show', afterShowSpy);
+
+    // Intercept wa-hide and prevent it
+    el.addEventListener('wa-hide', event => {
+      event.preventDefault();
+      hideSpy(event);
+    });
+
+    el.addEventListener('wa-after-hide', afterHideSpy);
+
+    // open the dropdown by triggering a click on the trigger
+    const trigger = el.querySelector<HTMLElement>('[slot="trigger"]')!;
+    trigger.click();
+
+    await waitUntil(() => showSpy.calledOnce);
+    await waitUntil(() => afterShowSpy.calledOnce);
+
+    expect(showSpy.callCount).to.equal(1);
+    expect(afterShowSpy.callCount).to.equal(1);
+
+    expect(el.open).to.be.true;
+
+    // click on the trigger (which should do nothing to the open state)
+    trigger.click();
+
+    await waitUntil(() => hideSpy.calledOnce);
+
+    expect(hideSpy.callCount).to.equal(1);
+    // after-hide should not have been called if hide is cancelled
+    expect(afterHideSpy.callCount).to.equal(0);
+
+    expect(el.open).to.be.true;
   });
 });

--- a/packages/webawesome/src/components/dropdown/dropdown.test.ts
+++ b/packages/webawesome/src/components/dropdown/dropdown.test.ts
@@ -9,9 +9,9 @@ describe('<wa-dropdown>', () => {
     expect(el).to.exist;
   });
 
-  it('should not be open by default', async () => {
+  it('should respect the open attribute when included', async () => {
     const el = await fixture<WaDropdown>(html`
-      <wa-dropdown>
+      <wa-dropdown open>
         <wa-button slot="trigger">Dropdown</wa-button>
         <wa-dropdown-item>One</wa-dropdown-item>
       </wa-dropdown>
@@ -20,7 +20,7 @@ describe('<wa-dropdown>', () => {
     await el.updateComplete;
     await aTimeout(200);
 
-    expect(el.open).to.be.false;
+    expect(el.open).to.be.true;
   });
 
   it('should fire a single show/after-show and hide/after-hide in normal open/close flow', async () => {

--- a/packages/webawesome/src/components/dropdown/dropdown.ts
+++ b/packages/webawesome/src/components/dropdown/dropdown.ts
@@ -109,6 +109,18 @@ export default class WaDropdown extends WebAwesomeElement {
 
   async updated(changedProperties: PropertyValues) {
     if (changedProperties.has('open')) {
+      const previousOpen = changedProperties.get('open');
+      // check if the previous value is the same
+      // (if they are, do not trigger menu showing / hiding)
+      if (previousOpen === this.open) {
+        return;
+      }
+      // check if we are changing from undefined to false
+      // (if we are, we can skip menu hiding)
+      if (previousOpen === undefined && this.open === false) {
+        return;
+      }
+
       this.customStates.set('open', this.open);
 
       if (this.open) {
@@ -224,6 +236,12 @@ export default class WaDropdown extends WebAwesomeElement {
     this.dispatchEvent(showEvent);
     if (showEvent.defaultPrevented) {
       this.open = false;
+      return;
+    }
+
+    // if this dropdown is already open, do nothing
+    // (this can happen when wa-hide was cancelled)
+    if (this.popup.active) {
       return;
     }
 


### PR DESCRIPTION
## Summary

Related issue: #1483 

Previously, when cancelling the `wa-hide` event for a `<wa-dropdown>`, developers would see the browser hang on an infinite loop. This was caused by constant flipping of the `this.open` property, set as `true` in [dropdown.ts:257-260](https://github.com/shoelace-style/webawesome/blob/5a6ce1c4d397e5e64c9ed513e2fc2d18fe142184/packages/webawesome/src/components/dropdown/dropdown.ts#L257-L260) (where we handle `preventDefault` in `hideMenu`), and then set as `false` in [dropdown.ts:230](https://github.com/shoelace-style/webawesome/blob/5a6ce1c4d397e5e64c9ed513e2fc2d18fe142184/packages/webawesome/src/components/dropdown/dropdown.ts#L230) (where we close all dropdowns, including `this`).

### Why do we need this?

When trying to implement a combobox (using an input as a trigger), we'd like the ability to better control the showing and hiding of the dropdown menu. That requires the ability to specifically cancel `wa-hide` (not just `wa-select`).

### Solutions

There were many different ways to solve this, including:
1. checking and skipping `this` when closing dropdowns in [dropdown.ts:230](https://github.com/shoelace-style/webawesome/blob/5a6ce1c4d397e5e64c9ed513e2fc2d18fe142184/packages/webawesome/src/components/dropdown/dropdown.ts#L230)
2. keeping track of the cancellation as a dedicated (private) variable
3. removing the `.open` side-effect in the [hideMenu](https://github.com/shoelace-style/webawesome/blob/5a6ce1c4d397e5e64c9ed513e2fc2d18fe142184/packages/webawesome/src/components/dropdown/dropdown.ts#L258) and [showMenu](https://github.com/shoelace-style/webawesome/blob/5a6ce1c4d397e5e64c9ed513e2fc2d18fe142184/packages/webawesome/src/components/dropdown/dropdown.ts#L226) handlers
4. Gating inside the `showMenu` and `hideMenu` calls, checking if the menu is already closed or open.
5. Gating the `showMenu` and `hideMenu` calls in the [updated](https://github.com/shoelace-style/webawesome/blob/5a6ce1c4d397e5e64c9ed513e2fc2d18fe142184/packages/webawesome/src/components/dropdown/dropdown.ts#L114-L119) function

In this PR, I've opted for a combination of the last two options. This feels the most semantically correct (we only want to call `showMenu` and `hideMenu` when we intend to trigger those functions). I'm happy to implement one of the other options, or explore a different solution here if that would be more desirable.

## Recording

Below is a recording using a modified version of the `<wa-dropdown>` docs.

<details>
<summary>Code Snippet (modified)</summary>

```html
<div class="dropdown-checkboxes">
  <wa-dropdown>
    <wa-button slot="trigger" with-caret>View</wa-button>

    <wa-dropdown-item type="checkbox" value="canvas" checked>Show canvas</wa-dropdown-item>
    <wa-dropdown-item type="checkbox" value="grid" checked>Show grid</wa-dropdown-item>
    <wa-dropdown-item type="checkbox" value="source">Show source</wa-dropdown-item>

    <wa-divider></wa-divider>

    <wa-dropdown-item value="preferences">Preferences…</wa-dropdown-item>
  </wa-dropdown>
</div>

<script>
  const container = document.querySelector('.dropdown-checkboxes');
  const dropdown = container.querySelector('wa-dropdown');

  dropdown.addEventListener('wa-select', event => {
    if (event.detail.item.type === 'checkbox') {
      // Checkbox
      console.log(event.detail.item.value, event.detail.item.checked ? 'checked' : 'unchecked');
    } else {
      // Not a checkbox
      console.log(event.detail.item.value);
    }
  });

  // NEW EVENT LISTENERS FOR TESTING wa-hide
  dropdown.addEventListener('wa-hide', event => {
    event.preventDefault();
  });
  // (cancelling wa-select is still required)
  dropdown.addEventListener('wa-select', event => {
    event.preventDefault();
  })
</script>
```

</details>

<video aria-label="a user's cursor clicks on a button to open a menu, and then clicks on a checklist selection. The menu stays open, and on clicking the button control and the background, the menu stays open." src="https://github.com/user-attachments/assets/02ba9efa-3d41-4ecc-9abe-4a87f7d33ae7"></video>

## Testing

Aside from manual testing, this PR adds the following unit tests:
1. `<wa-dropdown> should not be open by default`
2. `<wa-dropdown> should fire a single show/after-show and hide/after-hide in normal open/close flow`
3. `<wa-dropdown> should fire a single show/after-show and hide/after-hide when wa-hide event is cancelled`

## Other changes

There are still some semantic oddities with the underlying code here. In an effort to reduce the total number of lines changed, I've opted not to only make the changes required to fix the bug here, however here are some other pieces that are probably worth fixing as a follow up (with potentially more dedicated testing).

1. Setting `this.open = true` in the `hideMenu` `preventDefault` handler assumes that the menu was already open. This isn't always the case (e.g. when the component is first upgraded, `open` is set to `undefined`, and triggers a `hideMenu` call). We should either remove these, or account for whatever the previous `open` value actually was. This is somewhat handled in the `updated` function call now, but if we ever expose `hideMenu` or `showMenu`, this could cause unexpected behaviors.
2. `closeAllSubmenus` is called regardless of whether or not the `wa-hide` event was cancelled. This should almost certainly be moved to inside `hideMenu`.
3. `showMenu` still closes all dropdowns (including `this`) and then reopens itself. It might be worth checking and skipping when `dropdown === this`.
4. We dynamically sync `aria-expanded` in syncAriaAttributes for `nativeButton`, but not the underlying `this.menu`
