### PR TITLE
Add N2 theme with a few design tokens + brand, danger, and gray color tokens

### DIFF
--- a/packages/webawesome/docs/_data/themer.js
+++ b/packages/webawesome/docs/_data/themer.js
@@ -62,6 +62,66 @@ export const themes = [
   },
   // #endregion
 
+  {
+    //
+    // #region N2
+    //
+    name: 'N2',
+    description: 'N2 theme',
+    filename: 'n2.css',
+    isPro: false,
+    fonts: {
+      body: {
+        name: 'Open Sans (sans-serif)',
+        css: '"Open Sans", system-ui, sans-serif',
+        href: null,
+      },
+      heading: {
+        name: 'Open Sans (sans-serif)',
+        css: '"Open Sans", system-ui, sans-serif',
+        href: null,
+      },
+      code: {
+        name: 'OS Default (monospace)',
+        css: 'ui-monospace, monospace',
+        href: null,
+      },
+      longform: {
+        name: 'OS Default (serif)',
+        css: 'ui-serif, serif',
+        href: null,
+      },
+    },
+    icons: {
+      family: 'classic',
+      weight: 1,
+    },
+    palette: {
+      name: 'N2',
+      filename: 'n2.css',
+    },
+    colorBrand: {
+      color: 'green',
+    },
+    tokens: {
+      // Fonts
+      '--wa-font-family-body': '"Open Sans", system-ui, sans-serif',
+      '--wa-font-family-heading': 'var(--wa-font-family-body)',
+      '--wa-font-family-code': 'ui-monospace, monospace',
+      '--wa-font-family-longform': 'ui-serif, serif',
+      '--wa-font-weight-body': 400,
+      '--wa-font-weight-heading': 600,
+      '--wa-font-weight-code': 400,
+      '--wa-font-weight-longform': 400,
+
+      // Elements
+      '--wa-border-radius-scale': 1,
+      '--wa-space-scale': 1,
+      '--wa-border-width-scale': 1,
+    },
+  },
+  // #endregion
+
   //
   // #region Awesome
   //

--- a/packages/webawesome/src/styles/themes/n2.css
+++ b/packages/webawesome/src/styles/themes/n2.css
@@ -1,0 +1,35 @@
+/**
+ * Do not edit directly, this file was auto-generated.
+ */
+
+:root {
+  --wa-color-brand-40: #5a6329;
+  --wa-color-brand-50: #6e7a35;
+  --wa-color-brand-60: #828f3f;
+  --wa-color-brand-70: #acbe52;
+  --wa-color-brand-80: #f1f6d4;
+  --wa-color-gray-40: #222222;
+  --wa-color-gray-50: #333333;
+  --wa-color-gray-60: #666666;
+  --wa-color-gray-70: #999999;
+  --wa-color-gray-80: #cccccc;
+  --wa-color-gray-90: #eeeeee;
+  --wa-color-gray-95: #f6f6f6;
+  --wa-color-danger-10: #581f20;
+  --wa-color-danger-20: #802c2d;
+  --wa-color-danger-30: #aa3132;
+  --wa-color-danger-40: #d52f31;
+  --wa-color-danger-50: #ff4f44;
+  --wa-color-danger-60: #ff8171;
+  --wa-color-danger-70: #ffaa9c;
+  --wa-color-danger-80: #ffd3c8;
+  --wa-color-danger-90: #fff6f0;
+  --wa-color-danger-95: #fffbf8;
+  --wa-color-danger-05: #431819;
+  --wa-font-sans: 'Open Sans', sans-serif;
+  --wa-font-family-body: 'Open Sans', sans-serif;
+  --wa-border-radius-s: 3.75px;
+  --wa-border-radius-m: 3.75px;
+  --wa-border-radius-l: 3.75px;
+  --wa-button-height-medium: 40px;
+}

--- a/packages/webawesome/src/styles/themes/n2.css
+++ b/packages/webawesome/src/styles/themes/n2.css
@@ -1,7 +1,3 @@
-/**
- * Do not edit directly, this file was auto-generated.
- */
-
 :root {
   --wa-color-brand-40: #5a6329;
   --wa-color-brand-50: #6e7a35;


### PR DESCRIPTION
Add a N2 theme so we can demo components on WebAwesome documentation site. All theming is done with design tokens.

<img width="838" height="499" alt="Screenshot 2026-04-09 at 9 14 57 AM" src="https://github.com/user-attachments/assets/ea598647-9a0d-41f0-bc86-068755a3e8da" />
<img width="806" height="741" alt="Screenshot 2026-04-09 at 9 14 45 AM" src="https://github.com/user-attachments/assets/cf77e7cc-7d36-43d4-bf9a-f85cbc562ccc" />
<img width="858" height="813" alt="Screenshot 2026-04-09 at 9 14 11 AM" src="https://github.com/user-attachments/assets/7feb0c7f-3940-46c1-9091-15e76400da9d" />
<img width="824" height="864" alt="Screenshot 2026-04-09 at 9 14 04 AM" src="https://github.com/user-attachments/assets/aba6ec6a-2122-4f9d-a9eb-1543e5659a4a" />
