### PR TITLE
Add Changelog Notification Sign Up

### DIFF
--- a/packages/webawesome/docs/_includes/changelog-email-signup.njk
+++ b/packages/webawesome/docs/_includes/changelog-email-signup.njk
@@ -13,7 +13,7 @@
           <wa-icon name="envelope" variant="regular" slot="start"></wa-icon>
         </wa-input>
         <wa-button type="submit">
-          Yes, Please
+          Yes, please
           <wa-icon name="arrow-right" variant="regular" slot="end"></wa-icon>
         </wa-button>
       </div>

--- a/packages/webawesome/docs/_includes/changelog-email-signup.njk
+++ b/packages/webawesome/docs/_includes/changelog-email-signup.njk
@@ -1,0 +1,24 @@
+<wa-card appearance="filled" class="changelog-email-signup" style="margin-block: var(--wa-space-2xl);">
+  <div class="wa-stack">
+    <h2 class="wa-heading-m" data-no-anchor>Get notified when new versions drop!</h2>
+    <form
+      class="js-cm-form"
+      id="subForm"
+      action="https://www.createsend.com/t/subscribeerror?description="
+      method="post"
+      data-id="191722FC90141D02184CB1B62AB3DC2630DE139369AE5777A9AF397A41389E52F158F82598068910193B7DDB0516E83D9CC991AC03030DF79FF82195F2F0B7C1"
+    >
+      <div class="wa-flank:end">
+        <wa-input type="email" name="cm-tidujkj-tidujkj" class="js-cm-email-input qa-input-email wa-visually-hidden-label"  id="fieldEmail" label="Email Address" placeholder="dennis.t.nedry@jurrasicpark.com" required>
+          <wa-icon name="envelope" variant="regular" slot="start"></wa-icon>
+        </wa-input>
+        <wa-button type="submit">
+          Yes, Please
+          <wa-icon name="arrow-right" variant="regular" slot="end"></wa-icon>
+        </wa-button>
+      </div>
+    </form>
+    <p class="wa-caption-s">No spam. No marketing nonsense. Unsubscribe any time.</p>
+  </div>
+</wa-card>
+<script type="text/javascript" src="https://js.createsend1.com/javascript/copypastesubscribeformlogic.js"></script>

--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -358,7 +358,6 @@ h1.title {
 }
 
 /* Images & Figures */
-
 figure.signpost {
   display: flex;
   flex-direction: column;
@@ -672,5 +671,19 @@ wa-scroller:has(.component-table) {
     min-height: 16lh;
     height: 65vh;
     max-height: 21lh;
+  }
+}
+
+/* changelog */
+.changelog-email-signup {
+  background-color: var(--wa-color-brand-fill-quiet);
+  margin-block-end: var(--wa-space-3xl);
+
+  wa-input[type='email'] {
+    --wa-form-control-border-color: var(--wa-color-brand-border-loud);
+
+    wa-icon[slot='start'] {
+      color: var(--wa-color-brand-on-quiet);
+    }
   }
 }

--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -673,17 +673,3 @@ wa-scroller:has(.component-table) {
     max-height: 21lh;
   }
 }
