### PR TITLE
Support disabled link buttons

### DIFF
--- a/packages/webawesome/docs/docs/components/button.md
+++ b/packages/webawesome/docs/docs/components/button.md
@@ -213,6 +213,12 @@ Use the `disabled` attribute to disable a button.
 <wa-button variant="neutral" disabled>Neutral</wa-button>
 <wa-button variant="warning" disabled>Warning</wa-button>
 <wa-button variant="danger" disabled>Danger</wa-button>
+
+<br /><br />
+
+<wa-button href="https://example.com/" disabled>Link</wa-button>
+<wa-button href="https://example.com/" target="_blank" disabled>New Window</wa-button>
+<wa-button href="/assets/images/logo.svg" download="shoelace.svg" disabled>Download</wa-button>
 ```
 
 ### Styling Buttons

--- a/packages/webawesome/src/components/button/button.styles.ts
+++ b/packages/webawesome/src/components/button/button.styles.ts
@@ -181,14 +181,14 @@ export default css`
   }
 
   /* Disabled state */
-  .button.disabled {
+  :host([disabled]) {
     opacity: 0.5;
     cursor: not-allowed;
-  }
 
-  /* When disabled, prevent mouse events from bubbling up from children */
-  .button.disabled * {
-    pointer-events: none;
+    /* When disabled, prevent mouse events from bubbling up from children */
+    .button {
+      pointer-events: none;
+    }
   }
 
   /* Keep it last so Safari doesn't stop parsing this block */

--- a/packages/webawesome/src/components/button/button.test.ts
+++ b/packages/webawesome/src/components/button/button.test.ts
@@ -59,6 +59,11 @@ describe('<wa-button>', () => {
           const el = await fixture<WaButton>(html` <wa-button href="some/path" disabled>Button Label</wa-button> `);
           expect(el.shadowRoot!.querySelector('a[disabled]')).not.to.exist;
         });
+
+        it('should inert the native <a> when rendering an <a>', async () => {
+          const el = await fixture<WaButton>(html` <wa-button href="some/path" disabled>Button Label</wa-button> `);
+          expect(el.shadowRoot!.querySelector('a[inert]')).to.exist;
+        });
       });
 
       it('should have title if title attribute is set', async () => {

--- a/packages/webawesome/src/components/button/button.ts
+++ b/packages/webawesome/src/components/button/button.ts
@@ -72,7 +72,7 @@ export default class WaButton extends WebAwesomeFormAssociatedElement {
   /** Draws the button with a caret. Used to indicate that the button triggers a dropdown menu or similar behavior. */
   @property({ attribute: 'with-caret', type: Boolean, reflect: true }) withCaret = false;
 
-  /** Disables the button. Does not apply to link buttons. */
+  /** Disables the button. */
   @property({ type: Boolean }) disabled = false;
 
   /** Draws the button in a loading state. */
@@ -269,6 +269,7 @@ export default class WaButton extends WebAwesomeFormAssociatedElement {
           'is-icon-button': this.isIconButton,
         })}
         ?disabled=${ifDefined(isLink ? undefined : this.disabled)}
+        ?inert=${ifDefined(isLink ? this.disabled : undefined)}
         type=${ifDefined(isLink ? undefined : this.type)}
         title=${this.title /* An empty title prevents browser validation tooltips from appearing on hover */}
         name=${ifDefined(isLink ? undefined : this.name)}


### PR DESCRIPTION
#106 doesn't give much context. I assume effort was allocated to higher priority items, nevertheless, this does seem to cover support for disabled link buttons.