### PR TITLE
Apply flexbox by default with `wa-align-items-*` and `wa-justify-content-*` utils

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -14,8 +14,9 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 ## Next
 
 - Fixed a bug in `<wa-combobox>` that prevented the listbox from opening when options were preselected [issue:1883]
-- Added `justify-content` CSS utilities [pr:1930]
-- Added missing `.wa-gap-4xl` utility class [pr:1931]
+- Added `wa-justify-content-*` utility classes [pr:1930]
+- Added missing `wa-gap-4xl` utility class [pr:1931]
+- Modified `wa-align-items-*` utility classes to apply `display: flex` by default [pr:1943]
 
 ## 3.1.0
 

--- a/packages/webawesome/src/styles/utilities/align-items.css
+++ b/packages/webawesome/src/styles/utilities/align-items.css
@@ -1,4 +1,15 @@
 @layer wa-utilities {
+  /* Apply Flexbox with 0 specificity to ensure an align-items util produces a visible change */
+  :where(
+    .wa-align-items-start,
+    .wa-align-items-end,
+    .wa-align-items-center,
+    .wa-align-items-stretch,
+    .wa-align-items-baseline
+  ) {
+    display: flex;
+  }
+
   .wa-align-items-start {
     align-items: flex-start;
   }

--- a/packages/webawesome/src/styles/utilities/justify-content.css
+++ b/packages/webawesome/src/styles/utilities/justify-content.css
@@ -1,4 +1,16 @@
 @layer wa-utilities {
+  /* Apply Flexbox with 0 specificity to ensure a justify-content util produces a visible change */
+  :where(
+    .wa-justify-content-start,
+    .wa-justify-content-end,
+    .wa-justify-content-center,
+    .wa-justify-content-space-around,
+    .wa-justify-content-space-between,
+    .wa-justify-content-space-evenly
+  ) {
+    display: flex;
+  }
+
   .wa-justify-content-start {
     justify-content: flex-start;
   }


### PR DESCRIPTION
Because the `align-items` and `justify-content` properties don't apply to block-level boxes, our `wa-align-items-*` and `wa-justify-content-*` utility classes don't have any effect on elements outside of flexbox, grid, or multicol formatting contexts.

To ensure these utilities can be used on their own and still produce meaningful results, this PR adds `display: flex` to each of these classes with 0 specificity (using `:where()`). We already take the same approach with our `wa-gap-*` utilities.