### PR TITLE
Don't trim descenders in dropdown items

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -24,6 +24,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug in `<wa-scroller>` that caused horizontal page overflow in Chrome when containing wide content such as tables
 - Fixed a bug in `<wa-details>` and native `<details>` that caused full-width elements to overflow the details content [issue:2137]
 - Fixed the `autocorrect` property type in `<wa-input>` and `<wa-combobox>` to use `boolean` instead of a string union
+- Fixed a bug in `<wa-dropdown-item>` that caused descenders to get clipped at certain line heights [issue:2207]
 - Improved `<wa-tree>` and `<wa-tree-item>` so all internal dimensions (labels, checkboxes, expand buttons, etc.) scale proportionally with `font-size`, making it easy to resize the tree [discuss:2147]
 - Improved `<wa-combobox>`
   - Added `autocapitalize`, `autocorrect`, `enterkeyhint`, `inputmode`, and `spellcheck` properties to `<wa-combobox>` to support virtual keyboard customization

--- a/packages/webawesome/src/components/dropdown-item/dropdown-item.styles.ts
+++ b/packages/webawesome/src/components/dropdown-item/dropdown-item.styles.ts
@@ -88,9 +88,6 @@ export default css`
   #label {
     flex: 1 1 auto;
     min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
 
   #details {


### PR DESCRIPTION
Fixes https://github.com/shoelace-style/webawesome/issues/2207

The issue was with `overflow: hidden` which was there for text truncation, but text truncation never occurs because the host is flex and items default to `min-width: auto` which prevents shrinking below content size, e.g.:

<img width="628" alt="CleanShot 2026-03-25 at 09 11 25@2x" src="https://github.com/user-attachments/assets/deac1fe1-d4f1-409a-96c9-381083a9f743" />
<br><br>

@lindsaym-fa I removed the truncation properties. I assume this to be safe because the label didn't wrap in the first place. Users who desire truncation or wrapping can apply custom styles if desired, but I think this cover 99% of uses cases since menu items shouldn't normally be very long anyways.