### PR TITLE
Docs: Sidebar Shine Up

### DIFF
--- a/packages/webawesome/docs/_includes/nav-docs.njk
+++ b/packages/webawesome/docs/_includes/nav-docs.njk
@@ -7,6 +7,10 @@
     <wa-icon slot="start" name="block-brick" variant="regular" label="Patterns" class="icon-embiggen"></wa-icon>
     Patterns
   </wa-button>
+    <wa-button appearance="plain" href="/docs/patterns/layouts/" data-track-event="navigation:header_link_click" data-track-destination="layouts">
+    <wa-icon slot="start" name="table-layout" variant="regular" label="Layouts" class="icon-embiggen"></wa-icon>
+    Layouts
+  </wa-button>
   <wa-button appearance="plain" href="/docs/themes" data-track-event="navigation:header_link_click" data-track-destination="themes">
     <wa-icon slot="start" name="palette" variant="regular" label="Themes" class="icon-embiggen"></wa-icon>
     Themes

--- a/packages/webawesome/docs/_includes/sidebar-colophon.njk
+++ b/packages/webawesome/docs/_includes/sidebar-colophon.njk
@@ -5,7 +5,7 @@
     <span class="wa-caption-xs wa-cluster wa-gap-xs">
       Version {{ package.version }}
       <wa-icon id="version-icon-info" family="duotone" variant="regular" name="party-horn"></wa-icon>
-      <wa-tooltip for="version-icon-info" distance="2" class="wa-font-size-xs">Here be freshly launched Awesome and no wa-dragons</wa-tooltip>
+      <wa-tooltip for="version-icon-info" distance="2" class="wa-font-size-xs" style="--max-width: auto;">Here be freshly launched Awesome and no wa-dragons</wa-tooltip>
     </span>
     <span class="wa-caption-xs">&copy; Fonticons, Inc.</span>
   </div>

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -371,10 +371,10 @@
 <!-- Patterns -->
 <wa-details appearance="outlined">
   <h2 slot="summary" class="wa-split">
-    <span class="wa-cluster wa-gap-xs">
+    <a class="wa-cluster wa-gap-xs" href="/docs/patterns/" title="Overview">
       <wa-icon name="block-brick" variant="regular" aria-hidden="true"></wa-icon>
       Patterns
-    </span>
+    </a>
     {{ proBadge({ description: "Patterns require access to Web Awesome Pro" }) }}
   </h2>
   <ul>

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -370,18 +370,16 @@
 
 <!-- Patterns -->
 <wa-details appearance="outlined">
-  <h2 slot="summary">
-    <a class="wa-cluster wa-gap-xs" href="/docs/patterns/" title="Overview">
+  <h2 slot="summary" class="wa-split">
+    <span class="wa-cluster wa-gap-xs">
       <wa-icon name="block-brick" variant="regular" aria-hidden="true"></wa-icon>
       Patterns
-    </a>
+    </span>
+    {{ proBadge({ description: "Patterns require access to Web Awesome Pro" }) }}
   </h2>
   <ul>
     <li>
-      <span class="wa-split">
-        <a href="/docs/patterns/app/">App</a>
-        {{ proBadge() }}
-      </span>
+      <a href="/docs/patterns/app/">App</a>
       <ul>
         <li>
           <a href="/docs/patterns/app/action-panel/">Action Panel</a>
@@ -425,10 +423,7 @@
       </ul>
     </li>
     <li>
-      <span class="wa-split">
-        <a href="/docs/patterns/blog-news/">Blog &amp; News</a>
-        {{ proBadge() }}
-      </span>
+      <a href="/docs/patterns/blog-news/">Blog &amp; News</a>
       <ul>
         <li>
           <a href="/docs/patterns/blog-news/banners/">Banners</a>
@@ -487,10 +482,7 @@
       </ul>
     </li>
     <li>
-      <span class="wa-split">
-        <a href="/docs/patterns/ecommerce/">Ecommerce</a>
-        {{ proBadge() }}
-      </span>
+      <a href="/docs/patterns/ecommerce/">Ecommerce</a>
       <ul>
         <li>
           <a href="/docs/patterns/ecommerce/category-filter/">Category Filter</a>
@@ -528,10 +520,7 @@
       </ul>
     </li>
     <li>
-      <span class="wa-split">
-        <a href="/docs/patterns/layouts/">Layouts</a>
-        {{ proBadge() }}
-      </span>
+      <a href="/docs/patterns/layouts/">Layouts</a>
       <ul>
         <li>
           <a href="/docs/patterns/layouts/ecommerce/">Ecommerce</a>

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -342,7 +342,7 @@
   <h2 slot="summary">
     <a class="wa-cluster wa-gap-xs" href="/docs/layout/" title="Overview">
       <wa-icon name="ruler-combined" variant="regular" aria-hidden="true"></wa-icon>
