### PR TITLE
updated autoloader

### DIFF
--- a/packages/webawesome/src/utilities/autoloader.test.ts
+++ b/packages/webawesome/src/utilities/autoloader.test.ts
@@ -1,0 +1,179 @@
+import { expect } from '@open-wc/testing';
+import sinon from 'sinon';
+import { discover } from './autoloader.js';
+
+describe('autoloader', () => {
+  describe('discover()', () => {
+    it('should dispatch wa-discovery-complete event after discovering components', async () => {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+
+      const handler = sinon.spy();
+      container.addEventListener('wa-discovery-complete', handler);
+
+      // Add an undefined component
+      container.innerHTML = '<wa-button>Test</wa-button>';
+
+      await discover(container);
+
+      expect(handler).to.have.been.calledOnce;
+
+      container.remove();
+    });
+
+    it('should dispatch wa-discovery-complete even when no components need registration', async () => {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+
+      const handler = sinon.spy();
+      container.addEventListener('wa-discovery-complete', handler);
+
+      // No components in the container
+      container.innerHTML = '<div>No components here...</div>';
+
+      await discover(container);
+
+      expect(handler).to.have.been.calledOnce;
+
+      container.remove();
+    });
+
+    it('should wait for component updateComplete before dispatching wa-discovery-complete', async () => {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+
+      // Add a component that needs to be discovered
+      container.innerHTML = '<wa-spinner></wa-spinner>';
+
+      // Track the order of events
+      const events: string[] = [];
+
+      container.addEventListener('wa-discovery-complete', () => {
+        events.push('discovery-complete');
+      });
+
+      await discover(container);
+
+      // After discover completes, the spinner should be rendered
+      const spinner = container.querySelector('wa-spinner');
+      expect(spinner).to.exist;
+
+      // The component should be defined
+      expect(customElements.get('wa-spinner')).to.exist;
+
+      // The component should have a shadow root with content (indicating it has rendered)
+      expect(spinner!.shadowRoot).to.exist;
+      expect(spinner!.shadowRoot!.children.length).to.be.greaterThan(0);
+
+      container.remove();
+    });
+
+    it('should have components fully rendered when wa-discovery-complete fires', async () => {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+
+      // Add multiple WA components
+      container.innerHTML = `
+        <wa-button>Button</wa-button>
+        <wa-badge>Badge</wa-badge>
+      `;
+
+      let buttonRendered = false;
+      let badgeRendered = false;
+
+      container.addEventListener('wa-discovery-complete', () => {
+        const button = container.querySelector('wa-button');
+        const badge = container.querySelector('wa-badge');
+
+        // Check that shadow DOM content exists (component has rendered)
+        buttonRendered = !!(button?.shadowRoot && button.shadowRoot.children.length > 0);
+        badgeRendered = !!(badge?.shadowRoot && badge.shadowRoot.children.length > 0);
+      });
+
+      await discover(container);
+
+      expect(buttonRendered).to.be.true;
+      expect(badgeRendered).to.be.true;
+
+      container.remove();
+    });
+
+    it('should handle nested components', async () => {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+
+      // Add nested components
+      container.innerHTML = `
+        <wa-card>
+          <wa-button slot="footer">Action</wa-button>
+        </wa-card>
+      `;
+
+      const handler = sinon.spy();
+      container.addEventListener('wa-discovery-complete', handler);
+
+      await discover(container);
+
+      expect(handler).to.have.been.calledOnce;
+
+      const card = container.querySelector('wa-card');
+      const button = container.querySelector('wa-button');
+
+      // Both components should be defined and rendered
+      expect(card?.shadowRoot).to.exist;
+      expect(button?.shadowRoot).to.exist;
+
+      container.remove();
+    });
+
+    it('should not fail when components fail to import', async () => {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+
+      // Add a non-existent component (will fail to import)
+      container.innerHTML = '<wa-nonexistent-component-xyz></wa-nonexistent-component-xyz>';
+
+      const handler = sinon.spy();
+      container.addEventListener('wa-discovery-complete', handler);
+
+      // Suppress the expected console warning
+      const warnStub = sinon.stub(console, 'warn');
+
+      await discover(container);
+
+      // Event should still fire even if some imports fail
+      expect(handler).to.have.been.calledOnce;
+
+      // Warning should have been logged
+      expect(warnStub).to.have.been.called;
+
+      warnStub.restore();
+      container.remove();
+    });
+
+    it('should handle components that are already defined', async () => {
+      const container = document.createElement('div');
+      document.body.appendChild(container);
+
+      // First, ensure wa-button is defined by discovering it
+      container.innerHTML = '<wa-button>First</wa-button>';
+      await discover(container);
+
+      // Now add another component (already defined)
+      const container2 = document.createElement('div');
+      document.body.appendChild(container2);
+      container2.innerHTML = '<wa-button>Second</wa-button>';
+
+      const handler = sinon.spy();
+      container2.addEventListener('wa-discovery-complete', handler);
+
+      await discover(container2);
+
+      // Should still complete successfully
+      expect(handler).to.have.been.calledOnce;
+
+      container.remove();
+      container2.remove();
+    });
+  });
+});

