### PR TITLE
Remove default `border-radius` from `svg` elements

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -18,6 +18,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug that caused 0ms animations to not fire correctly in the internal `animateWithClass()` function [pr#2068]
 - Fixed a bug that caused `<wa-dropdown>` elements to scroll the document in Chrome 145
 - Updated `<wa-icon>` to use [Font Awesome 7.2.0](https://fontawesome.com/changelog#v7-2-0) [pr:2059]
+- Modified native styles so that `border-radius` does not apply to `svg` elements by default [pr:2078]
 
 ## 3.2.1
 

--- a/packages/webawesome/src/styles/native.css
+++ b/packages/webawesome/src/styles/native.css
@@ -328,7 +328,11 @@
   video {
     max-width: 100%;
     height: auto;
+  }
 
+  img,
+  picture,
+  video {
     border-radius: var(--wa-border-radius-m);
   }
 


### PR DESCRIPTION
Updates `native.css` to exclude `svg` elements from the rule that sets a default `border-radius` on media.

SVGs are so often iconographic or have transparent backgrounds that rounding the corners is likely to do more harm than good.