### PR TITLE
Fix import of `wa-popup` in dropdown.ts

### DIFF
--- a/packages/webawesome/src/components/dropdown/dropdown.ts
+++ b/packages/webawesome/src/components/dropdown/dropdown.ts
@@ -17,7 +17,8 @@ import { LocalizeController } from '../../utilities/localize.js';
 import type WaButton from '../button/button.js';
 import '../dropdown-item/dropdown-item.js';
 import type WaDropdownItem from '../dropdown-item/dropdown-item.js';
-import WaPopup from '../popup/popup.js'; // Added import for wa-popup
+import '../popup/popup.js';
+import type WaPopup from '../popup/popup.js';
 import styles from './dropdown.styles.js';
 
 const openDropdowns = new Set<WaDropdown>();


### PR DESCRIPTION
Import to register custom element `wa-popup` used to render the dropdown.

There is no 
```ts
  static dependencies = { 'wa-popup': WaPopup };
```
in this module, like it is eg. in https://github.com/shoelace-style/webawesome/blob/080f96f496d6ca31149c7684eb70ea35e4ec5fc0/packages/webawesome/src/components/tooltip/tooltip.ts#L41
Would this be an alternative / also required?