### PR TITLE
Tree sizing

### DIFF
--- a/packages/webawesome/docs/docs/components/tree.md
+++ b/packages/webawesome/docs/docs/components/tree.md
@@ -6,45 +6,39 @@ category: Navigation
 ---
 
 ```html {.example}
-<wa-tree selection="multiple">
-  <wa-tree-item>
-    Parent Node
-    <wa-tree-item selected>Child Node 1</wa-tree-item>
-    <wa-tree-item>
-      Child Node 2
-      <wa-tree-item>Child Node 2 - 1</wa-tree-item>
-      <wa-tree-item>Child Node 2 - 2</wa-tree-item>
-    </wa-tree-item>
-  </wa-tree-item>
-</wa-tree>
-```
-
-```html {.example}
-<wa-tree>
-  <wa-tree-item>
+<wa-tree style="--indent-guide-width: 1px;">
+  <wa-tree-item expanded>
     Deciduous
     <wa-tree-item>Birch</wa-tree-item>
-    <wa-tree-item>
+    <wa-tree-item expanded>
       Maple
       <wa-tree-item>Field maple</wa-tree-item>
       <wa-tree-item>Red maple</wa-tree-item>
       <wa-tree-item>Sugar maple</wa-tree-item>
     </wa-tree-item>
     <wa-tree-item>Oak</wa-tree-item>
+    <wa-tree-item>Walnut</wa-tree-item>
   </wa-tree-item>
 
   <wa-tree-item>
     Coniferous
     <wa-tree-item>Cedar</wa-tree-item>
-    <wa-tree-item>Pine</wa-tree-item>
+    <wa-tree-item>
+      Pine
+      <wa-tree-item>Eastern white pine</wa-tree-item>
+      <wa-tree-item>Ponderosa pine</wa-tree-item>
+      <wa-tree-item>Scots pine</wa-tree-item>
+    </wa-tree-item>
     <wa-tree-item>Spruce</wa-tree-item>
+    <wa-tree-item>Fir</wa-tree-item>
   </wa-tree-item>
 
   <wa-tree-item>
-    Non-trees
-    <wa-tree-item>Bamboo</wa-tree-item>
-    <wa-tree-item>Cactus</wa-tree-item>
-    <wa-tree-item>Fern</wa-tree-item>
+    Tropical
+    <wa-tree-item>Banyan</wa-tree-item>
+    <wa-tree-item>Coconut palm</wa-tree-item>
+    <wa-tree-item>Mahogany</wa-tree-item>
+    <wa-tree-item>Teak</wa-tree-item>
   </wa-tree-item>
 </wa-tree>
 ```
@@ -69,19 +63,27 @@ The `selection` attribute lets you change the selection behavior of the tree.
 <br />
 
 <wa-tree class="tree-selectable">
-  <wa-tree-item>
-    Item 1
-    <wa-tree-item>
-      Item A
-      <wa-tree-item>Item Z</wa-tree-item>
-      <wa-tree-item>Item Y</wa-tree-item>
-      <wa-tree-item>Item X</wa-tree-item>
+  <wa-tree-item expanded>
+    Electronics
+    <wa-tree-item expanded>
+      Computers
+      <wa-tree-item>Laptops</wa-tree-item>
+      <wa-tree-item>Desktops</wa-tree-item>
+      <wa-tree-item>Tablets</wa-tree-item>
     </wa-tree-item>
-    <wa-tree-item>Item B</wa-tree-item>
-    <wa-tree-item>Item C</wa-tree-item>
+    <wa-tree-item>
+      Phones
+      <wa-tree-item>Smartphones</wa-tree-item>
+      <wa-tree-item>Accessories</wa-tree-item>
+    </wa-tree-item>
   </wa-tree-item>
-  <wa-tree-item>Item 2</wa-tree-item>
-  <wa-tree-item>Item 3</wa-tree-item>
+  <wa-tree-item>
+    Clothing
+    <wa-tree-item>Shirts</wa-tree-item>
+    <wa-tree-item>Pants</wa-tree-item>
+    <wa-tree-item>Shoes</wa-tree-item>
+  </wa-tree-item>
+  <wa-tree-item>Books</wa-tree-item>
 </wa-tree>
 
 <script>
