### PR TITLE
Extend Typography's Font Size Scale + Utilities

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -15,11 +15,14 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Added `--wa-space-5xl` design token to all themes  [issue:1606]
 - Added `wa-gap-5xl` utility class  [issue:1606]
 - Added `wa-gap-4xl` to the gap utility `:where()` selector
+- Added `--wa-font-size-3xs` and `--wa-font-size-5xl` design tokens [issue:1606]
+- Added `*-3xs` and `*-5xl` to `wa-font-size`, `wa-body`, `wa-heading`, `wa-caption`, and `wa-longform` utility classes [issue:1606]
 - Fixed the off-centered position of indent guides in `<wa-tree>`
 - Fixed slider styling when using the `label` slot so that it matches attribute use. [issue:2124]
 - Fixed a bug in `<wa-scroller>` that caused horizontal page overflow in Chrome when containing wide content such as tables
 - Improved `<wa-tree>` and `<wa-tree-item>` so all internal dimensions (labels, checkboxes, expand buttons, etc.) scale proportionally with `font-size`, making it easy to resize the tree [discuss:2147]
 - [Docs]: Updated space, gap, stack, and cluster documentation for the new tokens and utilities [issue:1606]
+- [Docs]: Updated typography and text documentation for the new tokens and utilities [issue:1606]
 
 ## 3.3.1
 

--- a/packages/webawesome/docs/docs/tokens/typography.md
+++ b/packages/webawesome/docs/docs/tokens/typography.md
@@ -17,7 +17,7 @@ Font families are assigned specific roles &mdash; like heading or code &mdash; t
 
 ## Font Size
 
