### PR TITLE
wa-input: Fix withoutSpinButtons

### DIFF
--- a/packages/webawesome/src/components/input/input.ts
+++ b/packages/webawesome/src/components/input/input.ts
@@ -138,7 +138,7 @@ export default class WaInput extends WebAwesomeFormAssociatedElement {
   @property({ attribute: 'password-visible', type: Boolean }) passwordVisible = false;
 
   /** Hides the browser's built-in increment/decrement spin buttons for number inputs. */
-  @property({ attribute: 'without-spin-buttons', type: Boolean }) withoutSpinButtons = false;
+  @property({ attribute: 'without-spin-buttons', type: Boolean, reflect: true }) withoutSpinButtons = false;
 
   /** Makes the input a required field. */
   @property({ type: Boolean, reflect: true }) required = false;


### PR DESCRIPTION
withoutSpinButtons in `wa-input` needs to be reflected to support property binding.