@@ -95,6 +97,52 @@ The `selection` attribute lets you change the selection behavior of the tree.
 </script>
 ```
 
+### Size
+
+Trees inherit their font size by default. You can change the size of a tree and all of its items by setting `font-size` on the `<wa-tree>` element. All internal dimensions, including checkboxes, expand buttons, and labels, scale proportionally.
+
+```html {.example}
+<wa-tree style="font-size: .75rem;" selection="multiple">
+  <wa-tree-item expanded>
+    Small
+    <wa-tree-item>Newsletters</wa-tree-item>
+    <wa-tree-item>
+      Promotions
+      <wa-tree-item>Weekly deals</wa-tree-item>
+      <wa-tree-item>Seasonal sales</wa-tree-item>
+    </wa-tree-item>
+  </wa-tree-item>
+</wa-tree>
+
+<br />
+
+<wa-tree selection="multiple">
+  <wa-tree-item expanded>
+    Default
+    <wa-tree-item>Newsletters</wa-tree-item>
+    <wa-tree-item>
+      Promotions
+      <wa-tree-item>Weekly deals</wa-tree-item>
+      <wa-tree-item>Seasonal sales</wa-tree-item>
+    </wa-tree-item>
+  </wa-tree-item>
+</wa-tree>
+
+<br />
+
+<wa-tree style="font-size: 1.5rem;" selection="multiple">
+  <wa-tree-item expanded>
+    Large
+    <wa-tree-item>Newsletters</wa-tree-item>
+    <wa-tree-item>
+      Promotions
+      <wa-tree-item>Weekly deals</wa-tree-item>
+      <wa-tree-item>Seasonal sales</wa-tree-item>
+    </wa-tree-item>
+  </wa-tree-item>
+</wa-tree>
+```
+
 ### Showing Indent Guides
 
 Indent guides can be drawn by setting `--indent-guide-width`. You can also change the color, offset, and style, using `--indent-guide-color`, `--indent-guide-style`, and `--indent-guide-offset`, respectively.
@@ -102,29 +150,33 @@ Indent guides can be drawn by setting `--indent-guide-width`. You can also chang
 ```html {.example}
 <wa-tree class="tree-with-lines">
   <wa-tree-item expanded>
-    Deciduous
-    <wa-tree-item>Birch</wa-tree-item>
+    Design
     <wa-tree-item expanded>
-      Maple
-      <wa-tree-item>Field maple</wa-tree-item>
-      <wa-tree-item>Red maple</wa-tree-item>
-      <wa-tree-item>Sugar maple</wa-tree-item>
+      Brand
+      <wa-tree-item>Colors</wa-tree-item>
+      <wa-tree-item>Typography</wa-tree-item>
+      <wa-tree-item>Logo</wa-tree-item>
     </wa-tree-item>
-    <wa-tree-item>Oak</wa-tree-item>
+    <wa-tree-item>
+      Components
+      <wa-tree-item>Buttons</wa-tree-item>
+      <wa-tree-item>Forms</wa-tree-item>
+      <wa-tree-item>Navigation</wa-tree-item>
+    </wa-tree-item>
+  </wa-tree-item>
+
+  <wa-tree-item expanded>
+    Development
+    <wa-tree-item>Frontend</wa-tree-item>
+    <wa-tree-item>Backend</wa-tree-item>
+    <wa-tree-item>Infrastructure</wa-tree-item>
   </wa-tree-item>
 
   <wa-tree-item>
-    Coniferous
-    <wa-tree-item>Cedar</wa-tree-item>
-    <wa-tree-item>Pine</wa-tree-item>
-    <wa-tree-item>Spruce</wa-tree-item>
-  </wa-tree-item>
-
-  <wa-tree-item>
-    Non-trees
-    <wa-tree-item>Bamboo</wa-tree-item>
-    <wa-tree-item>Cactus</wa-tree-item>
-    <wa-tree-item>Fern</wa-tree-item>
+    Marketing
+    <wa-tree-item>Social Media</wa-tree-item>
+    <wa-tree-item>Email Campaigns</wa-tree-item>
+    <wa-tree-item>Analytics</wa-tree-item>
   </wa-tree-item>
 </wa-tree>
 
