### PR TITLE
Add `wa-button` class for `<a>` elements

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -13,6 +13,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 
 ## Next
 
+- Added `wa-button` class for styling `<a>` elements as buttons [pr:2040]
 - Fixed a bug `<wa-color-picker>` that prevented it from flipping horizontally when position to the right of the viewport. [pr:2024]
 
 ## 3.2.1

--- a/packages/webawesome/docs/docs/utilities/native.md
+++ b/packages/webawesome/docs/docs/utilities/native.md
@@ -331,7 +331,7 @@ Add the `wa-hover-rows` class to highlight table rows on hover and the `wa-zebra
 
 ### Details
 
-Create disclosure widgets with `<details>` and `<summary>`. Details closely match the appearance of [`<wa-details>`](/docs/components/details/).
+Create disclosure widgets with `<details>` and `<summary>`. Details match the appearance of [`<wa-details>`](/docs/components/details/).
 
 ```html {.example}
 <details>
@@ -345,7 +345,7 @@ Create disclosure widgets with `<details>` and `<summary>`. Details closely matc
 
 ### Dialog
 
-Create modal and non-modal dialog boxes with `<dialog>`. Dialogs closely match the appearance of [`<wa-dialog>`](/docs/components/dialog/).
+Create modal and non-modal dialog boxes with `<dialog>`. Dialogs match the appearance of [`<wa-dialog>`](/docs/components/dialog/).
 
 ```html {.example}
 <dialog id="dialog-example">
@@ -367,7 +367,7 @@ Create modal and non-modal dialog boxes with `<dialog>`. Dialogs closely match t
 
 ### Progress
 
-Create progress indicators with `<progress>`. Progress indicators closely match the appearance of [`<wa-progress-bar>`](/docs/components/progress-bar/).
+Create progress indicators with `<progress>`. Progress indicators match the appearance of [`<wa-progress-bar>`](/docs/components/progress-bar/).
 
 ```html {.example}
 <progress value="40" max="100"></progress>
