### PR TITLE
Fix for dialog and drawer using user agent default colors

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -15,6 +15,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 
 - Added `wa-button` class for styling `<a>` elements as buttons [pr:2040]
 - Fixed a bug `<wa-color-picker>` that prevented it from flipping horizontally when position to the right of the viewport. [pr:2024]
+- Fixed a bug by adding `color: inherit` to the `<wa-dialog>` and `<wa-drawer>` styles so they inherit the text color from the document context rather than the browser default. [pr:2064]
 
 ## 3.2.1
 

--- a/packages/webawesome/src/components/dialog/dialog.styles.ts
+++ b/packages/webawesome/src/components/dialog/dialog.styles.ts
@@ -24,6 +24,7 @@ export default css`
     width: var(--width);
     max-width: calc(100% - var(--wa-space-2xl));
     max-height: calc(100% - var(--wa-space-2xl));
+    color: inherit;
     background-color: var(--wa-color-surface-raised);
     border-radius: var(--wa-panel-border-radius);
     border: none;

--- a/packages/webawesome/src/components/drawer/drawer.styles.ts
+++ b/packages/webawesome/src/components/drawer/drawer.styles.ts
@@ -24,6 +24,7 @@ export default css`
     max-width: 100%;
     max-height: 100%;
     overflow: hidden;
+    color: inherit;
     background-color: var(--wa-color-surface-raised);
     border: none;
     box-shadow: var(--wa-shadow-l);


### PR DESCRIPTION
  Fixes #1978
---
- Fixes dialog and drawer components using the user agent default text color (`canvastext`) instead of respecting  design tokens
- Adds `color: inherit` to the `wa-dialog` and `wa-drawer` styles so they inherit the text color from the document context rather than the browser default                                                                                                                                                                                                   
                                                                            
