### PR TITLE
Fix native select styles

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -8,11 +8,18 @@ Web Awesome follows [Semantic Versioning](https://semver.org/). Breaking changes
 
 Components with the <wa-badge variant="warning">Experimental</wa-badge> badge should not be used in production. They are made available as release candidates for development and testing purposes. As such, changes to experimental components will not be subject to semantic versioning.
 
+## Unreleased
+
+<small>TBD</small>
+
+- Added a new free component: `<wa-markdown>` (#6 of 14 per stretch goals)
+- Fixed a bug in the native styles utility where `<select>` text could overlap the caret icon when the selected option had a long name
+- Fixed a bug in the native styles utility where `<select multiple>` did not expand to show multiple options
+
 ## 3.4.0
 
 <small>March 25th, 2026</small>
 
-- Added a new free component: `<wa-markdown>` (#6 of 14 per stretch goals)
 - Added `--wa-space-5xl` design token to all themes  [issue:1606]
 - Added `wa-gap-5xl` utility class  [issue:1606]
 - Added `wa-gap-4xl` to the gap utility `:where()` selector

--- a/packages/webawesome/src/styles/native.css
+++ b/packages/webawesome/src/styles/native.css
@@ -1084,15 +1084,22 @@
     position: relative;
 
     min-width: 0;
-    overflow: hidden;
-
     background-image: var(--icon-caret), var(--icon-caret);
     background-repeat: no-repeat;
     background-position: center right var(--wa-form-control-padding-inline);
     background-blend-mode: hue, difference;
     background-size: 1rem 1rem;
+    text-overflow: ellipsis;
+    padding-inline-end: calc(var(--wa-form-control-padding-inline) + 1rem + var(--wa-space-xs));
+    overflow: hidden;
 
     cursor: pointer;
+
+    &[multiple] {
+      height: auto;
+      background-image: none;
+      padding-inline: var(--wa-form-control-padding-inline);
+    }
   }
   /* #endregion */
 


### PR DESCRIPTION
Before
<img width="589" alt="CleanShot 2026-03-25 at 16 41 30@2x" src="https://github.com/user-attachments/assets/8792c085-c0f0-40b2-b1cd-b02faf4f54fe" />

After
<img width="744" alt="CleanShot 2026-03-25 at 16 39 07@2x" src="https://github.com/user-attachments/assets/41c16f97-8625-4b51-9f84-9f26cb7a666a" />


Fixes https://github.com/shoelace-style/webawesome/issues/2193