### PR TITLE
POC: Refactor button groups using pure CSS

### DIFF
--- a/packages/webawesome/docs/docs/components/button-group.md
+++ b/packages/webawesome/docs/docs/components/button-group.md
@@ -5,22 +5,69 @@ layout: component
 category: Actions
 ---
 
+## Special cases not tracked by examples (remove after refactor)
+
+Slotted buttons might be nested in other elements, such as divs. The button group should still be able to detect these buttons properly.
+
 ```html {.example}
 <wa-button-group label="Alignment">
-  <wa-button>Left</wa-button>
+  <div>
+    <wa-button>Left nested</wa-button>
+  </div>
   <wa-button>Center</wa-button>
-  <wa-button>Right</wa-button>
+  <div>
+    <wa-button>Right nested</wa-button>
+  </div>
 </wa-button-group>
 ```
 
-## Examples
-
-### Vertical Button Groups
-
-Set the `orientation` attribute to `vertical` to make a vertical button group.
+A negative example where multiple buttons are nested within the same div. That didn't work before and should produce the same result after the refactor (no grouping).
 
 ```html {.example}
-<wa-button-group orientation="vertical" label="Options">
+<wa-button-group label="Alignment">
+  <div>
+    <wa-button>Left nested</wa-button>
+    <wa-button>Inbetween nested</wa-button>
+  </div>
+  <wa-button>Center</wa-button>
+  <div>
+    <wa-button>Right nested</wa-button>
+  </div>
+</wa-button-group>
+```
+
+Outlined or `filled-outlined` buttons should collapse after refactor.
+
+```html {.example}
+<wa-button-group label="Alignment">
+  <div>
+    <wa-button appearance="outlined">Left outlined</wa-button>
+  </div>
+  <wa-button appearance="outlined">Center outlined</wa-button>
+  <div>
+    <wa-button appearance="outlined">Right outlined</wa-button>
+  </div>
+</wa-button-group>
+
+<p></p>
+
+<wa-button-group label="Alignment">
+  <div>
+    <wa-button appearance="filled-outlined">Left outlined</wa-button>
+  </div>
+  <wa-button appearance="filled-outlined">Center outlined</wa-button>
+  <div>
+    <wa-button appearance="filled-outlined">Right outlined</wa-button>
+  </div>
+</wa-button-group>
+```
+
+Some strange behavior applies to vertical button groups with an explicit height: The button containers are forced to stretch and align its contents (the actual buttons) to the start.
+
+Maybe the idea was to either stretch the buttons to fill the whole height or it relates to a specific use case.
+
+```html {.example}
+<wa-button-group orientation="vertical" label="Options" style="width: 300px; height: 300px">
   <wa-button>
     <wa-icon slot="start" name="plus"></wa-icon>
     New
@@ -37,6 +84,45 @@ Set the `orientation` attribute to `vertical` to make a vertical button group.
     <wa-icon slot="start" name="print"></wa-icon>
     Print
   </wa-button>
+</wa-button-group>
+```
+
+For completeness, an example of mixed button usage
+
+```html {.example}
+<wa-button-group label="Alignment">
+  <wa-button appearance="filled">Left</wa-button>
+  <wa-button appearance="outlined">Center</wa-button>
+  <wa-button appearance="filled-outlined">Right</wa-button>
+</wa-button-group>
+```
+
+---
+
+```html {.example}
+<wa-button-group label="Alignment">
+  <wa-button>Left</wa-button>
+  <wa-button>Center</wa-button>
+  <wa-button>Right</wa-button>
+</wa-button-group>
+```
+
+## Examples
+
+### Vertical Button Groups
+
+Set the `orientation` attribute to `vertical` to make a vertical button group.
+
+```html {.example}
+<wa-button-group orientation="vertical" label="Options">
+  <wa-button>Button</wa-button>
+  <wa-dropdown>
+    <wa-button slot="trigger" with-caret>Dropdown</wa-button>
+    <wa-dropdown-item>Item 1</wa-dropdown-item>
+    <wa-dropdown-item>Item 2</wa-dropdown-item>
+    <wa-dropdown-item>Item 3</wa-dropdown-item>
+  </wa-dropdown>
+  <wa-button>Button</wa-button>
 </wa-button-group>
 ```
 

