### PR TITLE
Docs: Set Up Redirects

### DIFF
--- a/packages/webawesome/docs/.eleventy.js
+++ b/packages/webawesome/docs/.eleventy.js
@@ -124,6 +124,7 @@ export default async function (eleventyConfig) {
   eleventyConfig.addFilter('stripExtension', string => path.parse(string + '').name);
   eleventyConfig.addFilter('stripPrefix', content => content.replace(/^wa-/, ''));
   eleventyConfig.addFilter('uniqueId', (_value, length = 8) => nanoid(length));
+  eleventyConfig.addFilter('urlencode', value => encodeURI(String(value ?? '')));
 
   eleventyConfig.addGlobalData('eleventyComputed', {
     // Page title with smart + default site name formatting
@@ -168,6 +169,20 @@ export default async function (eleventyConfig) {
       if (bValue === firstValue) return 1;
       return 0;
     });
+  });
+
+  eleventyConfig.addCollection('aliasRedirects', function (collectionApi) {
+    const pairs = [];
+    for (const page of collectionApi.getAll()) {
+      const aliases = page.data?.aliases;
+      if (!Array.isArray(aliases)) continue;
+      const to = page.url ?? '';
+      for (const alias of aliases) {
+        const from = (alias + '').split('/').filter(Boolean).join('/');
+        if (from) pairs.push({ from, to });
+      }
+    }
+    return pairs;
   });
 
   //

--- a/packages/webawesome/docs/docs/redirects.njk
+++ b/packages/webawesome/docs/docs/redirects.njk
@@ -1,0 +1,20 @@
+---
+pagination:
+  data: collections.aliasRedirects
+  size: 1
+  alias: redirect
+permalink: "{{ redirect.from }}/index.html"
+layout: null
+eleventyExcludeFromCollections: true
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0;url={{ redirect.to }}">
+  <title>Redirecting…</title>
+</head>
+<body>
+  <p>Redirecting to <a href="{{ redirect.to }}">{{ redirect.to }}</a>.</p>
+</body>
+</html>

--- a/packages/webawesome/docs/docs/utilities/align-items.md
+++ b/packages/webawesome/docs/docs/utilities/align-items.md
@@ -3,6 +3,8 @@ title: Align Items
 description: Control cross-axis alignment in flex and grid containers with align-items and align-self utility classes.
 layout: docs
 tags: layoutUtilities
+aliases:
+  - /docs/utilities/self-align
 ---
 
 <style>


### PR DESCRIPTION
Following up on a thread from https://github.com/shoelace-style/webawesome/pull/2010#pullrequestreview-3745765118...

This work allows Docs pages to have alternate URLs that send people to the same page.  

For example, `/docs/utilities/self-align` will redirect to the Align Items Docs (`/docs/utilities/align-items/`).

### How it works
- In a Doc-based view's front matter, you add an aliases list with the alternate path(s).
- The build creates a small redirect page at each alias (meta refresh + “click here” link), so the alias URL works when you open it.
- No server or app changes: everything is static HTML.


### How to add an alias
On the Doc-based view you want an alias to point to, add an `aliases` entry to the front matter like:

```md
---
...
aliases:
  - /docs/utilities/self-align
 ...
---
```

You can list multiple aliases; each gets its own redirect page.

