### PR TITLE
Docs: Add Data Processing Agreement to Sidebar Nav

### DIFF
--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -486,6 +486,7 @@
   <li><a href="/tos">Terms of Service</a></li>
   <li><a href="/privacy">Privacy Policy</a></li>
   <li><a href="/refunds">Refund Policy</a></li>
+  <li><a href="/dpa">Data Processing Agreement</a></li>
 </ul>
 
 <wa-divider style="--spacing: var(--wa-space-xl);"></wa-divider>


### PR DESCRIPTION
This PR adds a link to the Data Processing Agreement in the documentation sidebar navigation, placing it alongside other legal and policy documents.