### PR TITLE
Remove extra period in tooltip docs

### DIFF
--- a/packages/webawesome/src/components/tooltip/tooltip.ts
+++ b/packages/webawesome/src/components/tooltip/tooltip.ts
@@ -79,7 +79,7 @@ export default class WaTooltip extends WebAwesomeElement {
   /** The amount of time to wait before showing the tooltip when the user mouses in. */
   @property({ attribute: 'show-delay', type: Number }) showDelay = 150;
 
-  /** The amount of time to wait before hiding the tooltip when the user mouses out.. */
+  /** The amount of time to wait before hiding the tooltip when the user mouses out. */
   @property({ attribute: 'hide-delay', type: Number }) hideDelay = 0;
 
   /**


### PR DESCRIPTION
This removes the second period in the docs, which gets reflected on the website

I didn't create an issue for this first because of how trivial it is, which seems to be allowed in the contribution guidelines. That being said if I should open one anyway, please let me know and I'd be happy to do so