### PR TITLE
Update changelog with leftover items

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -14,7 +14,6 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 ## Next
 
 - Added `<wa-combobox>` as an experimental pro component [issue:1074]
-- Added `<wa-video>` as an experimental pro component [issue:985]
 - Added version 2.0.0 of the [official Web Awesome Figma Design Kit](/docs/resources/figma)
 - Added npm support for Web Awesome Pro
 - Added `layers.css` to define cascade layer order and updated palettes, themes, native styles, and utilities to import the new rule for more fail-safe modularity [pr:1793]

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -14,6 +14,9 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 ## Next
 
 - Added `<wa-combobox>` as an experimental pro component [issue:1074]
+- Added `<wa-video>` as an experimental pro component [issue:985]
+- Added version 2.0.0 of the [official Web Awesome Figma Design Kit](/docs/resources/figma)
+- Added npm support for Web Awesome Pro
 - Added `layers.css` to define cascade layer order and updated palettes, themes, native styles, and utilities to import the new rule for more fail-safe modularity [pr:1793]
 - Fixed a bug in `<wa-slider>` that caused some touch devices to end up with the incorrect value [issue:1703]
 - Fixed a bug in `<wa-card>` that prevented some slots from being detected correctly [discuss:1450]


### PR DESCRIPTION
Adds these to the changelog for our upcoming release:
- Figma design kit 2.0.0
- npm support for WA Pro