### PR TITLE
Fix Label Styling When Using the `label` Slot

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -8,10 +8,13 @@ Web Awesome follows [Semantic Versioning](https://semver.org/). Breaking changes
 
 Components with the <wa-badge variant="warning">Experimental</wa-badge> badge should not be used in production. They are made available as release candidates for development and testing purposes. As such, changes to experimental components will not be subject to semantic versioning.
 
-## 3.3.2
+## Unreleased
+
+<small>TBD</small>
 
 - Fixed the off-centered position of indent guides in `<wa-tree>`
 - Improved `<wa-tree>` and `<wa-tree-item>` so all internal dimensions (labels, checkboxes, expand buttons, etc.) scale proportionally with `font-size`, making it easy to resize the tree [discuss:2147]
+- Fixed slider styling when using the `label` slot so that it matches attribute use. [issue:2124]
 
 ## 3.3.1
 

--- a/packages/webawesome/src/components/slider/slider.styles.ts
+++ b/packages/webawesome/src/components/slider/slider.styles.ts
@@ -26,7 +26,7 @@ export default css`
   }
 
   /* Add extra space between slider and label, when present */
-  #label:has(*:not(:empty)) ~ #slider {
+  #label.has-label ~ #slider {
     &.horizontal {
       margin-block-start: 0.5em;
     }


### PR DESCRIPTION
In Web Awesome, form control labels (slider, input, select, etc.) can be set either with the `label` attribute or by putting content in the `label` slot. 

Those two options weren’t always styled the same: slotted labels could use different typography and, on the slider, had less space above the track. This PR applies the same label styling and spacing for both attribute and slotted labels.

Fixes https://github.com/shoelace-style/webawesome/issues/2124