-Font sizes use a ratio of 1.125 to scale sizes proportionally. Starting with the medium (`m`) font size, smaller sizes (`s` through `2xs`) are 1.125x smaller as the sizes decrease, and larger sizes (`l` through `4xl`) are _twice_ 1.125x larger as sizes increase — here, the ratio is doubled to maximize impact between sizes.
+Font sizes use a ratio of 1.125 to scale sizes proportionally. Starting with the medium (`m`) font size, smaller sizes (`s` through `3xs`) are 1.125x smaller as the sizes decrease, and larger sizes (`l` through `5xl`) are _twice_ 1.125x larger as sizes increase — here, the ratio is doubled to maximize impact between sizes.
 
 Each value uses `rem` units and is rounded to the nearest whole pixel when rendered with [`round()`](https://developer.mozilla.org/en-US/docs/Web/CSS/round).
 
@@ -27,6 +27,7 @@ The calculations for each size and the resulting pixel value (assuming a 16px ro
 
 | Custom Property      | Default Value                     | Preview                                                    |
 | -------------------- | --------------------------------- | ---------------------------------------------------------- |
+| `--wa-font-size-3xs` | `round(calc(var(--wa-font-size-2xs) / 1.125), 1px)` <small>(10px)</small> | <div style="font-size: var(--wa-font-size-3xs)">AaBb</div> |
 | `--wa-font-size-2xs` | `round(calc(var(--wa-font-size-xs) / 1.125), 1px)` <small>(11px)</small> | <div style="font-size: var(--wa-font-size-2xs)">AaBb</div> |
 | `--wa-font-size-xs`  | `round(calc(var(--wa-font-size-s) / 1.125), 1px)` <small>(12px)</small>   | <div style="font-size: var(--wa-font-size-xs)">AaBb</div>  |
 | `--wa-font-size-s`   | `round(calc(var(--wa-font-size-m) / 1.125), 1px)` <small>(14px)</small>  | <div style="font-size: var(--wa-font-size-s)">AaBb</div>   |
@@ -35,7 +36,12 @@ The calculations for each size and the resulting pixel value (assuming a 16px ro
 | `--wa-font-size-xl`  | `round(calc(var(--wa-font-size-l) * 1.125 * 1.125), 1px)` <small>(25px)</small>  | <div style="font-size: var(--wa-font-size-xl)">AaBb</div>  |
 | `--wa-font-size-2xl` | `round(calc(var(--wa-font-size-xl) * 1.125 * 1.125), 1px)` <small>(32px)</small>      | <div style="font-size: var(--wa-font-size-2xl)">AaBb</div> |
 | `--wa-font-size-3xl` | `round(calc(var(--wa-font-size-2xl) * 1.125 * 1.125), 1px)` <small>(41px)</small> | <div style="font-size: var(--wa-font-size-3xl)">AaBb</div> |
-| `--wa-font-size-4xl` | `round(calc(var(--wa-font-size-3xl) * 1.125 * 1.125)` <small>(52px)</small>   | <div style="font-size: var(--wa-font-size-4xl)">AaBb</div> |
+| `--wa-font-size-4xl` | `round(calc(var(--wa-font-size-3xl) * 1.125 * 1.125), 1px)` <small>(52px)</small>   | <div style="font-size: var(--wa-font-size-4xl)">AaBb</div> |
+| `--wa-font-size-5xl` | `round(calc(var(--wa-font-size-4xl) * 1.125 * 1.125), 1px)` <small>(66px)</small>   | <div style="font-size: var(--wa-font-size-5xl)">AaBb</div> |
+
+:::info
+`3xs` and `2xs` fall below typical legibility. It's best to keep their use to non-essential UI only (e.g. labels, metadata) to maintain accessibility.
+:::
 
 You can also use these two custom properties make any font size proportionally smaller or larger to its parent.
 

--- a/packages/webawesome/docs/docs/utilities/text.md
+++ b/packages/webawesome/docs/docs/utilities/text.md
@@ -17,10 +17,15 @@ tags: styleUtilities
 
 Use `wa-body-*` classes to style the main content of your pages. Each class specifies a `font-size` that corresponds to a [font size token](/docs/tokens/typography/#font-size) from your theme.
 
+:::info
+`3xs` and `2xs` fall below typical legibility. It's best to keep their use to non-essential UI only (e.g. labels, metadata) to maintain accessibility.
+:::
+
 Alternatively, use `wa-body` to apply the same styling without an explicit font size.
 
 | Class Name    | Preview                                            |
 | ------------- | -------------------------------------------------- |
+| `wa-body-3xs` | <div class="wa-body-3xs">Five boxing wizards</div> |
 | `wa-body-2xs` | <div class="wa-body-2xs">Five boxing wizards</div> |
 | `wa-body-xs`  | <div class="wa-body-xs">Five boxing wizards</div>  |
 | `wa-body-s`   | <div class="wa-body-s">Five boxing wizards</div>   |
@@ -30,6 +35,7 @@ Alternatively, use `wa-body` to apply the same styling without an explicit font 
 | `wa-body-2xl` | <div class="wa-body-2xl">Five boxing wizards</div> |
 | `wa-body-3xl` | <div class="wa-body-3xl">Five boxing wizards</div> |
 | `wa-body-4xl` | <div class="wa-body-4xl">Five boxing wizards</div> |
+| `wa-body-5xl` | <div class="wa-body-5xl">Five boxing wizards</div> |
 
 ## Headings
 
@@ -39,6 +45,7 @@ Alternatively, use `wa-heading` to apply the same styling without an explicit fo
 
 | Class Name       | Preview                                               |
 | ---------------- | ----------------------------------------------------- |
+| `wa-heading-3xs` | <div class="wa-heading-3xs">Five boxing wizards</div> |
 | `wa-heading-2xs` | <div class="wa-heading-2xs">Five boxing wizards</div> |
 | `wa-heading-xs`  | <div class="wa-heading-xs">Five boxing wizards</div>  |
 | `wa-heading-s`   | <div class="wa-heading-s">Five boxing wizards</div>   |
@@ -48,6 +55,7 @@ Alternatively, use `wa-heading` to apply the same styling without an explicit fo
 | `wa-heading-2xl` | <div class="wa-heading-2xl">Five boxing wizards</div> |
 | `wa-heading-3xl` | <div class="wa-heading-3xl">Five boxing wizards</div> |
 | `wa-heading-4xl` | <div class="wa-heading-4xl">Five boxing wizards</div> |
+| `wa-heading-5xl` | <div class="wa-heading-5xl">Five boxing wizards</div> |
 
 ## Captions
 
@@ -57,6 +65,7 @@ Alternatively, use `wa-caption` to apply the same styling without an explicit fo
 
 | Class Name       | Preview                                               |
 | ---------------- | ----------------------------------------------------- |
+| `wa-caption-3xs` | <div class="wa-caption-3xs">Five boxing wizards</div> |
 | `wa-caption-2xs` | <div class="wa-caption-2xs">Five boxing wizards</div> |
 | `wa-caption-xs`  | <div class="wa-caption-xs">Five boxing wizards</div>  |
 | `wa-caption-s`   | <div class="wa-caption-s">Five boxing wizards</div>   |
@@ -66,6 +75,7 @@ Alternatively, use `wa-caption` to apply the same styling without an explicit fo
 | `wa-caption-2xl` | <div class="wa-caption-2xl">Five boxing wizards</div> |
 | `wa-caption-3xl` | <div class="wa-caption-3xl">Five boxing wizards</div> |
 | `wa-caption-4xl` | <div class="wa-caption-4xl">Five boxing wizards</div> |
+| `wa-caption-5xl` | <div class="wa-caption-5xl">Five boxing wizards</div> |
 
 ## Longform
 
@@ -75,6 +85,7 @@ Alternatively, use `wa-longform` to apply the same styling without an explicit f
 
 | Class Name        | Preview                                                |
 | ----------------- | ------------------------------------------------------ |
+| `wa-longform-3xs` | <div class="wa-longform-3xs">Five boxing wizards</div> |
 | `wa-longform-2xs` | <div class="wa-longform-2xs">Five boxing wizards</div> |
 | `wa-longform-xs`  | <div class="wa-longform-xs">Five boxing wizards</div>  |
 | `wa-longform-s`   | <div class="wa-longform-s">Five boxing wizards</div>   |
@@ -84,6 +95,7 @@ Alternatively, use `wa-longform` to apply the same styling without an explicit f
 | `wa-longform-2xl` | <div class="wa-longform-2xl">Five boxing wizards</div> |
 | `wa-longform-3xl` | <div class="wa-longform-3xl">Five boxing wizards</div> |
 | `wa-longform-4xl` | <div class="wa-longform-4xl">Five boxing wizards</div> |
+| `wa-longform-5xl` | <div class="wa-longform-5xl">Five boxing wizards</div> |
 
 ## Links
 
@@ -119,6 +131,7 @@ Use single-purpose `wa-font-size-*` classes to apply a given [font size](/docs/t
 
 | Class Name         | Preview                                                 |
 | ------------------ | ------------------------------------------------------- |
+| `wa-font-size-3xs` | <div class="wa-font-size-3xs">Five boxing wizards</div> |
 | `wa-font-size-2xs` | <div class="wa-font-size-2xs">Five boxing wizards</div> |
 | `wa-font-size-xs`  | <div class="wa-font-size-xs">Five boxing wizards</div>  |
 | `wa-font-size-s`   | <div class="wa-font-size-s">Five boxing wizards</div>   |
@@ -128,6 +141,7 @@ Use single-purpose `wa-font-size-*` classes to apply a given [font size](/docs/t
 | `wa-font-size-2xl` | <div class="wa-font-size-2xl">Five boxing wizards</div> |
 | `wa-font-size-3xl` | <div class="wa-font-size-3xl">Five boxing wizards</div> |
 | `wa-font-size-4xl` | <div class="wa-font-size-4xl">Five boxing wizards</div> |
+| `wa-font-size-5xl` | <div class="wa-font-size-5xl">Five boxing wizards</div> |
 
 ## Font Weight
 

--- a/packages/webawesome/src/styles/themes/awesome.css
+++ b/packages/webawesome/src/styles/themes/awesome.css
@@ -195,6 +195,7 @@
      * For larger font sizes, each size is twice 1.125x larger to maximize impact.
      * Each value uses `rem` units and is rounded to the nearest whole pixel when rendered. */
     --wa-font-size-scale: 1;
+    --wa-font-size-3xs: round(calc(var(--wa-font-size-2xs) / 1.125), 1px); /* 10px */
     --wa-font-size-2xs: round(calc(var(--wa-font-size-xs) / 1.125), 1px); /* 11px */
     --wa-font-size-xs: round(calc(var(--wa-font-size-s) / 1.125), 1px); /* 12px */
     --wa-font-size-s: round(calc(var(--wa-font-size-m) / 1.125), 1px); /* 14px */
@@ -204,6 +205,7 @@
     --wa-font-size-2xl: round(calc(var(--wa-font-size-xl) * 1.125 * 1.125), 1px); /* 32px */
     --wa-font-size-3xl: round(calc(var(--wa-font-size-2xl) * 1.125 * 1.125), 1px); /* 41px */
     --wa-font-size-4xl: round(calc(var(--wa-font-size-3xl) * 1.125 * 1.125), 1px); /* 52px */
+    --wa-font-size-5xl: round(calc(var(--wa-font-size-4xl) * 1.125 * 1.125), 1px); /* 66px */
 
     --wa-font-size-smaller: round(calc(1em / 1.125), 1px);
     --wa-font-size-larger: round(calc(1em * 1.125 * 1.125), 1px);

--- a/packages/webawesome/src/styles/themes/default.css
+++ b/packages/webawesome/src/styles/themes/default.css
@@ -189,6 +189,7 @@
      * For larger font sizes, each size is twice 1.125x larger to maximize impact.
      * Each value uses `rem` units and is rounded to the nearest whole pixel when rendered. */
     --wa-font-size-scale: 1;
+    --wa-font-size-3xs: round(calc(var(--wa-font-size-2xs) / 1.125), 1px); /* 10px */
     --wa-font-size-2xs: round(calc(var(--wa-font-size-xs) / 1.125), 1px); /* 11px */
     --wa-font-size-xs: round(calc(var(--wa-font-size-s) / 1.125), 1px); /* 12px */
     --wa-font-size-s: round(calc(var(--wa-font-size-m) / 1.125), 1px); /* 14px */
@@ -198,6 +199,7 @@
     --wa-font-size-2xl: round(calc(var(--wa-font-size-xl) * 1.125 * 1.125), 1px); /* 32px */
     --wa-font-size-3xl: round(calc(var(--wa-font-size-2xl) * 1.125 * 1.125), 1px); /* 41px */
     --wa-font-size-4xl: round(calc(var(--wa-font-size-3xl) * 1.125 * 1.125), 1px); /* 52px */
+    --wa-font-size-5xl: round(calc(var(--wa-font-size-4xl) * 1.125 * 1.125), 1px); /* 66px */
 
     --wa-font-size-smaller: round(calc(1em / 1.125), 1px);
     --wa-font-size-larger: round(calc(1em * 1.125 * 1.125), 1px);

--- a/packages/webawesome/src/styles/themes/shoelace.css
+++ b/packages/webawesome/src/styles/themes/shoelace.css
@@ -194,6 +194,7 @@
      * For larger font sizes, each size is twice 1.125x larger to maximize impact.
      * Each value uses `rem` units and is rounded to the nearest whole pixel when rendered. */
     --wa-font-size-scale: 1;
+    --wa-font-size-3xs: round(calc(var(--wa-font-size-2xs) / 1.125), 1px); /* 10px */
     --wa-font-size-2xs: round(calc(var(--wa-font-size-xs) / 1.125), 1px); /* 11px */
     --wa-font-size-xs: round(calc(var(--wa-font-size-s) / 1.125), 1px); /* 12px */
     --wa-font-size-s: round(calc(var(--wa-font-size-m) / 1.125), 1px); /* 14px */
@@ -203,6 +204,7 @@
     --wa-font-size-2xl: round(calc(var(--wa-font-size-xl) * 1.125 * 1.125), 1px); /* 32px */
     --wa-font-size-3xl: round(calc(var(--wa-font-size-2xl) * 1.125 * 1.125), 1px); /* 41px */
     --wa-font-size-4xl: round(calc(var(--wa-font-size-3xl) * 1.125 * 1.125), 1px); /* 52px */
+    --wa-font-size-5xl: round(calc(var(--wa-font-size-4xl) * 1.125 * 1.125), 1px); /* 66px */
 
     --wa-font-size-smaller: round(calc(1em / 1.125), 1px);
     --wa-font-size-larger: round(calc(1em * 1.125 * 1.125), 1px);

--- a/packages/webawesome/src/styles/utilities/text.css
+++ b/packages/webawesome/src/styles/utilities/text.css
@@ -26,6 +26,14 @@
     line-height: var(--wa-line-height-normal);
   }
 
+  .wa-font-size-3xs,
+  .wa-body-3xs,
+  .wa-heading-3xs,
+  .wa-caption-3xs,
+  .wa-longform-3xs {
+    font-size: var(--wa-font-size-3xs);
+  }
+
   .wa-font-size-2xs,
   .wa-body-2xs,
   .wa-heading-2xs,
@@ -96,6 +104,14 @@
   .wa-caption-4xl,
   .wa-longform-4xl {
     font-size: var(--wa-font-size-4xl);
+  }
+
+  .wa-font-size-5xl,
+  .wa-body-5xl,
+  .wa-heading-5xl,
+  .wa-caption-5xl,
+  .wa-longform-5xl {
+    font-size: var(--wa-font-size-5xl);
   }
 
   .wa-font-weight-light {


### PR DESCRIPTION
This work extends Web Awesome’s typography scale by adding `3xs`(10px) and `5xl` (66px) to the `--wa-font-size-*` tokens and to all related utility classes (`wa-body-*`, `wa-heading-*`, `wa-caption-*`, `wa-longform-*`, `wa-font-size-*`), and updates the typography and text docs (including an accessibility note for sub-12px sizes) and the changelog. 

Addresses https://github.com/shoelace-style/webawesome/issues/1606.