### PR TITLE
Improve button gaps when wrapping

### DIFF
--- a/packages/webawesome/docs/docs/components/button.md
+++ b/packages/webawesome/docs/docs/components/button.md
@@ -16,11 +16,13 @@ category: Actions
 Use the `variant` attribute to set the button's semantic variant.
 
 ```html {.example}
-<wa-button variant="neutral">Neutral</wa-button>
-<wa-button variant="brand">Brand</wa-button>
-<wa-button variant="success">Success</wa-button>
-<wa-button variant="warning">Warning</wa-button>
-<wa-button variant="danger">Danger</wa-button>
+<div class="wa-cluster wa-gap-2xs">
+  <wa-button variant="neutral">Neutral</wa-button>
+  <wa-button variant="brand">Brand</wa-button>
+  <wa-button variant="success">Success</wa-button>
+  <wa-button variant="warning">Warning</wa-button>
+  <wa-button variant="danger">Danger</wa-button>
+</div>
 ```
 
 ### Appearance
@@ -29,35 +31,35 @@ Use the `appearance` attribute to change the button's visual appearance.
 
 ```html {.example}
 <div class="wa-stack">
-  <div class="wa-gap-2xs">
+  <div class="wa-cluster wa-gap-2xs">
     <wa-button appearance="accent" variant="neutral">Accent</wa-button>
     <wa-button appearance="filled-outlined" variant="neutral">Filled-Outlined</wa-button>
     <wa-button appearance="filled" variant="neutral">Filled</wa-button>
     <wa-button appearance="outlined" variant="neutral">Outlined</wa-button>
     <wa-button appearance="plain" variant="neutral">Plain</wa-button>
   </div>
-  <div class="wa-gap-2xs">
+  <div class="wa-cluster wa-gap-2xs">
     <wa-button appearance="accent" variant="brand">Accent</wa-button>
     <wa-button appearance="filled-outlined" variant="brand">Filled-Outlined</wa-button>
     <wa-button appearance="filled" variant="brand">Filled</wa-button>
     <wa-button appearance="outlined" variant="brand">Outlined</wa-button>
     <wa-button appearance="plain" variant="brand">Plain</wa-button>
   </div>
-  <div class="wa-gap-2xs">
+  <div class="wa-cluster wa-gap-2xs">
     <wa-button appearance="accent" variant="success">Accent</wa-button>
     <wa-button appearance="filled-outlined" variant="success">Filled-Outlined</wa-button>
     <wa-button appearance="filled" variant="success">Filled</wa-button>
     <wa-button appearance="outlined" variant="success">Outlined</wa-button>
     <wa-button appearance="plain" variant="success">Plain</wa-button>
   </div>
-  <div class="wa-gap-2xs">
+  <div class="wa-cluster wa-gap-2xs">
     <wa-button appearance="accent" variant="warning">Accent</wa-button>
     <wa-button appearance="filled-outlined" variant="warning">Filled-Outlined</wa-button>
     <wa-button appearance="filled" variant="warning">Filled</wa-button>
     <wa-button appearance="outlined" variant="warning">Outlined</wa-button>
     <wa-button appearance="plain" variant="warning">Plain</wa-button>
   </div>
-  <div class="wa-gap-2xs">
+  <div class="wa-cluster wa-gap-2xs">
     <wa-button appearance="accent" variant="danger">Accent</wa-button>
     <wa-button appearance="filled-outlined" variant="danger">Filled-Outlined</wa-button>
     <wa-button appearance="filled" variant="danger">Filled</wa-button>
@@ -72,9 +74,11 @@ Use the `appearance` attribute to change the button's visual appearance.
 Use the `size` attribute to change a button's size.
 
 ```html {.example}
-<wa-button size="small">Small</wa-button>
-<wa-button size="medium">Medium</wa-button>
-<wa-button size="large">Large</wa-button>
+<div class="wa-cluster wa-gap-2xs">
+  <wa-button size="small">Small</wa-button>
+  <wa-button size="medium">Medium</wa-button>
+  <wa-button size="large">Large</wa-button>
+</div>
 ```
 
 ### Pill Buttons
@@ -82,9 +86,11 @@ Use the `size` attribute to change a button's size.
 Use the `pill` attribute to give buttons rounded edges.
 
 ```html {.example}
