### PR TITLE
Ensure consistent input heights in flex/grid containers

### DIFF
--- a/packages/webawesome/src/components/input/input.styles.ts
+++ b/packages/webawesome/src/components/input/input.styles.ts
@@ -6,7 +6,6 @@ export default css`
   }
 
   .text-field {
-    flex: auto;
     display: flex;
     align-items: stretch;
     justify-content: start;

--- a/packages/webawesome/src/styles/component/form-control.styles.ts
+++ b/packages/webawesome/src/styles/component/form-control.styles.ts
@@ -1,7 +1,8 @@
 import { css } from 'lit';
 
 export default css`
-  :host {
+  :host,
+  [part~='form-control'] {
     display: flex;
     flex-direction: column;
   }

--- a/packages/webawesome/src/styles/component/form-control.styles.ts
+++ b/packages/webawesome/src/styles/component/form-control.styles.ts
@@ -1,10 +1,14 @@
 import { css } from 'lit';
 
 export default css`
-  :host,
-  [part~='form-control'] {
+  :host {
     display: flex;
     flex-direction: column;
+  }
+
+  /* Treat wrapped labels, inputs, and hints as direct children of the host element */
+  [part~='form-control'] {
+    display: contents;
   }
 
   /* Label */


### PR DESCRIPTION
Fixes two styles that caused inconsistent input, select, and combobox heights in flex/grid containers (example in #1876):

1. Adds `display: contents` to `form-control` parts to ignore the wrapper for styling and instead expose its child elements (label, input, and hint) to the flex rules applied to the host element
2. Removes `flex: auto` from `<wa-input>`'s internal `.text-field` to ensure the field always respects its given `height`

---

### 'Shots

**Before**
<img width="839" height="122" alt="Screenshot 2025-12-30 at 4 31 37 PM" src="https://github.com/user-attachments/assets/3bfb367a-a5f4-472e-bf8b-8ea1cada5410" />


**After**
<img width="839" height="122" alt="Screenshot 2025-12-30 at 4 30 46 PM" src="https://github.com/user-attachments/assets/1d5de3e5-dd5e-4f5e-ac11-7dc7b9c5cc49" />

---

### Explanation

There's a bit of a complicated interaction of CSS layout models here. Here's what I understand to be true:

`form-control.styles.ts` applies `display: flex` and `flex-direction: column` to the host element for every form control to consistently arrange labels, inputs, and hints. However, some components like `<wa-select>`, `<wa-combobox>`, and `<wa-color-picker>` have an additional internal `part="form-control"` wrapper, which prevents wrapped labels, inputs, and hints from being included in the host's flex layout.

Notably, this means that labels follow a typical block document flow and rest on the text baseline — whereas flexbox alignment isn't based on text lines — causing a smidge of extra whitespace above the label. With this extra whitespace, components like `<wa-select>` have a slightly inflated height compared to `<wa-input>`.

Meanwhile, `flex: auto` is applied to the text field in `<wa-input>`, and this shorthand assumes `flex-grow: 1`. This means that, given free space in a flex container — whether that space is vertical or horizontal — the text field will grow to occupy the free space.

And, the final piece of the puzzle: utilities like `.wa-grid` assume `align-items: stretch`, which cause the grid items within to stretch vertically to fill the entire available height for the grid row. The same is true for flex containers with `align-items: stretch`.

So, with `<wa-select>`'s modicum of additional height, `<wa-input>`'s growable text field, and `.wa-grid`'s directive for stretchy grid items, `<wa-input>`'s text field stretches a few pixels so that the host element matches the height of its neighboring `<wa-select>`.