--- a/packages/webawesome/src/components/button-group/button-group.styles.ts
+++ b/packages/webawesome/src/components/button-group/button-group.styles.ts
@@ -47,18 +47,37 @@ export default css`
     --_wa-button-vertical-indent: 1px;
     --_wa-button-vertical-indent-outlined: calc(var(--wa-border-width-s) * -1);
   }
+
+  /* All buttons that are not in front or at the end get their border radius removed */
+  ::slotted(:not(:first-child):not(:last-child)) {
+    --_wa-button-start-start-radius: 0;
+    --_wa-button-start-end-radius: 0;
+    --_wa-button-end-start-radius: 0;
+    --_wa-button-end-end-radius: 0;
   }
 
-  /* Button groups with at least one outlined button will not have a gap and instead have borders overlap */
-  .button-group.has-outlined {
-    gap: 0;
-
-    &:not([aria-orientation='vertical']):not(.button-group-vertical)::slotted(:not(:first-child)) {
-      margin-inline-start: calc(-1 * var(--border-width));
+  /* Remove leading and trailing buttons border radius individually */
+  :host([orientation='horizontal']) {
+    ::slotted(:first-child) {
+      --_wa-button-start-end-radius: 0;
+      --_wa-button-end-end-radius: 0;
     }
 
-    &:is([aria-orientation='vertical'], .button-group-vertical)::slotted(:not(:first-child)) {
-      margin-block-start: calc(-1 * var(--border-width));
+    ::slotted(:last-child) {
+      --_wa-button-start-start-radius: 0;
+      --_wa-button-end-start-radius: 0;
+    }
+  }
+
+  :host([orientation='vertical']) {
+    ::slotted(:first-child) {
+      --_wa-button-end-start-radius: 0;
+      --_wa-button-end-end-radius: 0;
+    }
+
+    ::slotted(:last-child) {
+      --_wa-button-start-start-radius: 0;
+      --_wa-button-start-end-radius: 0;
     }
   }
 `;

--- a/packages/webawesome/src/components/button-group/button-group.styles.ts
+++ b/packages/webawesome/src/components/button-group/button-group.styles.ts
@@ -10,7 +10,6 @@ export default css`
     position: relative;
     isolation: isolate;
     flex-wrap: wrap;
-    gap: 1px;
 
     @media (hover: hover) {
       > :hover,
@@ -28,9 +27,26 @@ export default css`
     &::slotted([checked]) {
       z-index: 2 !important;
     }
+
+    :host([orientation='horizontal']) & {
+      flex-direction: row;
+    }
+
+    :host([orientation='vertical']) & {
+      flex-direction: column;
+    }
   }
-  :host([orientation='vertical']) .button-group {
-    flex-direction: column;
+
+  /* Set custom properties to be inherited by slotted buttons */
+  :host([orientation='horizontal']) {
+    --_wa-button-horizontal-indent: 1px;
+    --_wa-button-horizontal-indent-outlined: calc(var(--wa-border-width-s) * -1);
+  }
+
+  :host([orientation='vertical']) {
+    --_wa-button-vertical-indent: 1px;
+    --_wa-button-vertical-indent-outlined: calc(var(--wa-border-width-s) * -1);
+  }
   }
 
   /* Button groups with at least one outlined button will not have a gap and instead have borders overlap */

--- a/packages/webawesome/src/components/button-group/button-group.test.ts
+++ b/packages/webawesome/src/components/button-group/button-group.test.ts
@@ -29,8 +29,9 @@ describe('<wa-button-group>', () => {
           await expect(group).to.be.accessible();
         });
       });
