### PR TITLE
Set default cursor for empty `<wa-tree-item>` expand buttons

### DIFF
--- a/packages/webawesome/src/components/tree-item/tree-item.styles.ts
+++ b/packages/webawesome/src/components/tree-item/tree-item.styles.ts
@@ -85,6 +85,10 @@ export default css`
     display: none;
   }
 
+  .tree-item:not(.tree-item-has-expand-button):not(.tree-item-loading) .expand-button {
+    cursor: default;
+  }
+
   .tree-item-loading .expand-icon-slot wa-icon {
     display: none;
   }


### PR DESCRIPTION
I've noticed that hovering over a `<wa-tree-item>` with no children still results in a pointer cursor. This PR addresses that issue.

**Before**

https://github.com/user-attachments/assets/785cdcee-1d05-446e-b807-2dca4e073f78

---

**After**

https://github.com/user-attachments/assets/6b5528b4-666e-480b-96a6-8dd86f3e8550

