### PR TITLE
Fix animateWithClass for 0ms duration

### DIFF
--- a/packages/webawesome/src/internal/animate.ts
+++ b/packages/webawesome/src/internal/animate.ts
@@ -19,14 +19,12 @@ export function animateWithClass(el: Element, className: string) {
     }
     el.classList.add(className);
 
-    // if there are no animations or animation is set to 0ms, resolve immediately
-    if (el.getAnimations().length === 0) {
-      el.classList.remove(className);
-      resolve();
-      return;
-    }
-
+    let resolved = false;
     let onEnd = () => {
+      if (resolved) {
+        return;
+      }
+      resolved = true;
       el.classList.remove(className);
       resolve();
       controller.abort();
@@ -34,6 +32,13 @@ export function animateWithClass(el: Element, className: string) {
 
     el.addEventListener('animationend', onEnd, { once: true, signal });
     el.addEventListener('animationcancel', onEnd, { once: true, signal });
+
+    // if there are no animations or animation is set to 0ms, end immediately
+    requestAnimationFrame(() => {
+      if (!resolved && el.getAnimations().length === 0) {
+        onEnd();
+      }
+    });
   });
 }
 

--- a/packages/webawesome/src/internal/animate.ts
+++ b/packages/webawesome/src/internal/animate.ts
@@ -17,8 +17,14 @@ export function animateWithClass(el: Element, className: string) {
     if (el.classList.contains(className)) {
       return;
     }
-    el.classList.remove(className);
     el.classList.add(className);
+
+    // if there are no animations or animation is set to 0ms, resolve immediately
+    if (el.getAnimations().length === 0) {
+      el.classList.remove(className);
+      resolve();
+      return;
+    }
 
     let onEnd = () => {
       el.classList.remove(className);
@@ -28,7 +34,6 @@ export function animateWithClass(el: Element, className: string) {
 
     el.addEventListener('animationend', onEnd, { once: true, signal });
     el.addEventListener('animationcancel', onEnd, { once: true, signal });
-    // TODO add failsafe if neither of these fires
   });
 }
 


### PR DESCRIPTION
If you set `--show-duration` for example to respect reduced motion the dialog events doesn't fire correctly.
We had this issue at least on Windows PCs.

With this fix I check if the element actually has animation if not resolve the animation. 
I tested it on Windows.

I also removed the TODO because this should now fulfill all suitable cases.