### PR TITLE
Add SSR guards

### DIFF
--- a/packages/webawesome/docs/docs/experimental/ssr.md
+++ b/packages/webawesome/docs/docs/experimental/ssr.md
@@ -110,6 +110,38 @@ function fixDeclarativeShadowDOM(e) {
 });
 ```
 
+### The `with-*` Attributes
+
+Some components use slot detection to conditionally render parts of their template. For example, `<wa-dialog>` only renders its footer when a `footer` slot is present. During SSR, slot detection doesn't work because the DOM isn't available, so these parts would be missing from the initial server-rendered markup.
+
+To solve this, components that rely on slot detection provide `with-*` attributes. These tell the component to render the relevant section during SSR, before hydration kicks in and slot detection takes over.
+
+```html
+<!-- Without with-footer, the footer won't appear in the server-rendered HTML -->
+<wa-dialog with-footer>
+  <p>Dialog content</p>
+  <div slot="footer">
+    <wa-button>Close</wa-button>
+  </div>
+</wa-dialog>
+```
+
+These attributes are only needed for SSR._ After the component hydrates on the client, slot detection works normally and the attributes have no effect.
+
+#### For Contributors
+
+When adding slot detection to a component's render method using `HasSlotController`, always include an SSR fallback using the `hasUpdated` ternary pattern:
+
+```ts
+// Add a with-* property
+@property({ attribute: 'with-label', type: Boolean }) withLabel = false;
+
+// In render(), fall back to the with-* property before the component has hydrated
+const hasLabelSlot = this.hasUpdated
+  ? this.hasSlotController.test('label')
+  : this.withLabel;
+```
+
 ## Known Issues
 
 Here are some known issues and things we're still working on.

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -30,6 +30,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Improved the accessibility of `<wa-rating>` by moving role and ARIA attributes to the host element [issue:#2205]
 - Improved the accessibility of `<wa-rating>` by moving role and ARIA attributes to the host element [issue:2205]
 - Improved performance of `<wa-textarea>` by only creating a resize observer when necessary
+- Improved SSR compatibility by adding server-side rendering guards to components that use browser-only APIs
 
 ## 3.4.0
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -29,6 +29,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug in `<wa-dropdown-item>` where the `click` event could still fire when the item was disabled [issue:#1817]
 - Improved the accessibility of `<wa-rating>` by moving role and ARIA attributes to the host element [issue:#2205]
 - Improved the accessibility of `<wa-rating>` by moving role and ARIA attributes to the host element [issue:2205]
+- Improved performance of `<wa-textarea>` by only creating a resize observer when necessary
 
 ## 3.4.0
 

--- a/packages/webawesome/docs/docs/resources/contributing.md
+++ b/packages/webawesome/docs/docs/resources/contributing.md
@@ -374,6 +374,28 @@ To solve this, a shared dismissible stack is maintained in `src/internal/dismiss
 
 This pattern is modeled after the `scroll.ts` lock pattern. Refer to existing overlay components such as `<wa-dialog>` or `<wa-drawer>` for examples.
 
