### PR TITLE
Fix color tokens in Agent Skill

### DIFF
--- a/packages/webawesome/scripts/agent-skill.js
+++ b/packages/webawesome/scripts/agent-skill.js
@@ -713,8 +713,8 @@ CSS variables follow the pattern \`--wa-color-{hue}-{tint}\`:
 
 \`\`\`css
 .my-element {
-  color: var(--wa-color-blue-600);
-  background: var(--wa-color-gray-100);
+  color: var(--wa-color-blue-60);
+  background: var(--wa-color-gray-10);
 }
 \`\`\`
 


### PR DESCRIPTION
Corrects the color tokens in the Agent Skill documentation by changing from three-digit tint values (e.g., -600, -100) to two-digit tint values (e.g., -60, -10).