-<wa-button size="small" pill>Small</wa-button>
-<wa-button size="medium" pill>Medium</wa-button>
-<wa-button size="large" pill>Large</wa-button>
+<div class="wa-cluster wa-gap-2xs">
+  <wa-button size="small" pill>Small</wa-button>
+  <wa-button size="medium" pill>Medium</wa-button>
+  <wa-button size="large" pill>Large</wa-button>
+</div>
 ```
 
 ### Link Buttons
@@ -92,9 +98,11 @@ Use the `pill` attribute to give buttons rounded edges.
 It's often helpful to have a button that works like a link. This is possible by setting the `href` attribute, which will make the component render an `<a>` under the hood. This gives you all the default link behavior the browser provides (e.g. [[CMD/CTRL/SHIFT]] + [[CLICK]]) and exposes the `rel`, `target`, and `download` attributes.
 
 ```html {.example}
-<wa-button href="https://example.com/">Link</wa-button>
-<wa-button href="https://example.com/" target="_blank">New Window</wa-button>
-<wa-button href="/assets/images/logo.svg" download="shoelace.svg">Download</wa-button>
+<div class="wa-cluster wa-gap-2xs">
+  <wa-button href="https://example.com/">Link</wa-button>
+  <wa-button href="https://example.com/" target="_blank">New Window</wa-button>
+  <wa-button href="/assets/images/logo.svg" download="shoelace.svg">Download</wa-button>
+</div>
 ```
 
 ### Icon Buttons
@@ -102,7 +110,7 @@ It's often helpful to have a button that works like a link. This is possible by 
 When only an [icon](/docs/components/icon) is slotted into the `label` slot, the button becomes an icon button. In this case, it's important to give the icon a label for users with assistive devices. Icon buttons can use any appearance or variant.
 
 ```html {.example}
-<div class="wa-cluster">
+<div class="wa-cluster wa-gap-2xs">
   <wa-button variant="neutral" appearance="accent"><wa-icon name="house" label="Home"></wa-icon></wa-button>
   <wa-button variant="neutral" appearance="outlined"><wa-icon name="house" label="Home"></wa-icon></wa-button>
   <wa-button variant="neutral" appearance="filled"><wa-icon name="house" label="Home"></wa-icon></wa-button>
@@ -115,9 +123,11 @@ When only an [icon](/docs/components/icon) is slotted into the `label` slot, the
 As expected, buttons can be given a custom width by setting the `width` CSS property. This is useful for making buttons span the full width of their container on smaller screens.
 
 ```html {.example}
-<wa-button size="small" style="width: 100%; margin-bottom: 1rem;">Small</wa-button>
-<wa-button size="medium" style="width: 100%; margin-bottom: 1rem;">Medium</wa-button>
-<wa-button size="large" style="width: 100%;">Large</wa-button>
+<div class="wa-stack">
+  <wa-button size="small" style="width: 100%;">Small</wa-button>
+  <wa-button size="medium" style="width: 100%;">Medium</wa-button>
+  <wa-button size="large" style="width: 100%;">Large</wa-button>
+</div>
 ```
 
 ### Start & End Decorations
@@ -125,57 +135,61 @@ As expected, buttons can be given a custom width by setting the `width` CSS prop
 Use the `start` and `end` slots to add presentational elements like `<wa-icon>` next to the button label.
 
 ```html {.example}
-<wa-button size="small">
-  <wa-icon slot="start" name="gear"></wa-icon>
-  Settings
-</wa-button>
+<div class="wa-stack">
+  <div class="wa-cluster wa-gap-2xs">
+    <wa-button size="small">
+      <wa-icon slot="start" name="gear"></wa-icon>
+      Settings
+    </wa-button>
 
-<wa-button size="small">
-  <wa-icon slot="end" name="undo"></wa-icon>
-  Refresh
-</wa-button>
+    <wa-button size="small">
+      <wa-icon slot="end" name="undo"></wa-icon>
+      Refresh
+    </wa-button>
 
-<wa-button size="small">
-  <wa-icon slot="start" name="link"></wa-icon>
-  <wa-icon slot="end" name="arrow-up-right-from-square"></wa-icon>
-  Open
-</wa-button>
+    <wa-button size="small">
+      <wa-icon slot="start" name="link"></wa-icon>
+      <wa-icon slot="end" name="arrow-up-right-from-square"></wa-icon>
+      Open
+    </wa-button>
+  </div>
 
-<br /><br />
+  <div class="wa-cluster wa-gap-2xs">
+    <wa-button>
+      <wa-icon slot="start" name="gear"></wa-icon>
+      Settings
+    </wa-button>
 
-<wa-button>
-  <wa-icon slot="start" name="gear"></wa-icon>
-  Settings
-</wa-button>
+    <wa-button>
+      <wa-icon slot="end" name="undo"></wa-icon>
+      Refresh
+    </wa-button>
 
-<wa-button>
-  <wa-icon slot="end" name="undo"></wa-icon>
-  Refresh
-</wa-button>
+    <wa-button>
+      <wa-icon slot="start" name="link"></wa-icon>
+      <wa-icon slot="end" name="arrow-up-right-from-square"></wa-icon>
+      Open
+    </wa-button>
+  </div>
 
-<wa-button>
-  <wa-icon slot="start" name="link"></wa-icon>
-  <wa-icon slot="end" name="arrow-up-right-from-square"></wa-icon>
-  Open
-</wa-button>
+  <div class="wa-cluster wa-gap-2xs">
+    <wa-button size="large">
+      <wa-icon slot="start" name="gear"></wa-icon>
+      Settings
+    </wa-button>
 
-<br /><br />
+    <wa-button size="large">
+      <wa-icon slot="end" name="undo"></wa-icon>
+      Refresh
+    </wa-button>
 
-<wa-button size="large">
-  <wa-icon slot="start" name="gear"></wa-icon>
-  Settings
-</wa-button>
-
-<wa-button size="large">
-  <wa-icon slot="end" name="undo"></wa-icon>
-  Refresh
-</wa-button>
-
-<wa-button size="large">
-  <wa-icon slot="start" name="link"></wa-icon>
-  <wa-icon slot="end" name="arrow-up-right-from-square"></wa-icon>
-  Open
-</wa-button>
+    <wa-button size="large">
+      <wa-icon slot="start" name="link"></wa-icon>
+      <wa-icon slot="end" name="arrow-up-right-from-square"></wa-icon>
+      Open
+    </wa-button>
+  </div>
+</div>
 ```
 
 ### Caret