@@ -143,20 +195,20 @@ If you want to disable this behavior after the first load, simply remove the `la
 
 ```html {.example}
 <wa-tree>
-  <wa-tree-item lazy>Available Trees</wa-tree-item>
+  <wa-tree-item lazy>Remote Repositories</wa-tree-item>
 </wa-tree>
 
 <script type="module">
   const lazyItem = document.querySelector('wa-tree-item[lazy]');
 
   lazyItem.addEventListener('wa-lazy-load', () => {
-    // Simulate asynchronous loading
+    // Simulate fetching data from a server
     setTimeout(() => {
-      const subItems = ['Birch', 'Cedar', 'Maple', 'Pine'];
+      const repos = ['design-system', 'marketing-site', 'mobile-app', 'api-gateway'];
 
-      for (const item of subItems) {
+      for (const repo of repos) {
         const treeItem = document.createElement('wa-tree-item');
-        treeItem.innerText = item;
+        treeItem.innerText = repo;
         lazyItem.append(treeItem);
       }
 
@@ -176,30 +228,32 @@ Use the `expand-icon` and `collapse-icon` slots to change the expand and collaps
   <wa-icon name="square-plus" variant="solid" slot="expand-icon"></wa-icon>
   <wa-icon name="square-minus" variant="solid" slot="collapse-icon"></wa-icon>
 
-  <wa-tree-item>
-    Deciduous
-    <wa-tree-item>Birch</wa-tree-item>
-    <wa-tree-item>
-      Maple
-      <wa-tree-item>Field maple</wa-tree-item>
-      <wa-tree-item>Red maple</wa-tree-item>
-      <wa-tree-item>Sugar maple</wa-tree-item>
+  <wa-tree-item expanded>
+    Recipes
+    <wa-tree-item expanded>
+      Breakfast
+      <wa-tree-item>Pancakes</wa-tree-item>
+      <wa-tree-item>Omelette</wa-tree-item>
+      <wa-tree-item>Granola</wa-tree-item>
     </wa-tree-item>
-    <wa-tree-item>Oak</wa-tree-item>
+    <wa-tree-item>
+      Lunch
+      <wa-tree-item>Caesar salad</wa-tree-item>
+      <wa-tree-item>Grilled chicken wrap</wa-tree-item>
+    </wa-tree-item>
+    <wa-tree-item>
+      Dinner
+      <wa-tree-item>Pasta carbonara</wa-tree-item>
+      <wa-tree-item>Stir fry</wa-tree-item>
+      <wa-tree-item>Roasted salmon</wa-tree-item>
+    </wa-tree-item>
   </wa-tree-item>
 
   <wa-tree-item>
-    Coniferous
-    <wa-tree-item>Cedar</wa-tree-item>
-    <wa-tree-item>Pine</wa-tree-item>
-    <wa-tree-item>Spruce</wa-tree-item>
-  </wa-tree-item>
-
-  <wa-tree-item>
-    Non-trees
-    <wa-tree-item>Bamboo</wa-tree-item>
-    <wa-tree-item>Cactus</wa-tree-item>
-    <wa-tree-item>Fern</wa-tree-item>
+    Desserts
+    <wa-tree-item>Chocolate cake</wa-tree-item>
+    <wa-tree-item>Tiramisu</wa-tree-item>
+    <wa-tree-item>Fruit tart</wa-tree-item>
   </wa-tree-item>
 </wa-tree>
 
@@ -221,38 +275,64 @@ Decorative icons can be used before labels to provide hints for each node.
     <wa-icon name="folder" variant="regular"></wa-icon>
     Documents
 
-    <wa-tree-item>
-      <wa-icon name="folder" variant="regular"> </wa-icon>
+    <wa-tree-item expanded>
+      <wa-icon name="folder" variant="regular"></wa-icon>
       Photos
       <wa-tree-item>
         <wa-icon name="image" variant="regular"></wa-icon>
-        birds.jpg
+        vacation.jpg
       </wa-tree-item>
       <wa-tree-item>
         <wa-icon name="image" variant="regular"></wa-icon>
-        kitten.jpg
+        family-portrait.png
       </wa-tree-item>
       <wa-tree-item>
         <wa-icon name="image" variant="regular"></wa-icon>
-        puppy.jpg
+        sunset.jpg
+      </wa-tree-item>
+    </wa-tree-item>
+
+    <wa-tree-item expanded>
+      <wa-icon name="folder" variant="regular"></wa-icon>
+      Work
+      <wa-tree-item>
+        <wa-icon name="file-pdf" variant="regular"></wa-icon>
+        quarterly-report.pdf
+      </wa-tree-item>
+      <wa-tree-item>
+        <wa-icon name="file-lines" variant="regular"></wa-icon>
+        budget.xls
+      </wa-tree-item>
+      <wa-tree-item>
+        <wa-icon name="file" variant="regular"></wa-icon>
+        meeting-notes.txt
       </wa-tree-item>
     </wa-tree-item>
 
     <wa-tree-item>
       <wa-icon name="folder" variant="regular"></wa-icon>
-      Writing
+      Personal
       <wa-tree-item>
         <wa-icon name="file" variant="regular"></wa-icon>
-        draft.txt
+        journal.txt
       </wa-tree-item>
       <wa-tree-item>
         <wa-icon name="file-pdf" variant="regular"></wa-icon>
-        final.pdf
+        resume.pdf
       </wa-tree-item>
-      <wa-tree-item>
-        <wa-icon name="file-lines" variant="regular"></wa-icon>
-        sales.xls
-      </wa-tree-item>
+    </wa-tree-item>
+  </wa-tree-item>
+
+  <wa-tree-item>
+    <wa-icon name="folder" variant="regular"></wa-icon>
+    Downloads
+    <wa-tree-item>
+      <wa-icon name="file-zipper" variant="regular"></wa-icon>
+      archive.zip
+    </wa-tree-item>
+    <wa-tree-item>
+      <wa-icon name="file" variant="regular"></wa-icon>
+      readme.txt
     </wa-tree-item>
   </wa-tree-item>
 </wa-tree>

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -8,6 +8,11 @@ Web Awesome follows [Semantic Versioning](https://semver.org/). Breaking changes
 
 Components with the <wa-badge variant="warning">Experimental</wa-badge> badge should not be used in production. They are made available as release candidates for development and testing purposes. As such, changes to experimental components will not be subject to semantic versioning.
 
+## 3.3.2
+
+- Fixed the off-centered position of indent guides in `<wa-tree>`
+- Improved `<wa-tree>` and `<wa-tree-item>` so all internal dimensions (labels, checkboxes, expand buttons, etc.) scale proportionally with `font-size`, making it easy to resize the tree [discuss:2147]
+
 ## 3.3.1
 
 <small>March 4th, 2026</small>

--- a/packages/webawesome/src/components/tree-item/tree-item.styles.ts
+++ b/packages/webawesome/src/components/tree-item/tree-item.styles.ts
@@ -2,6 +2,8 @@ import { css } from 'lit';
 
 export default css`
   :host {
+    /* Private - set by the component to control indentation depth */
+    --indent: 0px;
     --show-duration: 200ms;
     --hide-duration: 200ms;
 
@@ -16,7 +18,7 @@ export default css`
   }
 
   slot:not([name])::slotted(wa-icon) {
-    margin-inline-end: var(--wa-space-xs);
+    margin-inline-end: 0.5em;
   }
 
   .tree-item {
@@ -38,7 +40,7 @@ export default css`
   .checkbox,
   .label {
     font-family: inherit;
-    font-size: var(--wa-font-size-m);
+    font-size: inherit;
     font-weight: inherit;
   }
 
@@ -49,7 +51,7 @@ export default css`
 
   .indentation {
     display: block;
-    width: 1em;
+    width: var(--indent);
     flex-shrink: 0;
   }
 
@@ -100,7 +102,7 @@ export default css`
   .item {
     display: flex;
     align-items: center;
-    border-inline-start: solid 3px transparent;
+    border-inline-start: solid 0.1875em transparent;
   }
 
   :host([disabled]) .item {
@@ -132,7 +134,6 @@ export default css`
 
   .children {
     display: block;
-    font-size: calc(1em + var(--indent-size, var(--wa-space-m)));
   }
 
   /* Indentation lines */
@@ -145,7 +146,7 @@ export default css`
     position: absolute;
     top: var(--indent-guide-offset);
     bottom: var(--indent-guide-offset);
-    inset-inline-start: calc(1em - (var(--indent-guide-width) / 2) - 1px);
+    inset-inline-start: calc(0.1875em + var(--indent) + 1em - (var(--indent-guide-width) / 2));
     border-inline-end: var(--indent-guide-width) var(--indent-guide-style) var(--indent-guide-color);
     z-index: 1;
   }

--- a/packages/webawesome/src/components/tree-item/tree-item.ts
+++ b/packages/webawesome/src/components/tree-item/tree-item.ts
@@ -107,6 +107,8 @@ export default class WaTreeItem extends WebAwesomeElement {
     if (this.isNestedItem()) {
       this.slot = 'children';
     }
+
+    this.updateIndentation();
   }
 
   firstUpdated() {
@@ -139,6 +141,19 @@ export default class WaTreeItem extends WebAwesomeElement {
   private isNestedItem(): boolean {
     const parent = this.parentElement;
     return !!parent && WaTreeItem.isTreeItem(parent);
+  }
+
+  /** Counts the nesting depth and sets the private --indent property on the host for indentation. */
+  private updateIndentation() {
+    let depth = 0;
+    let node = this.parentElement;
+    while (node) {
+      if (WaTreeItem.isTreeItem(node)) {
+        depth++;
+      }
+      node = node.parentElement;
+    }
+    this.style.setProperty('--indent', `calc(${depth} * var(--indent-size, var(--wa-space-m)))`);
   }
 
   private handleChildrenSlotChange() {

--- a/packages/webawesome/src/components/tree-item/tree-item.ts
+++ b/packages/webawesome/src/components/tree-item/tree-item.ts
@@ -153,7 +153,7 @@ export default class WaTreeItem extends WebAwesomeElement {
       }
       node = node.parentElement;
     }
-    this.style.setProperty('--indent', `calc(${depth} * var(--indent-size, var(--wa-space-m)))`);
+    this.style.setProperty('--indent', `calc(${depth} * var(--indent-size, 2em))`);
   }
 
   private handleChildrenSlotChange() {

--- a/packages/webawesome/src/components/tree/tree.styles.ts
+++ b/packages/webawesome/src/components/tree/tree.styles.ts
@@ -10,7 +10,7 @@ export default css`
     --indent-guide-offset: 0;
     --indent-guide-style: solid;
     --indent-guide-width: 0;
-    --indent-size: var(--wa-space-l);
+    --indent-size: 2em;
 
     display: block;
   }

--- a/packages/webawesome/src/components/tree/tree.styles.ts
+++ b/packages/webawesome/src/components/tree/tree.styles.ts
@@ -13,11 +13,5 @@ export default css`
     --indent-size: var(--wa-space-l);
 
     display: block;
-
-    /*
-     * Tree item indentation uses the "em" unit to increment its width on each level, so setting the font size to zero
-     * here removes the indentation for all the nodes on the first level.
-     */
-    font-size: 0;
   }
 `;


### PR DESCRIPTION
Per my suggestion in #2147, this makes `<wa-tree>` scale with the current font size. At the moment, the base font is hard coded making it really hard to resize.

<img width="1462" height="968" alt="CleanShot 2026-03-12 at 15 21 33@2x" src="https://github.com/user-attachments/assets/6eff7fd2-010a-4389-a81d-0bacedd84eba" />
To do this, I needed to update the indent guide logic which previously used a `font-size: 0` trick. As part of this rework, I noticed the indent guides were off centered. This PR also fixes that.

Before
<img width="1454" height="820" alt="CleanShot 2026-03-12 at 15 13 42@2x" src="https://github.com/user-attachments/assets/8ebdc169-0840-4e02-8449-762033a9c215" />

After
<img width="1454" height="886" alt="CleanShot 2026-03-12 at 15 14 01@2x" src="https://github.com/user-attachments/assets/e66ed7e9-95e4-41ed-b124-68cd4c375994" />

Then I got carried away and touched up some of the examples in the docs. 😅 