### PR TITLE
Improve performance of select and combobox

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -25,13 +25,14 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug in `<wa-details>` and native `<details>` that caused full-width elements to overflow the details content [issue:2137]
 - Fixed the `autocorrect` property type in `<wa-input>` and `<wa-combobox>` to use `boolean` instead of a string union
 - Improved `<wa-tree>` and `<wa-tree-item>` so all internal dimensions (labels, checkboxes, expand buttons, etc.) scale proportionally with `font-size`, making it easy to resize the tree [discuss:2147]
-- Improved combobox
+- Improved `<wa-combobox>`
   - Added `autocapitalize`, `autocorrect`, `enterkeyhint`, `inputmode`, and `spellcheck` properties to `<wa-combobox>` to support virtual keyboard customization
   - Added `allow-create` attribute to `<wa-combobox>` that lets users create new options on the fly. When typing text that doesn't match any existing option, a "Create [value]" option appears. Selecting it adds a real `<wa-option>` to the DOM. Fires a cancelable `wa-create` event for custom handling.
   - Added `input` event dispatching to `<wa-combobox>` when the user types, matching the behavior of `<wa-input>` and native form controls
   - Fixed a bug in `<wa-combobox>` where custom values were not committed on blur when `allow-custom-value` was set
   - Fixed a bug in `<wa-combobox>` where clearing the input and blurring would restore the previous selection instead of clearing the value
   - Removed the `autocomplete` property from `<wa-combobox>` since it conflicted with the native HTML attribute
+- Improved `<wa-select>`, `<wa-combobox>`, and `<wa-option>` performance with large numbers of options by batching slot changes, caching options, and lazily rendering check icons
 - [Docs]: Updated space, gap, stack, and cluster documentation for the new tokens and utilities [issue:1606]
 - [Docs]: Updated typography and text documentation for the new tokens and utilities [issue:1606]
 

--- a/packages/webawesome/src/components/option/option.ts
+++ b/packages/webawesome/src/components/option/option.ts
@@ -35,7 +35,9 @@ export default class WaOption extends WebAwesomeElement {
 
   // @ts-expect-error - Controller is currently unused
   private readonly localize = new LocalizeController(this);
+  private cachedDefaultLabel = '';
   private isInitialized = false;
+  private isDefaultLabelDirty = true;
 
   @query('.label') defaultSlot: HTMLSlotElement;
 
@@ -78,15 +80,16 @@ export default class WaOption extends WebAwesomeElement {
       return this._label;
     }
 
-    if (!this.defaultLabel) {
-      this.updateDefaultLabel();
-    }
-
     return this.defaultLabel;
   }
 
   /** The default label, generated from the element contents. Will be equal to `label` in most cases. */