+### Server-Side Rendering (SSR)
+
+Web Awesome supports server-side rendering via [Lit SSR](https://lit.dev/docs/ssr/overview/). During SSR, Lit calls `constructor()` and `connectedCallback()` but does **not** call `firstUpdated()`, `updated()`, or event handlers. This means browser-only APIs such as `document.*`, `window.*`, `ResizeObserver`, `MutationObserver`, etc. need to be guarded in constructors, class field initializers, `connectedCallback()`, and module-level code. Guards are _not_ needed in `firstUpdated()`, `updated()`, event handlers, or `@watch` handlers.
+
+To guard browser-only code, import `isServer` from `lit` and short circuit early or wrap the relevant code. Do not shim browser APIs on `globalThis` as a workaround — use `isServer` guards directly.
+
+```ts
+import { isServer } from 'lit';
+
+connectedCallback() {
+  super.connectedCallback();
+
+  // SSR guard: ResizeObserver is not available during server-side rendering
+  if (isServer) {
+    return;
+  }
+
+  this.resizeObserver = new ResizeObserver(() => this.handleResize());
+  this.resizeObserver.observe(this);
+}
+```
+
 ### System Icons
 
 Avoid inlining SVG icons inside of templates. If a component requires an icon, make sure `<wa-icon>` is a dependency of the component and use the [system library](/docs/components/icon#customizing-the-system-library):

--- a/packages/webawesome/docs/docs/resources/contributing.md
+++ b/packages/webawesome/docs/docs/resources/contributing.md
@@ -396,6 +396,28 @@ connectedCallback() {
 }
 ```
 
+#### Slot Detection and `with-*` Attributes
+
+Some components use `HasSlotController` to conditionally render parts of their template (e.g. a footer that only appears when a `footer` slot is present). During SSR, slot detection doesn't work because the DOM isn't available, so these parts would be missing from the initial server-rendered markup.
+
+To solve this, components that rely on slot detection in their `render()` method must provide `with-*` attributes as SSR fallbacks. Use the `hasUpdated` ternary pattern:
+
+```ts
+/**
+ * Only required for SSR. Set to `true` if you're slotting in a `label` element so the server-rendered markup
+ * includes the label before the component hydrates on the client.
+ */
+@property({ attribute: 'with-label', type: Boolean }) withLabel = false;
+
+render() {
+  const hasLabelSlot = this.hasUpdated
+    ? this.hasSlotController.test('label')
+    : this.withLabel;
+}
+```
+
+Before the component has hydrated (`hasUpdated` is `false`), the `with-*` property is used. After hydration, `HasSlotController` takes over with real slot detection. All `with-*` SSR properties must include a JSDoc comment that clearly states the property is only required for SSR.
+
 ### System Icons
 
 Avoid inlining SVG icons inside of templates. If a component requires an icon, make sure `<wa-icon>` is a dependency of the component and use the [system library](/docs/components/icon#customizing-the-system-library):

--- a/packages/webawesome/src/components/button/button.ts
+++ b/packages/webawesome/src/components/button/button.ts
@@ -77,6 +77,18 @@ export default class WaButton extends WebAwesomeFormAssociatedElement {
   /** Draws the button with a caret. Used to indicate that the button triggers a dropdown menu or similar behavior. */
   @property({ attribute: 'with-caret', type: Boolean, reflect: true }) withCaret = false;
 
+  /**
+   * Only required for SSR. Set to `true` if you're slotting in a `start` element so the server-rendered markup
+   * includes the start slot before the component hydrates on the client.
+   */
+  @property({ attribute: 'with-start', type: Boolean }) withStart = false;
+
+  /**
+   * Only required for SSR. Set to `true` if you're slotting in an `end` element so the server-rendered markup
+   * includes the end slot before the component hydrates on the client.
+   */
+  @property({ attribute: 'with-end', type: Boolean }) withEnd = false;
+
   /** Disables the button. */
   @property({ type: Boolean }) disabled = false;
 
@@ -293,8 +305,8 @@ export default class WaButton extends WebAwesomeFormAssociatedElement {
           loading: this.loading,
           rtl: this.localize.dir() === 'rtl',
           'has-label': this.hasSlotController.test('[default]'),
-          'has-start': this.hasSlotController.test('start'),
-          'has-end': this.hasSlotController.test('end'),
+          'has-start': this.hasUpdated ? this.hasSlotController.test('start') : this.withStart,
+          'has-end': this.hasUpdated ? this.hasSlotController.test('end') : this.withEnd,
           'is-icon-button': this.isIconButton,
         })}
         ?disabled=${ifDefined(isLink ? undefined : this.disabled)}

--- a/packages/webawesome/src/components/card/card.ts
+++ b/packages/webawesome/src/components/card/card.ts
@@ -44,13 +44,22 @@ export default class WaCard extends WebAwesomeElement {
   @property({ reflect: true })
   appearance: 'accent' | 'filled' | 'outlined' | 'filled-outlined' | 'plain' = 'outlined';
 
-  /** Renders the card with a header. Only needed for SSR, otherwise is automatically added. */
+  /**
+   * Only required for SSR. Set to `true` if you're slotting in a `header` element so the server-rendered markup
+   * includes the header before the component hydrates on the client.
+   */
   @property({ attribute: 'with-header', type: Boolean, reflect: true }) withHeader = false;
 
-  /** Renders the card with an image. Only needed for SSR, otherwise is automatically added. */
+  /**
+   * Only required for SSR. Set to `true` if you're slotting in a `media` element so the server-rendered markup
+   * includes the media before the component hydrates on the client.
+   */
   @property({ attribute: 'with-media', type: Boolean, reflect: true }) withMedia = false;
 
-  /** Renders the card with a footer. Only needed for SSR, otherwise is automatically added. */
+  /**
+   * Only required for SSR. Set to `true` if you're slotting in a `footer` element so the server-rendered markup
+   * includes the footer before the component hydrates on the client.
+   */
   @property({ attribute: 'with-footer', type: Boolean, reflect: true }) withFooter = false;
 
   /** Renders the card's orientation **/

--- a/packages/webawesome/src/components/carousel/carousel.ts
+++ b/packages/webawesome/src/components/carousel/carousel.ts
@@ -103,8 +103,12 @@ export default class WaCarousel extends WebAwesomeElement {
 
   connectedCallback(): void {
     super.connectedCallback();
-    this.setAttribute('role', 'region');
-    this.setAttribute('aria-label', this.localize.term('carousel'));
+
+    // SSR guard: setAttribute is not available during server-side rendering
+    if (!isServer) {
+      this.setAttribute('role', 'region');
+      this.setAttribute('aria-label', this.localize.term('carousel'));
+    }
   }
 
   disconnectedCallback(): void {

--- a/packages/webawesome/src/components/color-picker/color-picker.ts
+++ b/packages/webawesome/src/components/color-picker/color-picker.ts
@@ -173,7 +173,16 @@ export default class WaColorPicker extends WebAwesomeFormAssociatedElement {
   /** The default value of the form control. Primarily used for resetting the form control. */
   @property({ attribute: 'value', reflect: true }) defaultValue: string | null = this.getAttribute('value') || null;
 
+  /**
+   * Only required for SSR. Set to `true` if you're slotting in a `label` element so the server-rendered markup
+   * includes the label before the component hydrates on the client.
+   */
   @property({ attribute: 'with-label', reflect: true, type: Boolean }) withLabel = false;
+
+  /**
+   * Only required for SSR. Set to `true` if you're slotting in a `hint` element so the server-rendered markup
+   * includes the hint before the component hydrates on the client.
+   */
   @property({ attribute: 'with-hint', reflect: true, type: Boolean }) withHint = false;
 
   @state() private hasEyeDropper: boolean = false;

--- a/packages/webawesome/src/components/dialog/dialog.ts
+++ b/packages/webawesome/src/components/dialog/dialog.ts
@@ -77,6 +77,12 @@ export default class WaDialog extends WebAwesomeElement {
   /** When enabled, the dialog will be closed when the user clicks outside of it. */
   @property({ attribute: 'light-dismiss', type: Boolean }) lightDismiss = false;
 
+  /**
+   * Only required for SSR. Set to `true` if you're slotting in a `footer` element so the server-rendered markup
+   * includes the footer before the component hydrates on the client.
+   */
+  @property({ attribute: 'with-footer', type: Boolean }) withFooter = false;
+
   firstUpdated() {
     if (this.open) {
       this.addOpenListeners();
@@ -212,7 +218,7 @@ export default class WaDialog extends WebAwesomeElement {
 
   render() {
     const hasHeader = !this.withoutHeader;
-    const hasFooter = this.hasSlotController.test('footer');
+    const hasFooter = this.hasUpdated ? this.hasSlotController.test('footer') : this.withFooter;
 
     return html`
       <dialog

--- a/packages/webawesome/src/components/drawer/drawer.ts
+++ b/packages/webawesome/src/components/drawer/drawer.ts
@@ -86,6 +86,12 @@ export default class WaDrawer extends WebAwesomeElement {
   /** When enabled, the drawer will be closed when the user clicks outside of it. */
   @property({ attribute: 'light-dismiss', type: Boolean }) lightDismiss = true;
 
+  /**
+   * Only required for SSR. Set to `true` if you're slotting in a `footer` element so the server-rendered markup
+   * includes the footer before the component hydrates on the client.
+   */
+  @property({ attribute: 'with-footer', type: Boolean }) withFooter = false;
+
   firstUpdated() {
     if (isServer) {
       return;
@@ -225,7 +231,7 @@ export default class WaDrawer extends WebAwesomeElement {
 
   render() {
     const hasHeader = !this.withoutHeader;
-    const hasFooter = this.hasSlotController.test('footer');
+    const hasFooter = this.hasUpdated ? this.hasSlotController.test('footer') : this.withFooter;
 
     return html`
       <dialog

--- a/packages/webawesome/src/components/input/input.ts
+++ b/packages/webawesome/src/components/input/input.ts
@@ -210,12 +210,14 @@ export default class WaInput extends WebAwesomeFormAssociatedElement {
   @property() inputmode: 'none' | 'text' | 'decimal' | 'numeric' | 'tel' | 'search' | 'email' | 'url';
 
   /**
-   * Used for SSR. Will determine if the SSRed component will have the label slot rendered on initial paint.
+   * Only required for SSR. Set to `true` if you're slotting in a `label` element so the server-rendered markup
+   * includes the label before the component hydrates on the client.
    */
   @property({ attribute: 'with-label', type: Boolean }) withLabel = false;
 
   /**
-   * Used for SSR. Will determine if the SSRed component will have the hint slot rendered on initial paint.
+   * Only required for SSR. Set to `true` if you're slotting in a `hint` element so the server-rendered markup
+   * includes the hint before the component hydrates on the client.
    */
   @property({ attribute: 'with-hint', type: Boolean }) withHint = false;
 

--- a/packages/webawesome/src/components/number-input/number-input.ts
+++ b/packages/webawesome/src/components/number-input/number-input.ts
@@ -149,12 +149,14 @@ export default class WaNumberInput extends WebAwesomeFormAssociatedElement {
   @property() inputmode: 'numeric' | 'decimal' = 'numeric';
 
   /**
-   * Used for SSR. Will determine if the SSRed component will have the label slot rendered on initial paint.
+   * Only required for SSR. Set to `true` if you're slotting in a `label` element so the server-rendered markup
+   * includes the label before the component hydrates on the client.
    */
   @property({ attribute: 'with-label', type: Boolean }) withLabel = false;
 
   /**
-   * Used for SSR. Will determine if the SSRed component will have the hint slot rendered on initial paint.
+   * Only required for SSR. Set to `true` if you're slotting in a `hint` element so the server-rendered markup
+   * includes the hint before the component hydrates on the client.
    */
   @property({ attribute: 'with-hint', type: Boolean }) withHint = false;
 

--- a/packages/webawesome/src/components/radio-group/radio-group.ts
+++ b/packages/webawesome/src/components/radio-group/radio-group.ts
@@ -105,12 +105,14 @@ export default class WaRadioGroup extends WebAwesomeFormAssociatedElement {
   @property({ type: Boolean, reflect: true }) required = false;
 
   /**
-   * Used for SSR. if true, will show slotted label on initial render.
+   * Only required for SSR. Set to `true` if you're slotting in a `label` element so the server-rendered markup
+   * includes the label before the component hydrates on the client.
    */
   @property({ type: Boolean, attribute: 'with-label' }) withLabel = false;
 
   /**
-   * Used for SSR. if true, will show slotted hint on initial render.
+   * Only required for SSR. Set to `true` if you're slotting in a `hint` element so the server-rendered markup
+   * includes the hint before the component hydrates on the client.
    */
   @property({ type: Boolean, attribute: 'with-hint' }) withHint = false;
 

--- a/packages/webawesome/src/components/resize-observer/resize-observer.ts
+++ b/packages/webawesome/src/components/resize-observer/resize-observer.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { html, isServer } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { WaResizeEvent } from '../../events/resize.js';
 import { watch } from '../../internal/watch.js';
@@ -27,14 +27,18 @@ export default class WaResizeObserver extends WebAwesomeElement {
 
   connectedCallback() {
     super.connectedCallback();
-    this.resizeObserver = new ResizeObserver((entries: ResizeObserverEntry[]) => {
-      this.dispatchEvent(new WaResizeEvent({ entries }));
-    });
 
-    if (!this.disabled) {
-      this.updateComplete.then(() => {
-        this.startObserver();
+    // SSR guard: ResizeObserver is not available during server-side rendering
+    if (!isServer) {
+      this.resizeObserver = new ResizeObserver((entries: ResizeObserverEntry[]) => {
+        this.dispatchEvent(new WaResizeEvent({ entries }));
       });
+
+      if (!this.disabled) {
+        this.updateComplete.then(() => {
+          this.startObserver();
+        });
+      }
     }
   }
 

--- a/packages/webawesome/src/components/scroller/scroller.ts
+++ b/packages/webawesome/src/components/scroller/scroller.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { html, isServer } from 'lit';
 import { customElement, eventOptions, property, query, state } from 'lit/decorators.js';
 import WebAwesomeElement from '../../internal/webawesome-element.js';
 import { LocalizeController } from '../../utilities/localize.js';
@@ -23,7 +23,7 @@ export default class WaScroller extends WebAwesomeElement {
   static css = [styles];
 
   private readonly localize = new LocalizeController(this);
-  private resizeObserver = new ResizeObserver(() => this.updateScroll());
+  private resizeObserver: ResizeObserver | null = null;
 
   @query('#content') content: HTMLElement;
 
@@ -40,12 +40,17 @@ export default class WaScroller extends WebAwesomeElement {
 
   connectedCallback() {
     super.connectedCallback();
-    this.resizeObserver.observe(this);
+
+    // SSR guard: ResizeObserver is not available during server-side rendering
+    if (!isServer) {
+      this.resizeObserver = new ResizeObserver(() => this.updateScroll());
+      this.resizeObserver.observe(this);
+    }
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    this.resizeObserver.disconnect();
+    this.resizeObserver?.disconnect();
   }
 
   private handleKeyDown(event: KeyboardEvent) {

--- a/packages/webawesome/src/components/select/select.ts
+++ b/packages/webawesome/src/components/select/select.ts
@@ -254,12 +254,14 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
   @property({ attribute: 'hint' }) hint = '';
 
   /**
-   * Used for SSR purposes when a label is slotted in. Will show the label on first render.
+   * Only required for SSR. Set to `true` if you're slotting in a `label` element so the server-rendered markup
+   * includes the label before the component hydrates on the client.
    */
   @property({ attribute: 'with-label', type: Boolean }) withLabel = false;
 
   /**
-   * Used for SSR purposes when hint is slotted in. Will show the hint on first render.
+   * Only required for SSR. Set to `true` if you're slotting in a `hint` element so the server-rendered markup
+   * includes the hint before the component hydrates on the client.
    */
   @property({ attribute: 'with-hint', type: Boolean }) withHint = false;
 

--- a/packages/webawesome/src/components/slider/slider.ts
+++ b/packages/webawesome/src/components/slider/slider.ts
@@ -196,6 +196,18 @@ export default class WaSlider extends WebAwesomeFormAssociatedElement {
   @property({ attribute: 'with-tooltip', type: Boolean }) withTooltip = false;
 
   /**
+   * Only required for SSR. Set to `true` if you're slotting in a `label` element so the server-rendered markup
+   * includes the label before the component hydrates on the client.
+   */
+  @property({ attribute: 'with-label', type: Boolean }) withLabel = false;
+
+  /**
+   * Only required for SSR. Set to `true` if you're slotting in a `hint` element so the server-rendered markup
+   * includes the hint before the component hydrates on the client.
+   */
+  @property({ attribute: 'with-hint', type: Boolean }) withHint = false;
+
+  /**
    * A custom formatting function to apply to the value. This will be shown in the tooltip and announced by screen
    * readers. Must be set with JavaScript. Property only.
    */
@@ -777,8 +789,8 @@ export default class WaSlider extends WebAwesomeFormAssociatedElement {
   }
 
   render() {
-    const hasLabelSlot = this.hasSlotController.test('label');
-    const hasHintSlot = this.hasSlotController.test('hint');
+    const hasLabelSlot = this.hasUpdated ? this.hasSlotController.test('label') : this.withLabel;
+    const hasHintSlot = this.hasUpdated ? this.hasSlotController.test('hint') : this.withHint;
     const hasLabel = this.label ? true : !!hasLabelSlot;
     const hasHint = this.hint ? true : !!hasHintSlot;
     const hasReference = this.hasSlotController.test('reference');

--- a/packages/webawesome/src/components/split-panel/split-panel.ts
+++ b/packages/webawesome/src/components/split-panel/split-panel.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { html, isServer } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { WaRepositionEvent } from '../../events/reposition.js';
@@ -78,11 +78,15 @@ export default class WaSplitPanel extends WebAwesomeElement {
 
   connectedCallback() {
     super.connectedCallback();
-    this.resizeObserver = new ResizeObserver(entries => this.handleResize(entries));
-    this.updateComplete.then(() => this.resizeObserver.observe(this));
 
-    this.detectSize();
-    this.cachedPositionInPixels = this.percentageToPixels(this.position);
+    // SSR guard: ResizeObserver is not available during server-side rendering
+    if (!isServer) {
+      this.resizeObserver = new ResizeObserver(entries => this.handleResize(entries));
+      this.updateComplete.then(() => this.resizeObserver.observe(this));
+
+      this.detectSize();
+      this.cachedPositionInPixels = this.percentageToPixels(this.position);
+    }
   }
 
   disconnectedCallback() {

--- a/packages/webawesome/src/components/switch/switch.ts
+++ b/packages/webawesome/src/components/switch/switch.ts
@@ -101,7 +101,8 @@ export default class WaSwitch extends WebAwesomeFormAssociatedElement {
   @property({ attribute: 'hint' }) hint = '';
 
   /**
-   * Used for SSR. If you slot in hint, make sure to add `with-hint` to your component to get it to properly render with SSR.
+   * Only required for SSR. Set to `true` if you're slotting in a `hint` element so the server-rendered markup
+   * includes the hint before the component hydrates on the client.
    */
   @property({ attribute: 'with-hint', type: Boolean }) withHint = false;
 

--- a/packages/webawesome/src/components/tab-group/tab-group.ts
+++ b/packages/webawesome/src/components/tab-group/tab-group.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { html, isServer } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { WaTabHideEvent } from '../../events/tab-hide.js';
@@ -80,6 +80,11 @@ export default class WaTabGroup extends WebAwesomeElement {
 
   connectedCallback() {
     super.connectedCallback();
+
+    // SSR guard: browser observers and DOM APIs are not available during server-side rendering
+    if (isServer) {
+      return;
+    }
 
     this.resizeObserver = new ResizeObserver(() => {
       this.updateScrollControls();

--- a/packages/webawesome/src/components/textarea/textarea.ts
+++ b/packages/webawesome/src/components/textarea/textarea.ts
@@ -45,7 +45,7 @@ export default class WaTextarea extends WebAwesomeFormAssociatedElement {
 
   assumeInteractionOn = ['blur', 'input'];
   private readonly hasSlotController = new HasSlotController(this, 'hint', 'label');
-  private resizeObserver: ResizeObserver;
+  private resizeObserver?: ResizeObserver;
 
   @query('.control') input: HTMLTextAreaElement;
   @query('[part~="base"]') base: HTMLDivElement;
@@ -164,11 +164,9 @@ export default class WaTextarea extends WebAwesomeFormAssociatedElement {
   connectedCallback() {
     super.connectedCallback();
 
-    this.resizeObserver = new ResizeObserver(() => this.setTextareaDimensions());
-
     this.updateComplete.then(() => {
       this.setTextareaDimensions();
-      this.resizeObserver.observe(this.input);
+      this.updateResizeObserver();
 
       if (this.didSSR && this.input && this.value !== this.input.value) {
         const value = this.input.value;
@@ -180,8 +178,22 @@ export default class WaTextarea extends WebAwesomeFormAssociatedElement {
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    if (this.input) {
-      this.resizeObserver?.unobserve(this.input);
+    this.resizeObserver?.disconnect();
+    this.resizeObserver = undefined;
+  }
+
+  /** Creates or destroys the resize observer based on the current resize mode. */
+  private updateResizeObserver() {
+    // The resize observer is only needed for manual resize modes (vertical, horizontal, both)
+    // to sync the base wrapper dimensions with the textarea.
+    const needsObserver = this.resize !== 'none' && this.resize !== 'auto';
+
+    if (needsObserver && !this.resizeObserver && this.input) {
+      this.resizeObserver = new ResizeObserver(() => this.setTextareaDimensions());
+      this.resizeObserver.observe(this.input);
+    } else if (!needsObserver && this.resizeObserver) {
+      this.resizeObserver.disconnect();
+      this.resizeObserver = undefined;
     }
   }
 
@@ -253,6 +265,7 @@ export default class WaTextarea extends WebAwesomeFormAssociatedElement {
   updated(changedProperties: PropertyValues<this>) {
     if (changedProperties.has('resize')) {
       this.setTextareaDimensions();
+      this.updateResizeObserver();
     }
 
     super.updated(changedProperties);

--- a/packages/webawesome/src/components/textarea/textarea.ts
+++ b/packages/webawesome/src/components/textarea/textarea.ts
@@ -152,12 +152,14 @@ export default class WaTextarea extends WebAwesomeFormAssociatedElement {
   @property() inputmode: 'none' | 'text' | 'decimal' | 'numeric' | 'tel' | 'search' | 'email' | 'url';
 
   /**
-   * Used for SSR. If you're slotting in a `label` element, make sure to set this to `true`.
+   * Only required for SSR. Set to `true` if you're slotting in a `label` element so the server-rendered markup
+   * includes the label before the component hydrates on the client.
    */
   @property({ attribute: 'with-label', type: Boolean }) withLabel = false;
 
   /**
-   * Used for SSR. If you're slotting in a `hint` element, make sure to set this to `true`.
+   * Only required for SSR. Set to `true` if you're slotting in a `hint` element so the server-rendered markup
+   * includes the hint before the component hydrates on the client.
    */
   @property({ attribute: 'with-hint', type: Boolean }) withHint = false;
 

--- a/packages/webawesome/src/components/tree/tree.ts
+++ b/packages/webawesome/src/components/tree/tree.ts
@@ -106,13 +106,16 @@ export default class WaTree extends WebAwesomeElement {
   async connectedCallback() {
     super.connectedCallback();
 
-    this.setAttribute('role', 'tree');
-    this.setAttribute('tabindex', '0');
+    // SSR guard: MutationObserver is not available during server-side rendering
+    if (!isServer) {
+      this.setAttribute('role', 'tree');
+      this.setAttribute('tabindex', '0');
 
-    await this.updateComplete;
+      await this.updateComplete;
 
-    this.mutationObserver = new MutationObserver(this.handleTreeChanged);
-    this.mutationObserver.observe(this, { childList: true, subtree: true });
+      this.mutationObserver = new MutationObserver(this.handleTreeChanged);
+      this.mutationObserver.observe(this, { childList: true, subtree: true });
+    }
   }
 
   disconnectedCallback() {

--- a/packages/webawesome/src/components/zoomable-frame/zoomable-frame.ts
+++ b/packages/webawesome/src/components/zoomable-frame/zoomable-frame.ts
@@ -1,5 +1,5 @@
 import type { PropertyValues } from 'lit';
-import { html } from 'lit';
+import { html, isServer } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { ColorSchemeController } from '../../internal/color-scheme-controller.js';
@@ -33,9 +33,8 @@ export default class WaZoomableFrame extends WebAwesomeElement {
 
   private readonly localize = new LocalizeController(this);
   private availableZoomLevels: number[] = [];
-  // Watches document.documentElement class changes (e.g. theme-selector, color-scheme-selector).
-  // Only active while withThemeSync is true.
-  private readonly themeObserver = new MutationObserver(() => this.syncTheme());
+  // SSR guard: MutationObserver is not available during server-side rendering
+  private themeObserver: MutationObserver | null = !isServer ? new MutationObserver(() => this.syncTheme()) : null;
 
   constructor() {
     super();
@@ -170,10 +169,10 @@ export default class WaZoomableFrame extends WebAwesomeElement {
 
     if (changedProperties.has('withThemeSync')) {
       if (this.withThemeSync) {
-        this.themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+        this.themeObserver?.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
         this.syncTheme(); // Apply immediately when toggled on
       } else {
-        this.themeObserver.disconnect();
+        this.themeObserver?.disconnect();
       }
     }
   }
@@ -208,7 +207,7 @@ export default class WaZoomableFrame extends WebAwesomeElement {
 
   override disconnectedCallback() {
     super.disconnectedCallback();
-    this.themeObserver.disconnect();
+    this.themeObserver?.disconnect();
   }
 
   private syncTheme() {

--- a/packages/webawesome/src/internal/webawesome-element.ts
+++ b/packages/webawesome/src/internal/webawesome-element.ts
@@ -56,12 +56,16 @@ export default class WebAwesomeElement extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
-    // Helpful comment node inside the shadow root that links to the docs
-    this.shadowRoot?.prepend(
-      document.createComment(
-        ` Web Awesome: https://webawesome.com/docs/components/${this.localName.replace('wa-', '')} `,
-      ),
-    );
+
+    // SSR guard: document is not available during server-side rendering
+    if (!isServer) {
+      // Helpful comment node inside the shadow root that links to the docs
+      this.shadowRoot?.prepend(
+        document.createComment(
+          ` Web Awesome: https://webawesome.com/docs/components/${this.localName.replace('wa-', '')} `,
+        ),
+      );
+    }
   }
 
   attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null) {


### PR DESCRIPTION
This PR adds guards to improve the SSR experience. It also adds guidance in `contributing.md` for developing with SSR in mind. I will work on a subsequent PR for the `HasSlotController` since those changes might be more controversial.

This PR also includes a small performance improvement to `<wa-textarea>` by loading the resize observer lazily only when necessary.

Fixes #1858
Fixes #2174
Fixes #2178

Companion PR for pro is at https://github.com/shoelace-style/webawesome-pro/pull/175

@KonnorRogers One thing this PR does not do is re-enable SSR tests.