### PR TITLE
Card: Body Part Wrapper + Fix Horizontal `::slotted` Rules

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -23,6 +23,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug in `<wa-scroller>` that caused horizontal page overflow in Chrome when containing wide content such as tables
 - Fixed a bug in `<wa-details>` and native `<details>` that caused full-width elements to overflow the details content [issue:2137]
 - Fixed a bug in `<wa-slider>` that introduced a `required` attribute which isn't valid on range elements [issue:1471]
+- Fixed horizontal layout styles in `<wa-card>` that used invalid or non-matching `::slotted()` selectors for the body and actions regions [pr:2198]
 <small>TBD</small>
 - Fixed the `autocorrect` property type in `<wa-input>` and `<wa-combobox>` to use `boolean` instead of a string union
 - Fixed a bug in `<wa-select>` which caused it to not be clearable with initial values set [pr:2141]
@@ -36,6 +37,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
   - Fixed a bug in `<wa-combobox>` where clearing the input and blurring would restore the previous selection instead of clearing the value
   - Removed the `autocomplete` property from `<wa-combobox>` since it conflicted with the native HTML attribute
 - Improved `<wa-select>`, `<wa-combobox>`, and `<wa-option>` performance with large numbers of options by batching slot changes, caching options, and lazily rendering check icons
+- Improved `<wa-card>`: the `body` part wraps the default slot in a container instead of on the slot, preserving normal slot display and accessibility [pr:2198]
 - [Docs]: Updated space, gap, stack, and cluster documentation for the new tokens and utilities [issue:1606]
 - [Docs]: Updated typography and text documentation for the new tokens and utilities [issue:1606]
 

--- a/packages/webawesome/src/components/card/card.styles.ts
+++ b/packages/webawesome/src/components/card/card.styles.ts
@@ -131,7 +131,7 @@ export default css`
     }
   }
 
-  :host([orientation='horizontal']) ::slotted([slot='body']) {
+  :host([orientation='horizontal']) .body slot::slotted(*) {
     display: block;
     height: 100%;
     margin: 0;

--- a/packages/webawesome/src/components/card/card.styles.ts
+++ b/packages/webawesome/src/components/card/card.styles.ts
@@ -137,7 +137,7 @@ export default css`
     margin: 0;
   }
 
-  :host([orientation='horizontal']) ::slotted([slot='actions']) {
+  :host([orientation='horizontal']) slot[name='actions']::slotted(*) {
     display: flex;
     align-items: center;
     padding: var(--spacing);

--- a/packages/webawesome/src/components/card/card.test.ts
+++ b/packages/webawesome/src/components/card/card.test.ts
@@ -22,6 +22,18 @@ describe('<wa-card>', () => {
           `);
           await expect(el).to.be.accessible();
         });
+
+        it('exposes the default slot inside a [part="body"] wrapper (matches dialog-style markup)', async () => {
+          const el = await fixture<WaCard>(html`<wa-card>Main content</wa-card>`);
+          const bodyPart = el.shadowRoot!.querySelector('[part="body"]');
+          expect(bodyPart?.localName).to.eq('div');
+          expect(bodyPart?.classList.contains('body')).to.be.true;
+          const defaultSlot = bodyPart?.querySelector('slot:not([name])');
+          expect(defaultSlot).to.be.instanceOf(HTMLSlotElement);
+          const assigned = (defaultSlot as HTMLSlotElement).assignedNodes({ flatten: true });
+          const text = assigned.map(n => n.textContent ?? '').join('');
+          expect(text).to.contain('Main content');
+        });
       });
 
       describe('when provided an element in the slot "header" to render a header', () => {

--- a/packages/webawesome/src/components/card/card.ts
+++ b/packages/webawesome/src/components/card/card.ts
@@ -69,7 +69,7 @@ export default class WaCard extends WebAwesomeElement {
     if (this.orientation === 'horizontal') {
       return html`
         <slot name="media" part="media" class="media"></slot>
-        <slot part="body" class="body"></slot>
+        <div part="body" class="body"><slot></slot></div>
         <slot name="actions" part="actions" class="actions"></slot>
       `;
     }
@@ -87,7 +87,7 @@ export default class WaCard extends WebAwesomeElement {
             <slot name="header"></slot>
           </header>`}
 
-      <slot part="body" class="body"></slot>
+      <div part="body" class="body"><slot></slot></div>
       ${this.hasSlotController.test('footer-actions')
         ? html` <footer part="footer" class="footer has-actions">
             <slot name="footer"></slot>


### PR DESCRIPTION
`wa-card` used a `<slot part="body">` for the main (default) content. Other components (e.g. `wa-dialog`, `wa-drawer`) expose the `body` CSS part on a **wrapper** around the default slot instead. 

This PR aligns with that pattern and refines the horizontal layout CSS.

## Changes

1. **Markup** — Wrap the default slot in `<div part="body" class="body"><slot></slot></div>` for vertical and horizontal orientations. The public API remains unchanged: the main content still uses the default slot; `::part(body)` still targets the main content region (now the wrapper `div`), consistent with the “container” wording in the documentation.

2. **Horizontal styles**
   - **Body:** Replace `::slotted([slot='body'])` with `.body slot::slotted(*)`. There is no named `body` slot; the old rule did not match default-slot content.
   - **Actions:** Replace a root-level `::slotted([slot='actions'])` with `slot[name='actions']::slotted(*)`, which is the valid `slot::slotted(...)` form for the actions slot.

3. **Tests** — Add a test that `[part="body"]` is a `div` containing the default slot and that default-slot content is assigned as expected.