### PR TITLE
Lit change-in-update warnings from many components #1269

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -13,6 +13,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 
 ## Next
 
+- Fixed a bug in `<wa-card>`, `<wa-slider>`, `<wa-checkbox>`, `<wa-radio-group>`, and `<wa-select>` that occurred when reactive properties were set after update cycles completed [pr:1269]
 - Fixed a bug `<wa-color-picker>` that prevented it from flipping horizontally when position to the right of the viewport. [pr:2024]
 
 ## 3.2.1

--- a/packages/webawesome/src/components/card/card.ts
+++ b/packages/webawesome/src/components/card/card.ts
@@ -57,7 +57,7 @@ export default class WaCard extends WebAwesomeElement {
   @property({ reflect: true })
   orientation: 'horizontal' | 'vertical' = 'vertical';
 
-  updated() {
+  protected willUpdate() {
     // Enable the respective slots when detected
     if (!this.withHeader && this.hasSlotController.test('header')) this.withHeader = true;
     if (!this.withMedia && this.hasSlotController.test('media')) this.withMedia = true;

--- a/packages/webawesome/src/components/checkbox/checkbox.ts
+++ b/packages/webawesome/src/components/checkbox/checkbox.ts
@@ -123,14 +123,6 @@ export default class WaCheckbox extends WebAwesomeFormAssociatedElement {
     });
   }
 
-  @watch('defaultChecked')
-  handleDefaultCheckedChange() {
-    if (!this.hasInteracted && this.checked !== this.defaultChecked) {
-      this.checked = this.defaultChecked;
-      this.handleValueOrCheckedChange();
-    }
-  }
-
   handleValueOrCheckedChange() {
     // These @watch() commands seem to override the base element checks for changes, so we need to setValue for the form and and updateValidity()
     this.setValue(this.checked ? this.value : null, this._value);

--- a/packages/webawesome/src/components/radio-group/radio-group.ts
+++ b/packages/webawesome/src/components/radio-group/radio-group.ts
@@ -193,7 +193,7 @@ export default class WaRadioGroup extends WebAwesomeFormAssociatedElement {
     this.focus();
   }
 
-  private async syncRadioElements() {
+  private syncRadioElements() {
     const radios = this.getAllRadios();
 
     // Set positioning data attributes and properties
@@ -205,27 +205,23 @@ export default class WaRadioGroup extends WebAwesomeFormAssociatedElement {
       radio.toggleAttribute('data-wa-radio-inner', index !== 0 && index !== radios.length - 1);
       radio.toggleAttribute('data-wa-radio-last', index === radios.length - 1);
 
-      // Set forceDisabled state based on radio group's disabled state
-      (radio as WaRadio).forceDisabled = this.disabled;
+      // Set forceDisabled state based on radio group's disabled state - only if changed
+      if ((radio as WaRadio).forceDisabled !== this.disabled) {
+        (radio as WaRadio).forceDisabled = this.disabled;
+      }
+
+      // Set checked state - only if changed to avoid triggering unnecessary updates
+      const shouldBeChecked = !radio.disabled && radio.value === this.value;
+      if (radio.checked !== shouldBeChecked) {
+        radio.checked = shouldBeChecked;
+      }
     });
-
-    await Promise.all(
-      radios.map(async radio => {
-        await radio.updateComplete;
-
-        if (!radio.disabled && radio.value === this.value) {
-          radio.checked = true;
-        } else {
-          radio.checked = false;
-        }
-      }),
-    );
 
     // Manage tabIndex based on disabled state and checked status
     if (this.disabled) {
       // If radio group is disabled, all radios should not be tabbable
       radios.forEach(radio => {
-        radio.tabIndex = -1;
+        if (radio.tabIndex !== -1) radio.tabIndex = -1;
       });
     } else {
       // Normal tabbing behavior
@@ -236,12 +232,14 @@ export default class WaRadioGroup extends WebAwesomeFormAssociatedElement {
         if (checkedRadio) {
           // If there's a checked radio, it should be tabbable
           enabledRadios.forEach(radio => {
-            radio.tabIndex = radio.checked ? 0 : -1;
+            const expectedTabIndex = radio.checked ? 0 : -1;
+            if (radio.tabIndex !== expectedTabIndex) radio.tabIndex = expectedTabIndex;
           });
         } else {
           // If no radio is checked, first enabled radio should be tabbable
           enabledRadios.forEach((radio, index) => {
-            radio.tabIndex = index === 0 ? 0 : -1;
+            const expectedTabIndex = index === 0 ? 0 : -1;
+            if (radio.tabIndex !== expectedTabIndex) radio.tabIndex = expectedTabIndex;
           });
         }
       }
@@ -250,7 +248,7 @@ export default class WaRadioGroup extends WebAwesomeFormAssociatedElement {
       radios
         .filter(radio => radio.disabled)
         .forEach(radio => {
-          radio.tabIndex = -1;
+          if (radio.tabIndex !== -1) radio.tabIndex = -1;
         });
     }
   }

--- a/packages/webawesome/src/components/select/select.ts
+++ b/packages/webawesome/src/components/select/select.ts
@@ -117,7 +117,9 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
   @state() displayLabel = '';
   @state() currentOption: WaOption;
   @state() selectedOptions: WaOption[] = [];
-  @state() optionValues: Set<string | null> | undefined;
+
+  // Not reactive - only used internally for filtering, not rendering
+  private optionValues: Set<string | null> | undefined;
 
   /** The name of the select, submitted as a name/value pair with form data. */
   @property({ reflect: true }) name = '';

--- a/packages/webawesome/src/components/slider/slider.ts
+++ b/packages/webawesome/src/components/slider/slider.ts
@@ -362,7 +362,12 @@ export default class WaSlider extends WebAwesomeFormAssociatedElement {
 
     if (this.isRange) {
       // Handle min/max values for range mode - clamp during willUpdate to avoid change-in-update warnings
-      if (changedProperties.has('minValue') || changedProperties.has('maxValue') || changedProperties.has('min') || changedProperties.has('max')) {
+      if (
+        changedProperties.has('minValue') ||
+        changedProperties.has('maxValue') ||
+        changedProperties.has('min') ||
+        changedProperties.has('max')
+      ) {
         // Ensure min doesn't exceed max
         const clampedMinValue = clamp(this.minValue, this.min, this.maxValue);
         const clampedMaxValue = clamp(this.maxValue, this.minValue, this.max);

--- a/packages/webawesome/src/components/slider/slider.ts
+++ b/packages/webawesome/src/components/slider/slider.ts
@@ -357,6 +357,27 @@ export default class WaSlider extends WebAwesomeFormAssociatedElement {
     }
   }
 
+  protected willUpdate(changedProperties: PropertyValues<this>) {
+    super.willUpdate(changedProperties);
+
+    if (this.isRange) {
+      // Handle min/max values for range mode - clamp during willUpdate to avoid change-in-update warnings
+      if (changedProperties.has('minValue') || changedProperties.has('maxValue') || changedProperties.has('min') || changedProperties.has('max')) {
+        // Ensure min doesn't exceed max
+        const clampedMinValue = clamp(this.minValue, this.min, this.maxValue);
+        const clampedMaxValue = clamp(this.maxValue, this.minValue, this.max);
+        if (clampedMinValue !== this.minValue) this.minValue = clampedMinValue;
+        if (clampedMaxValue !== this.maxValue) this.maxValue = clampedMaxValue;
+      }
+    } else {
+      // Handle value for single thumb mode
+      if (changedProperties.has('value') || changedProperties.has('min') || changedProperties.has('max')) {
+        const clampedValue = clamp(this.value, this.min, this.max);
+        if (clampedValue !== this.value) this.value = clampedValue;
+      }
+    }
+  }
+
   updated(changedProperties: PropertyValues<this>) {
     // Handle range mode changes
     if (changedProperties.has('range')) {
@@ -364,29 +385,14 @@ export default class WaSlider extends WebAwesomeFormAssociatedElement {
     }
 
     if (this.isRange) {
-      // Handle min/max values for range mode
+      // Update form value when range values change
       if (changedProperties.has('minValue') || changedProperties.has('maxValue')) {
-        // Ensure min doesn't exceed max
-        this.minValue = clamp(this.minValue, this.min, this.maxValue);
-        this.maxValue = clamp(this.maxValue, this.minValue, this.max);
-        // Update form value
         this.updateFormValue();
       }
     } else {
-      // Handle value for single thumb mode
+      // Update form value for single thumb mode
       if (changedProperties.has('value')) {
-        this.value = clamp(this.value, this.min, this.max);
         this.setValue(String(this.value));
-      }
-    }
-
-    // Handle min/max
-    if (changedProperties.has('min') || changedProperties.has('max')) {
-      if (this.isRange) {
-        this.minValue = clamp(this.minValue, this.min, this.max);
-        this.maxValue = clamp(this.maxValue, this.min, this.max);
-      } else {
-        this.value = clamp(this.value, this.min, this.max);
       }
     }
 


### PR DESCRIPTION
Fixes #1269 - Lit "change-in-update" warnings that occur when components set reactive properties after an update cycle completes, causing inefficient re-renders.                                                                                                                                                                                                                
   
  Changes
---                                                                                                                                                                                                                                                                                                                                                         
 - `wa-card`: Move slot detection from `updated()` to `willUpdate()` so property changes are part of the current render cycle
  - `wa-slider`: Move value clamping logic to `willUpdate()` while keeping form value updates in `updated()`
  - `wa-checkbox`: Remove duplicate `@watch('defaultChecked')` handler since `willUpdate()` already handles this case
  - `wa-radio-group`: Add change detection before setting child properties (forceDisabled, checked, tabIndex) to avoid triggering unnecessary updates
  - wa-select: Remove `@state()` decorator from optionValues since it's only used internally for filtering, not for rendering

Why these changes
---
  Lit's development mode warns when a component schedules a new update after one just completed. This typically happens when:
  1. Reactive properties are set in `updated()` instead of `willUpdate()`
  2. Properties are marked as `@state()` when they don't actually affect rendering
  3. Child element properties are set unconditionally during parent updates

Testing
---

  All existing tests pass.