### PR TITLE
Add disabled custom state to option

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -19,12 +19,13 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug in the native styles utility where `<select multiple>` did not expand to show multiple options
 - Added a new free component: `<wa-markdown>` (#6 of 14 per stretch goals)
 - Added form association to `<wa-rating>`
-- Added a default slot to `<wa-copy-button>` so users can provide custom buttons [issue:#1327]
+- Added a default slot to `<wa-copy-button>` so users can provide custom buttons [issue:1327]
 - Added `:state(success)` and `:state(error)` CSS custom states to `<wa-copy-button>` for styling feedback on custom triggers
 - Added the `disabled`, `icon-button`, `link`, and `loading` custom states to `<wa-button>` [discuss:2185]
-- Fixed a bug in `<wa-badge>` where `role` was incorrectly set on a `<slot>` element, which is not allowed per spec [#2163]
+- Added the `disabled` custom state to `<wa-option>` so the disabled style applies when using the property [issue:1997]
+- Fixed a bug in `<wa-badge>` where `role` was incorrectly set on a `<slot>` element, which is not allowed per spec [issue:2163]
 - Fixed a bug in `<wa-toast-item>` where the progress ring's continuously updating value was announced by screen readers [issue:2126]
-- Improved the accessibility of `<wa-rating>` by moving role and ARIA attributes to the host element [issue:#2205]
+- Improved the accessibility of `<wa-rating>` by moving role and ARIA attributes to the host element [issue:2205]
 
 ## 3.4.0
 

--- a/packages/webawesome/src/components/option/option.styles.ts
+++ b/packages/webawesome/src/components/option/option.styles.ts
@@ -22,20 +22,20 @@ export default css`
   }
 
   @media (hover: hover) {
-    :host(:not([disabled], :state(current)):is(:state(hover), :hover)) {
+    :host(:not(:state(disabled), :state(current)):is(:state(hover), :hover)) {
       background-color: var(--wa-color-neutral-fill-normal);
       color: var(--wa-color-neutral-on-normal);
     }
   }
 
   :host(:state(current)),
-  :host([disabled]:state(current)) {
+  :host(:state(disabled):state(current)) {
     background-color: var(--wa-color-brand-fill-loud);
     color: var(--wa-color-brand-on-loud);
     opacity: 1;
   }
 
-  :host([disabled]) {
+  :host(:state(disabled)) {
     outline: none;
     opacity: 0.5;
     cursor: not-allowed;

--- a/packages/webawesome/src/components/option/option.ts
+++ b/packages/webawesome/src/components/option/option.ts
@@ -27,6 +27,7 @@ import styles from './option.styles.js';
  *
  * @cssstate current - The user has keyed into the option, but hasn't selected it yet (shows a highlight)
  * @cssstate selected - The option is selected and has aria-selected="true"
+ * @cssstate disabled - Applied when the option is disabled
  * @cssstate hover - Like `:hover` but works while dragging in Safari
  */
 @customElement('wa-option')
@@ -165,6 +166,7 @@ export default class WaOption extends WebAwesomeElement {
 
     if (changedProperties.has('disabled')) {
       this.setAttribute('aria-disabled', this.disabled ? 'true' : 'false');
+      this.customStates.set('disabled', this.disabled);
     }
 
     if (changedProperties.has('selected')) {


### PR DESCRIPTION
Fixes #1997. The disabled attribute doesn't reflect but we were relying on it in styles. The more appropriate fix is a custom state for disabled.