### PR TITLE
Docs: Add More Custom Iconography to Sidebar

### DIFF
--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -4,7 +4,10 @@
 {% from "planned-badge.njk" import plannedBadge %}
 
 {# Getting started #}
-<h2>Getting Started</h2>
+<h2 class="wa-cluster wa-gap-xs">
+  <wa-icon name="rocket-launch" aria-hidden="true"></wa-icon>
+  Getting Started
+</h2>
 <ul>
   <li><a href="/docs/">Installation</a></li>
   <li><a href="/docs/usage">Usage</a></li>
@@ -14,15 +17,19 @@
 </ul>
 
 {# Resources #}
-<h2>Resources</h2>
+<h2 class="wa-cluster wa-gap-xs">
+  <wa-icon name="book-spine" aria-hidden="true"></wa-icon>
+  Resources
+</h2>
 <ul>
   <li><a href="/docs/resources/support">Help & Support</a></li>
   <li><a href="https://github.com/shoelace-style/webawesome/">Source Code</a></li>
   <li>
     <span class="wa-split">
-      <a href="/docs/resources/figma">Figma Design Kit</a></li>
-      {{ proBadge() }}
-    </span>
+      <a href="/docs/resources/figma">Figma Design Kit</a>
+  </li>
+  {{ proBadge() }}
+  </span>
   </li>
   <li><a href="/docs/resources/accessibility">Accessibility</a></li>
   <li><a href="/docs/resources/browser-support">Browser Support</a></li>
@@ -32,7 +39,10 @@
 </ul>
 
 {# AI #}
-<h2>Using AI with Web Awesome</h2>
+<h2 class="wa-cluster wa-gap-xs">
+  <wa-icon name="sparkles" aria-hidden="true"></wa-icon>
+  Using AI with Web Awesome
+</h2>
 <ul>
   <li>
     <a class="wa-cluster wa-gap-xs" href="/docs/resources/agent-skills">
@@ -129,7 +139,10 @@
         </li>
       </ul>
     </li>
-    <li><span class="is-planned wa-split">Charts <span><a href="https://github.com/shoelace-style/webawesome/issues/1073" target="_blank">{{ plannedBadge("A Web Awesome Kickstarter stretch goal!") }}</a>{{ proBadge({ description: "This will require access to Web Awesome Pro" }) }}</span></span></li>
+    <li><span class="is-planned wa-split">Charts <span><a
+            href="https://github.com/shoelace-style/webawesome/issues/1073" target="_blank">{{ plannedBadge("A Web
+            Awesome Kickstarter stretch goal!") }}</a>{{ proBadge({ description: "This will require access to Web
+          Awesome Pro" }) }}</span></span></li>
     <li><a href="/docs/components/checkbox/">Checkbox</a></li>
     <li><a href="/docs/components/color-picker/">Color Picker</a></li>
     <li>
@@ -148,8 +161,14 @@
         <wa-icon name="flask" aria-hidden="true" class="icon-shrink"></wa-icon>
       </a>
     </li>
-    <li><span class="is-planned wa-split">Data Grid <span><a href="https://github.com/shoelace-style/webawesome/issues/1072" target="_blank">{{ plannedBadge("A Web Awesome Kickstarter stretch goal!") }}</a>{{ proBadge({ description: "This will require access to Web Awesome Pro" }) }}</span></span></li>
-    <li><span class="is-planned wa-split">Date Picker <span><a href="https://github.com/shoelace-style/webawesome/issues/1075" target="_blank">{{ plannedBadge("A Web Awesome Kickstarter stretch goal!") }}</a>{{ proBadge({ description: "This will require access to Web Awesome Pro" }) }}</span></span></li>
+    <li><span class="is-planned wa-split">Data Grid <span><a
+            href="https://github.com/shoelace-style/webawesome/issues/1072" target="_blank">{{ plannedBadge("A Web
+            Awesome Kickstarter stretch goal!") }}</a>{{ proBadge({ description: "This will require access to Web
+          Awesome Pro" }) }}</span></span></li>
+    <li><span class="is-planned wa-split">Date Picker <span><a
+            href="https://github.com/shoelace-style/webawesome/issues/1075" target="_blank">{{ plannedBadge("A Web
+            Awesome Kickstarter stretch goal!") }}</a>{{ proBadge({ description: "This will require access to Web
+          Awesome Pro" }) }}</span></span></li>
     <li><a href="/docs/components/details/">Details</a></li>
     <li><a href="/docs/components/dialog/">Dialog</a></li>
     <li><a href="/docs/components/divider/">Divider</a></li>
@@ -213,7 +232,9 @@
     </li>
     <li><a href="/docs/components/tag/">Tag</a></li>
     <li><a href="/docs/components/textarea/">Textarea</a></li>
-    <li><span class="is-planned wa-split">Toast <span><a href="https://github.com/shoelace-style/webawesome/issues/105" target="_blank">{{ plannedBadge("A Web Awesome Kickstarter stretch goal!") }}</a>{{ proBadge( { description: "This will require access to Web Awesome Pro" }) }}</span></span></li>
+    <li><span class="is-planned wa-split">Toast <span><a href="https://github.com/shoelace-style/webawesome/issues/105"
+            target="_blank">{{ plannedBadge("A Web Awesome Kickstarter stretch goal!") }}</a>{{ proBadge( { description:
+          "This will require access to Web Awesome Pro" }) }}</span></span></li>
     <li><a href="/docs/components/tooltip/">Tooltip</a></li>
     <li>
       <a href="/docs/components/tree/">Tree</a>
@@ -221,7 +242,9 @@
         <li><a href="/docs/components/tree-item/">Tree Item</a></li>
       </ul>
     </li>
-    <li><span class="is-planned wa-split">Video <span><a href="https://github.com/shoelace-style/webawesome/issues/985" target="_blank">{{ plannedBadge("A Web Awesome Kickstarter stretch goal!") }}</a>{{ proBadge( { description: "This will require access to Web Awesome Pro" }) }}</span></span></li>
+    <li><span class="is-planned wa-split">Video <span><a href="https://github.com/shoelace-style/webawesome/issues/985"
+            target="_blank">{{ plannedBadge("A Web Awesome Kickstarter stretch goal!") }}</a>{{ proBadge( { description:
+          "This will require access to Web Awesome Pro" }) }}</span></span></li>
     <li><a href="/docs/components/zoomable-frame">Zoomable Frame</a></li>
     {# PLOP_NEW_COMPONENT_PLACEHOLDER #}
   </ul>
@@ -338,7 +361,8 @@
         </li>
         <li>
           <a href="/docs/patterns/app/pagination/">Pagination</a>
-        </li><li>
+        </li>
+        <li>
           <a href="/docs/patterns/app/password/">Password</a>
         </li>
         <li>
@@ -355,7 +379,7 @@
         {{ proBadge() }}
       </span>
       <ul>
-      <li>
+        <li>
           <a href="/docs/patterns/blog-news/banners/">Banners</a>
         </li>
         <li>
@@ -470,7 +494,10 @@
 </wa-details>
 
 <!-- Theming -->
-<h2>Theming</h2>
+<h2 class="wa-cluster wa-gap-xs">
+  <wa-icon name="palette" aria-hidden="true"></wa-icon>
+  Theming
+</h2>
 <ul>
   <li><a href="/docs/color-palettes">Color Palettes</a></li>
   <li><a href="/docs/themes">Themes</a></li>
@@ -497,7 +524,10 @@
 </wa-details>
 
 {# Policies #}
-<h2>Terms &amp; Policies</h2>
+<h2 class="wa-cluster wa-gap-xs">
+  <wa-icon name="file-contract" aria-hidden="true"></wa-icon>
+  Terms &amp; Policies
+</h2>
 <ul>
   <li><a href="/license"><span class="wa-visually-hidden">Web Awesome </span>Free License</a></li>
   <li><a href="/license/pro"><span class="wa-visually-hidden">Web Awesome </span>Pro License</a></li>
@@ -516,17 +546,20 @@
     <p class="wa-caption-xs wa-cluster wa-gap-xs">
       Version {{ package.version }}
       <wa-icon id="version-icon-info" family="duotone" variant="regular" name="party-horn"></wa-icon>
-      <wa-tooltip for="version-icon-info" distance="2" class="wa-font-size-xs">Here be freshly launched Awesome and no wa-dragons</wa-tooltip>
+      <wa-tooltip for="version-icon-info" distance="2" class="wa-font-size-xs">Here be freshly launched Awesome and no
+        wa-dragons</wa-tooltip>
     </p>
     <p class="wa-caption-xs">&copy; Fonticons, Inc.</p>
   </div>
 
   <div class="wa-cluster wa-gap-0 wa-caption-xs the-socials">
     <h2 class="wa-visually-hidden">Web Awesome Elsewhere</h2>
-    <a href="https://github.com/shoelace-style/webawesome" rel="noopener noreferrer" target="_blank" class="appearance-plain">
+    <a href="https://github.com/shoelace-style/webawesome" rel="noopener noreferrer" target="_blank"
+      class="appearance-plain">
       <wa-icon family="brands" name="github" label="GitHub"></wa-icon>
     </a>
-    <a href="https://bsky.app/profile/webawesome.com" rel="noopener noreferrer" target="_blank" class="appearance-plain">
+    <a href="https://bsky.app/profile/webawesome.com" rel="noopener noreferrer" target="_blank"
+      class="appearance-plain">
       <wa-icon family="brands" name="bluesky" label="Bluesky"></wa-icon>
     </a>
     <a href="https://mastodon.social/@webawesome" rel="noopener noreferrer" target="_blank" class="appearance-plain">

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -27,9 +27,8 @@
   <li>
     <span class="wa-split">
       <a href="/docs/resources/figma">Figma Design Kit</a>
-  </li>
-  {{ proBadge() }}
-  </span>
+      {{ proBadge() }}
+    </span>
   </li>
   <li><a href="/docs/resources/accessibility">Accessibility</a></li>
   <li><a href="/docs/resources/browser-support">Browser Support</a></li>
@@ -140,9 +139,7 @@
       </ul>
     </li>
     <li><span class="is-planned wa-split">Charts <span><a
-            href="https://github.com/shoelace-style/webawesome/issues/1073" target="_blank">{{ plannedBadge("A Web
-            Awesome Kickstarter stretch goal!") }}</a>{{ proBadge({ description: "This will require access to Web
-          Awesome Pro" }) }}</span></span></li>
+            href="https://github.com/shoelace-style/webawesome/issues/1073" target="_blank">{{ plannedBadge("A Web Awesome Kickstarter stretch goal!") }}</a>{{ proBadge({ description: "This will require access to Web Awesome Pro" }) }}</span></span></li>
     <li><a href="/docs/components/checkbox/">Checkbox</a></li>
     <li><a href="/docs/components/color-picker/">Color Picker</a></li>
     <li>
@@ -162,13 +159,9 @@
       </a>
     </li>
     <li><span class="is-planned wa-split">Data Grid <span><a
-            href="https://github.com/shoelace-style/webawesome/issues/1072" target="_blank">{{ plannedBadge("A Web
-            Awesome Kickstarter stretch goal!") }}</a>{{ proBadge({ description: "This will require access to Web
-          Awesome Pro" }) }}</span></span></li>
+            href="https://github.com/shoelace-style/webawesome/issues/1072" target="_blank">{{ plannedBadge("A Web Awesome Kickstarter stretch goal!") }}</a>{{ proBadge({ description: "This will require access to Web Awesome Pro" }) }}</span></span></li>
     <li><span class="is-planned wa-split">Date Picker <span><a
-            href="https://github.com/shoelace-style/webawesome/issues/1075" target="_blank">{{ plannedBadge("A Web
-            Awesome Kickstarter stretch goal!") }}</a>{{ proBadge({ description: "This will require access to Web
-          Awesome Pro" }) }}</span></span></li>
+            href="https://github.com/shoelace-style/webawesome/issues/1075" target="_blank">{{ plannedBadge("A Web Awesome Kickstarter stretch goal!") }}</a>{{ proBadge({ description: "This will require access to Web Awesome Pro" }) }}</span></span></li>
     <li><a href="/docs/components/details/">Details</a></li>
     <li><a href="/docs/components/dialog/">Dialog</a></li>
     <li><a href="/docs/components/divider/">Divider</a></li>
@@ -233,8 +226,7 @@
     <li><a href="/docs/components/tag/">Tag</a></li>
     <li><a href="/docs/components/textarea/">Textarea</a></li>
     <li><span class="is-planned wa-split">Toast <span><a href="https://github.com/shoelace-style/webawesome/issues/105"
-            target="_blank">{{ plannedBadge("A Web Awesome Kickstarter stretch goal!") }}</a>{{ proBadge( { description:
-          "This will require access to Web Awesome Pro" }) }}</span></span></li>
+            target="_blank">{{ plannedBadge("A Web Awesome Kickstarter stretch goal!") }}</a>{{ proBadge({ description: "This will require access to Web Awesome Pro" }) }}</span></span></li>
     <li><a href="/docs/components/tooltip/">Tooltip</a></li>
     <li>
       <a href="/docs/components/tree/">Tree</a>
@@ -243,8 +235,7 @@
       </ul>
     </li>
     <li><span class="is-planned wa-split">Video <span><a href="https://github.com/shoelace-style/webawesome/issues/985"
-            target="_blank">{{ plannedBadge("A Web Awesome Kickstarter stretch goal!") }}</a>{{ proBadge( { description:
-          "This will require access to Web Awesome Pro" }) }}</span></span></li>
+            target="_blank">{{ plannedBadge("A Web Awesome Kickstarter stretch goal!") }}</a>{{ proBadge({ description: "This will require access to Web Awesome Pro" }) }}</span></span></li>
     <li><a href="/docs/components/zoomable-frame">Zoomable Frame</a></li>
     {# PLOP_NEW_COMPONENT_PLACEHOLDER #}
   </ul>
@@ -546,8 +537,7 @@
     <p class="wa-caption-xs wa-cluster wa-gap-xs">
       Version {{ package.version }}
       <wa-icon id="version-icon-info" family="duotone" variant="regular" name="party-horn"></wa-icon>
-      <wa-tooltip for="version-icon-info" distance="2" class="wa-font-size-xs">Here be freshly launched Awesome and no
-        wa-dragons</wa-tooltip>
+      <wa-tooltip for="version-icon-info" distance="2" class="wa-font-size-xs">Here be freshly launched Awesome and no wa-dragons</wa-tooltip>
     </p>
     <p class="wa-caption-xs">&copy; Fonticons, Inc.</p>
   </div>

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -5,7 +5,7 @@
 
 {# Getting started #}
 <h2 class="wa-cluster wa-gap-xs">
-  <wa-icon name="rocket-launch" aria-hidden="true"></wa-icon>
+  <wa-icon name="rocket-launch" variant="regular" aria-hidden="true"></wa-icon>
   Getting Started
 </h2>
 <ul>
@@ -18,7 +18,7 @@
 
 {# Resources #}
 <h2 class="wa-cluster wa-gap-xs">
-  <wa-icon name="book-spine" aria-hidden="true"></wa-icon>
+  <wa-icon name="book-spine" variant="regular" aria-hidden="true"></wa-icon>
   Resources
 </h2>
 <ul>
@@ -39,7 +39,7 @@
 
 {# AI #}
 <h2 class="wa-cluster wa-gap-xs">
-  <wa-icon name="sparkles" aria-hidden="true"></wa-icon>
+  <wa-icon name="sparkles" variant="regular" aria-hidden="true"></wa-icon>
   Using AI with Web Awesome
 </h2>
 <ul>
@@ -60,7 +60,7 @@
 <wa-details appearance="outlined">
   <h2 slot="summary">
     <a class="wa-cluster wa-gap-xs" href="/docs/frameworks/">
-      <wa-icon name="puzzle" aria-hidden="true"></wa-icon>
+      <wa-icon name="puzzle" variant="regular" aria-hidden="true"></wa-icon>
       Frameworks
     </a>
   </h2>
@@ -97,7 +97,7 @@
 <wa-details appearance="outlined">
   <h2 slot="summary">
     <a class="wa-cluster wa-gap-xs" href="/docs/components/" title="Overview">
-      <wa-icon name="trowel-bricks" aria-hidden="true"></wa-icon>
+      <wa-icon name="trowel-bricks" variant="regular" aria-hidden="true"></wa-icon>
       Components
     </a>
   </h2>
@@ -244,7 +244,7 @@
 <!-- Data Visualization -->
 <wa-details appearance="outlined">
   <h2 slot="summary">
-    <wa-icon name="chart-area" aria-hidden="true"></wa-icon>
+    <wa-icon name="chart-area" variant="regular" aria-hidden="true"></wa-icon>
     Data Visualization
   </h2>
   <ul>
@@ -264,7 +264,7 @@
 <wa-details appearance="outlined">
   <h2 slot="summary">
     <a class="wa-cluster wa-gap-xs" href="/docs/utilities/" title="Overview">
-      <wa-icon name="brush" aria-hidden="true"></wa-icon>
+      <wa-icon name="brush" variant="regular" aria-hidden="true"></wa-icon>
       Style Utilities
     </a>
   </h2>
@@ -282,7 +282,7 @@
 <wa-details appearance="outlined">
   <h2 slot="summary">
     <a class="wa-cluster wa-gap-xs" href="/docs/layout/" title="Overview">
-      <wa-icon name="ruler-combined" aria-hidden="true"></wa-icon>
+      <wa-icon name="ruler-combined" variant="regular" aria-hidden="true"></wa-icon>
       Layout
     </a>
   </h2>
@@ -312,7 +312,7 @@
 <wa-details appearance="outlined">
   <h2 slot="summary">
     <a class="wa-cluster wa-gap-xs" href="/docs/patterns/" title="Overview">
-      <wa-icon name="block-brick" aria-hidden="true"></wa-icon>
+      <wa-icon name="block-brick" variant="regular" aria-hidden="true"></wa-icon>
       Patterns
     </a>
   </h2>
@@ -486,7 +486,7 @@
 
 <!-- Theming -->
 <h2 class="wa-cluster wa-gap-xs">
-  <wa-icon name="palette" aria-hidden="true"></wa-icon>
+  <wa-icon name="palette" variant="regular" aria-hidden="true"></wa-icon>
   Theming
 </h2>
 <ul>
@@ -498,7 +498,7 @@
 <wa-details appearance="outlined">
   <h2 slot="summary">
     <a class="wa-cluster wa-gap-xs" href="/docs/tokens/" title="Overview">
-      <wa-icon name="coin-front" aria-hidden="true"></wa-icon>
+      <wa-icon name="coin-front" variant="regular" aria-hidden="true"></wa-icon>
       Design Tokens
     </a>
   </h2>
@@ -516,7 +516,7 @@
 
 {# Policies #}
 <h2 class="wa-cluster wa-gap-xs">
-  <wa-icon name="file-contract" aria-hidden="true"></wa-icon>
+  <wa-icon name="file-contract" variant="regular" aria-hidden="true"></wa-icon>
   Terms &amp; Policies
 </h2>
 <ul>

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -51,7 +51,7 @@
 <wa-details appearance="outlined">
   <h2 slot="summary">
     <a class="wa-cluster wa-gap-xs" href="/docs/frameworks/">
-      <wa-icon name="grid-2" aria-hidden="true"></wa-icon>
+      <wa-icon name="puzzle" aria-hidden="true"></wa-icon>
       Frameworks
     </a>
   </h2>
@@ -88,7 +88,7 @@
 <wa-details appearance="outlined">
   <h2 slot="summary">
     <a class="wa-cluster wa-gap-xs" href="/docs/components/" title="Overview">
-      <wa-icon name="grid-2" aria-hidden="true"></wa-icon>
+      <wa-icon name="trowel-bricks" aria-hidden="true"></wa-icon>
       Components
     </a>
   </h2>
@@ -250,7 +250,7 @@
 <wa-details appearance="outlined">
   <h2 slot="summary">
     <a class="wa-cluster wa-gap-xs" href="/docs/utilities/" title="Overview">
-      <wa-icon name="grid-2" aria-hidden="true"></wa-icon>
+      <wa-icon name="brush" aria-hidden="true"></wa-icon>
       Style Utilities
     </a>
   </h2>
@@ -268,7 +268,7 @@
 <wa-details appearance="outlined">
   <h2 slot="summary">
     <a class="wa-cluster wa-gap-xs" href="/docs/layout/" title="Overview">
-      <wa-icon name="grid-2" aria-hidden="true"></wa-icon>
+      <wa-icon name="ruler-combined" aria-hidden="true"></wa-icon>
       Layout
     </a>
   </h2>
@@ -298,7 +298,7 @@
 <wa-details appearance="outlined">
   <h2 slot="summary">
     <a class="wa-cluster wa-gap-xs" href="/docs/patterns/" title="Overview">
-      <wa-icon name="grid-2" aria-hidden="true"></wa-icon>
+      <wa-icon name="block-brick" aria-hidden="true"></wa-icon>
       Patterns
     </a>
   </h2>
@@ -480,7 +480,7 @@
 <wa-details appearance="outlined">
   <h2 slot="summary">
     <a class="wa-cluster wa-gap-xs" href="/docs/tokens/" title="Overview">
-      <wa-icon name="grid-2" aria-hidden="true"></wa-icon>
+      <wa-icon name="coin-front" aria-hidden="true"></wa-icon>
       Design Tokens
     </a>
   </h2>

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -47,13 +47,13 @@
   <li>
     <a class="wa-cluster wa-gap-xs" href="/docs/resources/agent-skills">
       Agent Skills
-      <wa-icon name="flask" aria-hidden="true" class="icon-shrink"></wa-icon>
+      <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
     </a>
   </li>
   <li>
     <a class="wa-cluster wa-gap-xs" href="/docs/resources/llms">
       LLMs
-      <wa-icon name="flask" aria-hidden="true" class="icon-shrink"></wa-icon>
+      <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
     </a>
   </li>
 </ul>
@@ -106,7 +106,7 @@
     <li>
       <span class="wa-split">
         <a class="wa-cluster wa-gap-xs" href="/docs/components/page/">
-          Page <wa-icon name="flask" aria-hidden="true" class="icon-shrink"></wa-icon>
+          Page <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
         </a>
         {{ proBadge() }}
       </span>
@@ -128,13 +128,13 @@
     <li>
       <a class="wa-cluster wa-gap-xs" href="/docs/components/carousel/">
         Carousel
-        <wa-icon name="flask" aria-hidden="true" class="icon-shrink"></wa-icon>
+        <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
       </a>
       <ul>
         <li>
           <a class="wa-cluster wa-gap-xs" href="/docs/components/carousel-item/">
             Carousel Item
-            <wa-icon name="flask" aria-hidden="true" class="icon-shrink"></wa-icon>
+            <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
           </a>
         </li>
       </ul>
@@ -149,7 +149,7 @@
       <span class="wa-split">
         <span>
           <a href="/docs/components/combobox">Combobox</a>
-          <wa-icon name="flask" aria-hidden="true" class="icon-shrink"></wa-icon>
+          <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
         </span>
         {{ proBadge() }}
       </span>
@@ -158,7 +158,7 @@
     <li>
       <a class="wa-cluster wa-gap-xs" href="/docs/components/copy-button/">
         Copy Button
-        <wa-icon name="flask" aria-hidden="true" class="icon-shrink"></wa-icon>
+        <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
       </a>
     </li>
     <li><span class="is-planned wa-split">Data Grid <span><a
@@ -183,7 +183,7 @@
       <span class="wa-split">
         <span>
           <a href="/docs/components/file-input">File Input</a>
-          <wa-icon name="flask" aria-hidden="true" class="icon-shrink"></wa-icon>
+          <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
         </span>
         {{ proBadge() }}
       </span>
@@ -261,7 +261,7 @@
       <span class="wa-split">
         <span>
           <a href="/docs/components/sparkline">Sparkline</a>
-          <wa-icon name="flask" aria-hidden="true" class="icon-shrink"></wa-icon>
+          <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
         </span>
         {{ proBadge() }}
       </span>
@@ -309,7 +309,7 @@
     <li>
       <span class="wa-split">
         <a class="wa-cluster wa-gap-xs" href="/docs/components/page/">
-          Page <wa-icon name="flask" aria-hidden="true" class="icon-shrink"></wa-icon>
+          Page <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
         </a>
         {{ proBadge() }}
       </span>

--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -220,20 +220,8 @@ wa-page > header {
 }
 
 #sidebar {
-  h2 {
-    a {
-      color: var(--wa-color-text-normal);
-      text-decoration: none;
-
-      wa-icon {
-        font-size: var(--wa-font-size-s);
-        font-weight: var(--wa-font-weight-action);
-      }
-
-      &:hover {
-        text-decoration: underline;
-      }
-    }
+  h2 a {
+    --wa-color-text-link: var(--wa-color-text-normal);
   }
 
   wa-button.delete {

--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -221,8 +221,6 @@ wa-page > header {
 
 #sidebar {
   h2 {
-    color: var(--wa-color-text-quiet);
-
     a {
       color: var(--wa-color-text-normal);
       text-decoration: none;

--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -146,6 +146,12 @@ wa-page > header {
     margin-block-start: var(--wa-space-xs);
   }
 
+  /* visually align icon with child list's border-start */
+  h2:has(wa-icon) {
+    position: relative;
+    inset-inline-start: calc(var(--wa-space-xs) * -1);
+  }
+
   wa-details {
     --spacing: 0;
 


### PR DESCRIPTION
This PR enhances the documentation sidebar by adding custom icons to section headings and updating existing icons for better visual organization. The changes include both visual improvements through new icons and CSS adjustments to properly position headings containing icons. 

| Before | After |
|--------|--------|
| <img width="592" height="1534" alt="CleanShot 2026-02-04 at 13 18 40@2x" src="https://github.com/user-attachments/assets/cfc67725-e4f0-49da-a8ef-2f57ae6a91d5" /> | <img width="590" height="1526" alt="CleanShot 2026-02-04 at 16 12 29@2x" src="https://github.com/user-attachments/assets/761fc014-eefd-4470-a2d8-c320cae90a67" /> | 

**Changes:**
- Added custom icons to "Getting Started", "Resources", "Using AI with Web Awesome", "Theming", and "Terms & Policies" section headings
- Updated icons for "Frameworks" (grid-2 → puzzle), "Components" (grid-2 → trowel-bricks), "Style Utilities" (grid-2 → brush), and "Patterns" (grid-2 → block-brick)
- Added CSS rule to adjust positioning of `h2` elements containing icons
- Using new `de-emphasize` class to visually downplay experimental iconography