### PR TITLE
Make dropdown headings not use !important styles

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -17,6 +17,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Added the `disabled`, `icon-button`, `link`, and `loading` custom states to `<wa-button>` [discuss:2185]
 - Fixed a bug in `<wa-badge>` where `role` was incorrectly set on a `<slot>` element, which is not allowed per spec [#2163]
 - Fixed a bug in `<wa-toast-item>` where the progress ring's continuously updating value was announced by screen readers [issue:2126]
+- Fixed a bug in `<wa-dropdown>` where heading colors in the menu used `!important`, preventing users from overriding them with light DOM styles [issue:2102]
 - Improved the accessibility of `<wa-rating>` by moving role and ARIA attributes to the host element [issue:#2205]
 
 ## 3.4.0

--- a/packages/webawesome/src/components/dropdown/dropdown.styles.ts
+++ b/packages/webawesome/src/components/dropdown/dropdown.styles.ts
@@ -41,7 +41,7 @@ export default css`
       display: block !important;
       margin: 0.25em 0 !important;
       padding: 0.25em 0.75em !important;
-      color: var(--wa-color-text-quiet) !important;
+      color: var(--wa-color-text-quiet);
       font-family: var(--wa-font-family-body) !important;
       font-weight: var(--wa-font-weight-semibold) !important;
       font-size: var(--wa-font-size-smaller) !important;


### PR DESCRIPTION
Fixes the issue described in #2102.

The `::slotted()` selector was setting color with `!important` from inside the shadow DOM, making it impossible to override the color in userland. (There's an example in the user's CodePen.)