### PR TITLE
Dropdown Item: Only set aria-checked when type is checkbox

### DIFF
--- a/packages/webawesome/src/components/dropdown-item/dropdown-item.test.ts
+++ b/packages/webawesome/src/components/dropdown-item/dropdown-item.test.ts
@@ -27,4 +27,36 @@ describe('<wa-dropdown-item>', () => {
     await clickOnElement(el);
     expect(clickHandler).to.have.been.calledOnce;
   });
+
+  it('should not have aria-checked when type is normal', async () => {
+    const el = await fixture<WaDropdownItem>(html` <wa-dropdown-item>Item</wa-dropdown-item> `);
+    await el.updateComplete;
+    expect(el.hasAttribute('aria-checked')).to.be.false;
+  });
+
+  it('should have aria-checked when type is checkbox', async () => {
+    const el = await fixture<WaDropdownItem>(html` <wa-dropdown-item type="checkbox">Item</wa-dropdown-item> `);
+    await el.updateComplete;
+    expect(el.getAttribute('aria-checked')).to.equal('false');
+  });
+
+  it('should have aria-checked="true" when type is checkbox and checked', async () => {
+    const el = await fixture<WaDropdownItem>(
+      html` <wa-dropdown-item type="checkbox" checked>Item</wa-dropdown-item> `
+    );
+    await el.updateComplete;
+    expect(el.getAttribute('aria-checked')).to.equal('true');
+  });
+
+  it('should remove aria-checked when type changes from checkbox to normal', async () => {
+    const el = await fixture<WaDropdownItem>(
+      html` <wa-dropdown-item type="checkbox" checked>Item</wa-dropdown-item> `
+    );
+    await el.updateComplete;
+    expect(el.getAttribute('aria-checked')).to.equal('true');
+
+    el.type = 'normal';
+    await el.updateComplete;
+    expect(el.hasAttribute('aria-checked')).to.be.false;
+  });
 });

--- a/packages/webawesome/src/components/dropdown-item/dropdown-item.test.ts
+++ b/packages/webawesome/src/components/dropdown-item/dropdown-item.test.ts
@@ -41,17 +41,13 @@ describe('<wa-dropdown-item>', () => {
   });
 
   it('should have aria-checked="true" when type is checkbox and checked', async () => {
-    const el = await fixture<WaDropdownItem>(
-      html` <wa-dropdown-item type="checkbox" checked>Item</wa-dropdown-item> `
-    );
+    const el = await fixture<WaDropdownItem>(html` <wa-dropdown-item type="checkbox" checked>Item</wa-dropdown-item> `);
     await el.updateComplete;
     expect(el.getAttribute('aria-checked')).to.equal('true');
   });
 
   it('should remove aria-checked when type changes from checkbox to normal', async () => {
-    const el = await fixture<WaDropdownItem>(
-      html` <wa-dropdown-item type="checkbox" checked>Item</wa-dropdown-item> `
-    );
+    const el = await fixture<WaDropdownItem>(html` <wa-dropdown-item type="checkbox" checked>Item</wa-dropdown-item> `);
     await el.updateComplete;
     expect(el.getAttribute('aria-checked')).to.equal('true');
 

--- a/packages/webawesome/src/components/dropdown-item/dropdown-item.ts
+++ b/packages/webawesome/src/components/dropdown-item/dropdown-item.ts
@@ -110,7 +110,11 @@ export default class WaDropdownItem extends WebAwesomeElement {
     }
 
     if (changedProperties.has('checked')) {
-      this.setAttribute('aria-checked', this.checked ? 'true' : 'false');
+      if (this.type === 'checkbox') {
+        this.setAttribute('aria-checked', this.checked ? 'true' : 'false');
+      } else {
+        this.removeAttribute('aria-checked');
+      }
       this.customStates.set('checked', this.checked);
     }
 
@@ -123,8 +127,10 @@ export default class WaDropdownItem extends WebAwesomeElement {
     if (changedProperties.has('type')) {
       if (this.type === 'checkbox') {
         this.setAttribute('role', 'menuitemcheckbox');
+        this.setAttribute('aria-checked', this.checked ? 'true' : 'false');
       } else {
         this.setAttribute('role', 'menuitem');
+        this.removeAttribute('aria-checked');
       }
     }
 


### PR DESCRIPTION
## Summary

- Guard `aria-checked` behind `type === 'checkbox'` so normal menu items no longer get an invalid `aria-checked` attribute
- Handle type changes by adding/removing `aria-checked` when switching to/from checkbox
- Add tests verifying `aria-checked` presence/absence for normal and checkbox types

Fixes #2179