### PR TITLE
Improve QR code API

### DIFF
--- a/packages/webawesome/docs/docs/components/qr-code.md
+++ b/packages/webawesome/docs/docs/components/qr-code.md
@@ -41,20 +41,32 @@ QR codes are useful for providing small pieces of information to users who can q
 
 ## Examples
 
-### Colors
-
-Use the `fill` and `background` attributes to modify the QR code's colors. You should always ensure good contrast for optimal compatibility with QR code scanners.
-
-```html {.example}
-<wa-qr-code value="https://shoelace.style/" fill="deeppink" background="white"></wa-qr-code>
-```
-
 ### Size
 
 Use the `size` attribute to change the size of the QR code.
 
 ```html {.example}
 <wa-qr-code value="https://shoelace.style/" size="64"></wa-qr-code>
+```
+
+### Colors
+
+The QR code's fill color is determined by the current text color. To change it, set the CSS `color` property on the host element or an ancestor element.
+
+The canvas is always transparent, so use the `background` or `background-color` CSS property on the host element to set a background color.
+
+A _quiet zone_ is the blank space around a QR code that helps scanners detect it more reliably. Use the `padding` CSS property on the host element to add one.
+
+```html {.example}
+<wa-qr-code
+  value="https://shoelace.style/"
+  style="
+    color: var(--wa-color-indigo-20);
+    background-color: var(--wa-color-indigo-90);
+    border-radius: var(--wa-border-radius-m);
+    padding: 1rem;
+  "
+></wa-qr-code>
 ```
 
 ### Radius

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -39,6 +39,10 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug in `<wa-tree-item>` that caused the cursor to show a pointer when no expand icon was present [pr:1936]
 - Fixed a bug in `<wa-tree-item>` that caused the chevron to render the wrong direction in RTL [pr:1798]
 - Improved the Persian translation [#1923]
+- Improved `<wa-qr-code>` to use CSS `color` for fill and `background-color` on the host for background
+  - Deprecated the `fill` and `background` attributes
+  - Existing implementations now correctly adapt to light/dark mode automatically
+  - When using CSS, the QR code will now adapt to `color` and `background` color changes automatically
 - Modified `wa-align-items-*` utility classes to apply `display: flex` by default [pr:1943]
 
 ## 3.1.0

--- a/packages/webawesome/src/components/qr-code/qr-code.styles.ts
+++ b/packages/webawesome/src/components/qr-code/qr-code.styles.ts
@@ -2,15 +2,16 @@ import { css } from 'lit';
 
 export default css`
   :host {
-    --size: 128px;
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    aspect-ratio: 1;
   }
 
-  :host,
   canvas {
-    max-width: var(--size);
-    max-height: var(--size);
-    width: var(--size);
-    height: var(--size);
+    width: 100%;
+    height: 100%;
+    /* We force a near-instant transition so we can listen for transitionend when the color changes */
+    transition: color 1ms;
   }
 `;

--- a/packages/webawesome/src/components/qr-code/qr-code.test.ts
+++ b/packages/webawesome/src/components/qr-code/qr-code.test.ts
@@ -78,6 +78,7 @@ const getQrCodeColors = (qrCode: WaQrCode): QrCodeColors => {
 const red = new Color(255, 0, 0, 255);
 const white = new Color(255, 255, 255, 255);
 const blue = new Color(0, 0, 255, 255);
+const transparent = new Color(0, 0, 0, 0);
 
 const expectQrCodeColorsToBe = (qrCode: WaQrCode, expectedColors: QrCodeColors): void => {
   const qrCodeColors = getQrCodeColors(qrCode);
@@ -122,18 +123,32 @@ describe('<wa-qr-code>', () => {
         expectCanvasToHaveAriaLabel(qrCode, 'test label');
       });
 
-      it('sets the correct color for the qr code', async () => {
+      it('sets the correct color for the qr code using deprecated fill attribute', async () => {
         const qrCode = await fixture<WaQrCode>(html` <wa-qr-code value="test data" fill="red"></wa-qr-code>`);
 
-        expectQrCodeColorsToBe(qrCode, { foreground: red, background: white });
+        expectQrCodeColorsToBe(qrCode, { foreground: red, background: transparent });
       });
 
-      it('sets the correct background for the qr code', async () => {
+      it('sets the correct background for the qr code using deprecated background attribute', async () => {
         const qrCode = await fixture<WaQrCode>(
           html` <wa-qr-code value="test data" fill="red" background="blue"></wa-qr-code>`,
         );
 
         expectQrCodeColorsToBe(qrCode, { foreground: red, background: blue });
+      });
+
+      it('sets the correct color for the qr code using CSS color property', async () => {
+        const qrCode = await fixture<WaQrCode>(
+          html` <wa-qr-code value="test data" style="color: red;"></wa-qr-code>`,
+        );
+
+        expectQrCodeColorsToBe(qrCode, { foreground: red, background: transparent });
+      });
+
+      it('uses transparent background by default', async () => {
+        const qrCode = await fixture<WaQrCode>(html` <wa-qr-code value="test data" fill="white"></wa-qr-code>`);
+
+        expectQrCodeColorsToBe(qrCode, { foreground: white, background: transparent });
       });
 
       it('has the expected size', async () => {

--- a/packages/webawesome/src/components/qr-code/qr-code.test.ts
+++ b/packages/webawesome/src/components/qr-code/qr-code.test.ts
@@ -138,9 +138,7 @@ describe('<wa-qr-code>', () => {
       });
 
       it('sets the correct color for the qr code using CSS color property', async () => {
-        const qrCode = await fixture<WaQrCode>(
-          html` <wa-qr-code value="test data" style="color: red;"></wa-qr-code>`,
-        );
+        const qrCode = await fixture<WaQrCode>(html` <wa-qr-code value="test data" style="color: red;"></wa-qr-code>`);
 
         expectQrCodeColorsToBe(qrCode, { foreground: red, background: transparent });
       });

--- a/packages/webawesome/src/components/qr-code/qr-code.ts
+++ b/packages/webawesome/src/components/qr-code/qr-code.ts
@@ -31,11 +31,17 @@ export default class WaQrCode extends WebAwesomeElement {
   /** The size of the QR code, in pixels. */
   @property({ type: Number }) size = 128;
 
-  /** The fill color. This can be any valid CSS color, but not a CSS custom property. */
-  @property() fill = 'black';
+  /**
+   * The fill color. This can be any valid CSS color, but not a CSS custom property.
+   * @deprecated Use the `color` CSS property instead.
+   */
+  @property() fill = '';
 
-  /** The background color. This can be any valid CSS color or `transparent`. It cannot be a CSS custom property. */
-  @property() background = 'white';
+  /**
+   * The background color. This can be any valid CSS color or `transparent`. It cannot be a CSS custom property.
+   * @deprecated Use the `background` or `background-color` CSS property on the host element instead.
+   */
+  @property() background = '';
 
   /** The edge radius of each module. Must be between 0 and 0.5. */
   @property({ type: Number }) radius = 0;
@@ -57,10 +63,8 @@ export default class WaQrCode extends WebAwesomeElement {
     }
   }
 
-  @watch(['background', 'errorCorrection', 'fill', 'radius', 'size', 'value'])
+  @watch(['background', 'errorCorrection', 'fill', 'radius', 'size', 'value'], { waitUntilFirstUpdate: true })
   generate() {
-    this.style.setProperty('--size', `${this.size}px`);
-
     if (!this.hasUpdated) {
       return;
     }
@@ -74,13 +78,20 @@ export default class WaQrCode extends WebAwesomeElement {
       return;
     }
 
+    this.canvas.style.maxWidth = `${this.size}px`;
+    this.canvas.style.maxHeight = `${this.size}px`;
+
+    const computedStyle = getComputedStyle(this);
+
     (QrCreator as unknown as typeof _QrCreator.default).render(
       {
         text: this.value,
         radius: this.radius,
         ecLevel: this.errorCorrection,
-        fill: this.fill,
-        background: this.background,
+        // Use the deprecated `fill` attribute if set, otherwise use the current text color
+        fill: this.fill || computedStyle.color,
+        // Use the deprecated `background` attribute if set, otherwise use transparent (the host has the bg color now)
+        background: this.background || null,
         // We draw the canvas larger and scale its container down to avoid blurring on high-density displays
         size: this.size * 2,
       },
@@ -97,6 +108,7 @@ export default class WaQrCode extends WebAwesomeElement {
         class="qr-code"
         role="img"
         aria-label=${this.label?.length > 0 ? this.label : this.value}
+        @transitionend=${() => this.generate()}
       ></canvas>
     `;
   }

--- a/packages/webawesome/src/components/qr-code/qr-code.ts
+++ b/packages/webawesome/src/components/qr-code/qr-code.ts
@@ -108,7 +108,11 @@ export default class WaQrCode extends WebAwesomeElement {
         class="qr-code"
         role="img"
         aria-label=${this.label?.length > 0 ? this.label : this.value}
-        @transitionend=${() => this.generate()}
+        @transitionend=${(event: TransitionEvent) => {
+          if (event.propertyName === 'color') {
+            this.generate();
+          }
+        }}
       ></canvas>
     `;
   }


### PR DESCRIPTION
- Deprecates the `fill` and `background` attributes as discussed (they still work when set)
- Uses `color` and `background` CSS properties to determine the QR code's color and background, allowing it to automatically adapt when the color scheme changes
- Improves sizing so a QR quiet zone can be added via `padding`
- Updated the docs to demonstrate

This improves the component in a backward compatible way.

Related: #1986, #1866