### PR TITLE
Fix `wa-visually-hidden-label` for radio groups

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -48,6 +48,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug in `<wa-radio-group>` where `<wa-radio>` elements with an explicit size would be overridden by the radio group even when the group had no size set.
 - Fixed a bug in `<wa-radio-group>` that caused radio sizes to no work as documented [issue:2001]
 - Fixed a bug in `<wa-popover>` that caused event handlers to be lost when moving the host element around in the DOM [pr:1976]
+- Fixed a bug preventing the `wa-visually-hidden-label` class from hiding labels for radio groups and color pickers [pr:2012]
 - Improved the Persian translation [pr:1923]
 - Improved `<wa-qr-code>` to use CSS `color` for fill and `background-color` on the host for background
   - Deprecated the `fill` and `background` attributes

--- a/packages/webawesome/src/styles/component/visually-hidden.styles.ts
+++ b/packages/webawesome/src/styles/component/visually-hidden.styles.ts
@@ -4,7 +4,8 @@ export default css`
   .wa-visually-hidden:not(:focus-within),
   .wa-visually-hidden-force,
   .wa-visually-hidden-hint::part(hint),
-  .wa-visually-hidden-label::part(label) {
+  .wa-visually-hidden-label::part(label),
+  .wa-visually-hidden-label::part(form-control-label) {
     position: absolute !important;
     width: 1px !important;
     height: 1px !important;

--- a/packages/webawesome/src/styles/utilities/visually-hidden.css
+++ b/packages/webawesome/src/styles/utilities/visually-hidden.css
@@ -3,8 +3,7 @@
   .wa-visually-hidden-force,
   .wa-visually-hidden-hint::part(hint),
   .wa-visually-hidden-label::part(label), 
-  .wa-visually-hidden-label::part(form-control-label)
-   {
+  .wa-visually-hidden-label::part(form-control-label) {
     position: absolute !important;
     width: 1px !important;
     height: 1px !important;

--- a/packages/webawesome/src/styles/utilities/visually-hidden.css
+++ b/packages/webawesome/src/styles/utilities/visually-hidden.css
@@ -2,7 +2,9 @@
   .wa-visually-hidden:not(:focus-within),
   .wa-visually-hidden-force,
   .wa-visually-hidden-hint::part(hint),
-  .wa-visually-hidden-label::part(label) {
+  .wa-visually-hidden-label::part(label), 
+  .wa-visually-hidden-label::part(form-control-label)
+   {
     position: absolute !important;
     width: 1px !important;
     height: 1px !important;

--- a/packages/webawesome/src/styles/utilities/visually-hidden.css
+++ b/packages/webawesome/src/styles/utilities/visually-hidden.css
@@ -2,7 +2,7 @@
   .wa-visually-hidden:not(:focus-within),
   .wa-visually-hidden-force,
   .wa-visually-hidden-hint::part(hint),
-  .wa-visually-hidden-label::part(label), 
+  .wa-visually-hidden-label::part(label),
   .wa-visually-hidden-label::part(form-control-label) {
     position: absolute !important;
     width: 1px !important;


### PR DESCRIPTION
Adds `.wa-visually-hidden-label::part(form-control-label)` to our visually hidden utility classes to ensure it works with components like `<wa-radio-group>`. 

Report: https://github.com/shoelace-style/webawesome/issues/1933#issuecomment-3841568511