-      Layout
+      Layout Utilities
     </a>
   </h2>
   <ul>

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -258,7 +258,7 @@
       <wa-icon name="chart-area" variant="regular" aria-hidden="true"></wa-icon>
       Data Visualization
     </span>
-    {{ proBadge() }}
+    {{ proBadge({ description: "Data Visualization components require access to Web Awesome Pro" }) }}
   </h2>
   <ul>
     <li>

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -105,7 +105,8 @@
     <li>
       <span class="wa-split">
         <a class="wa-cluster wa-gap-xs" href="/docs/components/page/">
-          Page <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
+          Page
+          <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
         </a>
         {{ proBadge() }}
       </span>
@@ -356,7 +357,8 @@
     <li>
       <span class="wa-split">
         <a class="wa-cluster wa-gap-xs" href="/docs/components/page/">
-          Page <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
+          Page
+          <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
         </a>
         {{ proBadge() }}
       </span>

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -256,18 +256,62 @@
     <wa-icon name="chart-area" variant="regular" aria-hidden="true"></wa-icon>
     Data Visualization
     {{ proBadge() }}
-    <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
   </h2>
   <ul>
-    <li><a href="/docs/components/bar-chart">Bar Chart</a></li>
-    <li><a href="/docs/components/line-chart">Line Chart</a></li>
-    <li><a href="/docs/components/bubble-chart">Bubble Chart</a></li>
-    <li><a href="/docs/components/doughnut-chart">Doughnut Chart</a></li>
-    <li><a href="/docs/components/pie-chart">Pie Chart</a></li>
-    <li><a href="/docs/components/polar-area-chart">Polar Area Chart</a></li>
-    <li><a href="/docs/components/radar-chart">Radar Chart</a></li>
-    <li><a href="/docs/components/scatter-chart">Scatter Chart</a></li>
-    <li><a href="/docs/components/sparkline">Sparkline</a></li>
+    <li>
+      <a class="wa-cluster wa-gap-xs" href="/docs/components/bar-chart">
+        Bar Chart
+        <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
+      </a>
+    </li>
+    <li>
+      <a class="wa-cluster wa-gap-xs" href="/docs/components/line-chart">
+        Line Chart
+        <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
+      </a>
+    </li>
+    <li>
+      <a class="wa-cluster wa-gap-xs" href="/docs/components/bubble-chart">
+        Bubble Chart
+        <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
+      </a>
+    </li>
+    <li>
+      <a class="wa-cluster wa-gap-xs" href="/docs/components/doughnut-chart">
+        Doughnut Chart
+        <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
+      </a>
+    </li>
+    <li>
+      <a class="wa-cluster wa-gap-xs" href="/docs/components/pie-chart">
+        Pie Chart
+        <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
+      </a>
+    </li>
+    <li>
+      <a class="wa-cluster wa-gap-xs" href="/docs/components/polar-area-chart">
+        Polar Area Chart
+        <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
+      </a>
+    </li>
+    <li>
+      <a class="wa-cluster wa-gap-xs" href="/docs/components/radar-chart">
+        Radar Chart
+        <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
+      </a>
+    </li>
+    <li>
+      <a class="wa-cluster wa-gap-xs" href="/docs/components/scatter-chart">
+        Scatter Chart
+        <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
+      </a>
+    </li>
+    <li>
+      <a class="wa-cluster wa-gap-xs" href="/docs/components/sparkline">
+        Sparkline
+        <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
+      </a>
+    </li>
     <li><a href="/docs/components/chart">Advanced Usage</a></li>
   </ul>
 </wa-details>

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -254,7 +254,7 @@
 <!-- Data Visualization -->
 <wa-details appearance="outlined">
   <h2 slot="summary" class="wa-split">
-    <span>
+    <span class="wa-cluster wa-gap-xs">
       <wa-icon name="chart-area" variant="regular" aria-hidden="true"></wa-icon>
       Data Visualization
     </span>

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -253,9 +253,11 @@
 
 <!-- Data Visualization -->
 <wa-details appearance="outlined">
-  <h2 slot="summary">
-    <wa-icon name="chart-area" variant="regular" aria-hidden="true"></wa-icon>
-    Data Visualization
+  <h2 slot="summary" class="wa-split">
+    <span>
+      <wa-icon name="chart-area" variant="regular" aria-hidden="true"></wa-icon>
+      Data Visualization
+    </span>
     {{ proBadge() }}
   </h2>
   <ul>

