### PR TITLE
Upgrade `<wa-icon>` to Font Awesome `7.2.0`

### DIFF
--- a/packages/webawesome/docs/docs/components/icon.md
+++ b/packages/webawesome/docs/docs/components/icon.md
@@ -580,6 +580,13 @@ If you're a [Font Awesome Pro+ customer](https://fontawesome.com/), you have acc
   </div>
 
   <div class="wa-flank" style="--flank-size: 10ch;">
+    <a href="https://fontawesome.com/icons/packs/graphite" target="_blank">Graphite</a>
+    <div class="wa-cluster" style="font-size: 1.5em;">
+      <wa-icon family="graphite" variant="thin" name="house"></wa-icon>
+    </div>
+  </div>
+
+  <div class="wa-flank" style="--flank-size: 10ch;">
     <a href="https://fontawesome.com/icons/packs/whiteboard" target="_blank">Whiteboard</a>
     <div class="wa-cluster" style="font-size: 1.5em;">
       <wa-icon family="whiteboard" variant="semibold" name="house"></wa-icon>

--- a/packages/webawesome/docs/docs/components/icon.md
+++ b/packages/webawesome/docs/docs/components/icon.md
@@ -544,8 +544,8 @@ If you're a [Font Awesome Pro+ customer](https://fontawesome.com/), you have acc
     <div class="wa-cluster" style="font-size: 1.5em;">
       <wa-icon family="notdog" variant="solid" name="house"></wa-icon>
       <wa-icon
-        family="notdog"
-        variant="duo-solid"
+        family="notdog-duo"
+        variant="solid"
         name="house"
         style="--secondary-color: skyblue; --secondary-opacity: 0.8;"
       ></wa-icon>

