### PR TITLE
Fix `--track-width` not being applied correctly

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -24,6 +24,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Added the `disabled`, `icon-button`, `link`, and `loading` custom states to `<wa-button>` [discuss:2185]
 - Fixed a bug in `<wa-badge>` where `role` was incorrectly set on a `<slot>` element, which is not allowed per spec [#2163]
 - Fixed a bug in `<wa-toast-item>` where the progress ring's continuously updating value was announced by screen readers [issue:2126]
+- Fixed a bug in `<wa-spinner>` where the `--track-width` custom property was not being applied to the track and indicator properly [issue:1317]
 - Improved the accessibility of `<wa-rating>` by moving role and ARIA attributes to the host element [issue:#2205]
 
 ## 3.4.0

--- a/packages/webawesome/src/components/spinner/spinner.styles.ts
+++ b/packages/webawesome/src/components/spinner/spinner.styles.ts
@@ -6,6 +6,7 @@ export default css`
     --track-color: var(--wa-color-neutral-fill-normal);
     --indicator-color: var(--wa-color-brand-fill-loud);
     --speed: 2s;
+    --size: 1em;
 
     /*
       Resizing a spinner element using anything but font-size will break the animation because the animation uses em
@@ -15,8 +16,8 @@ export default css`
     */
     flex: none;
     display: inline-flex;
-    width: 1em;
-    height: 1em;
+    width: var(--size);
+    height: var(--size);
   }
 
   svg {
@@ -26,16 +27,28 @@ export default css`
     animation: spin var(--speed) linear infinite;
   }
 
+  .track,
+  .indicator {
+    --radius: calc(var(--size) / 2 - var(--track-width) / 2);
+    --circumference: calc(var(--radius) * 2 * 3.141592654);
+
+    cx: calc(var(--size) / 2);
+    cy: calc(var(--size) / 2);
+    r: var(--radius);
+    fill: none;
+    stroke-width: var(--track-width);
+  }
+
   .track {
     stroke: var(--track-color);
   }
 
   .indicator {
     stroke: var(--indicator-color);
-    stroke-dasharray: 75, 100;
-    stroke-dashoffset: -5;
-    animation: dash 1.5s ease-in-out infinite;
     stroke-linecap: round;
+    stroke-dasharray: calc(0.597 * var(--circumference)), calc(0.796 * var(--circumference));
+    stroke-dashoffset: calc(-0.04 * var(--circumference));
+    animation: dash 1.5s ease-in-out infinite;
   }
 
   @keyframes spin {
@@ -49,16 +62,16 @@ export default css`
 
   @keyframes dash {
     0% {
-      stroke-dasharray: 1, 150;
+      stroke-dasharray: calc(0.008 * var(--circumference)), calc(1.194 * var(--circumference));
       stroke-dashoffset: 0;
     }
     50% {
-      stroke-dasharray: 90, 150;
-      stroke-dashoffset: -35;
+      stroke-dasharray: calc(0.716 * var(--circumference)), calc(1.194 * var(--circumference));
+      stroke-dashoffset: calc(-0.278 * var(--circumference));
     }
     100% {
-      stroke-dasharray: 90, 150;
-      stroke-dashoffset: -124;
+      stroke-dasharray: calc(0.716 * var(--circumference)), calc(1.194 * var(--circumference));
+      stroke-dashoffset: calc(-0.987 * var(--circumference));
     }
   }
 `;

--- a/packages/webawesome/src/components/spinner/spinner.test.ts
+++ b/packages/webawesome/src/components/spinner/spinner.test.ts
@@ -25,6 +25,18 @@ describe('<wa-spinner>', () => {
           expect(getComputedStyle(spinner).flex).to.equal('0 0 auto');
         });
       });
+
+      describe('when --track-width is set', () => {
+        it('should apply --track-width to the SVG circles', async () => {
+          const spinner = await fixture<WaSpinner>(
+            html` <wa-spinner style="font-size: 50px; --track-width: 4px;"></wa-spinner> `
+          );
+          const track = spinner.shadowRoot!.querySelector('.track')!;
+          const indicator = spinner.shadowRoot!.querySelector('.indicator')!;
+          expect(getComputedStyle(track).strokeWidth).to.equal('4px');
+          expect(getComputedStyle(indicator).strokeWidth).to.equal('4px');
+        });
+      });
     });
   }
 });

--- a/packages/webawesome/src/components/spinner/spinner.test.ts
+++ b/packages/webawesome/src/components/spinner/spinner.test.ts
@@ -28,9 +28,9 @@ describe('<wa-spinner>', () => {
 
       describe('when --track-width is set', () => {
         it('should apply --track-width to the SVG circles', async () => {
-          const spinner = await fixture<WaSpinner>(
-            html` <wa-spinner style="font-size: 50px; --track-width: 4px;"></wa-spinner> `
-          );
+          const spinner = await fixture<WaSpinner>(html`
+            <wa-spinner style="font-size: 50px; --track-width: 4px;"></wa-spinner>
+          `);
           const track = spinner.shadowRoot!.querySelector('.track')!;
           const indicator = spinner.shadowRoot!.querySelector('.indicator')!;
           expect(getComputedStyle(track).strokeWidth).to.equal('4px');

--- a/packages/webawesome/src/components/spinner/spinner.ts
+++ b/packages/webawesome/src/components/spinner/spinner.ts
@@ -30,11 +30,10 @@ export default class WaSpinner extends WebAwesomeElement {
         role="progressbar"
         aria-label=${this.localize.term('loading')}
         fill="none"
-        viewBox="0 0 50 50"
         xmlns="http://www.w3.org/2000/svg"
       >
-        <circle class="track" cx="25" cy="25" r="20" fill="none" stroke-width="5" />
-        <circle class="indicator" cx="25" cy="25" r="20" fill="none" stroke-width="5" />
+        <circle class="track" />
+        <circle class="indicator" />
       </svg>
     `;
   }


### PR DESCRIPTION
This PR makes the spinners track width true to the actual value provided.

@lindsaym-fa I went with a 2px default because that seemed pretty close to the existing design.

Fixes #1317 and an alternative to https://github.com/shoelace-style/webawesome/pull/1316.