### PR TITLE
Support selecting frame document source in code examples

### DIFF
--- a/packages/webawesome/docs/_transformers/code-examples.js
+++ b/packages/webawesome/docs/_transformers/code-examples.js
@@ -1,5 +1,5 @@
+import { readFileSync } from 'fs';
 import { parse } from 'node-html-parser';
-import { v4 as uuid } from 'uuid';
 import { copyCode } from './copy-code.js';
 import { highlightCode } from './highlight-code.js';
 
@@ -25,7 +25,8 @@ export function codeExamplesTransformer(options = {}) {
       const hasButtons = !code.classList.contains('no-buttons');
       const isOpen = code.classList.contains('open') || !hasButtons;
       const noEdit = code.classList.contains('no-edit');
-      const id = `code-example-${uuid().slice(-12)}`;
+      const uuid = crypto.randomUUID();
+      const id = `code-example-${uuid.slice(-12)}`;
       let preview = pre.textContent;
 
       const langClass = [...code.classList.values()].find(val => val.startsWith('language-'));
@@ -38,7 +39,37 @@ export function codeExamplesTransformer(options = {}) {
       root.querySelectorAll('script').forEach(script => script.setAttribute('type', 'module'));
       preview = root.toString();
 
-      copyCode(code);
+      // Show the relevant code for <wa-zoomable-frame data-select-src>
+      let framePre, frameCode;
+      const frame = root.querySelector('wa-zoomable-frame');
+      if (frame?.hasAttribute('data-select-src')) {
+        let src = frame.getAttribute('src');
+        let source = frame.getAttribute('srcdoc');
+        if (!source && src) {
+          src += src.match(/\.html$/) ? '' : `${src.endsWith('/') ? '' : '/'}index.html`;
+          source = readFileSync(`./docs${src}`, 'utf8');
+        }
+        const selectors = frame?.getAttribute('data-select-src');
+        if (selectors) {
+          const sourceNode = parse(source, { voidTag: { closingSlash: true } });
+          sourceNode.querySelectorAll(selectors).forEach((fragment, i) => {
+            // Fix parse() formatting of wrapped first attributes and reduce
+            // indentation to match the least-indented line for each fragment
+            const html = fragment.outerHTML
+              .replace(/<([^\s>]+)(\s{2,})(?=[^\s>])/g, (_, tag, spaces) => `<${tag}\n${spaces.slice(1)}`)
+              .split('\n');
+            const lastLine = html[html.length - 1] || '';
+            const indent = new RegExp(`^${lastLine.match(/^\s*/)?.[0] ?? ''}`);
+            source = `${i ? source : ''}${html.map(line => line.replace(indent, '')).join('\n')}\n\n`;
+          });
+        }
+        const highlightedCode = highlightCode(source?.trim(), 'html');
+        framePre = parse(`<pre id="code-block-${uuid}"></pre>`).firstChild;
+        frameCode = parse(`<code class="example">${highlightedCode}</code>`).firstChild;
+        framePre.appendChild(frameCode);
+      }
+
+      copyCode(frameCode ?? code);
 
       const codeExample = parse(`
           <div class="code-example ${isOpen ? 'open' : ''}">
@@ -51,7 +82,7 @@ export function codeExamplesTransformer(options = {}) {
               </div>
             </div>
             <div class="code-example-source" id="${id}">
-              ${pre.outerHTML}
+              ${framePre?.outerHTML ?? pre.outerHTML}
             </div>
             ${
               hasButtons

--- a/packages/webawesome/docs/_transformers/code-examples.js
+++ b/packages/webawesome/docs/_transformers/code-examples.js
@@ -51,7 +51,7 @@ export function codeExamplesTransformer(options = {}) {
         }
         const selectors = frame?.getAttribute('data-select-src');
         if (selectors) {
-          const sourceNode = parse(source, { voidTag: { closingSlash: true } });
+          const sourceNode = parse(source, { comment: true, voidTag: { closingSlash: true } });
           sourceNode.querySelectorAll(selectors).forEach((fragment, i) => {
             // Fix parse() formatting of wrapped first attributes and reduce
             // indentation to match the least-indented line for each fragment


### PR DESCRIPTION
## Description
Support `data-select-src` on `<wa-zoomable-frame>` in code examples to make the relevant code visible/copyable.
* A boolean attribute shows the full source document.
* A string attribute shows the source document elements matching the given CSS selectors.
* Works with `src` and `srcdoc` attributes.

## Examples

### Current Behavior

<img width="885" height="391" alt="Screenshot 2026-01-15 at 6 41 37 PM" src="https://github.com/user-attachments/assets/6c814bdd-a1d6-4c73-a22b-aa7ff596cd21" />

### Proposed Behavior

#### Select full document source:

```html {.example}
<wa-zoomable-frame
  srcdoc="<!doctype html>
<html>
  <body>
    <h1>Hello, World!</h1>
    <p>This is inline content.</p>
  </body>
</html>"
  data-select-src
></wa-zoomable-frame>
```

<img width="885" height="465" alt="Screenshot 2026-01-15 at 6 40 23 PM" src="https://github.com/user-attachments/assets/4eede171-390b-4a5f-9253-9e142a86d4d4" />

#### Select `<body>` from source to focus on the relevant code:

```html {.example}
<wa-zoomable-frame
  srcdoc="<!doctype html>
<html>
  <body>
    <h1>Hello, World!</h1>
    <p>This is inline content.</p>
  </body>
</html>"
  data-select-src="body"
></wa-zoomable-frame>
```

<img width="885" height="398" alt="Screenshot 2026-01-15 at 6 39 11 PM" src="https://github.com/user-attachments/assets/62796752-c8ce-4154-ad8e-55650b12e9b3" />

See `src`-based examples in https://github.com/shoelace-style/webawesome-pro/pull/127.