### PR TITLE
Tab Group: Body Part Wrapper

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -39,6 +39,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
   - Removed the `autocomplete` property from `<wa-combobox>` since it conflicted with the native HTML attribute
 - Improved `<wa-select>`, `<wa-combobox>`, and `<wa-option>` performance with large numbers of options by batching slot changes, caching options, and lazily rendering check icons
 - Improved `<wa-card>`: the `body` part wraps the default slot in a container instead of on the slot, preserving normal slot display and accessibility [pr:2198]
+- Improved `<wa-tab-group>`: the `body` part wraps the default slot in a container instead of on the slot, consistent with `<wa-dialog>` and `<wa-card>.`
 - [Docs]: Updated space, gap, stack, and cluster documentation for the new tokens and utilities [issue:1606]
 - [Docs]: Updated typography and text documentation for the new tokens and utilities [issue:1606]
 

--- a/packages/webawesome/src/components/tab-group/tab-group.styles.ts
+++ b/packages/webawesome/src/components/tab-group/tab-group.styles.ts
@@ -100,7 +100,7 @@ export default css`
     margin-block-end: calc(-1 * var(--safe-track-width));
   }
 
-  .tab-group-top ::slotted(wa-tab-panel) {
+  .tab-group-top .body slot::slotted(wa-tab-panel) {
     --padding: var(--wa-space-xl) 0;
   }
 
@@ -151,7 +151,7 @@ export default css`
     margin-block-start: calc(-1 * var(--safe-track-width));
   }
 
-  .tab-group-bottom ::slotted(wa-tab-panel) {
+  .tab-group-bottom .body slot::slotted(wa-tab-panel) {
     --padding: var(--wa-space-xl) 0;
   }
 
@@ -188,7 +188,7 @@ export default css`
     margin-inline-end: calc(-1 * var(--safe-track-width));
   }
 
-  .tab-group-start ::slotted(wa-tab-panel) {
+  .tab-group-start .body slot::slotted(wa-tab-panel) {
     --padding: 0 var(--wa-space-xl);
   }
 
@@ -225,7 +225,7 @@ export default css`
     margin-inline-start: calc(-1 * var(--safe-track-width));
   }
 
-  .tab-group-end ::slotted(wa-tab-panel) {
+  .tab-group-end .body slot::slotted(wa-tab-panel) {
     --padding: 0 var(--wa-space-xl);
   }
 `;

--- a/packages/webawesome/src/components/tab-group/tab-group.test.ts
+++ b/packages/webawesome/src/components/tab-group/tab-group.test.ts
@@ -86,6 +86,20 @@ describe('<wa-tab-group>', () => {
         expect(tabGroup).to.be.visible;
       });
 
+      it('exposes the default slot inside a [part="body"] wrapper', async () => {
+        const tabGroup = await fixture<WaTabGroup>(html`
+          <wa-tab-group>
+            <wa-tab panel="general">General</wa-tab>
+            <wa-tab-panel name="general">This is the general tab panel.</wa-tab-panel>
+          </wa-tab-group>
+        `);
+        const bodyPart = tabGroup.shadowRoot!.querySelector('[part="body"]');
+        expect(bodyPart?.localName).to.eq('div');
+        expect(bodyPart?.classList.contains('body')).to.be.true;
+        const defaultSlot = bodyPart?.querySelector('slot:not([name])');
+        expect(defaultSlot).to.be.instanceOf(HTMLSlotElement);
+      });
+
       it('should not throw error when unmounted too fast', async () => {
         const el = await fixture(html` <div></div> `);
 

--- a/packages/webawesome/src/components/tab-group/tab-group.ts
+++ b/packages/webawesome/src/components/tab-group/tab-group.ts
@@ -57,7 +57,8 @@ export default class WaTabGroup extends WebAwesomeElement {
   private readonly localize = new LocalizeController(this);
 
   @query('.tab-group') tabGroup: HTMLElement;
-  @query('.body') body: HTMLSlotElement;
+  /** Default slot for `<wa-tab-panel>` children (inside the `body` part container). */
+  @query('.body slot') defaultSlot: HTMLSlotElement;
   @query('.nav') nav: HTMLElement;
 
   @state() private hasScrollControls = false;
@@ -157,7 +158,9 @@ export default class WaTabGroup extends WebAwesomeElement {
   }
 
   private getAllPanels() {
-    return [...this.body.assignedElements()].filter(el => el.tagName.toLowerCase() === 'wa-tab-panel') as [WaTabPanel];
+    return [...this.defaultSlot.assignedElements()].filter(el => el.tagName.toLowerCase() === 'wa-tab-panel') as [
+      WaTabPanel,
+    ];
   }
 
   private getActiveTab() {
@@ -444,7 +447,7 @@ export default class WaTabGroup extends WebAwesomeElement {
             : ''}
         </div>
 
-        <slot part="body" class="body" @slotchange=${this.syncTabsAndPanels}></slot>
+        <div part="body" class="body"><slot @slotchange=${this.syncTabsAndPanels}></slot></div>
       </div>
     `;
   }


### PR DESCRIPTION
Similar to the case in https://github.com/shoelace-style/webawesome/pull/2198...

`wa-tab-group` used `<slot part="body">` for the panel area. This matches the old “remove slot wrappers” pattern elsewhere, while `wa-dialog` and `wa-card` expose the `body` CSS part on a wrapper around the default slot. 

**This PR brings `tab-group` in line with that structure.**

### Changes
- **Markup:** `<div part="body" class="body"><slot @slotchange=…></slot></div>`; `syncTabsAndPanels` stays on the default slot.
- **Internals:** `@query('.body slot') defaultSlot` and `getAllPanels()` uses `defaultSlot` (public API remains unchanged: default slot for `<wa-tab-panel>`).
- **Styles:** Panel padding uses `.tab-group-* .body slot::slotted(wa-tab-panel)`; nav tab `::slotted(wa-tab[active])` rules remain unchanged.
- **Tests:** Assert `[part="body"]` is a `div` with an inner default slot.


### Compatibility
- **`::part(body)`** — Same part name; theme selectors keep working (the part is now on the wrapper `div`).