### PR TITLE
Select/combobox event fix

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -29,6 +29,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug in `<wa-dropdown>` where heading colors in the menu used `!important`, preventing users from overriding them with light DOM styles [issue:2102]
 - Fixed a bug in `<wa-select>` where the `:state(blank)` custom state was incorrectly applied when the selected option had an empty string value [issue:1920]
 - Fixed a bug in `<wa-dropdown-item>` where the `click` event could still fire when the item was disabled [issue:#1817]
+- Fixed a bug in `<wa-select>` + `<wa-option>` where the `change` and `input` events could dispatch with incorrect timing
 - Improved the accessibility of `<wa-rating>` by moving role and ARIA attributes to the host element [issue:#2205]
 - Improved the accessibility of `<wa-rating>` by moving role and ARIA attributes to the host element [issue:2205]
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -29,7 +29,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug in `<wa-dropdown>` where heading colors in the menu used `!important`, preventing users from overriding them with light DOM styles [issue:2102]
 - Fixed a bug in `<wa-select>` where the `:state(blank)` custom state was incorrectly applied when the selected option had an empty string value [issue:1920]
 - Fixed a bug in `<wa-dropdown-item>` where the `click` event could still fire when the item was disabled [issue:#1817]
-- Fixed a bug in `<wa-select>` + `<wa-option>` where the `change` and `input` events could dispatch with incorrect timing
+- Fixed a bug in `<wa-select>`, `<wa-combobox>`, and `<wa-option>` where the `change` and `input` events could dispatch with incorrect timing
 - Improved the accessibility of `<wa-rating>` by moving role and ARIA attributes to the host element [issue:#2205]
 - Improved the accessibility of `<wa-rating>` by moving role and ARIA attributes to the host element [issue:2205]
 

--- a/packages/webawesome/scripts/build.js
+++ b/packages/webawesome/scripts/build.js
@@ -45,7 +45,7 @@ export async function build(options = {}) {
   // packageData and version  need to be set within the `build()` function because this file gets imported by the app, which may not have generated its bundled directory yet, so this needs to be "lazily" evaluated.
   const packageData = JSON.parse(await readFile(join(getRootDir(), 'package.json'), 'utf-8'));
   const version = packageData.version;
-  console.log(`${chalk.hex('#ef6741')('🦊 Web Awesome')} v${version}\n`);
+  console.log(`${chalk.hex('#ef6741')('🦊 Web Awesome')} ${chalk.cyan(`v${version}\n`)}`);
   if (isDeveloping) {
     spinner.info('Development mode');
   }

--- a/packages/webawesome/src/components/option/option.ts
+++ b/packages/webawesome/src/components/option/option.ts
@@ -172,7 +172,6 @@ export default class WaOption extends WebAwesomeElement {
     if (changedProperties.has('selected')) {
       this.setAttribute('aria-selected', this.selected ? 'true' : 'false');
       this.customStates.set('selected', this.selected);
-      this.handleDefaultSlotChange();
     }
 
     if (changedProperties.has('value')) {

--- a/packages/webawesome/src/components/select/select.test.ts
+++ b/packages/webawesome/src/components/select/select.test.ts
@@ -218,6 +218,92 @@ describe('<wa-select>', () => {
           expect(handler).to.be.calledTwice;
           expect(el.value).to.equal(option2.value);
         });
+
+        it('should have the correct event.target.value at the time the change event fires', async () => {
+          const el = await fixture<WaSelect>(html`
+            <wa-select value="option-1">
+              <wa-option value="option-1">Option 1</wa-option>
+              <wa-option value="option-2">Option 2</wa-option>
+              <wa-option value="option-3">Option 3</wa-option>
+            </wa-select>
+          `);
+          const secondOption = el.querySelectorAll<WaOption>('wa-option')[1];
+          let valueAtChangeTime: string | string[] | null = null;
+          let valueAtInputTime: string | string[] | null = null;
+
+          el.addEventListener('change', (event: Event) => {
+            valueAtChangeTime = (event.target as WaSelect).value;
+          });
+          el.addEventListener('input', (event: Event) => {
+            valueAtInputTime = (event.target as WaSelect).value;
+          });
+
+          await el.show();
+          await clickOnElement(secondOption);
+          await el.updateComplete;
+
+          expect(valueAtChangeTime).to.equal('option-2');
+          expect(valueAtInputTime).to.equal('option-2');
+        });
+
+        it('should have the correct event.target.value when selecting from no initial value', async () => {
+          const el = await fixture<WaSelect>(html`
+            <wa-select>
+              <wa-option value="option-1">Option 1</wa-option>
+              <wa-option value="option-2">Option 2</wa-option>
+              <wa-option value="option-3">Option 3</wa-option>
+            </wa-select>
+          `);
+          const secondOption = el.querySelectorAll<WaOption>('wa-option')[1];
+          let valueAtChangeTime: string | string[] | null = null;
+
+          el.addEventListener('change', (event: Event) => {
+            valueAtChangeTime = (event.target as WaSelect).value;
+          });
+
+          await el.show();
+          await clickOnElement(secondOption);
+          await el.updateComplete;
+
+          expect(el.value).to.equal('option-2');
+          expect(valueAtChangeTime).to.equal('option-2');
+        });
+
+        it('should emit exactly one change and one input event per click interaction', async () => {
+          const el = await fixture<WaSelect>(html`
+            <wa-select value="option-1">
+              <wa-option value="option-1">Option 1</wa-option>
+              <wa-option value="option-2">Option 2</wa-option>
+              <wa-option value="option-3">Option 3</wa-option>
+            </wa-select>
+          `);
+          const changeHandler = sinon.spy();
+          const inputHandler = sinon.spy();
+
+          el.addEventListener('change', changeHandler);
+          el.addEventListener('input', inputHandler);
+
+          // First selection
+          await el.show();
+          await clickOnElement(el.querySelectorAll<WaOption>('wa-option')[1]);
+          await el.updateComplete;
+          await aTimeout(100);
+
+          expect(changeHandler).to.have.been.calledOnce;
+          expect(inputHandler).to.have.been.calledOnce;
+
+          // Second selection — wait for the dropdown to fully close then reopen
+          await aTimeout(500);
+          await el.show();
+          await aTimeout(500);
+          await clickOnElement(el.querySelectorAll<WaOption>('wa-option')[2]);
+          await el.updateComplete;
+          await aTimeout(100);
+
+          expect(changeHandler).to.have.been.calledTwice;
+          expect(inputHandler).to.have.been.calledTwice;
+          expect(el.value).to.equal('option-3');
+        });
       });
 
       // This can happen in on Microsoft Edge auto-filling an associated input element in the same form

--- a/packages/webawesome/src/components/select/select.ts
+++ b/packages/webawesome/src/components/select/select.ts
@@ -186,15 +186,11 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
 
     // Rebuild optionValues only when the cache has been invalidated
     if (this.optionValues === undefined) {
-      if (value == null) {
-        this.optionValues = new Set(null);
-      } else {
-        this.optionValues = new Set(
-          this.getAllOptions()
-            .filter(option => !option.disabled)
-            .map(option => option.value),
-        );
-      }
+      this.optionValues = new Set(
+        this.getAllOptions()
+          .filter(option => !option.disabled)
+          .map(option => option.value),
+      );
     }
 
     // Drop values not in the DOM


### PR DESCRIPTION
- Fixes a bug introduced in 3.4 where select events dispatch within correct timing
- Makes the build script output a little more colorful 🐠

[Reported on Discord](https://discord.com/channels/739437527907303535/1020332605599662181/1486667206275240016)

Also affects https://github.com/shoelace-style/webawesome-pro/pull/176