### PR TITLE
Fix dropdown disabled item click

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -25,6 +25,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug in `<wa-badge>` where `role` was incorrectly set on a `<slot>` element, which is not allowed per spec [#2163]
 - Fixed a bug in `<wa-toast-item>` where the progress ring's continuously updating value was announced by screen readers [issue:2126]
 - Improved the accessibility of `<wa-rating>` by moving role and ARIA attributes to the host element [issue:#2205]
+- Fixed a bug in `<wa-dropdown-item>` where the `click` event could still fire when the item was disabled [issue:#1817]
 
 ## 3.4.0
 

--- a/packages/webawesome/src/components/dropdown-item/dropdown-item.test.ts
+++ b/packages/webawesome/src/components/dropdown-item/dropdown-item.test.ts
@@ -20,6 +20,16 @@ describe('<wa-dropdown-item>', () => {
     expect(clickHandler).not.to.have.been.called;
   });
 
+  it('should not fire click event when disabled and .click() is called programmatically', async () => {
+    const el = await fixture<WaDropdownItem>(html` <wa-dropdown-item disabled>Item</wa-dropdown-item> `);
+    await el.updateComplete;
+
+    const clickHandler = sinon.spy();
+    el.addEventListener('click', clickHandler);
+    el.click();
+    expect(clickHandler).not.to.have.been.called;
+  });
+
   it('should fire click event when not disabled', async () => {
     const el = await fixture<WaDropdownItem>(html` <wa-dropdown-item>Item</wa-dropdown-item> `);
     const clickHandler = sinon.spy();

--- a/packages/webawesome/src/components/dropdown-item/dropdown-item.ts
+++ b/packages/webawesome/src/components/dropdown-item/dropdown-item.ts
@@ -84,6 +84,7 @@ export default class WaDropdownItem extends WebAwesomeElement {
 
   connectedCallback() {
     super.connectedCallback();
+    this.addEventListener('click', this.handleHostClick);
     this.addEventListener('mouseenter', this.handleMouseEnter.bind(this));
     this.shadowRoot!.addEventListener('click', this.handleClick, { capture: true });
     this.shadowRoot!.addEventListener('slotchange', this.handleSlotChange);
@@ -92,6 +93,7 @@ export default class WaDropdownItem extends WebAwesomeElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     this.closeSubmenu();
+    this.removeEventListener('click', this.handleHostClick);
     this.removeEventListener('mouseenter', this.handleMouseEnter);
     this.shadowRoot!.removeEventListener('click', this.handleClick, { capture: true });
     this.shadowRoot!.removeEventListener('slotchange', this.handleSlotChange);
@@ -244,6 +246,14 @@ export default class WaDropdownItem extends WebAwesomeElement {
         el.localName === 'wa-dropdown-item' && el.getAttribute('slot') === 'submenu' && !el.hasAttribute('disabled'),
     ) as WaDropdownItem[];
   }
+
+  /** Prevents click events from firing on the host when the item is disabled (e.g. programmatic .click() calls). */
+  private handleHostClick = (event: MouseEvent) => {
+    if (this.disabled) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }
+  };
 
   /** Prevents click events from firing when the item is disabled. */
   private handleClick = (event: MouseEvent) => {


### PR DESCRIPTION
This PR fixes disabled drop-down items, which were erroneously dispatching with `wa-select`.

See #1817