### PR TITLE
fix(dropdown-item): correct cursor for disabled items in submenus

### DIFF
--- a/packages/webawesome/src/components/dropdown-item/dropdown-item.styles.ts
+++ b/packages/webawesome/src/components/dropdown-item/dropdown-item.styles.ts
@@ -32,7 +32,6 @@ export default css`
   :host([disabled]) {
     opacity: 0.5;
     cursor: not-allowed;
-    pointer-events: none;
   }
 
   /* Danger variant */

--- a/packages/webawesome/src/components/dropdown-item/dropdown-item.ts
+++ b/packages/webawesome/src/components/dropdown-item/dropdown-item.ts
@@ -123,7 +123,6 @@ export default class WaDropdownItem extends WebAwesomeElement {
     if (changedProperties.has('disabled')) {
       this.setAttribute('aria-disabled', this.disabled ? 'true' : 'false');
       this.customStates.set('disabled', this.disabled);
-      this.style.pointerEvents = this.disabled ? 'none' : '';
     }
 
     if (changedProperties.has('type')) {


### PR DESCRIPTION
Closes #2276

## Problem

When a disabled wa-dropdown-item appears inside a submenu, the cursor shows as pointer instead of 
ot-allowed. This happens because setting pointer-events: none (both via CSS and the inline style set in updated()) causes the mouse to 'fall through' to the parent popup element, which has cursor: pointer.

## Root Cause

Two places were applying pointer-events: none to disabled items:

1. **CSS** — pointer-events: none in the :host(:state(disabled)), :host([disabled]) rule
2. **JS** — 	his.style.pointerEvents = this.disabled ? 'none' : '' in the updated() lifecycle callback

When pointer-events: none is set, the cursor displayed is determined by the element underneath, not the element itself. In a normal dropdown context that underlying element happens to have cursor: default, but inside a submenu popup it has cursor: pointer, causing the inconsistency.

## Fix

Remove pointer-events: none from both the CSS rule and the updated() inline style assignment. Click-event blocking for disabled items is already handled by the handleHostClick and handleClick event listeners, so no functionally is lost.

The cursor: not-allowed CSS declaration now applies correctly because the host element itself receives pointer events and the cursor style is respected.