-  @state() defaultLabel = '';
+  get defaultLabel(): string {
+    if (this.isDefaultLabelDirty || !this.cachedDefaultLabel) {
+      this.updateDefaultLabel();
+    }
+    return this.cachedDefaultLabel;
+  }
 
   connectedCallback() {
     super.connectedCallback();
@@ -95,7 +98,6 @@ export default class WaOption extends WebAwesomeElement {
 
     this.addEventListener('mouseenter', this.handleHover);
     this.addEventListener('mouseleave', this.handleHover);
-    this.updateDefaultLabel();
   }
 
   disconnectedCallback(): void {
@@ -106,16 +108,16 @@ export default class WaOption extends WebAwesomeElement {
   }
 
   private handleDefaultSlotChange() {
-    // Tell the controller to update the label
-    this.updateDefaultLabel();
+    // Mark the default label as needing recalculation
+    this.isDefaultLabelDirty = true;
 
     if (this.isInitialized) {
-      // When the label changes, tell the parent <wa-select> to update
+      // When the label changes, tell the parent <wa-select> to update. The parent's handleDefaultSlotChange already
+      // calls selectionChanged() internally, so we don't need to call it separately here.
       customElements.whenDefined('wa-select').then(() => {
         const controller = this.closest('wa-select');
         if (controller) {
           controller.handleDefaultSlotChange();
-          controller.selectionChanged?.();
         }
       });
 
@@ -125,7 +127,6 @@ export default class WaOption extends WebAwesomeElement {
         const controller = this.closest<WaSelect>('wa-combobox');
         if (controller) {
           controller.handleDefaultSlotChange();
-          controller.selectionChanged?.();
         }
       });
     } else {
@@ -203,9 +204,10 @@ export default class WaOption extends WebAwesomeElement {
   }
 
   private updateDefaultLabel() {
-    let oldValue = this.defaultLabel;
-    this.defaultLabel = getText(this).trim();
-    let changed = this.defaultLabel !== oldValue;
+    let oldValue = this.cachedDefaultLabel;
+    this.cachedDefaultLabel = getText(this).trim();
+    this.isDefaultLabelDirty = false;
+    let changed = this.cachedDefaultLabel !== oldValue;
 
     if (!this._label && changed) {
       // Uses default label, and it has changed
@@ -217,14 +219,16 @@ export default class WaOption extends WebAwesomeElement {
 
   render() {
     return html`
-      <wa-icon
-        part="checked-icon"
-        class="check"
-        name="check"
-        library="system"
-        variant="solid"
-        aria-hidden="true"
-      ></wa-icon>
+      ${this.selected
+        ? html`<wa-icon
+            part="checked-icon"
+            class="check"
+            name="check"
+            library="system"
+            variant="solid"
+            aria-hidden="true"
+          ></wa-icon>`
+        : html`<span part="checked-icon" class="check" aria-hidden="true"></span>`}
       <slot part="start" name="start" class="start"></slot>
       <slot part="label" class="label" @slotchange=${this.handleDefaultSlotChange}></slot>
       <slot part="end" name="end" class="end"></slot>

--- a/packages/webawesome/src/components/select/select.ts
+++ b/packages/webawesome/src/components/select/select.ts
@@ -98,11 +98,14 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
 
   assumeInteractionOn = ['blur', 'input'];
 
+  private cachedOptions: WaOption[] | null = null;
   private readonly hasSlotController = new HasSlotController(this, 'hint', 'label');
   private readonly localize = new LocalizeController(this);
   private selectionOrder: Map<string, number> = new Map();
   private typeToSelectString = '';
   private typeToSelectTimeout: number;
+  private slotChangePending = false;
+
   @query('.select') popup: WaPopup;
   @query('.combobox') combobox: HTMLSlotElement;
   @query('.display-input') displayInput: HTMLInputElement;
@@ -181,14 +184,17 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
       value = Array.isArray(value) ? value : [value];
     }
 
-    if (value == null) {
-      this.optionValues = new Set(null);
-    } else {
-      this.optionValues = new Set(
-        this.getAllOptions()
-          .filter(option => !option.disabled)
-          .map(option => option.value),
-      );
+    // Rebuild optionValues only when the cache has been invalidated
+    if (this.optionValues === undefined) {
+      if (value == null) {
+        this.optionValues = new Set(null);
+      } else {
+        this.optionValues = new Set(
+          this.getAllOptions()
+            .filter(option => !option.disabled)
+            .map(option => option.value),
+        );
+      }
     }
 
     // Drop values not in the DOM
@@ -290,7 +296,9 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
   connectedCallback() {
     super.connectedCallback();
 
-    this.handleDefaultSlotChange();
+    // Call processSlotChange directly so initial setup is synchronous.
+    // Subsequent option additions will be batched via handleDefaultSlotChange.
+    this.processSlotChange();
 
     // Because this is a form control, it shouldn't be opened initially
     this.open = false;
@@ -299,6 +307,7 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     this.removeOpenListeners();
+    this.cachedOptions = null;
   }
 
   private updateDefaultValue() {
@@ -576,12 +585,24 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
 
   /* @internal - used by options to update labels */
   public handleDefaultSlotChange() {
+    if (this.slotChangePending) return;
+    this.slotChangePending = true;
+    queueMicrotask(() => {
+      this.slotChangePending = false;
+      this.processSlotChange();
+    });
+  }
+
+  private processSlotChange() {
     if (!customElements.get('wa-option')) {
       customElements.whenDefined('wa-option').then(() => this.handleDefaultSlotChange());
     }
 
-    const allOptions = this.getAllOptions();
+    // Invalidate the options cache since slots have changed
+    this.cachedOptions = null;
     this.optionValues = undefined; // dirty the value so it gets recalculated
+
+    const allOptions = this.getAllOptions();
 
     // Update defaultValue if it hasn't been explicitly set and we have selected options
     this.updateDefaultValue();
@@ -637,10 +658,12 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
 
   // Gets an array of all `<wa-option>` elements
   private getAllOptions() {
+    if (this.cachedOptions) return this.cachedOptions;
     if (!this?.querySelectorAll) {
       return [];
     }
-    return [...this.querySelectorAll<WaOption>('wa-option')];
+    this.cachedOptions = [...this.querySelectorAll<WaOption>('wa-option')];
+    return this.cachedOptions;
   }
 
   // Gets the first `<wa-option>` element


### PR DESCRIPTION
See the discussion here: https://github.com/shoelace-style/webawesome/discussions/2197

- Improved `<wa-select>`, `<wa-combobox>`, and `<wa-option>` performance with large numbers of options by batching slot changes, caching options, and lazily rendering check icons

Companion PR: https://github.com/shoelace-style/webawesome-pro/pull/171