### PR TITLE
Fix Label Styling When Using the `label` Slot

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -8,6 +8,12 @@ Web Awesome follows [Semantic Versioning](https://semver.org/). Breaking changes
 
 Components with the <wa-badge variant="warning">Experimental</wa-badge> badge should not be used in production. They are made available as release candidates for development and testing purposes. As such, changes to experimental components will not be subject to semantic versioning.
 
+## Unreleased
+
+<small>TBD</small>
+
+- Fixed form control label styling when using the `label` slot so it matches the attribute. [issue:2124]
+
 ## 3.3.1
 
 <small>March 4th, 2026</small>

--- a/packages/webawesome/src/components/slider/slider.styles.ts
+++ b/packages/webawesome/src/components/slider/slider.styles.ts
@@ -26,7 +26,7 @@ export default css`
   }
 
   /* Add extra space between slider and label, when present */
-  #label:has(*:not(:empty)) ~ #slider {
+  #label.has-label ~ #slider {
     &.horizontal {
       margin-block-start: 0.5em;
     }

--- a/packages/webawesome/src/styles/component/form-control.styles.ts
+++ b/packages/webawesome/src/styles/component/form-control.styles.ts
@@ -21,6 +21,13 @@ export default css`
     margin-block-end: 0.5em;
   }
 
+  /* Slotted label content: same appearance as attribute label */
+  :is([part~='form-control-label'], [part~='label']).has-label::slotted(*) {
+    color: var(--wa-form-control-label-color);
+    font-weight: var(--wa-form-control-label-font-weight);
+    line-height: var(--wa-form-control-label-line-height);
+  }
+
   :host([required]) :is([part~='form-control-label'], [part~='label'])::after {
     content: var(--wa-form-control-required-content);
     margin-inline-start: var(--wa-form-control-required-content-offset);


### PR DESCRIPTION
In Web Awesome, form control labels (slider, input, select, etc.) can be set either with the `label` attribute or by putting content in the `label` slot. 

Those two options weren’t always styled the same: slotted labels could use different typography and, on the slider, had less space above the track. This PR applies the same label styling and spacing for both attribute and slotted labels.

Fixes https://github.com/shoelace-style/webawesome/issues/2124