### PR TITLE
Badge: Set `font-size` using  `––wa-font-size-3xs` 

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -17,6 +17,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Added `wa-gap-4xl` to the gap utility `:where()` selector
 - Added `--wa-font-size-3xs` and `--wa-font-size-5xl` design tokens [issue:1606]
 - Added `*-3xs` and `*-5xl` to `wa-font-size`, `wa-body`, `wa-heading`, `wa-caption`, and `wa-longform` utility classes [issue:1606]
+- Fixed `<wa-badge>` font size to use `--wa-font-size-3xs` now that the token is available [pr:2162]
 - Fixed the off-centered position of indent guides in `<wa-tree>`
 - Fixed slider styling when using the `label` slot so that it matches attribute use. [issue:2124]
 - Fixed a bug in `<wa-scroller>` that caused horizontal page overflow in Chrome when containing wide content such as tables

--- a/packages/webawesome/src/components/badge/badge.styles.ts
+++ b/packages/webawesome/src/components/badge/badge.styles.ts
@@ -9,7 +9,7 @@ export default css`
     justify-content: center;
     padding: 0.375em 0.625em;
     color: var(--wa-color-on-loud, var(--wa-color-brand-on-loud));
-    font-size: max(var(--wa-font-size-2xs), 0.75em);
+    font-size: max(var(--wa-font-size-3xs), 0.75em);
     font-weight: var(--wa-font-weight-semibold);
     line-height: 1;
     vertical-align: middle;


### PR DESCRIPTION
Updates `wa-badge` so `font-size` uses `max(var(--wa-font-size-3xs), 0.75em)` instead of `-2xs`, now that the `3xs` token is available from #2154.

Addresses suggestion from @lindsaym-fa in #2154.

Generated with [Claude Code](https://claude.ai/code)