--- a/packages/webawesome/src/utilities/autoloader.ts
+++ b/packages/webawesome/src/utilities/autoloader.ts
@@ -51,8 +51,14 @@ export async function discover(root: Document | Element | ShadowRoot) {
     }
   }
 
-  // Wait a cycle to allow the first Lit update to run
-  await new Promise(requestAnimationFrame);
+  // Wait for all components to complete their first render to prevent FOUCE.
+  // Using updateComplete ensures the component's shadow DOM is fully rendered.
+  if (tagsToRegister.length > 0) {
+    const elements = root.querySelectorAll<HTMLElement>(tagsToRegister.join(','));
+    await Promise.all(
+      [...elements].map(el => (el as HTMLElement & { updateComplete?: Promise<boolean> }).updateComplete),
+    );
+  }
 
   // Dispatch an event when discovery is complete.
   root.dispatchEvent(


### PR DESCRIPTION
 ## Summary: Fix for `wa-cloak` FOUCE Issue (#1366)                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                           
 ### Problem                                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                           
`wa-cloak` was being removed prematurely, causing FOUCE in Firefox. Components were rendering unstyled right before styles were applied.                                                                                                                                                
                                                                                                                                                                                                                                                                                                                                                                           
  **Root Cause:** The `discover()` function in `autoloader.ts` only waited one `requestAnimationFrame` cycle after component imports completed before firing the `wa-discovery-complete` event. This wasn't enough time for the components to finish their first render cycle.                                                                  
                                                                                                                                                                                                                                                                                                                                                                           
  ### Solution                                                                                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                           
  **File Modified:** `src/utilities/autoloader.ts`                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                           
  Replaced the single `requestAnimationFrame` promise with waiting for all discovered components' `updateComplete` promises to resolve. This ensures each component's shadow DOM is fully rendered before the `wa-cloak` class is removed.                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                           
  **Before**                                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                           
      await new Promise(requestAnimationFrame);                                                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                                                                           
  **After**                                                                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                           
      if (tagsToRegister.length > 0) {                                                                                                                                                                                                                                                                                                                                     
        const elements = root.querySelectorAll<HTMLElement>(tagsToRegister.join(','));                                                                                                                                                                                                                                                                                     
        await Promise.all(                                                                                                                                                                                                                                                                                                                                                 
          [...elements].map(el => (el as HTMLElement & { updateComplete?: Promise<boolean> }).updateComplete),                                                                                                                                                                                                                                                             
        );                                                                                                                                                                                                                                                                                                                                                                 
      }                                                                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                           
  `updateComplete` is a promise [Lit](https://lit.dev/docs/components/lifecycle/#updatecomplete); it resolves when the element has finished updating and rendering its template.                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                           
  ### Tests Added                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                           
  **File Created:** `src/utilities/autoloader.test.ts`                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                           
  - **dispatch `wa-discovery-complete` after discovering components** - Basic functionality verification                                                                                                                                                                                                                                                                     
  - **dispatch `wa-discovery-complete` even when no components need registration** - Edge case (empty container)                                                                                                                                                                                                                                                             
  - **wait for component updateComplete before dispatching** - Core fix verification                                                                                                                                                                                                                                                                                       
  - **have components fully rendered when `wa-discovery-complete` fires** - Core fix verification                                                                                                                                                                                                                                                                            
  - **handle nested components** - Complex DOM structures                                                                                                                                                                                                                                                                                                                  
  - **not fail when components fail to import** - Error handling / graceful degradation                                                                                                                                                                                                                                                                                    
  - **handle components that are already defined** - Pre-registered component edge case                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                           
  ### Verification                                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                           
  - **Build:** Passes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            
  - **New Autoloader Tests:** 7 passed     