### PR TITLE
Fix SVG fill in `<wa-icon>`

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -15,6 +15,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 
 - Fixed a bug in `<wa-slider>` that caused some touch devices to end up with the incorrect value [issue:1703]
 - Fixed a bug in `<wa-card>` that prevented some slots from being detected correctly [discuss:1450]
+- Fixed a bug in `<wa-icon>` that caused some icon libraries to render with the incorrect SVG fill [issue:1733]
 - Improved performance of `<wa-icon>` so initial rendering occurs faster, especially with multiple icons on the page [issue:1729]
 
 ## 3.0.0

--- a/packages/webawesome/src/components/icon/icon.css
+++ b/packages/webawesome/src/components/icon/icon.css
@@ -25,7 +25,6 @@
 
 svg {
   height: 1em;
-  fill: currentColor;
   overflow: visible;
 
   /* Duotone colors with path-specific opacity fallback */

--- a/packages/webawesome/src/components/icon/icon.ts
+++ b/packages/webawesome/src/components/icon/icon.ts
@@ -249,7 +249,7 @@ export default class WaIcon extends WebAwesomeElement {
       return this.svg;
     }
 
-    return html`<svg part="svg" fill="currentColor" width="16" height="16"></svg>`;
+    return html`<svg part="svg" width="16" height="16"></svg>`;
   }
 }
 


### PR DESCRIPTION
Fixes the issue described in #1733 by removing the fill attribute and style from the internal SVG.

@lindsaym-fa I can't find any visual differences in _any_ of the icon libraries with this change except for Lucide, which is where the bug was noticeable. Would you mind taking a second look?

---

Before:

<img width="1524" height="682" alt="CleanShot 2025-11-17 at 15 04 56@2x" src="https://github.com/user-attachments/assets/6bcd5e1d-02a6-4686-a3c4-748cba96e743" />

After:

<img width="1542" height="684" alt="CleanShot 2025-11-17 at 15 13 24@2x" src="https://github.com/user-attachments/assets/41451499-53ae-4280-85d2-9966dda3ed1a" />
