### PR TITLE
Updated focus function

### DIFF
--- a/packages/webawesome/src/components/select/select.ts
+++ b/packages/webawesome/src/components/select/select.ts
@@ -656,7 +656,7 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
       this.currentOption = option;
       option.current = true;
       option.tabIndex = 0;
-      option.focus();
+      option.focus({ preventScroll: true });
     }
   }
 


### PR DESCRIPTION
Related to #2075 

Adding `preventScroll: true` to the `focus` method fixes the "scroll" issue when opening and closing the select

### Before
https://github.com/user-attachments/assets/74c17705-9f93-4c41-9033-a5e5ec0953aa

### After
https://github.com/user-attachments/assets/e1151d99-33a7-47e9-8f86-acce272994e8

