### PR TITLE
Added a fix to support v-model within Vue for the Input component.

### DIFF
--- a/packages/webawesome/src/components/input/input.ts
+++ b/packages/webawesome/src/components/input/input.ts
@@ -231,8 +231,10 @@ export default class WaInput extends WebAwesomeFormAssociatedElement {
     this.input.focus();
   }
 
-  private handleInput() {
+  private handleInput(event: Event) {
     this.value = this.input.value;
+
+    this.relayNativeEvent(event, { bubbles: true, composed: true });
   }
 
   private handleKeyDown(event: KeyboardEvent) {


### PR DESCRIPTION
After messing about with Vue, I have added a tweak to the `handleInput` code within the Input component, this seems to have been done with the Textarea component, but not the Input. I have tested this by amending my local code and Vue's `v-model` works as expected.