### PR TITLE
Expose `--indicator-linecap` for progress-ring

### DIFF
--- a/packages/webawesome/docs/docs/components/progress-ring.md
+++ b/packages/webawesome/docs/docs/components/progress-ring.md
@@ -27,6 +27,14 @@ Use the `--track-width` and `--indicator-width` custom properties to set the wid
 <wa-progress-ring value="50" style="--track-width: 6px; --indicator-width: 12px;"></wa-progress-ring>
 ```
 
+### Indicator Linecap
+
+Use the `--indicator-linecap` custom property to set shape at the ends of the progress ring's indicator.
+
+```html {.example}
+<wa-progress-ring value="10" style="--track-width: 50%; --indicator-width: 50%; --indicator-linecap: butt"></wa-progress-ring>
+```
+
 ### Colors
 
 To change the color, use the `--track-color` and `--indicator-color` custom properties.

--- a/packages/webawesome/src/components/progress-ring/progress-ring.styles.ts
+++ b/packages/webawesome/src/components/progress-ring/progress-ring.styles.ts
@@ -7,6 +7,7 @@ export default css`
     --track-color: var(--wa-color-neutral-fill-normal);
     --indicator-width: var(--track-width);
     --indicator-color: var(--wa-color-brand-fill-loud);
+    --indicator-linecap: round;
     --indicator-transition-duration: 0.35s;
 
     display: inline-flex;
@@ -45,7 +46,7 @@ export default css`
   .indicator {
     stroke: var(--indicator-color);
     stroke-width: var(--indicator-width);
-    stroke-linecap: round;
+    stroke-linecap: var(--indicator-linecap);
     transition-property: stroke-dashoffset;
     transition-duration: var(--indicator-transition-duration);
     stroke-dasharray: var(--circumference) var(--circumference);

--- a/packages/webawesome/src/components/progress-ring/progress-ring.ts
+++ b/packages/webawesome/src/components/progress-ring/progress-ring.ts
@@ -21,6 +21,7 @@ import styles from './progress-ring.styles.js';
  * @cssproperty --track-color - The color of the track.
  * @cssproperty --indicator-width - The width of the indicator. Defaults to the track width.
  * @cssproperty --indicator-color - The color of the indicator.
+ * @cssproperty --indicator-linecap - The shape at the ends of the indicator.
  * @cssproperty --indicator-transition-duration - The duration of the indicator's transition when the value changes.
  */
 @customElement('wa-progress-ring')


### PR DESCRIPTION
Adds feature suggested in #1521.

<img width="694" height="407" alt="Screenshot 2025-12-09 at 13 46 02" src="https://github.com/user-attachments/assets/34796784-43fb-4a51-9046-0e82fc732a90" />