### PR TITLE
Remove the invalid `required` attribute from `<wa-slider>`

### DIFF
--- a/packages/webawesome/docs/docs/components/slider.md
+++ b/packages/webawesome/docs/docs/components/slider.md
@@ -281,14 +281,3 @@ Use the `disabled` attribute to disable a slider.
 <wa-slider label="Disabled" value="50" disabled></wa-slider>
 ```
 
-### Required
-
-Mark a slider as required using the `required` attribute. Users must interact with required sliders before the form can be submitted.
-
-```html {.example}
-<form action="about:blank" target="_blank" method="get">
-  <wa-slider name="slide" label="Required slider" min="0" max="10" required></wa-slider>
-  <br />
-  <button type="submit">Submit</button>
-</form>
-```

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -8,6 +8,10 @@ Web Awesome follows [Semantic Versioning](https://semver.org/). Breaking changes
 
 Components with the <wa-badge variant="warning">Experimental</wa-badge> badge should not be used in production. They are made available as release candidates for development and testing purposes. As such, changes to experimental components will not be subject to semantic versioning.
 
+## Unreleased
+
+- Fixed a bug in `<wa-slider>` that introduced a `required` attribute which isn't valid on range elements [issue:1471]
+
 ## 3.3.1
 
 <small>March 4th, 2026</small>

--- a/packages/webawesome/src/components/slider/slider.ts
+++ b/packages/webawesome/src/components/slider/slider.ts
@@ -179,9 +179,6 @@ export default class WaSlider extends WebAwesomeFormAssociatedElement {
   /** The granularity the value must adhere to when incrementing and decrementing. */
   @property({ type: Number }) step: number = 1;
 
-  /** Makes the slider a required field. */
-  @property({ type: Boolean, reflect: true }) required = false;
-
   /** Tells the browser to focus the slider when the page loads or a dialog is shown. */
   @property({ type: Boolean }) autofocus: boolean;
 

--- a/packages/webawesome/src/internal/validators/slider-validator.ts
+++ b/packages/webawesome/src/internal/validators/slider-validator.ts
@@ -2,17 +2,11 @@ import type WaSlider from '../../components/slider/slider.js';
 import type { Validator } from '../webawesome-form-associated-element.js';
 
 /**
- * Comprehensive validator for sliders that handles required, range, and step validation
+ * Comprehensive validator for sliders that handles range and step validation
  */
 export const SliderValidator = (): Validator<WaSlider> => {
-  // Create a native range input to get localized validation messages
-  const nativeRequiredRange = Object.assign(document.createElement('input'), {
-    type: 'range',
-    required: true,
-  });
-
   return {
-    observedAttributes: ['required', 'min', 'max', 'step'],
+    observedAttributes: ['min', 'max', 'step'],
     checkValidity(element) {
       const validity: ReturnType<Validator['checkValidity']> = {
         message: '',
@@ -33,14 +27,6 @@ export const SliderValidator = (): Validator<WaSlider> => {
         input.checkValidity();
         return input.validationMessage;
       };
-
-      // Check required validation first
-      if (element.required && !element.hasInteracted) {
-        validity.isValid = false;
-        validity.invalidKeys.push('valueMissing');
-        validity.message = nativeRequiredRange.validationMessage || 'Please fill out this field.';
-        return validity;
-      }
 
       // For range sliders, validate both values
       if (element.isRange) {


### PR DESCRIPTION
Fixes #1471

The `required` attribute is not a valid constraint for `<input type="range">` and we were erroneously trying to support it. Sliders, by nature, only support custom validity set by the user. There is no "required" state defined in the spec.