### PR TITLE
Add the ability to preload components via autoloader with `data-wa-preload`

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -15,6 +15,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 <small>TBD</small>
 
 - Added a new free component: `<wa-markdown>` (#6 of 14 per stretch goals)
+- Added the `data-wa-preload` attribute for preloading components that aren't on the page yet when using the autoloader [issue:1501]
 - Fixed a bug in the native styles utility where `<select>` text could overlap the caret icon when the selected option had a long name
 - Fixed a bug in the native styles utility where `<select multiple>` did not expand to show multiple options
 - Added a new free component: `<wa-markdown>` (#6 of 14 per stretch goals)

--- a/packages/webawesome/src/utilities/autoloader.ts
+++ b/packages/webawesome/src/utilities/autoloader.ts
@@ -39,6 +39,13 @@ export async function discover(root: Document | Element | ShadowRoot) {
     tags.push(rootTagName);
   }
 
+  // Collect tags from data-wa-preload attributes
+  const preloadSelectors = root.querySelectorAll('[data-wa-preload]');
+  const preloadRoots = root instanceof Element && root.hasAttribute('data-wa-preload') ? [root, ...preloadSelectors] : preloadSelectors;
+  for (const el of preloadRoots) {
+    tags.push(...(el as Element).getAttribute('data-wa-preload')!.split(/\s+/).filter(tag => tag.startsWith('wa-')));
+  }
+
   // Make the list unique
   const tagsToRegister = [...new Set(tags)];
 

--- a/packages/webawesome/src/utilities/autoloader.ts
+++ b/packages/webawesome/src/utilities/autoloader.ts
@@ -41,9 +41,15 @@ export async function discover(root: Document | Element | ShadowRoot) {
 
   // Collect tags from data-wa-preload attributes
   const preloadSelectors = root.querySelectorAll('[data-wa-preload]');
-  const preloadRoots = root instanceof Element && root.hasAttribute('data-wa-preload') ? [root, ...preloadSelectors] : preloadSelectors;
+  const preloadRoots =
+    root instanceof Element && root.hasAttribute('data-wa-preload') ? [root, ...preloadSelectors] : preloadSelectors;
   for (const el of preloadRoots) {
-    tags.push(...(el as Element).getAttribute('data-wa-preload')!.split(/\s+/).filter(tag => tag.startsWith('wa-')));
+    tags.push(
+      ...(el as Element)
+        .getAttribute('data-wa-preload')!
+        .split(/\s+/)
+        .filter(tag => tag.startsWith('wa-')),
+    );
   }
 
   // Make the list unique


### PR DESCRIPTION
As the title suggests, this lets you preload components that might not be on the page when the autoloader first runs. This works by collecting tag names in `data-wa-preload` attributes and adding them to the existing auto loader list.

This feature allows users who dynamically append new Web Awesome components _after_ the page first loads. By ensuring the components are preloaded up front, we eliminate FOUCE for those elements.

Note: I will add this to the documentation in a separate PR.

Closes #1501