### PR TITLE
fix: re-add page titles and metadata

### DIFF
--- a/packages/webawesome/docs/.eleventy.js
+++ b/packages/webawesome/docs/.eleventy.js
@@ -124,6 +124,22 @@ export default async function (eleventyConfig) {
   eleventyConfig.addFilter('stripExtension', string => path.parse(string + '').name);
   eleventyConfig.addFilter('stripPrefix', content => content.replace(/^wa-/, ''));
   eleventyConfig.addFilter('uniqueId', (_value, length = 8) => nanoid(length));
+
+  eleventyConfig.addGlobalData('eleventyComputed', {
+    // Page title with smart + default site name formatting
+    pageTitle: data => composePageTitle(data.title),
+    // Open Graph title with smart + default site name formatting
+    ogTitle: data => composePageTitle(data.ogTitle || data.title),
+    ogDescription: data => data.ogDescription || data.description,
+    ogImage: data => data.ogImage || siteMetadata.image,
+    ogUrl: data => {
+      if (data.ogUrl) return data.ogUrl;
+      const url = data.page?.url || '';
+      return url ? `${siteMetadata.url}${url}` : siteMetadata.url;
+    },
+    ogType: data => data.ogType || 'website',
+  });
+
   // Trims whitespace and pipes from the start and end of a string. Useful for CEM types, which can be pipe-delimited.
   // With Prettier 3, this means a leading pipe will exist be present when the line wraps.
   eleventyConfig.addFilter('trimPipes', content => {


### PR DESCRIPTION
related issue: #1775 

Currently the page title on all of the docs pages is just the page's URL (or part of it). For example:
- https://webawesome.com/docs/components/icon -> `https://webawesome.com/docs/`
- https://webawesome.com/docs/color-palettes -> `https://webawesome.com/docs/color-palettes`

Doing some quick investigating, this was caused by: https://github.com/shoelace-style/webawesome/pull/1750.

In the process of removing the "Last Modified Utility", the entire `addGlobalData` method was removed which also contains the logic for adding the composing the page title and meta tags.