### PR TITLE
Add documentation for `wa-justify-content-*` and `wa-gap-4xl` utilities

### DIFF
--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -200,8 +200,7 @@
   </h2>
   <ul>
     <li><a href="/docs/utilities/align-items/">Align Items</a></li>
-    <!-- Pending 3.2.0 release -->
-    <!-- <li><a href="/docs/utilities/justify-content/">Justify Content</a></li> -->
+    <li><a href="/docs/utilities/justify-content/">Justify Content</a></li>
     <li><a href="/docs/utilities/gap/">Gap</a></li>
     <li><a href="/docs/utilities/cluster/">Cluster</a></li>
     <li><a href="/docs/utilities/flank/">Flank</a></li>

--- a/packages/webawesome/docs/docs/utilities/gap.md
+++ b/packages/webawesome/docs/docs/utilities/gap.md
@@ -38,5 +38,4 @@ Besides `wa-gap-0`, which sets `gap` to zero, each class corresponds to one of t
 | `wa-gap-xl`  | `--wa-space-xl`  | <div class="preview-wrapper wa-cluster wa-gap-xl"><div class="preview-block"></div><div class="preview-block"></div></div>  |
 | `wa-gap-2xl` | `--wa-space-2xl` | <div class="preview-wrapper wa-cluster wa-gap-2xl"><div class="preview-block"></div><div class="preview-block"></div></div> |
 | `wa-gap-3xl` | `--wa-space-3xl` | <div class="preview-wrapper wa-cluster wa-gap-3xl"><div class="preview-block"></div><div class="preview-block"></div></div> |
-<!-- Pending 3.2.0 release -->
-<!-- | `wa-gap-4xl` | `--wa-space-4xl` | <div class="preview-wrapper wa-cluster wa-gap-4xl"><div class="preview-block"></div><div class="preview-block"></div></div> | -->
+| `wa-gap-4xl` | `--wa-space-4xl` | <div class="preview-wrapper wa-cluster wa-gap-4xl"><div class="preview-block"></div><div class="preview-block"></div></div> |

--- a/packages/webawesome/docs/docs/utilities/justify-content.md
+++ b/packages/webawesome/docs/docs/utilities/justify-content.md
@@ -3,8 +3,6 @@ title: Justify Content
 description: Justify content utilities determine how space is distributed between items in flex and grid containers.
 layout: docs
 tags: layoutUtilities
-unpublished: true
-unlisted: true
 ---
 
 <style>


### PR DESCRIPTION
Adds documentation for utilities included in our next minor version release, previously unlisted in #1938.

- Marks the "Justify Content" utility page as published and listed so that it appears in the docs
- Uncomments the `wa-gap-4xl` entry in the Gap utility page
- Adds the "Justify Content" link to the sidebar navigation