### PR TITLE
Fix form state restores in firefox

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -24,6 +24,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug in `<wa-dropdown-item>` that prevented the icon dependency from being imported [issue:1825]
 - Fixed a bug in `<wa-select>` that prevented clicks on the tag's remove button from removing options in multiple mode
 - Fixed a bug in `<wa-select>` that caused tags to appear in alphabetical order instead of selection order when using `multiple`
+- Fixed a bug in Form Controls where Firefox would restore the incorrect data. [pr:]
 - Improved performance of `<wa-icon>` so initial rendering occurs faster, especially with multiple icons on the page [issue:1729]
 - Improved performance of all components by fixing how CSS is imported and reused [issue:1812]
 - Modified the default `transition` styles of `<wa-dropdown-item>` to use design tokens [pr:1693]

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -24,7 +24,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug in `<wa-dropdown-item>` that prevented the icon dependency from being imported [issue:1825]
 - Fixed a bug in `<wa-select>` that prevented clicks on the tag's remove button from removing options in multiple mode
 - Fixed a bug in `<wa-select>` that caused tags to appear in alphabetical order instead of selection order when using `multiple`
-- Fixed a bug in Form Controls where Firefox would restore the incorrect data. [pr:]
+- Fixed a bug in Form Controls where Firefox would restore the incorrect data. [pr:1871]
 - Improved performance of `<wa-icon>` so initial rendering occurs faster, especially with multiple icons on the page [issue:1729]
 - Improved performance of all components by fixing how CSS is imported and reused [issue:1812]
 - Modified the default `transition` styles of `<wa-dropdown-item>` to use design tokens [pr:1693]

--- a/packages/webawesome/src/internal/webawesome-form-associated-element.ts
+++ b/packages/webawesome/src/internal/webawesome-form-associated-element.ts
@@ -300,8 +300,28 @@ export class WebAwesomeFormAssociatedElement
    * "restore", state is a string, File, or FormData object previously set as the second argument to setFormValue.
    */
   formStateRestoreCallback(state: string | File | FormData | null, reason: 'autocomplete' | 'restore') {
-    // @ts-expect-error We purposely do not have a value property. It makes things hard to extend.
-    this.value = state;
+    if (state instanceof FormData) {
+      // When we get FormData (like in Firefox) we need to need to make sure we match the value + element.
+      const form = this.getForm()
+      if (form) {
+        const index = Array.from(form.elements)
+          // Filter first so we can find the index of our element in respect to other elements with the same name.
+          .filter((el) => {
+            // @ts-expect-error
+            return this.name && el.name && el.name === this.name
+          })
+          .findIndex((el) => {
+            return el === this
+          })
+        if (index >= 0) {
+          // @ts-expect-error We purposely do not have a value property. It makes things hard to extend.
+          this.value = state.getAll(this.name)[index]
+        }
+      }
+    } else {
+      // @ts-expect-error We purposely do not have a value property. It makes things hard to extend.
+      this.value = state;
+    }
 
     if (reason === 'restore') {
       this.resetValidity();

--- a/packages/webawesome/src/internal/webawesome-form-associated-element.ts
+++ b/packages/webawesome/src/internal/webawesome-form-associated-element.ts
@@ -302,20 +302,20 @@ export class WebAwesomeFormAssociatedElement
   formStateRestoreCallback(state: string | File | FormData | null, reason: 'autocomplete' | 'restore') {
     if (state instanceof FormData) {
       // When we get FormData (like in Firefox) we need to need to make sure we match the value + element.
-      const form = this.getForm()
+      const form = this.getForm();
       if (form) {
         const index = Array.from(form.elements)
           // Filter first so we can find the index of our element in respect to other elements with the same name.
-          .filter((el) => {
+          .filter(el => {
             // @ts-expect-error
-            return this.name && el.name && el.name === this.name
+            return this.name && el.name && el.name === this.name;
           })
-          .findIndex((el) => {
-            return el === this
-          })
+          .findIndex(el => {
+            return el === this;
+          });
         if (index >= 0) {
           // @ts-expect-error We purposely do not have a value property. It makes things hard to extend.
-          this.value = state.getAll(this.name)[index]
+          this.value = state.getAll(this.name)[index];
         }
       }
     } else {


### PR DESCRIPTION
I kept noticing issues in FF with `formStateRestore` and it turns out I never accounted for FormData.