### PR TITLE
Fix details content overflow

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -22,6 +22,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed the off-centered position of indent guides in `<wa-tree>`
 - Fixed slider styling when using the `label` slot so that it matches attribute use. [issue:2124]
 - Fixed a bug in `<wa-scroller>` that caused horizontal page overflow in Chrome when containing wide content such as tables
+- Fixed a bug in `<wa-details>` and native `<details>` that caused full-width elements to overflow the details content [issue:2137]
 - Improved `<wa-tree>` and `<wa-tree-item>` so all internal dimensions (labels, checkboxes, expand buttons, etc.) scale proportionally with `font-size`, making it easy to resize the tree [discuss:2147]
 - Improved combobox
   - Added `allow-create` attribute to `<wa-combobox>` that lets users create new options on the fly. When typing text that doesn't match any existing option, a "Create [value]" option appears. Selecting it adds a real `<wa-option>` to the DOM. Fires a cancelable `wa-create` event for custom handling.

--- a/packages/webawesome/src/components/details/details.styles.ts
+++ b/packages/webawesome/src/components/details/details.styles.ts
@@ -10,7 +10,6 @@ export default css`
   }
 
   details {
-    /* box-sizing: border-box; */
     display: block;
     overflow-anchor: none;
     border: var(--wa-panel-border-width) var(--wa-color-surface-border) var(--wa-panel-border-style);

--- a/packages/webawesome/src/components/details/details.styles.ts
+++ b/packages/webawesome/src/components/details/details.styles.ts
@@ -10,6 +10,7 @@ export default css`
   }
 
   details {
+    /* box-sizing: border-box; */
     display: block;
     overflow-anchor: none;
     border: var(--wa-panel-border-width) var(--wa-color-surface-border) var(--wa-panel-border-style);
@@ -119,6 +120,7 @@ export default css`
 
   .content {
     display: block;
+    box-sizing: border-box; /* Ensure contents don't overflow */
     padding-block-start: var(--spacing);
     padding-inline: var(--spacing); /* Add horizontal padding */
     padding-block-end: var(--spacing); /* Add bottom padding */

--- a/packages/webawesome/src/styles/native.css
+++ b/packages/webawesome/src/styles/native.css
@@ -452,7 +452,7 @@
     }
 
     &::details-content {
-      box-sizing: border-box;  /* Ensure contents don't overflow */
+      box-sizing: border-box; /* Ensure contents don't overflow */
     }
 
     /* Print styles */

--- a/packages/webawesome/src/styles/native.css
+++ b/packages/webawesome/src/styles/native.css
@@ -451,6 +451,10 @@
       }
     }
 
+    &::details-content {
+      box-sizing: border-box;  /* Ensure contents don't overflow */
+    }
+
     /* Print styles */
     @media print {
       background: none;


### PR DESCRIPTION
Closes #2137 

tl;dr — `<details>` uses shadow DOM, which prevents our preferred `box-sizing` from being inherited by slotted content. This selectively adds `box-sizing: border-box` to details content.

---

Issue #2137 surfaced following #2100, which removed `!important` from rules setting `box-sizing` on host elements and their children.

Importantly (ha), re-introducing `!important` to those rules fixes the issue for WA components but leaves native elements high and dry. The crux of the issue lives in the `<details>`, which we use internally in `<wa-details>`: `<details>` uses shadow DOM with slots for the summary and content. These slots adopt the CSS default `box-sizing: content-box`, and our rules on `:host` elements circumvent that for WA components but don't do the same for native elements. Since we set `box-sizing: inherit` on elements globally, native elements inherit the `content-box` value on the slots in the `<details>` shadow DOM.

This PR selectively targets `.content` in `<wa-details>` and `::details-content` in `<details>` to settle the issue.

---

**Current:**
<img width="724" height="721" alt="Screenshot 2026-03-18 at 5 17 04 PM" src="https://github.com/user-attachments/assets/f6fb678e-ae9c-41fe-b03d-38b4382e66c7" />

**By re-introducing `!important`:**
<img width="724" height="714" alt="Screenshot 2026-03-18 at 5 17 37 PM" src="https://github.com/user-attachments/assets/9cd98247-ce93-43a1-a2ef-a32483c14900" />

**By targeting `.content` and `::details-content`:**
<img width="724" height="709" alt="Screenshot 2026-03-18 at 5 21 55 PM" src="https://github.com/user-attachments/assets/266b59f1-c330-4587-ba7d-7b4fed3bebd2" />
