### PR TITLE
Docs: Sync Up Pro Badge UI on Component Docs

### DIFF
--- a/packages/webawesome/docs/_layouts/component.njk
+++ b/packages/webawesome/docs/_layouts/component.njk
@@ -14,7 +14,7 @@
       {{ component.status }}
     </wa-badge>
     {% if isProComponent %}
-      {{ proBadge({ description: "This component requires access to Web Awesome Pro" }) }}
+      {{ proBadge({ description: (component.tagName | stripPrefix) | capitalize ~ " requires access to Web Awesome Pro" }) }}
     {% endif %}
   </div>
   <p class="component-summary">

--- a/packages/webawesome/docs/_layouts/component.njk
+++ b/packages/webawesome/docs/_layouts/component.njk
@@ -1,4 +1,5 @@
 {% extends '../_layouts/docs.njk' %}
+{% from "pro-badge.njk" import proBadge %}
 {% set component = getComponent('wa-' + page.fileSlug) %}
 
 {# Component header #}
@@ -13,7 +14,7 @@
       {{ component.status }}
     </wa-badge>
     {% if isProComponent %}
-      <wa-badge class="pro">Pro</wa-badge>
+      {{ proBadge({ description: "This component requires access to Web Awesome Pro" }) }}
     {% endif %}
   </div>
   <p class="component-summary">


### PR DESCRIPTION
This PR updates the component documentation layout to use a standardized `proBadge` macro for displaying Pro feature indicators, replacing the previous inline badge implementation with one that includes a descriptive tooltip.

**Changes:**
- Replaced inline `<wa-badge class="pro">Pro</wa-badge>` with the `proBadge` macro that provides a tooltip with component-specific description

---

<img width="4232" height="2552" alt="CleanShot 2026-02-11 at 09 40 38@2x" src="https://github.com/user-attachments/assets/28480ace-db06-49a5-980b-56185da63c1a" />
