### PR TITLE
Fix flashy outlines in Firefox

### DIFF
--- a/packages/webawesome/CLAUDE.md
+++ b/packages/webawesome/CLAUDE.md
@@ -1,0 +1,1 @@
+When asked to update the changelog, the file is docs/docs/resources/changelog.md. Add it to the unreleased section, not an existing version. If the unreleased section doesn't exist, create it.

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -15,8 +15,6 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 <small>TBD</small>
 
 - Added a new free component: `<wa-markdown>` (#6 of 14 per stretch goals)
-- Fixed a bug in the native styles utility where `<select>` text could overlap the caret icon when the selected option had a long name
-- Fixed a bug in the native styles utility where `<select multiple>` did not expand to show multiple options
 - Added a new free component: `<wa-markdown>` (#6 of 14 per stretch goals)
 - Added form association to `<wa-rating>`
 - Added a default slot to `<wa-copy-button>` so users can provide custom buttons [issue:#1327]
@@ -24,6 +22,9 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Added the `disabled`, `icon-button`, `link`, and `loading` custom states to `<wa-button>` [discuss:2185]
 - Fixed a bug in `<wa-badge>` where `role` was incorrectly set on a `<slot>` element, which is not allowed per spec [#2163]
 - Fixed a bug in `<wa-toast-item>` where the progress ring's continuously updating value was announced by screen readers [issue:2126]
+- Fixed a bug in form controls where the focus ring would flash white in dark mode in Firefox due to the browser transitioning from the system outline color [issue:2074]
+- Fixed a bug in the native styles utility where `<select>` text could overlap the caret icon when the selected option had a long name
+- Fixed a bug in the native styles utility where `<select multiple>` did not expand to show multiple options
 - Improved the accessibility of `<wa-rating>` by moving role and ARIA attributes to the host element [issue:#2205]
 
 ## 3.4.0

--- a/packages/webawesome/src/components/input/input.styles.ts
+++ b/packages/webawesome/src/components/input/input.styles.ts
@@ -5,6 +5,10 @@ export default css`
     border-width: 0;
   }
 
+  :host(:focus) {
+    outline: none;
+  }
+
   .text-field {
     display: flex;
     align-items: stretch;
@@ -26,16 +30,17 @@ export default css`
     width: 100%;
     transition:
       background-color var(--wa-transition-normal),
-      border var(--wa-transition-normal),
-      outline var(--wa-transition-fast);
+      border-color var(--wa-transition-normal),
+      outline-color var(--wa-transition-fast);
     transition-timing-function: var(--wa-transition-easing);
     background-color: var(--wa-form-control-background-color);
     box-shadow: var(--box-shadow);
     padding: 0 var(--wa-form-control-padding-inline);
+    outline: var(--wa-focus-ring-style) var(--wa-focus-ring-width) transparent;
+    outline-offset: var(--wa-focus-ring-offset);
 
     &:focus-within {
-      outline: var(--wa-focus-ring);
-      outline-offset: var(--wa-focus-ring-offset);
+      outline-color: var(--wa-color-focus);
     }
 
     /* Style disabled inputs */

--- a/packages/webawesome/src/components/number-input/number-input.styles.ts
+++ b/packages/webawesome/src/components/number-input/number-input.styles.ts
@@ -1,6 +1,10 @@
 import { css } from 'lit';
 
 export default css`
+  :host(:focus) {
+    outline: none;
+  }
+
   .number-field {
     display: flex;
     align-items: stretch;
@@ -21,15 +25,16 @@ export default css`
     width: 100%;
     transition:
       background-color var(--wa-transition-normal),
-      border var(--wa-transition-normal),
-      outline var(--wa-transition-fast);
+      border-color var(--wa-transition-normal),
+      outline-color var(--wa-transition-fast);
     transition-timing-function: var(--wa-transition-easing);
     background-color: var(--wa-form-control-background-color);
     padding: 0;
+    outline: var(--wa-focus-ring-style) var(--wa-focus-ring-width) transparent;
+    outline-offset: var(--wa-focus-ring-offset);
 
     &:focus-within {
-      outline: var(--wa-focus-ring);
-      outline-offset: var(--wa-focus-ring-offset);
+      outline-color: var(--wa-color-focus);
     }
 
     /* Style disabled inputs */

--- a/packages/webawesome/src/components/select/select.styles.ts
+++ b/packages/webawesome/src/components/select/select.styles.ts
@@ -23,8 +23,7 @@ export default css`
   }
 
   :host .enabled:is(.open, :focus-within) [part~='combobox'] {
-    outline: var(--wa-focus-ring);
-    outline-offset: var(--wa-focus-ring-offset);
+    outline-color: var(--wa-color-focus);
   }
 
   /** The popup */
@@ -79,9 +78,11 @@ export default css`
     vertical-align: middle;
     transition:
       background-color var(--wa-transition-normal),
-      border var(--wa-transition-normal),
-      outline var(--wa-transition-fast);
+      border-color var(--wa-transition-normal),
+      outline-color var(--wa-transition-fast);
     transition-timing-function: var(--wa-transition-easing);
+    outline: var(--wa-focus-ring-style) var(--wa-focus-ring-width) transparent;
+    outline-offset: var(--wa-focus-ring-offset);
 
     /* Pills */
     :host([pill]) & {

--- a/packages/webawesome/src/components/textarea/textarea.styles.ts
+++ b/packages/webawesome/src/components/textarea/textarea.styles.ts
@@ -19,10 +19,11 @@ export default css`
     border-style: var(--wa-form-control-border-style);
     border-width: var(--wa-form-control-border-width);
     -webkit-appearance: none;
+    outline: var(--wa-focus-ring-style) var(--wa-focus-ring-width) transparent;
+    outline-offset: var(--wa-focus-ring-offset);
 
     &:focus-within {
-      outline: var(--wa-focus-ring);
-      outline-offset: var(--wa-focus-ring-offset);
+      outline-color: var(--wa-color-focus);
     }
   }
 

--- a/packages/webawesome/src/styles/native.css
+++ b/packages/webawesome/src/styles/native.css
@@ -1017,9 +1017,11 @@
 
     transition:
       background-color var(--wa-transition-normal),
-      border var(--wa-transition-normal),
-      outline var(--wa-transition-fast);
+      border-color var(--wa-transition-normal),
+      outline-color var(--wa-transition-fast);
     transition-timing-function: var(--wa-transition-easing);
+    outline: var(--wa-focus-ring-style) var(--wa-focus-ring-width) transparent;
+    outline-offset: var(--wa-focus-ring-offset);
 
     cursor: text;
 
@@ -1030,13 +1032,8 @@
       -webkit-user-select: none;
     }
 
-    &:focus {
-      outline: none;
-    }
-
     &:focus-visible {
-      outline: var(--wa-focus-ring);
-      outline-offset: var(--wa-focus-ring-offset);
+      outline-color: var(--wa-color-focus);
     }
 
     &:disabled {


### PR DESCRIPTION
Fixes: https://github.com/shoelace-style/webawesome/issues/2074

This was caused only in Firefox by the browser transitioning from the default system styles. Transitioning just border color and outline color seems to solve it.

@lindsaym-fa I checked a number of themes, but let me know if you see anything off.

Pro companion PR: https://github.com/shoelace-style/webawesome-pro/pull/173