### PR TITLE
Revert `inert` and add changelog for disabled link buttons

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -27,6 +27,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Added missing `wa-gap-4xl` utility class [pr:1931]
 - Added `track` and `indicator` CSS parts to `<wa-progress-ring>` [pr:1863]
 - Added rotation, flip, and animation support to `<wa-icon>` with `rotate`, `flip`, and `animation` attributes supporting Font Awesome's animation utilities [pr:1824]
+- Added the ability to disabled link buttons in `<wa-button>` [pr:1848]
 - [Docs]: component APIs like slots, state, methods, etc, are now alphabetized [pr:1895]
 - [Docs]: component APIs now properly check their inheritance chain [pr:1895]
 - [Docs]: Included framework specific documentation for Svelte, Vue, and Angular. [pr:1895]

--- a/packages/webawesome/src/components/button/button.ts
+++ b/packages/webawesome/src/components/button/button.ts
@@ -158,7 +158,14 @@ export default class WaButton extends WebAwesomeFormAssociatedElement {
     return button;
   }
 
-  private handleClick() {
+  private handleClick(event: PointerEvent) {
+    // Prevent disabled and loading buttons from being clicked
+    if (this.disabled || this.loading) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      return;
+    }
+
     // Only create a light dom button for submit / reset buttons.
     if (this.type !== 'submit' && this.type !== 'reset') {
       return;
@@ -274,7 +281,6 @@ export default class WaButton extends WebAwesomeFormAssociatedElement {
           'is-icon-button': this.isIconButton,
         })}
         ?disabled=${ifDefined(isLink ? undefined : this.disabled)}
-        ?inert=${ifDefined(isLink ? this.disabled : undefined)}
         type=${ifDefined(isLink ? undefined : this.type)}
         title=${this.title /* An empty title prevents browser validation tooltips from appearing on hover */}
         name=${ifDefined(isLink ? undefined : this.name)}
@@ -284,7 +290,7 @@ export default class WaButton extends WebAwesomeFormAssociatedElement {
         download=${ifDefined(isLink ? this.download : undefined)}
         rel=${ifDefined(isLink && this.rel ? this.rel : undefined)}
         role=${ifDefined(isLink ? undefined : 'button')}
-        aria-disabled=${this.disabled ? 'true' : 'false'}
+        aria-disabled=${ifDefined(isLink && this.disabled ? 'true' : undefined)}
         tabindex=${this.disabled ? '-1' : '0'}
         @invalid=${this.isButton() ? this.handleInvalid : null}
         @click=${this.handleClick}


### PR DESCRIPTION
- Reverts `inert` for link buttons and prevents the event instead
- Adds changelog entry

Finishes up #1848