### PR TITLE
Fixed alignment for checked radios in the Awesome theme

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -24,6 +24,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Added the `disabled`, `icon-button`, `link`, and `loading` custom states to `<wa-button>` [discuss:2185]
 - Fixed a bug in `<wa-badge>` where `role` was incorrectly set on a `<slot>` element, which is not allowed per spec [#2163]
 - Fixed a bug in `<wa-toast-item>` where the progress ring's continuously updating value was announced by screen readers [issue:2126]
+- Fixed a bug in `<wa-radio>` where selected buttons in a horizontal radio group could appear slightly displaced when using a custom theme with CSS transforms
 - Improved the accessibility of `<wa-rating>` by moving role and ARIA attributes to the host element [issue:#2205]
 
 ## 3.4.0

--- a/packages/webawesome/src/styles/themes/awesome.css
+++ b/packages/webawesome/src/styles/themes/awesome.css
@@ -440,7 +440,6 @@
 
       &:state(checked) {
         box-shadow: initial;
-        transform: translate(var(--wa-shadow-offset-x-s), var(--wa-shadow-offset-y-s));
       }
     }
 


### PR DESCRIPTION
Bug: #1766

@lindsaym-fa I'm not sure if those styles were intentional to give the buttons a visual shift (or maybe they were intended for the active state?) but I removed the transform to fix the bug. Let me know if you want to add anything for these buttons during the active or checked state!

Before
<img width="369" alt="CleanShot 2026-03-26 at 13 17 04@2x" src="https://github.com/user-attachments/assets/ce560fc2-bc9a-4fe1-ba46-f87ae3417ce3" />

After
<img width="372" alt="CleanShot 2026-03-26 at 13 17 15@2x" src="https://github.com/user-attachments/assets/a80586f6-7848-4e92-a88a-4da6203823dc" />


