### PR TITLE
fix(popover): maintain event handlers when moved in DOM

### DIFF
--- a/packages/webawesome/src/components/popover/popover.ts
+++ b/packages/webawesome/src/components/popover/popover.ts
@@ -97,6 +97,17 @@ export default class WaPopover extends WebAwesomeElement {
     if (!this.id) {
       this.id = uniqueId('wa-popover-');
     }
+
+    // Recreate event controller if it was aborted
+    if (this.eventController.signal.aborted) {
+      this.eventController = new AbortController();
+    }
+
+    // Re-establish anchor connection after being moved in the DOM
+    if (this.for && this.anchor) {
+      this.anchor = null; // force reattach
+      this.handleForChange();
+    }
   }
 
   disconnectedCallback() {
@@ -295,9 +306,9 @@ export default class WaPopover extends WebAwesomeElement {
             arrow:popup__arrow
           "
           class=${classMap({
-            popover: true,
-            'popover-open': this.open,
-          })}
+      popover: true,
+      'popover-open': this.open,
+    })}
           placement=${this.placement}
           distance=${this.distance}
           skidding=${this.skidding}

--- a/packages/webawesome/src/components/popover/popover.ts
+++ b/packages/webawesome/src/components/popover/popover.ts
@@ -306,9 +306,9 @@ export default class WaPopover extends WebAwesomeElement {
             arrow:popup__arrow
           "
           class=${classMap({
-      popover: true,
-      'popover-open': this.open,
-    })}
+            popover: true,
+            'popover-open': this.open,
+          })}
           placement=${this.placement}
           distance=${this.distance}
           skidding=${this.skidding}


### PR DESCRIPTION
Fixes #1963


## Summary
When a popover element is moved in the DOM using `appendChild` or similar methods, the `AbortController` signal gets aborted in `disconnectedCallback`, causing all event listeners to be removed. This fix ensures event handlers are properly re-established when the element is reconnected.

## Changes
1. A new `AbortController` is created in `connectedCallback` if the previous one was aborted
2. The anchor connection is re-established by forcing `handleForChange` to run
3. Event listeners are properly re-attached with the new signal

This follows the same pattern used in the `wa-tooltip` component.

## Testing
- Manual testing confirms the popover now works correctly after being moved in the DOM
- The fix has been verified against the reproduction case in the original issue