### PR TITLE
Fix wa-size utility classes on native buttons in Shoelace theme

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -15,6 +15,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 
 - Added `wa-button` class for styling `<a>` elements as buttons [pr:2040]
 - Fixed a bug `<wa-color-picker>` that prevented it from flipping horizontally when position to the right of the viewport. [pr:2024]
+- Fixed a bug where `wa-size-*` was not working on native buttons styles in shoelace theme. [pr:2049]
 
 ## 3.2.1
 

--- a/packages/webawesome/src/styles/themes/shoelace.css
+++ b/packages/webawesome/src/styles/themes/shoelace.css
@@ -373,9 +373,9 @@
     }
 
     wa-button::part(label),
-    wa-radio[appearance='button'],
-    button,
-    input:where([type='button'], [type='reset'], [type='submit']) {
+    wa-radio[appearance='button']:not(.wa-size-s, .wa-size-m, .wa-size-l),
+    button:not(.wa-size-s, .wa-size-m, .wa-size-l),
+    input:where([type='button'], [type='reset'], [type='submit']):not(.wa-size-s, .wa-size-m, .wa-size-l) {
       font-size: var(--wa-font-size-smaller);
     }
 

--- a/packages/webawesome/src/styles/themes/shoelace.css
+++ b/packages/webawesome/src/styles/themes/shoelace.css
@@ -372,14 +372,52 @@
       color: var(--wa-color-neutral-on-loud);
     }
 
-    wa-button::part(label),
+    wa-button {
+      &::part(label) {
+        font-size: var(--wa-font-size-s);
+      }
+
+      &[size='small']::part(label),
+      &.wa-size-s::part(label) {
+        font-size: var(--wa-font-size-xs);
+      }
+
+      &[size='large']::part(label),
+      &.wa-size-l::part(label) {
+        font-size: var(--wa-font-size-m);
+      }
+    }
+
     wa-radio[appearance='button'],
     button,
     input[type='button'],
     input[type='reset'],
     input[type='submit'],
     a.wa-button {
-      font-size: var(--wa-font-size-smaller);
+      --_size: var(--wa-font-size-m);
+      font-size: var(--wa-font-size-s);
+
+      &[size='small'],
+      &.wa-size-s {
+        --_size: var(--wa-font-size-s);
+        font-size: var(--wa-font-size-xs);
+      }
+
+      &[size='large'],
+      &.wa-size-l {
+        --_size: var(--wa-font-size-l);
+        font-size: var(--wa-font-size-m);
+      }
+
+      /* Override em-based layout properties to use the intended size so that
+         height and padding match inputs at the same size, even though the
+         button's font-size is one step smaller for the Shoelace theme. */
+      --wa-form-control-padding-block: calc(0.75 * var(--_size));
+      --wa-form-control-padding-inline: var(--_size);
+      --wa-form-control-height: round(
+        calc(2 * var(--wa-form-control-padding-block) + var(--_size) * var(--wa-form-control-value-line-height)),
+        1px
+      );
     }
 
     wa-radio[appearance='button'] {


### PR DESCRIPTION
Fixes #1892

`wa-size-*` utility classes were not working on native button elements in the Shoelace theme due to a layer conflict. The Shoelace theme applies `font-size: var(--wa-font-size-smaller)` to buttons in `@layer wa-theme-overrides`, which comes after `@layer wa-utilities` in the layer order, so the theme always wins over the size utilities. 

Added `:not(.wa-size-s, .wa-size-m, .wa-size-l)` to the native button and radio-button selectors so the font-size override is skipped when a sizing utility class is present. This only affects the Shoelace theme. The `wa-button::part(label)` selector was left unchanged since it targets the shadow DOM label part, which correctly inherits and scales relative to the host element's font-size.

Result
---
<img width="1401" height="825" alt="Screenshot 2026-02-09 at 11 54 52 AM" src="https://github.com/user-attachments/assets/10278485-0061-47c7-a6ac-489a36e78576" />