-      describe('slotted button classes', () => {
-        it('slotted buttons have the right classes applied based on their order', async () => {
+
+      describe('slotted button custom properties', () => {
+        it('slotted buttons inherit the right custom properties based on their order', async () => {
           const group = await fixture<WaButtonGroup>(html`
             <wa-button-group>
               <wa-button>Button 1 Label</wa-button>
@@ -40,14 +41,22 @@ describe('<wa-button-group>', () => {
           `);
 
           const allButtons = group.querySelectorAll('wa-button');
-          const hasGroupClass = Array.from(allButtons).every(button =>
-            button.classList.contains('wa-button-group__button'),
-          );
-          expect(hasGroupClass).to.be.true;
+          Array.from(allButtons).every(button => expect(button).to.have.style('--_wa-button-horizontal-indent', '1px'));
 
-          expect(allButtons[0]).to.have.class('wa-button-group__button-first');
-          expect(allButtons[1]).to.have.class('wa-button-group__button-inner');
-          expect(allButtons[2]).to.have.class('wa-button-group__button-last');
+          expect(allButtons[0]).to.not.have.style('--_wa-button-start-start-radius', '0');
+          expect(allButtons[0]).to.have.style('--_wa-button-start-end-radius', '0');
+          expect(allButtons[0]).to.not.have.style('--_wa-button-end-start-radius', '0');
+          expect(allButtons[0]).to.have.style('--_wa-button-end-end-radius', '0');
+
+          expect(allButtons[1]).to.have.style('--_wa-button-start-start-radius', '0');
+          expect(allButtons[1]).to.have.style('--_wa-button-start-end-radius', '0');
+          expect(allButtons[1]).to.have.style('--_wa-button-end-start-radius', '0');
+          expect(allButtons[1]).to.have.style('--_wa-button-end-end-radius', '0');
+
+          expect(allButtons[2]).to.have.style('--_wa-button-start-start-radius', '0');
+          expect(allButtons[2]).to.not.have.style('--_wa-button-start-end-radius', '0');
+          expect(allButtons[2]).to.have.style('--_wa-button-end-start-radius', '0');
+          expect(allButtons[2]).to.not.have.style('--_wa-button-end-end-radius', '0');
         });
       });
 

--- a/packages/webawesome/src/components/button-group/button-group.ts
+++ b/packages/webawesome/src/components/button-group/button-group.ts
@@ -1,7 +1,6 @@
 import type { PropertyValues } from 'lit';
 import { html } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
-import { classMap } from 'lit/directives/class-map.js';
 import WebAwesomeElement from '../../internal/webawesome-element.js';
 import type WaButton from '../button/button.js';
 import styles from './button-group.styles.js';
@@ -39,7 +38,6 @@ export default class WaButtonGroup extends WebAwesomeElement {
 
     if (changedProperties.has('orientation')) {
       this.setAttribute('aria-orientation', this.orientation);
-      this.updateClassNames();
     }
   }
 
@@ -63,39 +61,11 @@ export default class WaButtonGroup extends WebAwesomeElement {
     button?.classList.remove('button-hover');
   }
 
-  private handleSlotChange() {
-    this.updateClassNames();
-  }
-
-  private updateClassNames() {
-    const slottedElements = [...this.defaultSlot.assignedElements({ flatten: true })] as HTMLElement[];
-    this.hasOutlined = false;
-
-    slottedElements.forEach(el => {
-      const index = slottedElements.indexOf(el);
-      const button = findButton(el);
-
-      if (button) {
-        if ((button as WaButton).appearance === 'outlined') this.hasOutlined = true;
-        button.classList.add('wa-button-group__button');
-        button.classList.toggle('wa-button-group__horizontal', this.orientation === 'horizontal');
-        button.classList.toggle('wa-button-group__vertical', this.orientation === 'vertical');
-        button.classList.toggle('wa-button-group__button-first', index === 0);
-        button.classList.toggle('wa-button-group__button-inner', index > 0 && index < slottedElements.length - 1);
-        button.classList.toggle('wa-button-group__button-last', index === slottedElements.length - 1);
-        button.classList.toggle('wa-button-group__button-radio', button.tagName.toLowerCase() === 'wa-radio-button');
-      }
-    });
-  }
-
   render() {
     return html`
       <slot
         part="base"
-        class=${classMap({
-          'button-group': true,
-          'has-outlined': this.hasOutlined,
-        })}
+        class="button-group"
         role="${this.disableRole ? 'presentation' : 'group'}"
         aria-label=${this.label}
         aria-orientation=${this.orientation}
@@ -103,7 +73,6 @@ export default class WaButtonGroup extends WebAwesomeElement {
         @focusin=${this.handleFocus}
         @mouseover=${this.handleMouseOver}
         @mouseout=${this.handleMouseOut}
-        @slotchange=${this.handleSlotChange}
       ></slot>
     `;
   }

--- a/packages/webawesome/src/components/button/button.styles.ts
+++ b/packages/webawesome/src/components/button/button.styles.ts
@@ -44,7 +44,10 @@ export default css`
     background-color: var(--wa-color-fill-loud, var(--wa-color-neutral-fill-loud));
     border-color: transparent;
     color: var(--wa-color-on-loud, var(--wa-color-neutral-on-loud));
-    border-radius: var(--wa-form-control-border-radius);
+    border-start-start-radius: var(--_wa-button-start-start-radius, var(--wa-form-control-border-radius));
+    border-start-end-radius: var(--_wa-button-start-end-radius, var(--wa-form-control-border-radius));
+    border-end-start-radius: var(--_wa-button-end-start-radius, var(--wa-form-control-border-radius));
+    border-end-end-radius: var(--_wa-button-end-end-radius, var(--wa-form-control-border-radius));
     border-style: var(--wa-border-style);
     border-width: var(--wa-border-width-s);
   }
@@ -229,7 +232,10 @@ export default css`
 
   /* Pill modifier */
   :host([pill]) .button {
-    border-radius: var(--wa-border-radius-pill);
+    border-start-start-radius: var(--_wa-button-start-start-radius, var(--wa-border-radius-pill));
+    border-start-end-radius: var(--_wa-button-start-end-radius, var(--wa-border-radius-pill));
+    border-end-start-radius: var(--_wa-button-end-start-radius, var(--wa-border-radius-pill));
+    border-end-end-radius: var(--_wa-button-end-end-radius, var(--wa-border-radius-pill));
   }
 
   /*

--- a/packages/webawesome/src/components/button/button.styles.ts
+++ b/packages/webawesome/src/components/button/button.styles.ts
@@ -51,6 +51,10 @@ export default css`
 
   /* Appearance modifiers */
   :host([appearance='plain']) {
+    /* Indentation overrides for grouping */
+    margin-inline-start: var(--_wa-button-horizontal-indent);
+    margin-block-start: var(--_wa-button-vertical-indent);
+
     .button {
       color: var(--wa-color-on-quiet, var(--wa-color-neutral-on-quiet));
       background-color: transparent;
@@ -73,6 +77,10 @@ export default css`
   }
 
   :host([appearance='outlined']) {
+    /* Indentation overrides for grouping outlined */
+    margin-inline-start: var(--_wa-button-horizontal-indent-outlined);
+    margin-block-start: var(--_wa-button-vertical-indent-outlined);
+
     .button {
       color: var(--wa-color-on-quiet, var(--wa-color-neutral-on-quiet));
       background-color: transparent;
@@ -95,6 +103,10 @@ export default css`
   }
 
   :host([appearance='filled']) {
+    /* Indentation overrides for grouping */
+    margin-inline-start: var(--_wa-button-horizontal-indent);
+    margin-block-start: var(--_wa-button-vertical-indent);
+
     .button {
       color: var(--wa-color-on-normal, var(--wa-color-neutral-on-normal));
       background-color: var(--wa-color-fill-normal, var(--wa-color-neutral-fill-normal));
@@ -121,6 +133,10 @@ export default css`
   }
 
   :host([appearance='filled-outlined']) {
+    /* Indentation overrides for grouping outlined */
+    margin-inline-start: var(--_wa-button-horizontal-indent-outlined);
+    margin-block-start: var(--_wa-button-vertical-indent-outlined);
+
     .button {
       color: var(--wa-color-on-normal, var(--wa-color-neutral-on-normal));
       background-color: var(--wa-color-fill-normal, var(--wa-color-neutral-fill-normal));
@@ -147,6 +163,10 @@ export default css`
   }
 
   :host([appearance='accent']) {
+    /* Indentation overrides for grouping */
+    margin-inline-start: var(--_wa-button-horizontal-indent);
+    margin-block-start: var(--_wa-button-vertical-indent);
+
     .button {
       color: var(--wa-color-on-loud, var(--wa-color-neutral-on-loud));
       background-color: var(--wa-color-fill-loud, var(--wa-color-neutral-fill-loud));

--- a/packages/webawesome/src/components/button/button.styles.ts
+++ b/packages/webawesome/src/components/button/button.styles.ts
@@ -339,26 +339,6 @@ export default css`
     margin-inline-start: 0.75em;
   }
 
-  /*
-   * Button group border radius modifications
-   */
-
-  /* Remove border radius from all grouped buttons by default */
-  :host(.wa-button-group__button) .button {
-    border-radius: 0;
-  }
-
-  /* Horizontal orientation */
-  :host(.wa-button-group__horizontal.wa-button-group__button-first) .button {
-    border-start-start-radius: var(--wa-form-control-border-radius);
-    border-end-start-radius: var(--wa-form-control-border-radius);
-  }
-
-  :host(.wa-button-group__horizontal.wa-button-group__button-last) .button {
-    border-start-end-radius: var(--wa-form-control-border-radius);
-    border-end-end-radius: var(--wa-form-control-border-radius);
-  }
-
   /* Vertical orientation */
   :host(.wa-button-group__vertical) {
     flex: 1 1 auto;
@@ -367,36 +347,5 @@ export default css`
   :host(.wa-button-group__vertical) .button {
     width: 100%;
     justify-content: start;
-  }
-
-  :host(.wa-button-group__vertical.wa-button-group__button-first) .button {
-    border-start-start-radius: var(--wa-form-control-border-radius);
-    border-start-end-radius: var(--wa-form-control-border-radius);
-  }
-
-  :host(.wa-button-group__vertical.wa-button-group__button-last) .button {
-    border-end-start-radius: var(--wa-form-control-border-radius);
-    border-end-end-radius: var(--wa-form-control-border-radius);
-  }
-
-  /* Handle pill modifier for button groups */
-  :host([pill].wa-button-group__horizontal.wa-button-group__button-first) .button {
-    border-start-start-radius: var(--wa-border-radius-pill);
-    border-end-start-radius: var(--wa-border-radius-pill);
-  }
-
-  :host([pill].wa-button-group__horizontal.wa-button-group__button-last) .button {
-    border-start-end-radius: var(--wa-border-radius-pill);
-    border-end-end-radius: var(--wa-border-radius-pill);
-  }
-
-  :host([pill].wa-button-group__vertical.wa-button-group__button-first) .button {
-    border-start-start-radius: var(--wa-border-radius-pill);
-    border-start-end-radius: var(--wa-border-radius-pill);
-  }
-
-  :host([pill].wa-button-group__vertical.wa-button-group__button-last) .button {
-    border-end-start-radius: var(--wa-border-radius-pill);
-    border-end-end-radius: var(--wa-border-radius-pill);
   }
 `;

--- a/packages/webawesome/src/components/button/button.styles.ts
+++ b/packages/webawesome/src/components/button/button.styles.ts
@@ -338,14 +338,4 @@ export default css`
   .button:not(.visually-hidden-label) [part='caret'] {
     margin-inline-start: 0.75em;
   }
-
-  /* Vertical orientation */
-  :host(.wa-button-group__vertical) {
-    flex: 1 1 auto;
-  }
-
-  :host(.wa-button-group__vertical) .button {
-    width: 100%;
-    justify-content: start;
-  }
 `;


### PR DESCRIPTION
This is the plan I made up to change the button styling when grouped.
I tried to group the changes in the commits accordingly, so one can go through step by step.

For comparison and to play around with some edge cases, I added some more examples to the button group docs for the time being. These can easily be removed by dropping / reverting 4fd9bbf.

---

## Prerequisites

These prerequisites are based on the current implementation of button groups. To prevent breaking changes, the following conditions must be met after the refactor:

- Tightly coupled buttons to button groups
- Grouping is applied initially and at runtime
- Single nested buttons are supported (current `findButton` logic), grouping multiple buttons is currently not supported

## Goal

- Fix race condition in button detection (`appearance === 'outlined'`)
  - Will fix the issue of outlined buttons not collapsing #1975
  - Will fix the issue of `filled-outlined` buttons not collapsing
- Simplify the internal API being independent of JavaScript detection logic
  - Prevent initial flesh of grouped buttons on page load
  - No expensive DOM traversal for styling purposes

## Steps

1. Introduce a convention for internal custom properties to avoid conflicts with user facing CSS variables. For example, prefix internal properties with `--internal-wa-*`, use triple dash `---wa-*` or something derived from js conventions like `--_wa-button-*` or `--$wa-button-*`.
   > For now, we just use an underscore `--_wa-button-*` to indicate internal properties, however, this can be changed easily later on.
2. Prepare `wa-button` to be styled internally from `wa-button-group` by introducing internal custom properties for indentation and border radius overrides:

   ```css
   consumed-in-button {
     /* Indentation overrides for grouping generic buttons (replacing the button group `gap`) */
     --_wa-button-horizontal-indent: 0;
     --_wa-button-vertical-indent: 0;

     /* Indentation overrides for grouping outlined buttons */
     --_wa-button-horizontal-indent-outlined: 0;
     --_wa-button-vertical-indent-outlined: 0;

     /* Border radius overrides for grouping */
     --_wa-button-start-start-radius: 0;
     --_wa-button-start-end-radius: 0;
     --_wa-button-end-start-radius: 0;
     --_wa-button-end-end-radius: 0;
   }
   ```

3. Introduce css selectors in `wa-button-group` to set custom properties to be inherited by slotted buttons. Make sure to:
   - replace group `gap` with button specific indentions
     - address outlined button individually
   - border radius overrides
     > Do not remove all border radius and add them back, but remove the _unneeded ones_ directly: Buttons have to know which exact radius their configurations need (pill, size dependent, etc.), the group just knows that some radii have to be _removed_.
4. Check some specific stuff not related to spacing or border radius, such as the vertical button group flex behavior and button width:

   ```css
   :host(.wa-button-group__vertical) {
     flex: 1 1 auto;
   }

   :host(.wa-button-group__vertical) .button {
     width: 100%;
     justify-content: start;
   }
   ```

   > These two pieces lead to a strange behavior I can't explain myself:\
   > The button hosts are forced to stretch across vertical button groups and align its contents (the actual buttons) to the top.\
   > Maybe the idea was to either stretch the whole buttons to cover all of the groups height if set explicitly, or it relates to a specific use case I don't get right now. Or is it some browser specific styling for flex items that I'm not aware of?\
   > @lindsaym-fa do you know what these styles were supposed to achieve?
