### PR TITLE
Add placement to color picker

### DIFF
--- a/packages/webawesome/docs/docs/components/color-picker.md
+++ b/packages/webawesome/docs/docs/components/color-picker.md
@@ -80,6 +80,19 @@ You can also pass an array of objects with `color` and `label` properties using 
 </script>
 ```
 
+### Placement
+
+The preferred placement of the dropdown can be set with the `placement` attribute. Note that the actual position may vary to ensure the panel remains in the viewport.
+
+```html {.example}
+<div class="wa-gap-m wa-align-items-baseline">
+  <wa-color-picker placement="top-start" label="Select a color"></wa-color-picker>
+  <wa-color-picker placement="bottom-end" label="Select a color"></wa-color-picker>
+  <wa-color-picker placement="right" label="Select a color"></wa-color-picker>
+  <wa-color-picker placement="left" label="Select a color"></wa-color-picker>
+</div>
+```
+
 ### Sizes
 
 Use the `size` attribute to change the color picker's trigger size.

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -13,6 +13,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 <small>TBD</small>
 
 - Added a new free component: `<wa-markdown>` (#6 of 14 per stretch goals)
+- Added `placement` attribute to `<wa-color-picker>` [issue:2099]
 - Fixed a bug in the native styles utility where `<select>` text could overlap the caret icon when the selected option had a long name
 - Fixed a bug in the native styles utility where `<select multiple>` did not expand to show multiple options
 - Added a new free component: `<wa-markdown>` (#6 of 14 per stretch goals)

--- a/packages/webawesome/src/components/color-picker/color-picker.ts
+++ b/packages/webawesome/src/components/color-picker/color-picker.ts
@@ -198,6 +198,24 @@ export default class WaColorPicker extends WebAwesomeFormAssociatedElement {
   /** Determines the size of the color picker's trigger */
   @property({ reflect: true }) size: 'small' | 'medium' | 'large' = 'medium';
 
+  /**
+   * The preferred placement of the color picker's popup. Note that the actual placement will vary as configured to
+   * keep the panel inside of the viewport.
+   */
+  @property({ reflect: true }) placement:
+    | 'top'
+    | 'top-start'
+    | 'top-end'
+    | 'bottom'
+    | 'bottom-start'
+    | 'bottom-end'
+    | 'right'
+    | 'right-start'
+    | 'right-end'
+    | 'left'
+    | 'left-start'
+    | 'left-end' = 'bottom-start';
+
   /** Removes the button that lets users toggle between format.   */
   @property({ attribute: 'without-format-toggle', type: Boolean }) withoutFormatToggle = false;
 
@@ -1336,7 +1354,7 @@ export default class WaColorPicker extends WebAwesomeFormAssociatedElement {
       <wa-popup
         class="color-popup"
         anchor="trigger"
-        placement="bottom-start"
+        placement=${this.placement}
         distance="0"
         skidding="0"
         flip


### PR DESCRIPTION
Adds the `placement` attribute to color picker to allow edge cases to reposition.

Fixes #2099