### PR TITLE
A Glow Up for Dialogs That Pop Up

### DIFF
--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -257,7 +257,6 @@
       z-index: 0;
     }
   }
-  /* #endregion */
 
   /* buttons with icon toggle on hover */
   wa-button .icon-hover {
@@ -268,6 +267,13 @@
   }
   wa-button:hover .icon-hover {
     display: inline-flex;
+  }
+
+  /* buttons that are "shushed" (visually muted) by default, but have their full presentation otherwise  */
+  wa-button.shush {
+    &:not(:hover):not(active)::part(base) {
+      color: var(--wa-color-text-quiet);
+    }
   }
   /* #endregion */
 

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -130,6 +130,13 @@
     }
   }
 
+  /* dialogs */
+  wa-dialog:has([slot='footer']) [slot='footer'] {
+    border-block-start: var(--wa-border-width-s) solid var(--wa-color-surface-border);
+    flex-grow: 1; /* make footer contents span entire width of dialog */
+    padding-block-start: var(--wa-space-l);
+  }
+
   /* anchor headings  */
   .anchor-heading a {
     opacity: 0;


### PR DESCRIPTION
This work updates our `utils.css` CSS to visually add a border and spacing to the footers of dialog elements used across webawesome.com. It is a companion to https://github.com/shoelace-style/webawesome-app/pull/268.