### PR TITLE
Wrap badge slots and fix invalid role

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -32,6 +32,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug in `<wa-dropdown-item>` that caused descenders to get clipped at certain line heights [issue:2207]
 - Fixed a bug in `<wa-number-input>` where pressing stepper buttons on a touch device would show the virtual keyboard and shift the page
 - Fixed a bug in `<wa-select>` which caused it to not be clearable with initial values set [pr:2141]
+- Fixed a bug in `<wa-badge>` where `role` was incorrectly set on a `<slot>` element, which is not allowed per spec [#2163]
 - Improved `<wa-tree>` and `<wa-tree-item>` so all internal dimensions (labels, checkboxes, expand buttons, etc.) scale proportionally with `font-size`, making it easy to resize the tree [discuss:2147]
 - Improved `<wa-combobox>`
   - Added `autocapitalize`, `autocorrect`, `enterkeyhint`, `inputmode`, and `spellcheck` properties to `<wa-combobox>` to support virtual keyboard customization

--- a/packages/webawesome/src/components/badge/badge.ts
+++ b/packages/webawesome/src/components/badge/badge.ts
@@ -39,11 +39,17 @@ export default class WaBadge extends WebAwesomeElement {
 
   render() {
     return html`
-      <slot name="start" part="start"></slot>
+      <span part="start">
+        <slot name="start"></slot>
+      </span>
 
-      <slot part="base" role="status"></slot>
+      <span part="base" role="status">
+        <slot></slot>
+      </span>
 
-      <slot name="end" part="end"></slot>
+      <span part="end">
+        <slot name="end"></slot>
+      </span>
     `;
   }
 }


### PR DESCRIPTION
Wraps slots per the WA convention and fixes #2163 by moving the `role` attribute off of the slot.