### PR TITLE
Don't inherit slots when generating a submitter

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -38,6 +38,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug in draggable elements that caused a TypeError on `touchend` events when `event.touches` was empty
 - Fixed a bug in `<wa-tree-item>` that caused the cursor to show a pointer when no expand icon was present [pr:1936]
 - Fixed a bug in `<wa-tree-item>` that caused the chevron to render the wrong direction in RTL [pr:1798]
+- Fixed a bug in `<wa-button>` that caused `<wa-dropdown>` elements to close immediately after opening when placed inside a `<form>` element
 - Improved the Persian translation [#1923]
 - Improved `<wa-qr-code>` to use CSS `color` for fill and `background-color` on the host for background
   - Deprecated the `fill` and `background` attributes

--- a/packages/webawesome/src/components/button/button.ts
+++ b/packages/webawesome/src/components/button/button.ts
@@ -136,7 +136,7 @@ export default class WaButton extends WebAwesomeFormAssociatedElement {
     const button = document.createElement('button');
 
     for (const attribute of this.attributes) {
-      if (attribute.name === 'style') {
+      if (['style', 'slot'].includes(attribute.name)) {
         // Skip style attributes as they *shouldn't* be necessary
         continue;
       }


### PR DESCRIPTION
See #1992

This regression was introduced in 3d395653fcd7113d0e22b4efc5bf7f101ec8d68f. The temporary submitter button was copying _all_ attributes except `style`, so it copied the dropdown trigger's `slot` attribute, effectively making it a second "trigger" and closing the dropdown.