### PR TITLE
Scope dialog util to `app-dialog` class

### DIFF
--- a/packages/webawesome/docs/_includes/dialog-ba-kickstarter.njk
+++ b/packages/webawesome/docs/_includes/dialog-ba-kickstarter.njk
@@ -1,6 +1,6 @@
 {% raw %}
 {% if isBuildAwesomePromoActive %}
-  <wa-dialog id="dialog-site" class="dialog-ba-kickstarter brand-build-awesome" light-dismiss without-header>
+  <wa-dialog id="dialog-site" class="dialog-ba-kickstarter brand-build-awesome app-dialog" light-dismiss without-header>
     <div class="ba-kickstarter-video">
       <div class="ba-kickstarter-video-poster" aria-hidden="true">
         <img src="/assets/images/placeholder-ba-video.png" alt="" />

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -389,7 +389,7 @@
   }
 
   /* dialogs */
-  wa-dialog:has([slot='footer']) [slot='footer'] {
+  wa-dialog.app-dialog [slot='footer'] {
     border-block-start: var(--wa-border-width-s) solid var(--wa-color-surface-border);
     flex-grow: 1; /* make footer contents span entire width of dialog */
     padding-block-start: var(--wa-space-l);


### PR DESCRIPTION
Adds `.app-dialog` to our dialog styles in `utils.css` to prevent our preferred styles from leaching into the `<wa-dialog>` examples in the docs.

**Issue**
<img width="512" height="257" alt="Screenshot 2026-03-06 at 4 03 47 PM" src="https://github.com/user-attachments/assets/26afd3cd-014f-473f-8f7c-a8b071a89f72" />

**Fixed**
<img width="512" height="233" alt="Screenshot 2026-03-06 at 3 43 31 PM" src="https://github.com/user-attachments/assets/b83319ed-dace-492e-ac98-f6d3a2978b45" />
