### PR TITLE
don't construct light dom buttons on non-form buttons

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -38,7 +38,8 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug in draggable elements that caused a TypeError on `touchend` events when `event.touches` was empty
 - Fixed a bug in `<wa-tree-item>` that caused the cursor to show a pointer when no expand icon was present [pr:1936]
 - Fixed a bug in `<wa-tree-item>` that caused the chevron to render the wrong direction in RTL [pr:1798]
-- Improved the Persian translation [#1923]
+- Fixed a bug in `<wa-button>` that caused `<wa-dropdown>` elements to close immediately after opening when placed inside a `<form>` element [pr:1996]
+- Improved the Persian translation [pr:1923]
 - Improved `<wa-qr-code>` to use CSS `color` for fill and `background-color` on the host for background
   - Deprecated the `fill` and `background` attributes
   - Existing implementations now correctly adapt to light/dark mode automatically

--- a/packages/webawesome/src/components/button/button.ts
+++ b/packages/webawesome/src/components/button/button.ts
@@ -159,6 +159,11 @@ export default class WaButton extends WebAwesomeFormAssociatedElement {
   }
 
   private handleClick() {
+    // Only create a light dom button for submit / reset buttons.
+    if (this.type !== "submit" && this.type !== "reset") {
+      return
+    }
+
     const form = this.getForm();
 
     if (!form) return;

--- a/packages/webawesome/src/components/button/button.ts
+++ b/packages/webawesome/src/components/button/button.ts
@@ -160,8 +160,8 @@ export default class WaButton extends WebAwesomeFormAssociatedElement {
 
   private handleClick() {
     // Only create a light dom button for submit / reset buttons.
-    if (this.type !== "submit" && this.type !== "reset") {
-      return
+    if (this.type !== 'submit' && this.type !== 'reset') {
+      return;
     }
 
     const form = this.getForm();


### PR DESCRIPTION
See https://github.com/shoelace-style/webawesome/issues/1992

This regression was introduced in https://github.com/shoelace-style/webawesome/commit/3d395653fcd7113d0e22b4efc5bf7f101ec8d68f. The temporary submitter button was being added to the DOM even on non-reset / non-submit buttons, effectively making it a second "trigger" and closing the dropdown.