### PR TITLE
Docs: Sync Up Search Iconography

### DIFF
--- a/packages/webawesome/docs/_includes/search.njk
+++ b/packages/webawesome/docs/_includes/search.njk
@@ -43,7 +43,7 @@
     </div>
 
     {# Footer #}
-    <footer>
+    <footer class="wa-cluster wa-justify-content-center wa-gap-xl">
       <small>
         <kbd aria-label="Up"><wa-icon name="arrow-up" family="micro"></wa-icon></kbd>
         <kbd aria-label="Down"><wa-icon name="arrow-down" family="micro"></wa-icon></kbd>

--- a/packages/webawesome/docs/assets/scripts/search.js
+++ b/packages/webawesome/docs/assets/scripts/search.js
@@ -331,7 +331,7 @@ async function updateResults(query = '') {
       a.href = page.url;
       a.innerHTML = `
         <div class="site-search-result-icon" aria-hidden="true">
-          <wa-icon name="${icon}"></wa-icon>
+          <wa-icon name="${icon}" variant="regular"></wa-icon>
         </div>
         <div class="site-search-result-details">
           <div class="site-search-result-title"></div>

--- a/packages/webawesome/docs/assets/scripts/search.js
+++ b/packages/webawesome/docs/assets/scripts/search.js
@@ -20,6 +20,40 @@ let resultSelected = false;
 const trackModule = res[2];
 const trackEvent = trackModule?.trackEvent || window.trackEvent || (() => {});
 
+const iconByPrefix = [
+  ['/license', 'file-contract'],
+  ['/tos', 'file-contract'],
+  ['/privacy', 'file-contract'],
+  ['/refunds', 'file-contract'],
+  ['/dpa', 'file-contract'],
+  ['/docs/color-palettes', 'palette'],
+  ['/docs/themes', 'palette'],
+  ['/docs/layout', 'ruler-combined'],
+  ['/docs/utilities/align-items', 'ruler-combined'],
+  ['/docs/utilities/justify-content', 'ruler-combined'],
+  ['/docs/utilities/flex-wrap', 'ruler-combined'],
+  ['/docs/utilities/gap', 'ruler-combined'],
+  ['/docs/utilities/cluster', 'ruler-combined'],
+  ['/docs/utilities/flank', 'ruler-combined'],
+  ['/docs/utilities/frame', 'ruler-combined'],
+  ['/docs/utilities/grid', 'ruler-combined'],
+  ['/docs/utilities/split', 'ruler-combined'],
+  ['/docs/utilities/stack', 'ruler-combined'],
+  ['/docs/utilities/native', 'code'],
+  ['/docs/utilities', 'brush'],
+  ['/docs/usage', 'rocket-launch'],
+  ['/docs/customizing', 'rocket-launch'],
+  ['/docs/form-controls', 'rocket-launch'],
+  ['/docs/localization', 'rocket-launch'],
+  ['/docs/components', 'trowel-bricks'],
+  ['/docs/patterns', 'block-brick'],
+  ['/docs/frameworks', 'puzzle'],
+  ['/docs/tokens', 'coin-front'],
+  ['/docs/resources/agent-skills', 'sparkles'],
+  ['/docs/resources/llms', 'sparkles'],
+  ['/docs/resources', 'book-spine'],
+].sort((a, b) => b[0].length - a[0].length);
+
 // We're using Turbo, so references to these elements aren't guaranteed to remain intact
 function getElements() {
   return {
@@ -325,13 +359,15 @@ async function updateResults(query = '') {
       li.setAttribute('id', `search-result-item-${match.ref}`);
       li.setAttribute('data-selected', index === 0 ? 'true' : 'false');
       if (page.url === '/') icon = 'home';
-      if (page.url.startsWith('/docs/utilities/native')) icon = 'code';
-      if (page.url.startsWith('/docs/components')) icon = 'trowel-bricks';
-      if (page.url.startsWith('/docs/patterns')) icon = 'block-brick';
-      if (page.url.startsWith('/docs/frameworks')) icon = 'puzzle';
-      if (page.url.startsWith('/docs/tokens')) icon = 'coin-front';
-      if (page.url.startsWith('/docs/resources')) icon = 'book-spine';
-      if (page.url.startsWith('/docs/theme') || page.url.startsWith('/docs/restyle')) icon = 'palette';
+      else if (page.url === '/docs') icon = 'rocket-launch';
+      else {
+        for (const [prefix, name] of iconByPrefix) {
+          if (page.url.startsWith(prefix)) {
+            icon = name;
+            break;
+          }
+        }
+      }
       a.href = page.url;
       a.innerHTML = `
         <div class="site-search-result-icon" aria-hidden="true">

--- a/packages/webawesome/docs/assets/scripts/search.js
+++ b/packages/webawesome/docs/assets/scripts/search.js
@@ -326,7 +326,11 @@ async function updateResults(query = '') {
       li.setAttribute('data-selected', index === 0 ? 'true' : 'false');
       if (page.url === '/') icon = 'home';
       if (page.url.startsWith('/docs/utilities/native')) icon = 'code';
-      if (page.url.startsWith('/docs/components')) icon = 'puzzle-piece';
+      if (page.url.startsWith('/docs/components')) icon = 'trowel-bricks';
+      if (page.url.startsWith('/docs/patterns')) icon = 'block-brick';
+      if (page.url.startsWith('/docs/frameworks')) icon = 'puzzle';
+      if (page.url.startsWith('/docs/tokens')) icon = 'coin-front';
+      if (page.url.startsWith('/docs/resources')) icon = 'book-spine';
       if (page.url.startsWith('/docs/theme') || page.url.startsWith('/docs/restyle')) icon = 'palette';
       a.href = page.url;
       a.innerHTML = `

--- a/packages/webawesome/docs/assets/styles/search.css
+++ b/packages/webawesome/docs/assets/styles/search.css
@@ -166,7 +166,7 @@
     justify-content: center;
 
     wa-icon {
-      font-size: 1.75rem;
+      font-size: var(--wa-font-size-xl);
       color: var(--wa-color-neutral-fill-loud);
     }
   }
@@ -185,7 +185,7 @@
   }
 
   .site-search-result-title {
-    font-size: 1.25rem;
+    font-size: var(--wa-font-size-l);
     font-weight: var(--wa-font-weight-semibold);
     color: var(--wa-color-brand-on-normal);
   }
@@ -205,9 +205,9 @@
 #site-search-empty {
   display: none;
   text-align: center;
-  font-size: 0.875rem;
+  font-size: var(--wa-font-size-s);
   color: var(--wa-color-text-quiet);
-  padding: 3rem 2rem;
+  padding: var(--wa-space-3xl) var(--wa-space-2xl);
 
   wa-icon {
     display: block;
@@ -224,16 +224,11 @@
 
 /* Footer */
 #site-search footer {
-  flex: 0 0 auto;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  gap: 2rem;
   color: var(--wa-color-text-quiet);
   border-top: var(--wa-panel-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
   border-bottom-left-radius: var(--wa-border-radius-l);
   border-bottom-right-radius: var(--wa-border-radius-l);
-  padding: 1rem;
+  padding: var(--wa-space-m);
 
   kbd {
     display: inline-flex;


### PR DESCRIPTION
This PR updates the search functionality's styling and iconography to use design tokens and standardized icons - which were recently revised in https://github.com/shoelace-style/webawesome/pull/2019. 

The changes aim to replace hardcoded CSS values with CSS variables for better consistency and maintainability, update the footer layout to use utility classes, and implement a comprehensive icon mapping system for search results that directly match the `sidebar.njk` nav's per-section iconography.

FYI, there's more refactor work to do than what was covered in https://github.com/shoelace-style/webawesome/pull/2029/commits/f3f7bc2994254168a5e5c32f1670f1ed4026676e, but that's a start.

| Before | After |
|--------|--------|
| <img width="2920" height="3192" alt="CleanShot 2026-02-05 at 11 41 18@2x" src="https://github.com/user-attachments/assets/d0d52e07-71fd-431f-be2e-c29dac5bbaca" /> | <img width="2920" height="3192" alt="CleanShot 2026-02-05 at 11 39 26@2x" src="https://github.com/user-attachments/assets/77efae4e-ee0a-472c-baef-1a6d46e64fbf" /> |
| <img width="2920" height="3192" alt="CleanShot 2026-02-05 at 11 41 30@2x" src="https://github.com/user-attachments/assets/543e63c7-6a28-46f2-800d-90a58e4b6171" /> | <img width="2920" height="3192" alt="CleanShot 2026-02-05 at 11 39 56@2x" src="https://github.com/user-attachments/assets/777f7fad-85a2-42b2-8e09-c90772ddaec9" /> | 