### PR TITLE
Fix `<wa-select multiple>` padding

### DIFF
--- a/packages/webawesome/src/components/select/select.styles.ts
+++ b/packages/webawesome/src/components/select/select.styles.ts
@@ -196,7 +196,7 @@ export default css`
     margin-inline-end: var(--wa-form-control-padding-inline);
   }
 
-  :host([multiple]) .start::slotted(*) {
+  :host([multiple]) .combobox:has(.tags wa-tag) .start::slotted(*) {
     margin-inline-start: calc(var(--wa-form-control-padding-inline) - var(--_padding-with-tags));
   }
 

--- a/packages/webawesome/src/components/select/select.styles.ts
+++ b/packages/webawesome/src/components/select/select.styles.ts
@@ -83,11 +83,6 @@ export default css`
       outline var(--wa-transition-fast);
     transition-timing-function: var(--wa-transition-easing);
 
-    :host([multiple]) .select:not(.placeholder-visible) & {
-      padding-inline-start: 0;
-      padding-block: calc(var(--wa-form-control-height) * 0.1 - var(--wa-form-control-border-width));
-    }
-
     /* Pills */
     :host([pill]) & {
       border-radius: var(--wa-border-radius-pill);
@@ -133,6 +128,16 @@ export default css`
     }
   }
 
+  /* Manage spacing when tags are present */
+  :host([multiple]) {
+    --_padding-with-tags: calc(var(--wa-form-control-height) * 0.1 - var(--wa-form-control-border-width));
+
+    & .combobox:has(.tags wa-tag) {
+      padding-block: var(--_padding-with-tags);
+      padding-inline-start: var(--_padding-with-tags);
+    }
+  }
+
   /* Visually hide the display input when multiple is enabled */
   :host([multiple]) .select:not(.placeholder-visible) .display-input {
     position: absolute;
@@ -161,7 +166,6 @@ export default css`
     flex: 1;
     align-items: center;
     flex-wrap: wrap;
-    margin-inline-start: 0.25em;
     gap: 0.25em;
 
     &::slotted(wa-tag) {
@@ -193,7 +197,7 @@ export default css`
   }
 
   :host([multiple]) .start::slotted(*) {
-    margin-inline: var(--wa-form-control-padding-inline);
+    margin-inline-start: calc(var(--wa-form-control-padding-inline) - var(--_padding-with-tags));
   }
 
   /* Clear button */

--- a/packages/webawesome/src/components/select/select.styles.ts
+++ b/packages/webawesome/src/components/select/select.styles.ts
@@ -139,7 +139,7 @@ export default css`
   }
 
   /* Visually hide the display input when multiple is enabled */
-  :host([multiple]) .select:not(.placeholder-visible) .display-input {
+  :host([multiple]) .combobox:has(.tags wa-tag) .display-input {
     position: absolute;
     z-index: -1;
     top: 0;

--- a/packages/webawesome/src/components/select/select.ts
+++ b/packages/webawesome/src/components/select/select.ts
@@ -932,7 +932,6 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
     const hasHint = this.hint ? true : !!hasHintSlot;
     const hasClearIcon =
       (this.hasUpdated || isServer) && this.withClear && !this.disabled && this.value && this.value.length > 0;
-    const isPlaceholderVisible = Boolean(this.placeholder && (!this.value || this.value.length === 0));
 
     return html`
       <div
@@ -963,7 +962,6 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
               disabled: this.disabled,
               enabled: !this.disabled,
               multiple: this.multiple,
-              'placeholder-visible': isPlaceholderVisible,
             })}
             placement=${this.placement}
             flip


### PR DESCRIPTION
Takes the same approach as implemented to `<wa-combobox multiple>` in https://github.com/shoelace-style/webawesome-pro/pull/164 

Adds private `--_padding-with-tags` for consistent block and inline padding when tags are present in `<wa-combobox multiple>`. The previous inconsistency wasn't noticeable in most themes, but it can be obvious in others.

Playful theme before:
<img width="409" height="62" alt="Screenshot 2026-03-17 at 2 46 19 PM" src="https://github.com/user-attachments/assets/5857ee89-1107-48df-b1f9-309bb50e5794" />


Playful theme after:
<img width="409" height="62" alt="Screenshot 2026-03-17 at 2 46 15 PM" src="https://github.com/user-attachments/assets/930ae7e6-91ba-4fa9-8964-a4cf0de1ec1b" />

