### PR TITLE
Add custom states to <wa-button>

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -19,6 +19,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Added support for labeled swatches in `<wa-color-picker>` by accepting an array of `{ color, label }` objects via the `swatches` property, improving screen reader accessibility
 - Added `*-3xs` and `*-5xl` to `wa-font-size`, `wa-body`, `wa-heading`, `wa-caption`, and `wa-longform` utility classes [issue:1606]
 - Added the ability to return promises from icon resolvers [discuss:2144]
+- Added the `disabled`, `icon-button`, `link`, and `loading` custom states to `<wa-button>` [discuss:2185]
 - Fixed a bug in `<wa-dropdown-item>` where `aria-checked` was incorrectly set on items when `type` was not `checkbox` [pr:2180]
 - Fixed `<wa-badge>` font size to use `--wa-font-size-3xs` now that the token is available [pr:2162]
 - Fixed the off-centered position of indent guides in `<wa-tree>`

--- a/packages/webawesome/src/components/button/button.ts
+++ b/packages/webawesome/src/components/button/button.ts
@@ -38,6 +38,11 @@ import styles from './button.styles.js';
  * @csspart end - The container that wraps the `end` slot.
  * @csspart caret - The button's caret icon, a `<wa-icon>` element.
  * @csspart spinner - The spinner that shows when the button is in the loading state.
+ *
+ * @cssstate disabled - Applied when the button is disabled.
+ * @cssstate icon-button - Applied when the button contains only a `<wa-icon>` with no other content.
+ * @cssstate link - Applied when the button is rendered as a link (i.e. `href` is set).
+ * @cssstate loading - Applied when the button is in the loading state.
  */
 @customElement('wa-button')
 export default class WaButton extends WebAwesomeFormAssociatedElement {
@@ -217,6 +222,7 @@ export default class WaButton extends WebAwesomeFormAssociatedElement {
 
     // It's only an icon button if there's an icon and nothing else
     this.isIconButton = hasIcon && !hasText && !hasOtherElements;
+    this.customStates.set('icon-button', this.isIconButton);
 
     if (this.isIconButton && !hasIconLabel) {
       console.warn(
@@ -236,7 +242,18 @@ export default class WaButton extends WebAwesomeFormAssociatedElement {
 
   @watch('disabled', { waitUntilFirstUpdate: true })
   handleDisabledChange() {
+    this.customStates.set('disabled', this.disabled);
     this.updateValidity();
+  }
+
+  @watch('href')
+  handleHrefChange() {
+    this.customStates.set('link', this.isLink());
+  }
+
+  @watch('loading', { waitUntilFirstUpdate: true })
+  handleLoadingChange() {
+    this.customStates.set('loading', this.loading);
   }
 
   // eslint-disable-next-line


### PR DESCRIPTION
Adds `disabled`, `icon-button`, `link`, and `loading` custom states to `<wa-button>`. The inspiration for this came from https://github.com/shoelace-style/webawesome/discussions/2185 because it should be simpler to style various button states. No new examples in the docs, but they're all listed in the Custom States table.