### PR TITLE
Don't focus on number input when tapping steppers on mobile

### DIFF
--- a/packages/webawesome/docs/docs/components/number-input.md
+++ b/packages/webawesome/docs/docs/components/number-input.md
@@ -159,7 +159,7 @@ Use [CSS parts](#css-parts) to customize the way form controls are drawn. This e
 <style>
   .label-on-left {
     display: grid;
-    grid-template-columns: auto 1fr;
+    grid-template-columns: auto minmax(0, 1fr);
     gap: var(--wa-space-l);
     align-items: center;
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -32,6 +32,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
   - Fixed a bug in `<wa-combobox>` where custom values were not committed on blur when `allow-custom-value` was set
   - Fixed a bug in `<wa-combobox>` where clearing the input and blurring would restore the previous selection instead of clearing the value
   - Removed the `autocomplete` property from `<wa-combobox>` since it conflicted with the native HTML attribute
+- Fixed a bug in `<wa-number-input>` where pressing stepper buttons on a touch device would show the virtual keyboard and shift the page
 - [Docs]: Updated space, gap, stack, and cluster documentation for the new tokens and utilities [issue:1606]
 - [Docs]: Updated typography and text documentation for the new tokens and utilities [issue:1606]
 

--- a/packages/webawesome/src/components/number-input/number-input.test.ts
+++ b/packages/webawesome/src/components/number-input/number-input.test.ts
@@ -448,7 +448,7 @@ describe('<wa-number-input>', () => {
           el.addEventListener('input', inputHandler);
           el.addEventListener('change', changeHandler);
 
-          incrementButton.click();
+          incrementButton.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
           await el.updateComplete;
 
           expect(el.value).to.equal('6');
@@ -465,7 +465,7 @@ describe('<wa-number-input>', () => {
           el.addEventListener('input', inputHandler);
           el.addEventListener('change', changeHandler);
 
-          decrementButton.click();
+          decrementButton.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
           await el.updateComplete;
 
           expect(el.value).to.equal('4');
@@ -478,11 +478,11 @@ describe('<wa-number-input>', () => {
           const incrementButton = el.shadowRoot!.querySelector<HTMLButtonElement>('[part~="stepper-increment"]')!;
           const decrementButton = el.shadowRoot!.querySelector<HTMLButtonElement>('[part~="stepper-decrement"]')!;
 
-          incrementButton.click();
+          incrementButton.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
           await el.updateComplete;
           expect(el.value).to.equal('5');
 
-          decrementButton.click();
+          decrementButton.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
           await el.updateComplete;
           expect(el.value).to.equal('5');
         });
@@ -492,11 +492,11 @@ describe('<wa-number-input>', () => {
           const incrementButton = el.shadowRoot!.querySelector<HTMLButtonElement>('[part~="stepper-increment"]')!;
           const decrementButton = el.shadowRoot!.querySelector<HTMLButtonElement>('[part~="stepper-decrement"]')!;
 
-          incrementButton.click();
+          incrementButton.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
           await el.updateComplete;
           expect(el.value).to.equal('5');
 
-          decrementButton.click();
+          decrementButton.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
           await el.updateComplete;
           expect(el.value).to.equal('5');
         });

--- a/packages/webawesome/src/components/number-input/number-input.ts
+++ b/packages/webawesome/src/components/number-input/number-input.ts
@@ -195,7 +195,7 @@ export default class WaNumberInput extends WebAwesomeFormAssociatedElement {
     }
   }
 
-  private handleStepperClick(direction: 'up' | 'down') {
+  private handleStepperPointerUp(direction: 'up' | 'down', event: PointerEvent) {
     if (this.disabled || this.readonly) return;
 
     if (direction === 'up') {
@@ -211,10 +211,16 @@ export default class WaNumberInput extends WebAwesomeFormAssociatedElement {
     this.dispatchEvent(new InputEvent('input', { bubbles: true, composed: true }));
     this.dispatchEvent(new Event('change', { bubbles: true, composed: true }));
 
-    this.input.focus();
+    // Avoid focusing the input on touch to prevent the virtual keyboard from showing
+    if (event.pointerType !== 'touch') {
+      this.input.focus();
+    }
   }
 
-  private maintainFocusOnPointerDown(event: PointerEvent) {
+  private handleStepperPointerDown(event: PointerEvent) {
+    // Avoid focusing the input on touch to prevent the virtual keyboard from showing
+    if (event.pointerType === 'touch') return;
+
     event.preventDefault();
     this.input.focus();
   }
@@ -301,8 +307,8 @@ export default class WaNumberInput extends WebAwesomeFormAssociatedElement {
                 tabindex="-1"
                 aria-label=${this.localize.term('decrement')}
                 ?disabled=${this.disabled || this.readonly || this.isAtMin}
-                @pointerdown=${this.maintainFocusOnPointerDown}
-                @click=${() => this.handleStepperClick('down')}
+                @pointerdown=${this.handleStepperPointerDown}
+                @pointerup=${(event: PointerEvent) => this.handleStepperPointerUp('down', event)}
               >
                 <slot name="decrement-icon">
                   <wa-icon name="minus" library="system"></wa-icon>
@@ -349,8 +355,8 @@ export default class WaNumberInput extends WebAwesomeFormAssociatedElement {
                 tabindex="-1"
                 aria-label=${this.localize.term('increment')}
                 ?disabled=${this.disabled || this.readonly || this.isAtMax}
-                @pointerdown=${this.maintainFocusOnPointerDown}
-                @click=${() => this.handleStepperClick('up')}
+                @pointerdown=${this.handleStepperPointerDown}
+                @pointerup=${(event: PointerEvent) => this.handleStepperPointerUp('up', event)}
               >
                 <slot name="increment-icon">
                   <wa-icon name="plus" library="system"></wa-icon>


### PR DESCRIPTION
Per https://github.com/shoelace-style/webawesome/discussions/2033#discussioncomment-16281423

The fix is for touch events only, as focus causes the screen to shift and the virtual keyboard to show unexpectedly. Mouse pointers still focus on the number input like `<input type="number">`.

Also fixes the side label example styles, which was causing the page to overflow horizontally.