### PR TITLE
Add spellcheck GitHub Action workflow

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,28 @@
+name: "Check spelling"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  spellcheck:
+    permissions:
+      contents: read
+      pull-requests: read
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - uses: streetsidesoftware/cspell-action@3294df585d3d639e30f3bc019cb11940b9866e95 # v8.0.0
+        with:
+          check_dot_files: false
+          incremental_files_only: true
+          inline: warning


### PR DESCRIPTION
- Uses cSpell. There's already a `cspell.yml`config in the project root so the GitHub Action will use that.
- Uses SHA1 pinned versions for improved security.
- Only checks for changed files.