### PR TITLE
Unlist unreleased utilities from the docs

### DIFF
--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -196,7 +196,8 @@
   </h2>
   <ul>
     <li><a href="/docs/utilities/align-items/">Align Items</a></li>
-    <li><a href="/docs/utilities/justify-content/">Justify Content</a></li>
+    <!-- Pending 3.2.0 release -->
+    <!-- <li><a href="/docs/utilities/justify-content/">Justify Content</a></li> -->
     <li><a href="/docs/utilities/gap/">Gap</a></li>
     <li><a href="/docs/utilities/cluster/">Cluster</a></li>
     <li><a href="/docs/utilities/flank/">Flank</a></li>

--- a/packages/webawesome/docs/docs/utilities/gap.md
+++ b/packages/webawesome/docs/docs/utilities/gap.md
@@ -30,4 +30,5 @@ Besides `wa-gap-0`, which sets `gap` to zero, each class corresponds to one of t
 | `wa-gap-xl`  | `--wa-space-xl`  | <div class="wa-cluster wa-gap-xl"><div class="preview-block"></div><div class="preview-block"></div></div>  |
 | `wa-gap-2xl` | `--wa-space-2xl` | <div class="wa-cluster wa-gap-2xl"><div class="preview-block"></div><div class="preview-block"></div></div> |
 | `wa-gap-3xl` | `--wa-space-3xl` | <div class="wa-cluster wa-gap-3xl"><div class="preview-block"></div><div class="preview-block"></div></div> |
-| `wa-gap-4xl` | `--wa-space-4xl` | <div class="wa-cluster wa-gap-4xl"><div class="preview-block"></div><div class="preview-block"></div></div> |
+<!-- Pending 3.2.0 release -->
+<!-- | `wa-gap-4xl` | `--wa-space-4xl` | <div class="wa-cluster wa-gap-4xl"><div class="preview-block"></div><div class="preview-block"></div></div> | -->

--- a/packages/webawesome/docs/docs/utilities/justify-content.md
+++ b/packages/webawesome/docs/docs/utilities/justify-content.md
@@ -3,6 +3,8 @@ title: Justify Content
 description: Justify content utilities determine how space is distributed between items in flex and grid containers.
 layout: docs
 tags: layoutUtilities
+unpublished: true
+unlisted: true
 ---
 
 <style>


### PR DESCRIPTION
This PR  hides unreleased utilities from the documentation that are pending a next minor version release.
- Marked the "Justify Content" utility page as unpublished and unlisted to hide it from production builds
- Commented out the wa-gap-4xl entry in the Gap utility documentation
- Removed the "Justify Content" link from the sidebar navigation