@@ -381,13 +381,19 @@ Native styles use [form control design tokens](/docs/tokens/component-groups/#fo
 
 ### Buttons
 
-Create buttons with `<button>` or `<input type="button | submit | reset">`. Buttons closely match the appearance of [`<wa-button>`](/docs/components/button/).
+Create buttons with `<button>` or `<input type="button | submit | reset">`. Buttons match the appearance of [`<wa-button>`](/docs/components/button/).
 
 ```html {.example}
 <button>Button</button>
 <input type="button" value="Input (button)" />
 <input type="submit" value="Input (submit)" />
 <input type="reset" value="Input (reset)" />
+```
+
+To create links that look like buttons, add the `wa-button` class to an `<a>` element.
+
+```html {.example}
+<a href="" class="wa-button">Link Button</a>
 ```
 
 Add the `wa-brand`, `wa-neutral`, `wa-success`, `wa-warning`, or `wa-danger` class to specify the button's [color variant](/docs/utilities/color/).
@@ -439,7 +445,7 @@ When using `<wa-icon>` within a button, wrap adjacent label text in `<span>` or 
 
 ### Form controls
 
-Create a variety of form controls with `<input type="">`, `<select>`, and `<textarea>`. Each control closely matches the appearance of the corresponding Web Awesome component.
+Create a variety of form controls with `<input type="">`, `<select>`, and `<textarea>`. Each control matches the appearance of the corresponding Web Awesome component.
 
 ```html {.example}
 <div class="wa-stack">

--- a/packages/webawesome/docs/docs/utilities/native.md
+++ b/packages/webawesome/docs/docs/utilities/native.md
@@ -331,7 +331,7 @@ Add the `wa-hover-rows` class to highlight table rows on hover and the `wa-zebra
 
 ### Details
 
-Create disclosure widgets with `<details>` and `<summary>`. Details match the appearance of [`<wa-details>`](/docs/components/details/).
+Create disclosure widgets with `<details>` and `<summary>`. Details closely match the appearance of [`<wa-details>`](/docs/components/details/).
 
 ```html {.example}
 <details>
@@ -345,7 +345,7 @@ Create disclosure widgets with `<details>` and `<summary>`. Details match the ap
 
 ### Dialog
 
-Create modal and non-modal dialog boxes with `<dialog>`. Dialogs match the appearance of [`<wa-dialog>`](/docs/components/dialog/).
+Create modal and non-modal dialog boxes with `<dialog>`. Dialogs closely match the appearance of [`<wa-dialog>`](/docs/components/dialog/).
 
 ```html {.example}
 <dialog id="dialog-example">
@@ -367,7 +367,7 @@ Create modal and non-modal dialog boxes with `<dialog>`. Dialogs match the appea
 
 ### Progress
 
-Create progress indicators with `<progress>`. Progress indicators match the appearance of [`<wa-progress-bar>`](/docs/components/progress-bar/).
+Create progress indicators with `<progress>`. Progress indicators closely match the appearance of [`<wa-progress-bar>`](/docs/components/progress-bar/).
 
 ```html {.example}
 <progress value="40" max="100"></progress>
@@ -445,7 +445,7 @@ When using `<wa-icon>` within a button, wrap adjacent label text in `<span>` or 
 
 ### Form controls
 
-Create a variety of form controls with `<input type="">`, `<select>`, and `<textarea>`. Each control matches the appearance of the corresponding Web Awesome component.
+Create a variety of form controls with `<input type="">`, `<select>`, and `<textarea>`. Each control closely matches the appearance of the corresponding Web Awesome component.
 
 ```html {.example}
 <div class="wa-stack">

--- a/packages/webawesome/docs/docs/utilities/native.md
+++ b/packages/webawesome/docs/docs/utilities/native.md
@@ -381,7 +381,7 @@ Native styles use [form control design tokens](/docs/tokens/component-groups/#fo
 
 ### Buttons
 
-Create buttons with `<button>` or `<input type="button | submit | reset">`. Buttons match the appearance of [`<wa-button>`](/docs/components/button/).
+Create buttons with `<button>` or `<input type="button | submit | reset">`. Buttons closely match the appearance of [`<wa-button>`](/docs/components/button/).
 
 ```html {.example}
 <button>Button</button>

--- a/packages/webawesome/src/styles/native.css
+++ b/packages/webawesome/src/styles/native.css
@@ -575,7 +575,8 @@
   input[type='button'],
   input[type='reset'],
   input[type='submit'],
-  input[type='file'] {
+  input[type='file'],
+  a.wa-button {
     /* We allow modifier classes on <input type="file">,
      * but these selectors ensure the styles only apply to
      * the file selector button in the user agent's shadow root */
@@ -610,7 +611,7 @@
     }
 
     /* Default styles for standard buttons */
-    :where(&:not(input[type='file'])) {
+    &:not(input[type='file']) {
       color: var(--wa-color-on-loud, var(--wa-color-neutral-on-loud));
       background-color: var(--wa-color-fill-loud, var(--wa-color-neutral-fill-loud));
       border-color: transparent;
@@ -635,7 +636,7 @@
     }
 
     /* Default styles for file selector buttons */
-    :where(&:is(input[type='file'])) {
+    &:is(input[type='file']) {
       &::file-selector-button {
         color: var(--wa-color-on-normal, var(--wa-color-neutral-on-normal));
         background-color: var(--wa-color-fill-normal, var(--wa-color-neutral-fill-normal));

--- a/packages/webawesome/src/styles/themes/awesome.css
+++ b/packages/webawesome/src/styles/themes/awesome.css
@@ -371,7 +371,8 @@
     button,
     input[type='button'],
     input[type='reset'],
-    input[type='submit'] {
+    input[type='submit'],
+    a.wa-button {
       --wa-color-shadow: var(--wa-color-border-normal);
       --wa-transition-slow: 0;
       --wa-transition-normal: 0;
@@ -387,7 +388,8 @@
     button,
     input[type='button'],
     input[type='reset'],
-    input[type='submit'] {
+    input[type='submit'],
+    a.wa-button {
       &:not([appearance~='plain']):not(.wa-plain) {
         &:where(:not(wa-button)),
         &::part(base) {
@@ -408,6 +410,15 @@
         }
       }
       .wa-dark & {
+        &:not(
+            [appearance='filled-outlined'],
+            [appearance='filled'],
+            [appearance='outlined'],
+            [appearance='plain'],
+            .wa-filled,
+            .wa-outlined,
+            .wa-plain
+          ),
         &[appearance~='accent'],
         &.wa-accent {
           &:not([disabled]):not(:disabled):active {
@@ -477,7 +488,17 @@
     button,
     input[type='button'],
     input[type='reset'],
-    input[type='submit'] {
+    input[type='submit'],
+    a.wa-button {
+      &:not(
+          [appearance='filled-outlined'],
+          [appearance='filled'],
+          [appearance='outlined'],
+          [appearance='plain'],
+          .wa-filled,
+          .wa-outlined,
+          .wa-plain
+        ),
       &[appearance='accent'],
       &.wa-accent {
         &:where(:not(wa-button)),
@@ -488,6 +509,15 @@
       }
 
       .wa-dark & {
+        &:not(
+            [appearance='filled-outlined'],
+            [appearance='filled'],
+            [appearance='outlined'],
+            [appearance='plain'],
+            .wa-filled,
+            .wa-outlined,
+            .wa-plain
+          ),
         &[appearance='accent'],
         &.wa-accent {
           &:where(:not(wa-button)),

--- a/packages/webawesome/src/styles/themes/awesome.css
+++ b/packages/webawesome/src/styles/themes/awesome.css
@@ -410,15 +410,6 @@
         }
       }
       .wa-dark & {
-        &:not(
-            [appearance='filled-outlined'],
-            [appearance='filled'],
-            [appearance='outlined'],
-            [appearance='plain'],
-            .wa-filled,
-            .wa-outlined,
-            .wa-plain
-          ),
         &[appearance~='accent'],
         &.wa-accent {
           &:not([disabled]):not(:disabled):active {
@@ -490,15 +481,6 @@
     input[type='reset'],
     input[type='submit'],
     a.wa-button {
-      &:not(
-          [appearance='filled-outlined'],
-          [appearance='filled'],
-          [appearance='outlined'],
-          [appearance='plain'],
-          .wa-filled,
-          .wa-outlined,
-          .wa-plain
-        ),
       &[appearance='accent'],
       &.wa-accent {
         &:where(:not(wa-button)),
@@ -509,15 +491,6 @@
       }
 
       .wa-dark & {
-        &:not(
-            [appearance='filled-outlined'],
-            [appearance='filled'],
-            [appearance='outlined'],
-            [appearance='plain'],
-            .wa-filled,
-            .wa-outlined,
-            .wa-plain
-          ),
         &[appearance='accent'],
         &.wa-accent {
           &:where(:not(wa-button)),

--- a/packages/webawesome/src/styles/themes/shoelace.css
+++ b/packages/webawesome/src/styles/themes/shoelace.css
@@ -375,7 +375,10 @@
     wa-button::part(label),
     wa-radio[appearance='button'],
     button,
-    input:where([type='button'], [type='reset'], [type='submit']) {
+    input[type='button'],
+    input[type='reset'],
+    input[type='submit'],
+    a.wa-button {
       font-size: var(--wa-font-size-smaller);
     }
 


### PR DESCRIPTION
Re-introduces support for styling `<a>` elements like buttons via a `wa-button` class

Changes:

- Adds `a.wa-button` to native button styling selectors so anchors can inherit button styles
- Updates Awesome and Shoelace themes to include `a.wa-button` in button-related overrides
- Documents link buttons in native utilities docs

---

Closes #1516
Completed by https://github.com/shoelace-style/webawesome-pro/pull/140