### PR TITLE
Add label support to color picker swatches

### DIFF
--- a/packages/webawesome/docs/docs/components/color-picker.md
+++ b/packages/webawesome/docs/docs/components/color-picker.md
@@ -60,6 +60,26 @@ Use the `swatches` attribute to add convenient presets to the color picker. Any 
 ></wa-color-picker>
 ```
 
+You can also pass an array of objects with `color` and `label` properties using JavaScript. When labels are provided, they will be used as the accessible name for each swatch instead of the raw color value.
+
+```html {.example}
+<wa-color-picker id="labeled-swatches" label="Select a color"></wa-color-picker>
+
+<script>
+  const colorPicker = document.getElementById('labeled-swatches');
+  colorPicker.swatches = [
+    { color: '#d0021b', label: 'Red' },
+    { color: '#f5a623', label: 'Orange' },
+    { color: '#f8e71c', label: 'Yellow' },
+    { color: '#7ed321', label: 'Green' },
+    { color: '#4a90e2', label: 'Blue' },
+    { color: '#bd10e0', label: 'Purple' },
+    { color: '#000', label: 'Black' },
+    { color: '#fff', label: 'White' }
+  ];
+</script>
+```
+
 ### Sizes
 
 Use the `size` attribute to change the color picker's trigger size.

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -16,6 +16,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Added `wa-gap-5xl` utility class  [issue:1606]
 - Added `wa-gap-4xl` to the gap utility `:where()` selector
 - Added `--wa-font-size-3xs` and `--wa-font-size-5xl` design tokens [issue:1606]
+- Added support for labeled swatches in `<wa-color-picker>` by accepting an array of `{ color, label }` objects via the `swatches` property, improving screen reader accessibility
 - Added `*-3xs` and `*-5xl` to `wa-font-size`, `wa-body`, `wa-heading`, `wa-caption`, and `wa-longform` utility classes [issue:1606]
 - Fixed the off-centered position of indent guides in `<wa-tree>`
 - Fixed slider styling when using the `label` slot so that it matches attribute use. [issue:2124]

--- a/packages/webawesome/src/components/color-picker/color-picker.ts
+++ b/packages/webawesome/src/components/color-picker/color-picker.ts
@@ -28,6 +28,11 @@ import '../popup/popup.js';
 import type WaPopup from '../popup/popup.js';
 import styles from './color-picker.styles.js';
 
+export interface WaColorPickerSwatch {
+  color: string;
+  label: string;
+}
+
 interface EyeDropperConstructor {
   new (): EyeDropperInterface;
 }
@@ -217,9 +222,11 @@ export default class WaColorPicker extends WebAwesomeFormAssociatedElement {
   /**
    * One or more predefined color swatches to display as presets in the color picker. Can include any format the color
    * picker can parse, including HEX(A), RGB(A), HSL(A), HSV(A), and CSS color names. Each color must be separated by a
-   * semicolon (`;`). Alternatively, you can pass an array of color values to this property using JavaScript.
+   * semicolon (`;`). Alternatively, you can pass an array of color values or an array of `{ color, label }` objects to
+   * this property using JavaScript. When using objects with labels, the label will be used for the swatch's accessible
+   * name instead of the raw color value.
    */
-  @property() swatches: string | string[] = '';
+  @property() swatches: string | string[] | WaColorPickerSwatch[] = '';
 
   /** Makes the color picker a required field. */
   @property({ type: Boolean, reflect: true }) required = false;
@@ -1050,9 +1057,12 @@ export default class WaColorPicker extends WebAwesomeFormAssociatedElement {
 
     const gridHandleX = this.saturation;
     const gridHandleY = 100 - this.brightness;
-    const swatches = Array.isArray(this.swatches)
-      ? this.swatches // allow arrays for legacy purposes
-      : this.swatches.split(';').filter(color => color.trim() !== '');
+    const normalizedSwatches: WaColorPickerSwatch[] = Array.isArray(this.swatches)
+      ? this.swatches.map(s => (typeof s === 'string' ? { color: s, label: s } : s))
+      : this.swatches
+          .split(';')
+          .filter(color => color.trim() !== '')
+          .map(color => ({ color: color.trim(), label: color.trim() }));
 
     const colorPicker = html`
       <div
@@ -1238,11 +1248,11 @@ export default class WaColorPicker extends WebAwesomeFormAssociatedElement {
           </wa-button-group>
         </div>
 
-        ${swatches.length > 0
+        ${normalizedSwatches.length > 0
           ? html`
               <div part="swatches" class="swatches">
-                ${swatches.map(swatch => {
-                  const parsedColor = this.parseColor(swatch);
+                ${normalizedSwatches.map(swatch => {
+                  const parsedColor = this.parseColor(swatch.color);
 
                   // If we can't parse it, skip it
                   if (!parsedColor) {
@@ -1255,8 +1265,8 @@ export default class WaColorPicker extends WebAwesomeFormAssociatedElement {
                       class="swatch transparent-bg"
                       tabindex=${ifDefined(this.disabled ? undefined : '0')}
                       role="button"
-                      aria-label=${swatch}
-                      @click=${() => this.selectSwatch(swatch)}
+                      aria-label=${swatch.label}
+                      @click=${() => this.selectSwatch(swatch.color)}
                       @keydown=${(event: KeyboardEvent) =>
                         !this.disabled && event.key === 'Enter' && this.setColor(parsedColor.hexa)}
                     >


### PR DESCRIPTION
Per #2067, this adds the [optional] ability to add labels to color swatches to control how screen readers announce them. 