--- a/packages/webawesome/docs/docs/components/icon.md
+++ b/packages/webawesome/docs/docs/components/icon.md
@@ -505,19 +505,6 @@ If you're a [Font Awesome Pro+ customer](https://fontawesome.com/), you have acc
 ```html {.example}
 <div class="wa-stack wa-gap-xl">
   <div class="wa-flank" style="--flank-size: 10ch;">
-    <a href="https://fontawesome.com/icons/packs/notdog" target="_blank">Notdog</a>
-    <div class="wa-cluster" style="font-size: 1.5em;">
-      <wa-icon family="notdog" variant="solid" name="house"></wa-icon>
-      <wa-icon
-        family="notdog"
-        variant="duo-solid"
-        name="house"
-        style="--secondary-color: skyblue; --secondary-opacity: 0.8;"
-      ></wa-icon>
-    </div>
-  </div>
-
-  <div class="wa-flank" style="--flank-size: 10ch;">
     <a href="https://fontawesome.com/icons/packs/chisel" target="_blank">Chisel</a>
     <div class="wa-cluster" style="font-size: 1.5em;">
       <wa-icon family="chisel" variant="regular" name="house"></wa-icon>
@@ -532,6 +519,13 @@ If you're a [Font Awesome Pro+ customer](https://fontawesome.com/), you have acc
   </div>
 
   <div class="wa-flank" style="--flank-size: 10ch;">
+    <a href="https://fontawesome.com/icons/packs/graphite" target="_blank">Graphite</a>
+    <div class="wa-cluster" style="font-size: 1.5em;">
+      <wa-icon family="graphite" variant="thin" name="house"></wa-icon>
+    </div>
+  </div>
+
+  <div class="wa-flank" style="--flank-size: 10ch;">
     <a href="https://fontawesome.com/icons/packs/jelly" target="_blank">Jelly</a>
     <div class="wa-cluster" style="font-size: 1.5em;">
       <wa-icon family="jelly" variant="regular" name="house"></wa-icon>
@@ -542,6 +536,19 @@ If you're a [Font Awesome Pro+ customer](https://fontawesome.com/), you have acc
         style="--secondary-color: skyblue; --secondary-opacity: 0.8;"
       ></wa-icon>
       <wa-icon family="jelly" variant="fill-regular" name="house"></wa-icon>
+    </div>
+  </div>
+
+  <div class="wa-flank" style="--flank-size: 10ch;">
+    <a href="https://fontawesome.com/icons/packs/notdog" target="_blank">Notdog</a>
+    <div class="wa-cluster" style="font-size: 1.5em;">
+      <wa-icon family="notdog" variant="solid" name="house"></wa-icon>
+      <wa-icon
+        family="notdog"
+        variant="duo-solid"
+        name="house"
+        style="--secondary-color: skyblue; --secondary-opacity: 0.8;"
+      ></wa-icon>
     </div>
   </div>
 
@@ -576,13 +583,6 @@ If you're a [Font Awesome Pro+ customer](https://fontawesome.com/), you have acc
         style="--secondary-color: skyblue; --secondary-opacity: 0.8;"
       ></wa-icon>
       <wa-icon family="utility-fill" variant="semibold" name="house"></wa-icon>
-    </div>
-  </div>
-
-  <div class="wa-flank" style="--flank-size: 10ch;">
-    <a href="https://fontawesome.com/icons/packs/graphite" target="_blank">Graphite</a>
-    <div class="wa-cluster" style="font-size: 1.5em;">
-      <wa-icon family="graphite" variant="thin" name="house"></wa-icon>
     </div>
   </div>
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -15,6 +15,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 
 - Added `wa-button` class for styling `<a>` elements as buttons [pr:2040]
 - Fixed a bug `<wa-color-picker>` that prevented it from flipping horizontally when position to the right of the viewport. [pr:2024]
+- Updated `<wa-icon>` to use [Font Awesome 7.2.0](https://fontawesome.com/changelog#v7-2-0) [pr:2059]
 
 ## 3.2.1
 

--- a/packages/webawesome/src/components/icon/library.default.ts
+++ b/packages/webawesome/src/components/icon/library.default.ts
@@ -66,6 +66,11 @@ function getIconUrl(name: string, family: string, variant: string) {
     folder = 'whiteboard-semibold';
   }
 
+  // Graphite (Pro+)
+  if (family === 'graphite') {
+    folder = 'graphite-thin';
+  }
+
   // Utility (Pro+)
   // Correct usage: family="utility", family="utility-duo", or family="utility-fill", variant="semibold"
   if (family === 'utility') {

--- a/packages/webawesome/src/components/icon/library.default.ts
+++ b/packages/webawesome/src/components/icon/library.default.ts
@@ -1,7 +1,7 @@
 import { getKitCode } from '../../utilities/base-path.js';
 import type { IconLibrary } from './library.js';
 
-const FA_VERSION = '7.1.0';
+const FA_VERSION = '7.2.0';
 
 function getIconUrl(name: string, family: string, variant: string) {
   const kitCode = getKitCode();

--- a/packages/webawesome/src/components/icon/library.default.ts
+++ b/packages/webawesome/src/components/icon/library.default.ts
@@ -8,17 +8,6 @@ function getIconUrl(name: string, family: string, variant: string) {
   const isPro = kitCode.length > 0;
   let folder = 'solid';
 
-  // Notdog (Pro+)
-  // Correct usage: family="notdog" or family="notdog-duo", variant="solid"
-  if (family === 'notdog') {
-    // NOTE: variant="duo-solid" is deprecated, use family="notdog-duo" variant="solid" instead
-    if (variant === 'solid') folder = 'notdog-solid';
-    if (variant === 'duo-solid') folder = 'notdog-duo-solid';
-  }
-  if (family === 'notdog-duo') {
-    folder = 'notdog-duo-solid';
-  }
-
   // Chisel (Pro+)
   if (family === 'chisel') {
     folder = 'chisel-regular';
@@ -27,6 +16,11 @@ function getIconUrl(name: string, family: string, variant: string) {
   // Etch (Pro+)
   if (family === 'etch') {
     folder = 'etch-solid';
+  }
+
+  // Graphite (Pro+)
+  if (family === 'graphite') {
+    folder = 'graphite-thin';
   }
 
   // Jelly (Pro+)
@@ -45,6 +39,17 @@ function getIconUrl(name: string, family: string, variant: string) {
     folder = 'jelly-fill-regular';
   }
 
+  // Notdog (Pro+)
+  // Correct usage: family="notdog" or family="notdog-duo", variant="solid"
+  if (family === 'notdog') {
+    // NOTE: variant="duo-solid" is deprecated, use family="notdog-duo" variant="solid" instead
+    if (variant === 'solid') folder = 'notdog-solid';
+    if (variant === 'duo-solid') folder = 'notdog-duo-solid';
+  }
+  if (family === 'notdog-duo') {
+    folder = 'notdog-duo-solid';
+  }
+
   // Slab (Pro+)
   // Correct usage: family="slab" or family="slab-press", variant="regular"
   if (family === 'slab') {
@@ -61,16 +66,6 @@ function getIconUrl(name: string, family: string, variant: string) {
     folder = 'thumbprint-light';
   }
 
-  // Whiteboard (Pro+)
-  if (family === 'whiteboard') {
-    folder = 'whiteboard-semibold';
-  }
-
-  // Graphite (Pro+)
-  if (family === 'graphite') {
-    folder = 'graphite-thin';
-  }
-
   // Utility (Pro+)
   // Correct usage: family="utility", family="utility-duo", or family="utility-fill", variant="semibold"
   if (family === 'utility') {
@@ -83,6 +78,11 @@ function getIconUrl(name: string, family: string, variant: string) {
     folder = 'utility-fill-semibold';
   }
 
+  // Whiteboard (Pro+)
+  if (family === 'whiteboard') {
+    folder = 'whiteboard-semibold';
+  }
+
   // Classic
   if (family === 'classic') {
     if (variant === 'thin') folder = 'thin';
@@ -91,20 +91,20 @@ function getIconUrl(name: string, family: string, variant: string) {
     if (variant === 'solid') folder = 'solid';
   }
 
-  // Sharp
-  if (family === 'sharp') {
-    if (variant === 'thin') folder = 'sharp-thin';
-    if (variant === 'light') folder = 'sharp-light';
-    if (variant === 'regular') folder = 'sharp-regular';
-    if (variant === 'solid') folder = 'sharp-solid';
-  }
-
   // Duotone
   if (family === 'duotone') {
     if (variant === 'thin') folder = 'duotone-thin';
     if (variant === 'light') folder = 'duotone-light';
     if (variant === 'regular') folder = 'duotone-regular';
     if (variant === 'solid') folder = 'duotone';
+  }
+
+  // Sharp
+  if (family === 'sharp') {
+    if (variant === 'thin') folder = 'sharp-thin';
+    if (variant === 'light') folder = 'sharp-light';
+    if (variant === 'regular') folder = 'sharp-regular';
+    if (variant === 'solid') folder = 'sharp-solid';
   }
 
   // Sharp Duotone


### PR DESCRIPTION
Addresses https://github.com/shoelace-style/webawesome/issues/2058 and gets our Icon Component to support the latest and greatest in [Font Awesome 7.2.0](https://fontawesome.com/changelog#v7-2-0), including the [Pro+ Graphite Pack](https://fontawesome.com/icons/packs/graphite).

### Previews
- [Pro+ Examples with Graphite](https://webawesome-git-talbs-7-dot-2-icons-4-u-font-awesome.vercel.app/docs/components/icon#font-awesome-pro)
- [Changelog](https://webawesome-git-talbs-7-dot-2-icons-4-u-font-awesome.vercel.app/docs/resources/changelog)