### PR TITLE
fix(wa-spinner): implement --track-width support

### DIFF
--- a/packages/webawesome/src/components/spinner/spinner.css
+++ b/packages/webawesome/src/components/spinner/spinner.css
@@ -24,10 +24,12 @@ svg {
 
 .track {
   stroke: var(--track-color);
+  stroke-width: var(--track-width);
 }
 
 .indicator {
   stroke: var(--indicator-color);
+  stroke-width: var(--track-width);
   stroke-dasharray: 75, 100;
   stroke-dashoffset: -5;
   animation: dash 1.5s ease-in-out infinite;

--- a/packages/webawesome/src/components/spinner/spinner.ts
+++ b/packages/webawesome/src/components/spinner/spinner.ts
@@ -33,8 +33,8 @@ export default class WaSpinner extends WebAwesomeElement {
         viewBox="0 0 50 50"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <circle class="track" cx="25" cy="25" r="20" fill="none" stroke-width="5" />
-        <circle class="indicator" cx="25" cy="25" r="20" fill="none" stroke-width="5" />
+        <circle class="track" cx="25" cy="25" r="20" fill="none" />
+        <circle class="indicator" cx="25" cy="25" r="20" fill="none" />
       </svg>
     `;
   }


### PR DESCRIPTION
The CSS variable --track-width is documented as a supported option, but the current implementation doesn’t apply it. This PR adds proper support for --track-width so the component behaves as documented.