### PR TITLE
Add missing layout utility descriptions

### DIFF
--- a/packages/webawesome/docs/docs/utilities/cluster.md
+++ b/packages/webawesome/docs/docs/utilities/cluster.md
@@ -20,6 +20,8 @@ tags: layoutUtilities
   }
 </style>
 
+{{ description }}
+
 ```html {.example}
 <div class="wa-cluster">
   <div></div>

--- a/packages/webawesome/docs/docs/utilities/flank.md
+++ b/packages/webawesome/docs/docs/utilities/flank.md
@@ -20,7 +20,7 @@ tags: layoutUtilities
   }
 </style>
 
-When space is limited, the items wrap.
+{{ description }} When space is limited, the items wrap.
 
 ```html {.example}
 <div class="wa-flank">

--- a/packages/webawesome/docs/docs/utilities/frame.md
+++ b/packages/webawesome/docs/docs/utilities/frame.md
@@ -19,6 +19,8 @@ tags: layoutUtilities
   }
 </style>
 
+{{ description }}
+
 ```html {.example}
 <div class="wa-frame" style="max-inline-size: 20rem;">
   <div></div>

--- a/packages/webawesome/docs/docs/utilities/grid.md
+++ b/packages/webawesome/docs/docs/utilities/grid.md
@@ -20,6 +20,8 @@ tags: layoutUtilities
   }
 </style>
 
+{{ description }}
+
 ```html {.example}
 <div class="wa-grid">
   <div></div>

--- a/packages/webawesome/docs/docs/utilities/split.md
+++ b/packages/webawesome/docs/docs/utilities/split.md
@@ -20,6 +20,8 @@ tags: layoutUtilities
   }
 </style>
 
+{{ description }}
+
 ```html {.example}
 <div class="wa-split">
   <div></div>

--- a/packages/webawesome/docs/docs/utilities/stack.md
+++ b/packages/webawesome/docs/docs/utilities/stack.md
@@ -20,6 +20,8 @@ tags: layoutUtilities
   }
 </style>
 
+{{ description }}
+
 ```html {.example}
 <div class="wa-stack">
   <div></div>


### PR DESCRIPTION
The descriptions for each of our layout utility classes seem to have gone missing at some point. This PR reintroduces these much-needed descriptions to the docs.