--- a/packages/webawesome/docs/_layouts/component.njk
+++ b/packages/webawesome/docs/_layouts/component.njk
@@ -7,12 +7,20 @@
   <div class="component-info">
     <code class="component-tag">&lt;{{ component.tagName }}&gt;</code>
     <wa-badge variant="neutral">Since {{ component.since }}</wa-badge>
-    <wa-badge
-      {% if component.status == 'stable' %}variant="brand"{% endif %}
-      {% if component.status == 'experimental' %}variant="warning" appearance="filled"{% endif %}
-    >
-      {{ component.status }}
-    </wa-badge>
+    {% if component.status %}
+      <wa-badge
+        {% if component.status == 'stable' %}variant="brand"{% endif %}
+        {% if component.status == 'experimental' %}variant="warning" appearance="filled"{% endif %}
+      >
+        {% if component.status == 'stable' %}
+          <wa-icon name="check" slot="start"></wa-icon>
+        {% endif %}
+        {% if component.status == 'experimental' %}
+          <wa-icon name="flask" slot="start"></wa-icon>
+        {% endif %}
+        {{ component.status | capitalize }}
+      </wa-badge>
+    {% endif %}
     {% if isProComponent %}
       {{ proBadge({ description: (component.tagName | stripPrefix) | capitalize ~ " requires access to Web Awesome Pro" }) }}
     {% endif %}

--- a/packages/webawesome/docs/assets/scripts/search.js
+++ b/packages/webawesome/docs/assets/scripts/search.js
@@ -57,6 +57,7 @@ const iconByPrefix = [
   ['/docs/components/sparkline', 'chart-area'],
   ['/docs/components', 'trowel-bricks'],
   ['/docs/patterns', 'block-brick'],
+  ['/docs/patterns/layouts', 'table-layout'],
   ['/docs/frameworks', 'puzzle'],
   ['/docs/tokens', 'coin-front'],
   ['/docs/resources/agent-skills', 'sparkles'],

--- a/packages/webawesome/docs/docs/layout.njk
+++ b/packages/webawesome/docs/docs/layout.njk
@@ -1,6 +1,6 @@
 ---
-title: Layout
-description: Layout components and utility classes help you organize content that can adapt to any device or screen size. See the [installation instructions](#installation) to use Web Awesome's layout tools in your project.
+title: Layout Utilities
+description: Layout utility classes help you organize content that can adapt to any device or screen size. See the [installation instructions](#installation) to use Web Awesome's layout tools in your project.
 layout: docs
 ---
 
@@ -46,7 +46,7 @@ layout: docs
 {% markdown %}
 ## Using Layout Utilities
 
-Layout utility classes are bundled with Web Awesome's [style utilities](/docs/utilities). By including style utilities in your project, you'll have access to layout utilities like `.wa-grid` and `.wa-stack`. 
+Layout utility classes are bundled with Web Awesome's [style utilities](/docs/utilities). By including style utilities in your project, you'll have access to layout utilities like `.wa-grid` and `.wa-stack`.
 {% endmarkdown %}
 
 <wa-tab-group>


### PR DESCRIPTION
This work started by touching up our Docs' sidebar UI and then spread into a few other aspects. Here's a summary of what was touched and why:

| What | Why |
|:-------------|:-----|
| Moved Experimental Icon to Data Viz Links | Since we may chose to promote individual data viz components to stable sooner than other (e.g. sparkline) and to visually reduce noise/awkward alignment in "Data Visualization" summary |
| Added Pro Badge to "Patterns" summary | To follow the pattern set in "Data Visualization". All Pro Badges on individual pattern components have bee removed |
| Renamed Layouts to Layout Utilities | To avoid confusion with Layout Patterns in nav/search |
| Promoted Layout Patterns in Docs Nav | To help drive attention to these | 
| Synced up iconography in search to include Layout Patterns | To help with wayfinding and for consistency | 
| Added flask icon to component's Experimental badge | To mirror iconography used in Sidebar
| Added check iconography and capitalization to component's status badge | For consistency with other badges and states of this one | 

| Previews |
|--------|
| <img width="2832" height="1540" alt="image" src="https://github.com/user-attachments/assets/28ba619f-8b65-4e73-80db-5cacf54813f4" /> |
| <img width="2832" height="1540" alt="image" src="https://github.com/user-attachments/assets/84fe9f7e-ad3f-4682-9e71-698420447341" /> | 
| <img width="2832" height="1540" alt="image" src="https://github.com/user-attachments/assets/2ece8adc-0446-4c42-ba6b-98b467e16b8b" /> |