### PR TITLE
updated qr code

### DIFF
--- a/packages/webawesome/src/components/qr-code/qr-code.styles.ts
+++ b/packages/webawesome/src/components/qr-code/qr-code.styles.ts
@@ -6,10 +6,13 @@ export default css`
     display: inline-block;
   }
 
-  :host,
+  .qr-code__base {
+    display: block;
+    box-sizing: content-box;
+  }
+
   canvas {
-    max-width: var(--size);
-    max-height: var(--size);
+    display: block;
     width: var(--size);
     height: var(--size);
   }

--- a/packages/webawesome/src/components/qr-code/qr-code.test.ts
+++ b/packages/webawesome/src/components/qr-code/qr-code.test.ts
@@ -139,10 +139,42 @@ describe('<wa-qr-code>', () => {
       it('has the expected size', async () => {
         const qrCode = await fixture<WaQrCode>(html` <wa-qr-code value="test data" size="100"></wa-qr-code>`);
 
-        const height = qrCode.getBoundingClientRect().height;
-        const width = qrCode.getBoundingClientRect().width;
-        expect(height).to.equal(100);
-        expect(width).to.equal(100);
+        const canvas = getCanvas(qrCode);
+        const canvasHeight = canvas.getBoundingClientRect().height;
+        const canvasWidth = canvas.getBoundingClientRect().width;
+        expect(canvasHeight).to.equal(100);
+        expect(canvasWidth).to.equal(100);
+      });
+
+      it('has a default margin of 4px', async () => {
+        const qrCode = await fixture<WaQrCode>(html` <wa-qr-code value="test data" size="100"></wa-qr-code>`);
+        await qrCode.updateComplete;
+
+        // The quiet zone should have the default margin
+        const baseEl = qrCode.shadowRoot?.querySelector('[part="base"]') as HTMLElement;
+        expect(baseEl).to.exist;
+        expect(baseEl.style.padding).to.equal('4px');
+        expect(baseEl.style.backgroundColor).to.equal('white');
+      });
+
+      it('respects custom margin value', async () => {
+        const qrCode = await fixture<WaQrCode>(html` <wa-qr-code value="test data" size="100" margin="10"></wa-qr-code>`);
+        await qrCode.updateComplete;
+
+        // The quiet zone should have the custom margin
+        const baseEl = qrCode.shadowRoot?.querySelector('[part="base"]') as HTMLElement;
+        expect(baseEl).to.exist;
+        expect(baseEl.style.padding).to.equal('10px');
+      });
+
+      it('can have margin set to 0', async () => {
+        const qrCode = await fixture<WaQrCode>(html` <wa-qr-code value="test data" size="100" margin="0"></wa-qr-code>`);
+        await qrCode.updateComplete;
+
+        // When margin is 0, the quiet zone padding should be 0
+        const baseEl = qrCode.shadowRoot?.querySelector('[part="base"]') as HTMLElement;
+        expect(baseEl).to.exist;
+        expect(baseEl.style.padding).to.equal('0px');
       });
     });
   }

--- a/packages/webawesome/src/components/qr-code/qr-code.ts
+++ b/packages/webawesome/src/components/qr-code/qr-code.ts
@@ -1,6 +1,7 @@
 import type { PropertyValues } from 'lit';
 import { html } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
+import { styleMap } from 'lit/directives/style-map.js';
 import type _QrCreator from 'qr-creator';
 import { watch } from '../../internal/watch.js';
 import WebAwesomeElement from '../../internal/webawesome-element.js';
@@ -44,6 +45,12 @@ export default class WaQrCode extends WebAwesomeElement {
   @property({ attribute: 'error-correction' }) errorCorrection: 'L' | 'M' | 'Q' | 'H' = 'H';
 
   /**
+   * The size of the quiet zone, a border around the QR code that helps with scanning. This should be at least 4
+   * modules wide (the default), but you can set it to any non-negative number. Set to 0 to remove the quiet zone.
+   */
+  @property({ type: Number }) margin = 4;
+
+  /**
    * Whether or not the qr-code generated.
    */
   // @ts-expect-error Don't know why it marks it as unused.
@@ -51,17 +58,17 @@ export default class WaQrCode extends WebAwesomeElement {
 
   firstUpdated(changedProperties: PropertyValues<this>) {
     super.firstUpdated(changedProperties);
-
-    if (this.hasUpdated) {
-      this.generate();
-    }
+    this.generate();
   }
 
-  @watch(['background', 'errorCorrection', 'fill', 'radius', 'size', 'value'])
+  @watch(['background', 'errorCorrection', 'fill', 'margin', 'radius', 'size', 'value'])
   generate() {
+    const totalSize = this.size + this.margin * 2;
     this.style.setProperty('--size', `${this.size}px`);
+    this.style.setProperty('width', `${totalSize}px`);
+    this.style.setProperty('height', `${totalSize}px`);
 
-    if (!this.hasUpdated) {
+    if (!this.canvas) {
       return;
     }
 
@@ -92,12 +99,20 @@ export default class WaQrCode extends WebAwesomeElement {
 
   render() {
     return html`