-
-/* changelog */
-.changelog-email-signup {
-  background-color: var(--wa-color-brand-fill-quiet);
-  margin-block-end: var(--wa-space-3xl);
-
-  wa-input[type='email'] {
-    --wa-form-control-border-color: var(--wa-color-brand-border-loud);
-
-    wa-icon[slot='start'] {
-      color: var(--wa-color-brand-on-quiet);
-    }
-  }
-}

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -8,32 +8,31 @@ Web Awesome follows [Semantic Versioning](https://semver.org/). Breaking changes
 
 Components with the <wa-badge variant="warning">Experimental</wa-badge> badge should not be used in production. They are made available as release candidates for development and testing purposes. As such, changes to experimental components will not be subject to semantic versioning.
 
-<wa-card class="changelog-email-signup">
-  <h1>Get Notified</h1>
-  <p>
-    We'll send you an email when new versions of Web Awesome drop. No spam.
-    No marketing nonsense. Unsubscribe any time.
-  </p>
-  <form
-    class="js-cm-form"
-    id="subForm"
-    action="https://www.createsend.com/t/subscribeerror?description="
-    method="post"
-    data-id="191722FC90141D02184CB1B62AB3DC2630DE139369AE5777A9AF397A41389E52F158F82598068910193B7DDB0516E83D9CC991AC03030DF79FF82195F2F0B7C1"
-  >
-    <label for="fieldEmail">Email </label>
-    <input
-      autocomplete="Email"
-      class="js-cm-email-input qa-input-email"
-      id="fieldEmail"
-      maxlength="200"
-      name="cm-tidujkj-tidujkj"
-      required=""
-      type="email"
-      style="margin-block-end: 1rem;"
+<wa-card appearance="filled" class="changelog-email-signup">
+  <div class="wa-stack">
+    <div class="wa-stack wa-gap-2xs">
+      <h2 class="wa-heading-m" data-no-anchor>Stay in the know about new Awesome!</h2>
+      <p>We'll send you an email when new versions of Web Awesome drop.</p>
+    </div>
+    <form
+      class="js-cm-form"
+      id="subForm"
+      action="https://www.createsend.com/t/subscribeerror?description="
+      method="post"
+      data-id="191722FC90141D02184CB1B62AB3DC2630DE139369AE5777A9AF397A41389E52F158F82598068910193B7DDB0516E83D9CC991AC03030DF79FF82195F2F0B7C1"
     >
-    <button type="submit">Notify me when new versions are released</button>
-  </form>
+      <div class="wa-flank:end">
+        <wa-input type="email" name="cm-tidujkj-tidujkj" class="js-cm-email-input qa-input-email wa-visually-hidden-label"  id="fieldEmail" label="Email Address" placeholder="lois.lane@dailyplanet.news" required>
+          <wa-icon name="envelope" variant="regular" slot="start"></wa-icon>
+        </wa-input>
+        <wa-button type="submit" variant="brand">
+          Email Me About Releases
+          <wa-icon name="arrow-right" variant="regular" slot="end"></wa-icon>
+        </wa-button>
+      </div>
+    </form>
+    <p class="wa-caption-s">No spam. No marketing nonsense. Unsubscribe any time.</p>
+  </div>
 </wa-card>
 <script type="text/javascript" src="https://js.createsend1.com/javascript/copypastesubscribeformlogic.js"></script>
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -8,30 +8,7 @@ Web Awesome follows [Semantic Versioning](https://semver.org/). Breaking changes
 
 Components with the <wa-badge variant="warning">Experimental</wa-badge> badge should not be used in production. They are made available as release candidates for development and testing purposes. As such, changes to experimental components will not be subject to semantic versioning.
 
-<wa-card appearance="filled" class="changelog-email-signup" style="margin-block-end: var(--wa-space-3xl);">
-  <div class="wa-stack">
-    <h2 class="wa-heading-m" data-no-anchor>Get notified when new versions drop!</h2>
-    <form
-      class="js-cm-form"
-      id="subForm"
-      action="https://www.createsend.com/t/subscribeerror?description="
-      method="post"
-      data-id="191722FC90141D02184CB1B62AB3DC2630DE139369AE5777A9AF397A41389E52F158F82598068910193B7DDB0516E83D9CC991AC03030DF79FF82195F2F0B7C1"
-    >
-      <div class="wa-flank:end">
-        <wa-input type="email" name="cm-tidujkj-tidujkj" class="js-cm-email-input qa-input-email wa-visually-hidden-label"  id="fieldEmail" label="Email Address" placeholder="dennis.t.nedry@jurrasicpark.com" required>
-          <wa-icon name="envelope" variant="regular" slot="start"></wa-icon>
-        </wa-input>
-        <wa-button type="submit">
-          Yes, Please
-          <wa-icon name="arrow-right" variant="regular" slot="end"></wa-icon>
-        </wa-button>
-      </div>
-    </form>
-    <p class="wa-caption-s">No spam. No marketing nonsense. Unsubscribe any time.</p>
-  </div>
-</wa-card>
-<script type="text/javascript" src="https://js.createsend1.com/javascript/copypastesubscribeformlogic.js"></script>
+{% include "changelog-email-signup.njk" %}
 
 ## Unreleased
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -8,6 +8,35 @@ Web Awesome follows [Semantic Versioning](https://semver.org/). Breaking changes
 
 Components with the <wa-badge variant="warning">Experimental</wa-badge> badge should not be used in production. They are made available as release candidates for development and testing purposes. As such, changes to experimental components will not be subject to semantic versioning.
 
+<wa-card class="changelog-email-signup">
+  <h1>Get Notified</h1>
+  <p>
+    We'll send you an email when new versions of Web Awesome drop. No spam.
+    No marketing nonsense. Unsubscribe any time.
+  </p>
+  <form
+    class="js-cm-form"
+    id="subForm"
+    action="https://www.createsend.com/t/subscribeerror?description="
+    method="post"
+    data-id="191722FC90141D02184CB1B62AB3DC2630DE139369AE5777A9AF397A41389E52F158F82598068910193B7DDB0516E83D9CC991AC03030DF79FF82195F2F0B7C1"
+  >
+    <label for="fieldEmail">Email </label>
+    <input
+      autocomplete="Email"
+      class="js-cm-email-input qa-input-email"
+      id="fieldEmail"
+      maxlength="200"
+      name="cm-tidujkj-tidujkj"
+      required=""
+      type="email"
+      style="margin-block-end: 1rem;"
+    >
+    <button type="submit">Notify me when new versions are released</button>
+  </form>
+</wa-card>
+<script type="text/javascript" src="https://js.createsend1.com/javascript/copypastesubscribeformlogic.js"></script>
+
 ## Unreleased
 
 <small>TBD</small>

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -8,12 +8,9 @@ Web Awesome follows [Semantic Versioning](https://semver.org/). Breaking changes
 
 Components with the <wa-badge variant="warning">Experimental</wa-badge> badge should not be used in production. They are made available as release candidates for development and testing purposes. As such, changes to experimental components will not be subject to semantic versioning.
 
-<wa-card appearance="filled" class="changelog-email-signup">
+<wa-card appearance="filled" class="changelog-email-signup" style="margin-block-end: var(--wa-space-3xl);">
   <div class="wa-stack">
-    <div class="wa-stack wa-gap-2xs">
-      <h2 class="wa-heading-m" data-no-anchor>Stay in the know about new Awesome!</h2>
-      <p>We'll send you an email when new versions of Web Awesome drop.</p>
-    </div>
+    <h2 class="wa-heading-m" data-no-anchor>Get notified when new versions drop!</h2>
     <form
       class="js-cm-form"
       id="subForm"
@@ -22,11 +19,11 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
       data-id="191722FC90141D02184CB1B62AB3DC2630DE139369AE5777A9AF397A41389E52F158F82598068910193B7DDB0516E83D9CC991AC03030DF79FF82195F2F0B7C1"
     >
       <div class="wa-flank:end">
-        <wa-input type="email" name="cm-tidujkj-tidujkj" class="js-cm-email-input qa-input-email wa-visually-hidden-label"  id="fieldEmail" label="Email Address" placeholder="lois.lane@dailyplanet.news" required>
+        <wa-input type="email" name="cm-tidujkj-tidujkj" class="js-cm-email-input qa-input-email wa-visually-hidden-label"  id="fieldEmail" label="Email Address" placeholder="dennis.t.nedry@jurrasicpark.com" required>
           <wa-icon name="envelope" variant="regular" slot="start"></wa-icon>
         </wa-input>
-        <wa-button type="submit" variant="brand">
-          Email Me About Releases
+        <wa-button type="submit">
+          Yes, Please
           <wa-icon name="arrow-right" variant="regular" slot="end"></wa-icon>
         </wa-button>
       </div>


### PR DESCRIPTION
Adds a signup form to the changelog so folks can choose to get notified when we ship new versions. This is a separate list, a no spam, no nonsense list. We will only use this to tell people about new releases and what's in them.

@talbs it's all yours 🧞‍♂️