### PR TITLE
Fix scroller bug that caused docs bug that seemed like toast bug 🙂‍↔️

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -8,6 +8,10 @@ Web Awesome follows [Semantic Versioning](https://semver.org/). Breaking changes
 
 Components with the <wa-badge variant="warning">Experimental</wa-badge> badge should not be used in production. They are made available as release candidates for development and testing purposes. As such, changes to experimental components will not be subject to semantic versioning.
 
+## Unreleased
+
+- Fixed a bug in `<wa-scroller>` that caused horizontal page overflow in Chrome when containing wide content such as tables
+
 ## 3.3.1
 
 <small>March 4th, 2026</small>

--- a/packages/webawesome/src/components/scroller/scroller.styles.ts
+++ b/packages/webawesome/src/components/scroller/scroller.styles.ts
@@ -12,6 +12,7 @@ export default css`
     display: block;
     position: relative;
     max-width: 100%;
+    overflow: hidden;
     isolation: isolate;
   }
 


### PR DESCRIPTION
This fixes #2157. It wasn't a toast bug. Wasn't a docs bug. It was an edge case Chrome layout bug because the scroller didn't have the proper overflow on its host.