### PR TITLE
Extend Space Scale + Utilities

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -12,9 +12,13 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 
 <small>TBD</small>
 
+- Added `--wa-space-5xl` design token to all themes  [issue:1606]
+- Added `wa-gap-5xl` utility class  [issue:1606]
+- Added `wa-gap-4xl` to the gap utility `:where()` selector
 - Fixed the off-centered position of indent guides in `<wa-tree>`
 - Improved `<wa-tree>` and `<wa-tree-item>` so all internal dimensions (labels, checkboxes, expand buttons, etc.) scale proportionally with `font-size`, making it easy to resize the tree [discuss:2147]
 - Fixed slider styling when using the `label` slot so that it matches attribute use. [issue:2124]
+- [Docs]: Updated space, gap, stack, and cluster documentation for the new tokens and utilities [issue:1606]
 
 ## 3.3.1
 

--- a/packages/webawesome/docs/docs/tokens/space.md
+++ b/packages/webawesome/docs/docs/tokens/space.md
@@ -51,3 +51,4 @@ The calculations for each size and the resulting pixel value (assuming a 16px ro
 | `--wa-space-2xl` | `calc(var(--wa-space-scale) * 2.5rem)` <small>(40px)</small>  | <div class="spacing-example" style="width: var(--wa-space-2xl)"></div> |
 | `--wa-space-3xl` | `calc(var(--wa-space-scale) * 3rem)` <small>(48px)</small>    | <div class="spacing-example" style="width: var(--wa-space-3xl)"></div> |
 | `--wa-space-4xl` | `calc(var(--wa-space-scale) * 4rem)` <small>(64px)</small>    | <div class="spacing-example" style="width: var(--wa-space-4xl)"></div> |
+| `--wa-space-5xl` | `calc(var(--wa-space-scale) * 5rem)` <small>(80px)</small>    | <div class="spacing-example" style="width: var(--wa-space-5xl)"></div> |

--- a/packages/webawesome/docs/docs/utilities/cluster.md
+++ b/packages/webawesome/docs/docs/utilities/cluster.md
@@ -133,6 +133,8 @@ By default, the gap between cluster items uses `--wa-space-m` from your theme. Y
 - `wa-gap-xl`
 - `wa-gap-2xl`
 - `wa-gap-3xl`
+- `wa-gap-4xl`
+- `wa-gap-5xl`
 
 ```html {.example}
 <div class="wa-stack">

--- a/packages/webawesome/docs/docs/utilities/gap.md
+++ b/packages/webawesome/docs/docs/utilities/gap.md
@@ -39,3 +39,4 @@ Besides `wa-gap-0`, which sets `gap` to zero, each class corresponds to one of t
 | `wa-gap-2xl` | `--wa-space-2xl` | <div class="preview-wrapper wa-cluster wa-gap-2xl"><div class="preview-block"></div><div class="preview-block"></div></div> |
 | `wa-gap-3xl` | `--wa-space-3xl` | <div class="preview-wrapper wa-cluster wa-gap-3xl"><div class="preview-block"></div><div class="preview-block"></div></div> |
 | `wa-gap-4xl` | `--wa-space-4xl` | <div class="preview-wrapper wa-cluster wa-gap-4xl"><div class="preview-block"></div><div class="preview-block"></div></div> |
+| `wa-gap-5xl` | `--wa-space-5xl` | <div class="preview-wrapper wa-cluster wa-gap-5xl"><div class="preview-block"></div><div class="preview-block"></div></div> |

--- a/packages/webawesome/docs/docs/utilities/stack.md
+++ b/packages/webawesome/docs/docs/utilities/stack.md
@@ -106,6 +106,8 @@ By default, the gap between stack items uses `--wa-space-m` from your theme. You
 - `wa-gap-xl`
 - `wa-gap-2xl`
 - `wa-gap-3xl`
+- `wa-gap-4xl`
+- `wa-gap-5xl`
 
 ```html {.example}
 <div class="wa-grid">

--- a/packages/webawesome/src/styles/themes/awesome.css
+++ b/packages/webawesome/src/styles/themes/awesome.css
@@ -239,6 +239,7 @@
     --wa-space-2xl: calc(var(--wa-space-scale) * 2.5rem); /* 40px */
     --wa-space-3xl: calc(var(--wa-space-scale) * 3rem); /* 48px */
     --wa-space-4xl: calc(var(--wa-space-scale) * 4rem); /* 64px */
+    --wa-space-5xl: calc(var(--wa-space-scale) * 5rem); /* 80px */
 
     --wa-content-spacing: var(--wa-space-l);
     /* #endregion */

--- a/packages/webawesome/src/styles/themes/default.css
+++ b/packages/webawesome/src/styles/themes/default.css
@@ -233,6 +233,7 @@
     --wa-space-2xl: calc(var(--wa-space-scale) * 2.5rem); /* 40px */
     --wa-space-3xl: calc(var(--wa-space-scale) * 3rem); /* 48px */
     --wa-space-4xl: calc(var(--wa-space-scale) * 4rem); /* 64px */
+    --wa-space-5xl: calc(var(--wa-space-scale) * 5rem); /* 80px */
 
     --wa-content-spacing: var(--wa-space-l);
     /* #endregion */

--- a/packages/webawesome/src/styles/themes/shoelace.css
+++ b/packages/webawesome/src/styles/themes/shoelace.css
@@ -238,6 +238,7 @@
     --wa-space-2xl: calc(var(--wa-space-scale) * 2.5rem); /* 40px */
     --wa-space-3xl: calc(var(--wa-space-scale) * 3rem); /* 48px */
     --wa-space-4xl: calc(var(--wa-space-scale) * 4rem); /* 64px */
+    --wa-space-5xl: calc(var(--wa-space-scale) * 5rem); /* 80px */
 
     --wa-content-spacing: var(--wa-space-l);
     /* #endregion */

--- a/packages/webawesome/src/styles/utilities/gap.css
+++ b/packages/webawesome/src/styles/utilities/gap.css
@@ -10,7 +10,9 @@
     .wa-gap-l,
     .wa-gap-xl,
     .wa-gap-2xl,
-    .wa-gap-3xl
+    .wa-gap-3xl,
+    .wa-gap-4xl,
+    .wa-gap-5xl
   ) {
     display: flex;
   }
@@ -47,5 +49,8 @@
   }
   .wa-gap-4xl {
     gap: var(--wa-space-4xl);
+  }
+  .wa-gap-5xl {
+    gap: var(--wa-space-5xl);
   }
 }


### PR DESCRIPTION
This work extends the space scale and gap utilities by adding `--wa-space-5xl` (5rem / 80px) and the `.wa-gap-5xl` utility, and updates the space, gap, cluster, and stack docs plus the changelog. 

It also fixes a bug where `wa-gap-4xl `was missing from the `:where()` selector in `gap.css`, so that class now gets the correct flex styling.

Addresses https://github.com/shoelace-style/webawesome/issues/1606.