### PR TITLE
Fix checkbox value when unchecked

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -10,6 +10,12 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 
 {% include "changelog-email-signup.njk" %}
 
+## Unreleased
+
+<small>TBD</small>
+
+- Fixed a bug in `<wa-checkbox>` where the `value` property returned `null` instead of `'on'` when unchecked
+
 ## 3.5.0
 
 <small>April 3rd, 2026</small>

--- a/packages/webawesome/src/components/checkbox/checkbox.test.ts
+++ b/packages/webawesome/src/components/checkbox/checkbox.test.ts
@@ -21,7 +21,7 @@ describe('<wa-checkbox>', () => {
         const el = await fixture<WaCheckbox>(html` <wa-checkbox></wa-checkbox> `);
 
         expect(el.name).to.equal(null);
-        expect(el.value).to.equal(null);
+        expect(el.value).to.equal('on');
         expect(el.title).to.equal('');
         expect(el.disabled).to.be.false;
         expect(el.required).to.be.false;
@@ -120,6 +120,24 @@ describe('<wa-checkbox>', () => {
         expect(inputPosition).to.equal('absolute');
       });
 
+      it('should default value to "on" when no value attribute is set', async () => {
+        const el = await fixture<WaCheckbox>(html` <wa-checkbox></wa-checkbox> `);
+        expect(el.value).to.equal('on');
+      });
+
+      it('should return the value regardless of checked state', async () => {
+        const el = await fixture<WaCheckbox>(html` <wa-checkbox value="myvalue" checked></wa-checkbox> `);
+
+        expect(el.checked).to.be.true;
+        expect(el.value).to.equal('myvalue');
+
+        el.checked = false;
+        await el.updateComplete;
+
+        expect(el.checked).to.be.false;
+        expect(el.value).to.equal('myvalue');
+      });
+
       it('Should keep its form value when going from checked -> unchecked -> checked', async () => {
         const form = await fixture<HTMLFormElement>(
           html`<form><wa-checkbox name="test" value="myvalue" checked>Checked</wa-checkbox></form>`,
@@ -134,7 +152,7 @@ describe('<wa-checkbox>', () => {
         await checkbox.updateComplete;
 
         expect(checkbox.checked).to.equal(false);
-        expect(checkbox.value).to.equal(null);
+        expect(checkbox.value).to.equal('myvalue');
         expect(new FormData(form).get('test')).to.equal(null);
 
         checkbox.checked = true;

--- a/packages/webawesome/src/components/checkbox/checkbox.ts
+++ b/packages/webawesome/src/components/checkbox/checkbox.ts
@@ -80,8 +80,7 @@ export default class WaCheckbox extends WebAwesomeFormAssociatedElement {
 
   /** The value of the checkbox, submitted as a name/value pair with form data. */
   get value(): string | null {
-    const val = this._value || 'on';
-    return this.checked ? val : null;
+    return this._value ?? 'on';
   }
 
   @property({ reflect: true })

--- a/packages/webawesome/src/components/switch/switch.test.ts
+++ b/packages/webawesome/src/components/switch/switch.test.ts
@@ -136,6 +136,24 @@ describe('<wa-switch>', () => {
         expect(inputPosition).to.equal('absolute');
       });
 
+      it('should default value to "on" when no value attribute is set', async () => {
+        const el = await fixture<WaSwitch>(html` <wa-switch></wa-switch> `);
+        expect(el.value).to.equal('on');
+      });
+
+      it('should return the value regardless of checked state', async () => {
+        const el = await fixture<WaSwitch>(html` <wa-switch value="myvalue" checked></wa-switch> `);
+
+        expect(el.checked).to.be.true;
+        expect(el.value).to.equal('myvalue');
+
+        el.checked = false;
+        await el.updateComplete;
+
+        expect(el.checked).to.be.false;
+        expect(el.value).to.equal('myvalue');
+      });
+
       describe('when submitting a form', () => {
         it('should submit the correct value when a value is provided', async () => {
           const form = await fixture<HTMLFormElement>(html`


### PR DESCRIPTION
Fixes the issue with unchecked checkbox's returning `null` instead of the assigned value described in #2254.