-      <canvas
+      <div
         part="base"
-        class="qr-code"
-        role="img"
-        aria-label=${this.label?.length > 0 ? this.label : this.value}
-      ></canvas>
+        class="qr-code__base"
+        style=${styleMap({
+          padding: `${this.margin}px`,
+          backgroundColor: this.background
+        })}
+      >
+        <canvas
+          class="qr-code"
+          role="img"
+          aria-label=${this.label?.length > 0 ? this.label : this.value}
+        ></canvas>
+      </div>
     `;
   }
 }


### PR DESCRIPTION
**Problem**: `wa-qr-code` extended edge-to-edge without a ["quiet zone"](https://www.the-qrcode-generator.com/blog/qr-code-quiet-zone) (buffer area), making them difficult _or_ impossible to scan on dark-themed websites.                                                                              
                                                                                                                                                                                                                                                      
  **Solution**: Added a `margin` property that creates a quiet zone around the QR code using the background color.                                                                                                                                    
                                                                                                                                                                                                                                                      
  ## Changes Made                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                      
  ### `src/components/qr-code/qr-code.ts`                                                                                                                                                                                                             
  - Added `margin` property (default: 4) for the quiet zone size in pixels                                                                                                                                                                            
  - Wrapped the canvas in a container `<div>` with padding and background color matching the QR code's background                                                                                                                                     
  - Updated `generate()` to set explicit width/height on the host element (including margin)                                                                                                                                                          
  - Changed the canvas check from `hasUpdated` to `!this.canvas` for more reliable timing                                                                                                                                                             
                                                                                                                                                                                                                                                      
  ### `src/components/qr-code/qr-code.styles.ts`                                                                                                                                                                                                      
  - Simplified styles for the new structure                                                                                                                                                                                                           
  - Container div uses `box-sizing: content-box` to ensure padding adds to dimensions                                                                                                                                                                 
                                                                                                                                                                                                                                                      
  ### `src/components/qr-code/qr-code.test.ts`                                                                                                                                                                                                        
  - Added tests for default margin (4px)                                                                                                                                                                                                              
  - Added tests for custom margin values                                                                                                                                                                                                              
  - Added test for margin=0 (no quiet zone)                                                                                                                                                                                                           
                                                                                                                                                                                                                                                      
  ## Usage                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                      
  ```html                                                                                                                                                                                                                                             
  <!-- Default (4px quiet zone) -->                                                                                                                                                                                                                   
  <wa-qr-code value="https://example.com"></wa-qr-code>                                                                                                                                                                                               
                                                                                                                                                                                                                                                      
  <!-- Custom margin -->                                                                                                                                                                                                                              
  <wa-qr-code value="https://example.com" margin="10"></wa-qr-code>                                                                                                                                                                                   
                                                                                                                                                                                                                                                      
  <!-- No quiet zone (not recommended) -->                                                                                                                                                                                                            
  <wa-qr-code value="https://example.com" margin="0"></wa-qr-code>                                                                                                                                                                                    
                                                                                                                                                                                                                                                      
  The default margin of 4 pixels follows the ISO/IEC 18004 specification recommendation of 4 modules for the quiet zone.                                                                                                                              
  ```      