### PR TITLE
Set a cooldown when updating deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14029,7 +14029,8 @@
       "devDependencies": {
         "@wc-toolkit/jsx-types": "^1.3.0",
         "eleventy-plugin-git-commit-date": "^0.1.3",
-        "esbuild": "^0.25.11"
+        "esbuild": "^0.25.11",
+        "npm-check-updates": "^19.1.2"
       },
       "engines": {
         "node": ">=14.17.0"
@@ -14037,7 +14038,7 @@
     },
     "packages/webawesome-pro": {
       "name": "@shoelace-style/webawesome-pro",
-      "version": "3.0.0-beta.6",
+      "version": "3.0.0",
       "dependencies": {
         "@ctrl/tinycolor": "4.1.0",
         "@floating-ui/dom": "^1.6.13",
@@ -14965,6 +14966,20 @@
       },
       "engines": {
         "node": "^18 || >=20"
+      }
+    },
+    "packages/webawesome/node_modules/npm-check-updates": {
+      "version": "19.1.2",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-19.1.2.tgz",
+      "integrity": "sha512-FNeFCVgPOj0fz89hOpGtxP2rnnRHR7hD2E8qNU8SMWfkyDZXA/xpgjsL3UMLSo3F/K13QvJDnbxPngulNDDo/g==",
+      "dev": true,
+      "bin": {
+        "ncu": "build/cli.js",
+        "npm-check-updates": "build/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0",
+        "npm": ">=8.12.1"
       }
     }
   }

--- a/packages/webawesome/package.json
+++ b/packages/webawesome/package.json
@@ -64,7 +64,7 @@
     "spellcheck": "cspell \"**/*.{js,ts,json,html,css,md}\" --no-progress --config=\"../../cspell.json\"",
     "verify": "npm run prettier && npm run build && npm run test",
     "prepublishOnly": "npm run verify",
-    "check-updates": "npx npm-check-updates --interactive --format group",
+    "check-updates": "npm-check-updates --cooldown 7 --interactive --format group",
     "print-version": "echo $npm_package_version",
     "tag-version": "git tag -a \"v$(npm run print-version | tail -n1)\" -m \"tag v$(npm run print-version | tail -n1)\"",
     "postversion": "npm run tag-version"
@@ -91,6 +91,7 @@
   "devDependencies": {
     "@wc-toolkit/jsx-types": "^1.3.0",
     "eleventy-plugin-git-commit-date": "^0.1.3",
-    "esbuild": "^0.25.11"
+    "esbuild": "^0.25.11",
+    "npm-check-updates": "^19.1.2"
   }
 }


### PR DESCRIPTION
This is just a minor update to ensure a seven-day cooldown when running `npm check-updates`.