@@ -183,12 +197,14 @@ Use the `start` and `end` slots to add presentational elements like `<wa-icon>` 
 Use the `with-caret` attribute to add a dropdown indicator when a button will trigger a dropdown, menu, or popover.
 
 ```html {.example}
-<wa-button size="small" with-caret>
-  <wa-icon name="gear" label="Settings"></wa-icon>
-</wa-button>
-<wa-button size="small" with-caret>Small</wa-button>
-<wa-button size="medium" with-caret>Medium</wa-button>
-<wa-button size="large" with-caret>Large</wa-button>
+<div class="wa-cluster wa-gap-2xs">
+  <wa-button size="small" with-caret>
+    <wa-icon name="gear" label="Settings"></wa-icon>
+  </wa-button>
+  <wa-button size="small" with-caret>Small</wa-button>
+  <wa-button size="medium" with-caret>Medium</wa-button>
+  <wa-button size="large" with-caret>Large</wa-button>
+</div>
 ```
 
 ### Loading
@@ -196,11 +212,13 @@ Use the `with-caret` attribute to add a dropdown indicator when a button will tr
 Use the `loading` attribute to make a button busy. The width will remain the same as before, preventing adjacent elements from moving around.
 
 ```html {.example}
-<wa-button variant="brand" loading>Brand</wa-button>
-<wa-button variant="success" loading>Success</wa-button>
-<wa-button variant="neutral" loading>Neutral</wa-button>
-<wa-button variant="warning" loading>Warning</wa-button>
-<wa-button variant="danger" loading>Danger</wa-button>
+<div class="wa-cluster wa-gap-2xs">
+  <wa-button variant="brand" loading>Brand</wa-button>
+  <wa-button variant="success" loading>Success</wa-button>
+  <wa-button variant="neutral" loading>Neutral</wa-button>
+  <wa-button variant="warning" loading>Warning</wa-button>
+  <wa-button variant="danger" loading>Danger</wa-button>
+</div>
 ```
 
 ### Disabled


### PR DESCRIPTION
This PR updates the button page in the docs so buttons wrap like this:

<img width="1452" height="522" alt="CleanShot 2026-03-12 at 13 59 35@2x" src="https://github.com/user-attachments/assets/2474b9db-e25a-4529-ac87-e1302232ca96" />

Instead of this:

<img width="1454" height="514" alt="CleanShot 2026-03-12 at 13 59 19@2x" src="https://github.com/user-attachments/assets/7133163f-c24f-4783-885a-c88aeca68ba7" />

It also turns the examples that don't wrap:

<img width="1462" height="812" alt="CleanShot 2026-03-12 at 14 02 31@2x" src="https://github.com/user-attachments/assets/9262eed7-f776-4983-97f0-193f8f6d2781" />

Into ones that do:

<img width="1460" height="1754" alt="CleanShot 2026-03-12 at 14 03 12@2x" src="https://github.com/user-attachments/assets/0eec7a75-b209-4099-b3c1-28e356e673a8" />
