### PR TITLE
Add Search Keyword Support + Populate Keywords

### DIFF
--- a/packages/webawesome/docs/_plugins/search.js
+++ b/packages/webawesome/docs/_plugins/search.js
@@ -40,10 +40,14 @@ export function searchPlugin(options = {}) {
 
     eleventyConfig.addPreprocessor('exclude-unlisted-from-search', '*', function (data, content) {
       if (data.unlisted) {
-        // no-op
         pagesToIndex.delete(data.page.inputPath);
       } else {
-        pagesToIndex.set(data.page.inputPath, true);
+        // Cache front matter keywords here (preprocessor has data access, transform does not)
+        pagesToIndex.set(data.page.inputPath, {
+          pending: true,
+          synonyms: data.synonyms || [],
+          useCases: data['use-cases'] || [],
+        });
       }
 
       return content;
@@ -51,7 +55,8 @@ export function searchPlugin(options = {}) {
 
     // With incremental builds we need this to be last in case stuff was added from metadata. _BUT_ in incremental builds, not every page is added to the "transform".
     eleventyConfig.addTransform('search', function (content) {
-      if (!pagesToIndex.has(this.page.inputPath)) {
+      const existing = pagesToIndex.get(this.page.inputPath);
+      if (!existing) {
         return content;
       }
 
@@ -77,6 +82,8 @@ export function searchPlugin(options = {}) {
         headings: options.getHeadings(doc).map(collapseWhitespace),
         content: collapseWhitespace(options.getContent(doc)),
         url: normalizeDisplayUrl(rawUrl),
+        synonyms: existing.synonyms || [],
+        useCases: existing.useCases || [],
       });
 
       return content;
@@ -95,9 +102,11 @@ export function searchPlugin(options = {}) {
 
         const cachedPagesMap = new Map(content.pages);
         for (const [key, value] of cachedPagesMap.entries()) {
-          // A page uses a cached value if `true` and it didnt get its value set in the "transform" hook. This is to get around the limitation of incremental builds not going over every file in transform.
-          if (pagesToIndex.get(key) === true) {
-            pagesToIndex.set(key, value);
+          // A page uses a cached value if it's still pending (not yet processed by the transform hook).
+          // This works around the limitation of incremental builds not running transform on every file.
+          const current = pagesToIndex.get(key);
+          if (current?.pending) {
+            pagesToIndex.set(key, { ...value, synonyms: current.synonyms, useCases: current.useCases });
           }
         }
       }
@@ -107,13 +116,20 @@ export function searchPlugin(options = {}) {
       getCachedPages();
 
       const searchIndex = new MiniSearch({
-        fields: ['t', 'h', 'c'],
+        fields: ['t', 'h', 's', 'u', 'c'],
         storeFields: [],
       });
 
       let index = 0;
       for (const [_inputPath, page] of pagesToIndex) {
-        searchIndex.add({ id: index, t: page.title, h: page.headings, c: page.content });
+        searchIndex.add({
+          id: index,
+          t: page.title,
+          h: page.headings,
+          s: (page.synonyms || []).join(' '),
+          u: (page.useCases || []).join(' '),
+          c: page.content,
+        });
         map[index] = { title: page.title, description: page.description, url: page.url };
         index++;
       }

--- a/packages/webawesome/docs/assets/scripts/search.js
+++ b/packages/webawesome/docs/assets/scripts/search.js
@@ -8,7 +8,7 @@ const res = await Promise.all([
 const MiniSearch = res[0].default;
 const searchData = await res[1].json();
 const searchIndex = MiniSearch.loadJSON(JSON.stringify(searchData.searchIndex), {
-  fields: ['t', 'h', 'c'],
+  fields: ['t', 'h', 's', 'u', 'c'],
 });
 const map = searchData.map;
 const searchDebounce = 200;
@@ -323,7 +323,7 @@ async function updateResults(query = '') {
       matches = searchIndex.search(trimmedQuery, {
         prefix: true,
         fuzzy: 0.2,
-        boost: { t: 20, h: 10 },
+        boost: { t: 20, s: 14, h: 10, u: 6, c: 1 },
       });
 
       // Re-rank results to prioritize title matches. Searches don't account for where in a title a match occurs, so

--- a/packages/webawesome/docs/docs/components/animated-image.md
+++ b/packages/webawesome/docs/docs/components/animated-image.md
@@ -3,8 +3,14 @@ title: Animated Image
 description: A component for displaying animated GIFs and WEBPs that play and pause on interaction.
 layout: component
 category: Imagery
-synonyms: ["gif", "webp", "motion image"]
-use-cases: ["animated gif", "play pause image", "hover animation"]
+synonyms:
+  - gif
+  - webp
+  - motion image
+use-cases:
+  - animated gif
+  - play pause image
+  - hover animation
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/animated-image.md
+++ b/packages/webawesome/docs/docs/components/animated-image.md
@@ -3,6 +3,8 @@ title: Animated Image
 description: A component for displaying animated GIFs and WEBPs that play and pause on interaction.
 layout: component
 category: Imagery
+synonyms: ["gif", "webp", "motion image"]
+use-cases: ["animated gif", "play pause image", "hover animation"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/animation.md
+++ b/packages/webawesome/docs/docs/components/animation.md
@@ -3,6 +3,8 @@ title: Animation
 description: Animate elements declaratively with nearly 100 baked-in presets, or roll your own with custom keyframes.
 layout: component
 category: Utilities
+synonyms: ["motion", "transition", "keyframes", "animate"]
+use-cases: ["entrance animation", "exit animation", "attention seeker", "scroll animation"]
 ---
 
 To animate an element, wrap it in `<wa-animation>` and set an animation `name`. The animation will not start until you add the `play` attribute. Refer to the [properties table](#properties) for a list of all animation options.

--- a/packages/webawesome/docs/docs/components/animation.md
+++ b/packages/webawesome/docs/docs/components/animation.md
@@ -3,8 +3,16 @@ title: Animation
 description: Animate elements declaratively with nearly 100 baked-in presets, or roll your own with custom keyframes.
 layout: component
 category: Utilities
-synonyms: ["motion", "transition", "keyframes", "animate"]
-use-cases: ["entrance animation", "exit animation", "attention seeker", "scroll animation"]
+synonyms:
+  - motion
+  - transition
+  - keyframes
+  - animate
+use-cases:
+  - entrance animation
+  - exit animation
+  - attention seeker
+  - scroll animation
 ---
 
 To animate an element, wrap it in `<wa-animation>` and set an animation `name`. The animation will not start until you add the `play` attribute. Refer to the [properties table](#properties) for a list of all animation options.

--- a/packages/webawesome/docs/docs/components/avatar.md
+++ b/packages/webawesome/docs/docs/components/avatar.md
@@ -3,8 +3,16 @@ title: Avatar
 description: Avatars are used to represent a person or object.
 layout: component
 category: Imagery
-synonyms: ["profile picture", "user image", "profile photo", "user icon"]
-use-cases: ["user profile", "initials", "placeholder image", "gravatar"]
+synonyms:
+  - profile picture
+  - user image
+  - profile photo
+  - user icon
+use-cases:
+  - user profile
+  - initials
+  - placeholder image
+  - gravatar
 ---
 
 By default, a generic icon will be shown. You can personalize avatars by adding custom icons, initials, and images. You should always provide a `label` for assistive devices.

--- a/packages/webawesome/docs/docs/components/avatar.md
+++ b/packages/webawesome/docs/docs/components/avatar.md
@@ -3,6 +3,8 @@ title: Avatar
 description: Avatars are used to represent a person or object.
 layout: component
 category: Imagery
+synonyms: ["profile picture", "user image", "profile photo", "user icon"]
+use-cases: ["user profile", "initials", "placeholder image", "gravatar"]
 ---
 
 By default, a generic icon will be shown. You can personalize avatars by adding custom icons, initials, and images. You should always provide a `label` for assistive devices.

--- a/packages/webawesome/docs/docs/components/badge.md
+++ b/packages/webawesome/docs/docs/components/badge.md
@@ -3,8 +3,17 @@ title: Badge
 description: Badges are used to draw attention and display statuses or counts.
 layout: component
 category: Feedback & Status
-synonyms: ["chip", "label", "count", "indicator", "pill"]
-use-cases: ["notification count", "status indicator", "unread count", "new indicator"]
+synonyms:
+  - chip
+  - label
+  - count
+  - indicator
+  - pill
+use-cases:
+  - notification count
+  - status indicator
+  - unread count
+  - new indicator
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/badge.md
+++ b/packages/webawesome/docs/docs/components/badge.md
@@ -3,6 +3,8 @@ title: Badge
 description: Badges are used to draw attention and display statuses or counts.
 layout: component
 category: Feedback & Status
+synonyms: ["chip", "label", "count", "indicator", "pill"]
+use-cases: ["notification count", "status indicator", "unread count", "new indicator"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/breadcrumb-item.md
+++ b/packages/webawesome/docs/docs/components/breadcrumb-item.md
@@ -3,8 +3,12 @@ title: Breadcrumb Item
 description: Breadcrumb Items are used inside breadcrumbs to represent different links.
 layout: component
 category: Navigation
-synonyms: ["breadcrumb link", "crumb"]
-use-cases: ["navigation link", "path segment"]
+synonyms:
+  - breadcrumb link
+  - crumb
+use-cases:
+  - navigation link
+  - path segment
 ---
 
 This component must be used as a child of `<wa-breadcrumb>`. Please see the [Breadcrumb docs](/docs/components/breadcrumb) to see examples of this component in action.

--- a/packages/webawesome/docs/docs/components/breadcrumb-item.md
+++ b/packages/webawesome/docs/docs/components/breadcrumb-item.md
@@ -3,6 +3,8 @@ title: Breadcrumb Item
 description: Breadcrumb Items are used inside breadcrumbs to represent different links.
 layout: component
 category: Navigation
+synonyms: ["breadcrumb link", "crumb"]
+use-cases: ["navigation link", "path segment"]
 ---
 
 This component must be used as a child of `<wa-breadcrumb>`. Please see the [Breadcrumb docs](/docs/components/breadcrumb) to see examples of this component in action.

--- a/packages/webawesome/docs/docs/components/breadcrumb.md
+++ b/packages/webawesome/docs/docs/components/breadcrumb.md
@@ -3,8 +3,14 @@ title: Breadcrumb
 description: Breadcrumbs provide a group of links so users can easily navigate a website's hierarchy.
 layout: component
 category: Navigation
-synonyms: ["breadcrumbs", "navigation trail", "path"]
-use-cases: ["wayfinding", "site navigation", "hierarchy navigation"]
+synonyms:
+  - breadcrumbs
+  - navigation trail
+  - path
+use-cases:
+  - wayfinding
+  - site navigation
+  - hierarchy navigation
 ---
 
 Breadcrumbs are usually placed before a page's main content with the current page shown last to indicate the user's position in the navigation.

--- a/packages/webawesome/docs/docs/components/breadcrumb.md
+++ b/packages/webawesome/docs/docs/components/breadcrumb.md
@@ -3,6 +3,8 @@ title: Breadcrumb
 description: Breadcrumbs provide a group of links so users can easily navigate a website's hierarchy.
 layout: component
 category: Navigation
+synonyms: ["breadcrumbs", "navigation trail", "path"]
+use-cases: ["wayfinding", "site navigation", "hierarchy navigation"]
 ---
 
 Breadcrumbs are usually placed before a page's main content with the current page shown last to indicate the user's position in the navigation.

--- a/packages/webawesome/docs/docs/components/button-group.md
+++ b/packages/webawesome/docs/docs/components/button-group.md
@@ -3,8 +3,15 @@ title: Button Group
 description: Button groups can be used to group related buttons into sections.
 layout: component
 category: Actions
-synonyms: ["button bar", "toolbar", "action group", "segmented control"]
-use-cases: ["toggle group", "split button", "grouped actions"]
+synonyms:
+  - button bar
+  - toolbar
+  - action group
+  - segmented control
+use-cases:
+  - toggle group
+  - split button
+  - grouped actions
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/button-group.md
+++ b/packages/webawesome/docs/docs/components/button-group.md
@@ -3,6 +3,8 @@ title: Button Group
 description: Button groups can be used to group related buttons into sections.
 layout: component
 category: Actions
+synonyms: ["button bar", "toolbar", "action group", "segmented control"]
+use-cases: ["toggle group", "split button", "grouped actions"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/button.md
+++ b/packages/webawesome/docs/docs/components/button.md
@@ -3,6 +3,8 @@ title: Button
 description: Buttons represent actions that are available to the user.
 layout: component
 category: Actions
+synonyms: ["btn", "action", "CTA", "submit"]
+use-cases: ["form submit", "link button", "icon button", "loading button"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/button.md
+++ b/packages/webawesome/docs/docs/components/button.md
@@ -3,8 +3,16 @@ title: Button
 description: Buttons represent actions that are available to the user.
 layout: component
 category: Actions
-synonyms: ["btn", "action", "CTA", "submit"]
-use-cases: ["form submit", "link button", "icon button", "loading button"]
+synonyms:
+  - btn
+  - action
+  - CTA
+  - submit
+use-cases:
+  - form submit
+  - link button
+  - icon button
+  - loading button
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/callout.md
+++ b/packages/webawesome/docs/docs/components/callout.md
@@ -3,8 +3,17 @@ title: Callout
 description: Callouts are used to display important messages inline.
 layout: component
 category: Feedback & Status
-synonyms: ["alert", "admonition", "notice", "banner", "infobox"]
-use-cases: ["warning message", "info message", "tip", "important note"]
+synonyms:
+  - alert
+  - admonition
+  - notice
+  - banner
+  - infobox
+use-cases:
+  - warning message
+  - info message
+  - tip
+  - important note
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/callout.md
+++ b/packages/webawesome/docs/docs/components/callout.md
@@ -3,6 +3,8 @@ title: Callout
 description: Callouts are used to display important messages inline.
 layout: component
 category: Feedback & Status
+synonyms: ["alert", "admonition", "notice", "banner", "infobox"]
+use-cases: ["warning message", "info message", "tip", "important note"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/card.md
+++ b/packages/webawesome/docs/docs/components/card.md
@@ -3,8 +3,16 @@ title: Card
 description: Cards can be used to group related subjects in a container.
 layout: component
 category: Organization
-synonyms: ["tile", "panel", "content box", "surface"]
-use-cases: ["product card", "info card", "media card", "feature card"]
+synonyms:
+  - tile
+  - panel
+  - content box
+  - surface
+use-cases:
+  - product card
+  - info card
+  - media card
+  - feature card
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/card.md
+++ b/packages/webawesome/docs/docs/components/card.md
@@ -3,6 +3,8 @@ title: Card
 description: Cards can be used to group related subjects in a container.
 layout: component
 category: Organization
+synonyms: ["tile", "panel", "content box", "surface"]
+use-cases: ["product card", "info card", "media card", "feature card"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/carousel-item.md
+++ b/packages/webawesome/docs/docs/components/carousel-item.md
@@ -3,8 +3,12 @@ title: Carousel Item
 description: A carousel item represent a slide within a carousel.
 layout: component
 category: Imagery
-synonyms: ["slide", "carousel slide"]
-use-cases: ["carousel content", "slide content"]
+synonyms:
+  - slide
+  - carousel slide
+use-cases:
+  - carousel content
+  - slide content
 ---
 
 This component must be used as a child of `<wa-carousel>`. Please see the [Carousel docs](/docs/components/carousel) to see examples of this component in action.

--- a/packages/webawesome/docs/docs/components/carousel-item.md
+++ b/packages/webawesome/docs/docs/components/carousel-item.md
@@ -3,6 +3,8 @@ title: Carousel Item
 description: A carousel item represent a slide within a carousel.
 layout: component
 category: Imagery
+synonyms: ["slide", "carousel slide"]
+use-cases: ["carousel content", "slide content"]
 ---
 
 This component must be used as a child of `<wa-carousel>`. Please see the [Carousel docs](/docs/components/carousel) to see examples of this component in action.

--- a/packages/webawesome/docs/docs/components/carousel.md
+++ b/packages/webawesome/docs/docs/components/carousel.md
@@ -3,6 +3,8 @@ title: Carousel
 description: Carousels display an arbitrary number of content slides along a horizontal or vertical axis.
 layout: component
 category: Imagery
+synonyms: ["slider", "slideshow", "image gallery", "rotator", "swiper"]
+use-cases: ["image carousel", "testimonial slider", "hero slider", "product gallery"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/carousel.md
+++ b/packages/webawesome/docs/docs/components/carousel.md
@@ -3,8 +3,17 @@ title: Carousel
 description: Carousels display an arbitrary number of content slides along a horizontal or vertical axis.
 layout: component
 category: Imagery
-synonyms: ["slider", "slideshow", "image gallery", "rotator", "swiper"]
-use-cases: ["image carousel", "testimonial slider", "hero slider", "product gallery"]
+synonyms:
+  - slider
+  - slideshow
+  - image gallery
+  - rotator
+  - swiper
+use-cases:
+  - image carousel
+  - testimonial slider
+  - hero slider
+  - product gallery
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/checkbox.md
+++ b/packages/webawesome/docs/docs/components/checkbox.md
@@ -3,8 +3,15 @@ title: Checkbox
 description: Checkboxes allow the user to toggle an option on or off.
 layout: component
 category: Form Controls
-synonyms: ["check", "tick", "checkmark"]
-use-cases: ["boolean toggle", "multi-select option", "terms agreement", "todo item"]
+synonyms:
+  - check
+  - tick
+  - checkmark
+use-cases:
+  - boolean toggle
+  - multi-select option
+  - terms agreement
+  - todo item
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/checkbox.md
+++ b/packages/webawesome/docs/docs/components/checkbox.md
@@ -3,6 +3,8 @@ title: Checkbox
 description: Checkboxes allow the user to toggle an option on or off.
 layout: component
 category: Form Controls
+synonyms: ["check", "tick", "checkmark"]
+use-cases: ["boolean toggle", "multi-select option", "terms agreement", "todo item"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/color-picker.md
+++ b/packages/webawesome/docs/docs/components/color-picker.md
@@ -3,6 +3,8 @@ title: Color Picker
 description: Color pickers allow the user to select a color.
 layout: component
 category: Form Controls
+synonyms: ["color chooser", "color selector", "colour picker", "eyedropper"]
+use-cases: ["color input", "hex picker", "rgb picker", "hsl picker"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/color-picker.md
+++ b/packages/webawesome/docs/docs/components/color-picker.md
@@ -3,8 +3,16 @@ title: Color Picker
 description: Color pickers allow the user to select a color.
 layout: component
 category: Form Controls
-synonyms: ["color chooser", "color selector", "colour picker", "eyedropper"]
-use-cases: ["color input", "hex picker", "rgb picker", "hsl picker"]
+synonyms:
+  - color chooser
+  - color selector
+  - colour picker
+  - eyedropper
+use-cases:
+  - color input
+  - hex picker
+  - rgb picker
+  - hsl picker
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/comparison.md
+++ b/packages/webawesome/docs/docs/components/comparison.md
@@ -3,8 +3,14 @@ title: Comparison
 description: Compare visual differences between similar content with a sliding panel.
 layout: component
 category: Imagery
-synonyms: ["before after", "image compare", "diff slider"]
-use-cases: ["image diff", "visual comparison", "slider comparison"]
+synonyms:
+  - before after
+  - image compare
+  - diff slider
+use-cases:
+  - image diff
+  - visual comparison
+  - slider comparison
 ---
 
 This is especially useful for comparing images, but can be used for comparing any type of content (for an example of using it to compare entire UIs, check out our [theme page](/docs/themes)).

--- a/packages/webawesome/docs/docs/components/comparison.md
+++ b/packages/webawesome/docs/docs/components/comparison.md
@@ -3,6 +3,8 @@ title: Comparison
 description: Compare visual differences between similar content with a sliding panel.
 layout: component
 category: Imagery
+synonyms: ["before after", "image compare", "diff slider"]
+use-cases: ["image diff", "visual comparison", "slider comparison"]
 ---
 
 This is especially useful for comparing images, but can be used for comparing any type of content (for an example of using it to compare entire UIs, check out our [theme page](/docs/themes)).

--- a/packages/webawesome/docs/docs/components/copy-button.md
+++ b/packages/webawesome/docs/docs/components/copy-button.md
@@ -3,6 +3,8 @@ title: Copy Button
 description: Copies data to the clipboard when the user clicks the button.
 layout: component
 category: Actions
+synonyms: ["clipboard", "copy to clipboard", "copy icon"]
+use-cases: ["code copy", "text copy", "share link"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/copy-button.md
+++ b/packages/webawesome/docs/docs/components/copy-button.md
@@ -3,8 +3,14 @@ title: Copy Button
 description: Copies data to the clipboard when the user clicks the button.
 layout: component
 category: Actions
-synonyms: ["clipboard", "copy to clipboard", "copy icon"]
-use-cases: ["code copy", "text copy", "share link"]
+synonyms:
+  - clipboard
+  - copy to clipboard
+  - copy icon
+use-cases:
+  - code copy
+  - text copy
+  - share link
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/details.md
+++ b/packages/webawesome/docs/docs/components/details.md
@@ -3,8 +3,17 @@ title: Details
 description: Details show a brief summary and expand to show additional content.
 layout: component
 category: Organization
-synonyms: ["accordion", "collapsible", "expandable", "disclosure", "expander"]
-use-cases: ["FAQ", "show more", "expandable section", "toggle content"]
+synonyms:
+  - accordion
+  - collapsible
+  - expandable
+  - disclosure
+  - expander
+use-cases:
+  - FAQ
+  - show more
+  - expandable section
+  - toggle content
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/details.md
+++ b/packages/webawesome/docs/docs/components/details.md
@@ -3,6 +3,8 @@ title: Details
 description: Details show a brief summary and expand to show additional content.
 layout: component
 category: Organization
+synonyms: ["accordion", "collapsible", "expandable", "disclosure", "expander"]
+use-cases: ["FAQ", "show more", "expandable section", "toggle content"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/dialog.md
+++ b/packages/webawesome/docs/docs/components/dialog.md
@@ -3,6 +3,8 @@ title: Dialog
 description: 'Dialogs, sometimes called "modals", appear above the page and require the user''s immediate attention.'
 layout: component
 category: Organization
+synonyms: ["modal", "popup", "lightbox", "overlay", "modal dialog"]
+use-cases: ["confirmation dialog", "alert dialog", "prompt", "login modal", "cookie consent"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/dialog.md
+++ b/packages/webawesome/docs/docs/components/dialog.md
@@ -3,8 +3,18 @@ title: Dialog
 description: 'Dialogs, sometimes called "modals", appear above the page and require the user''s immediate attention.'
 layout: component
 category: Organization
-synonyms: ["modal", "popup", "lightbox", "overlay", "modal dialog"]
-use-cases: ["confirmation dialog", "alert dialog", "prompt", "login modal", "cookie consent"]
+synonyms:
+  - modal
+  - popup
+  - lightbox
+  - overlay
+  - modal dialog
+use-cases:
+  - confirmation dialog
+  - alert dialog
+  - prompt
+  - login modal
+  - cookie consent
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/divider.md
+++ b/packages/webawesome/docs/docs/components/divider.md
@@ -3,8 +3,16 @@ title: Divider
 description: Dividers are used to visually separate or group elements.
 layout: component
 category: Organization
-synonyms: ["separator", "rule", "line", "hr", "horizontal rule"]
-use-cases: ["section divider", "content separator", "visual break"]
+synonyms:
+  - separator
+  - rule
+  - line
+  - hr
+  - horizontal rule
+use-cases:
+  - section divider
+  - content separator
+  - visual break
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/divider.md
+++ b/packages/webawesome/docs/docs/components/divider.md
@@ -3,6 +3,8 @@ title: Divider
 description: Dividers are used to visually separate or group elements.
 layout: component
 category: Organization
+synonyms: ["separator", "rule", "line", "hr", "horizontal rule"]
+use-cases: ["section divider", "content separator", "visual break"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/drawer.md
+++ b/packages/webawesome/docs/docs/components/drawer.md
@@ -3,8 +3,18 @@ title: Drawer
 description: Drawers slide in from a container to expose additional options and information.
 layout: component
 category: Organization
-synonyms: ["sidebar", "side panel", "offcanvas", "slide-out", "tray", "sheet"]
-use-cases: ["navigation drawer", "filter panel", "mobile menu", "bottom sheet"]
+synonyms:
+  - sidebar
+  - side panel
+  - offcanvas
+  - slide-out
+  - tray
+  - sheet
+use-cases:
+  - navigation drawer
+  - filter panel
+  - mobile menu
+  - bottom sheet
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/drawer.md
+++ b/packages/webawesome/docs/docs/components/drawer.md
@@ -3,6 +3,8 @@ title: Drawer
 description: Drawers slide in from a container to expose additional options and information.
 layout: component
 category: Organization
+synonyms: ["sidebar", "side panel", "offcanvas", "slide-out", "tray", "sheet"]
+use-cases: ["navigation drawer", "filter panel", "mobile menu", "bottom sheet"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/dropdown-item.md
+++ b/packages/webawesome/docs/docs/components/dropdown-item.md
@@ -3,6 +3,8 @@ title: Dropdown Item
 description: Provides items to select in a dropdown.
 layout: component
 category: Actions
+synonyms: ["menu item", "action item", "list item"]
+use-cases: ["dropdown option", "menu option", "command"]
 ---
 
 This component must be used as a child of `<wa-dropdown>`. Please see the [Dropdown docs](/docs/components/dropdown) to see examples of this component in action.

--- a/packages/webawesome/docs/docs/components/dropdown-item.md
+++ b/packages/webawesome/docs/docs/components/dropdown-item.md
@@ -3,8 +3,14 @@ title: Dropdown Item
 description: Provides items to select in a dropdown.
 layout: component
 category: Actions
-synonyms: ["menu item", "action item", "list item"]
-use-cases: ["dropdown option", "menu option", "command"]
+synonyms:
+  - menu item
+  - action item
+  - list item
+use-cases:
+  - dropdown option
+  - menu option
+  - command
 ---
 
 This component must be used as a child of `<wa-dropdown>`. Please see the [Dropdown docs](/docs/components/dropdown) to see examples of this component in action.

--- a/packages/webawesome/docs/docs/components/dropdown.md
+++ b/packages/webawesome/docs/docs/components/dropdown.md
@@ -3,6 +3,8 @@ title: Dropdown
 description: 'Dropdowns expose additional content that "drops down" in a panel.'
 layout: component
 category: Actions
+synonyms: ["menu", "context menu", "action menu", "popout"]
+use-cases: ["dropdown menu", "action list", "command menu", "right-click menu"]
 ---
 
 Dropdowns consist of a trigger and a panel. By default, activating the trigger will expose the panel and interacting outside of the panel will close it.

--- a/packages/webawesome/docs/docs/components/dropdown.md
+++ b/packages/webawesome/docs/docs/components/dropdown.md
@@ -3,8 +3,16 @@ title: Dropdown
 description: 'Dropdowns expose additional content that "drops down" in a panel.'
 layout: component
 category: Actions
-synonyms: ["menu", "context menu", "action menu", "popout"]
-use-cases: ["dropdown menu", "action list", "command menu", "right-click menu"]
+synonyms:
+  - menu
+  - context menu
+  - action menu
+  - popout
+use-cases:
+  - dropdown menu
+  - action list
+  - command menu
+  - right-click menu
 ---
 
 Dropdowns consist of a trigger and a panel. By default, activating the trigger will expose the panel and interacting outside of the panel will close it.

--- a/packages/webawesome/docs/docs/components/format-bytes.md
+++ b/packages/webawesome/docs/docs/components/format-bytes.md
@@ -3,8 +3,14 @@ title: Format Bytes
 description: Formats a number as a human readable bytes value.
 layout: component
 category: Utilities
-synonyms: ["file size", "byte formatter", "size formatter"]
-use-cases: ["human readable bytes", "storage size", "download size"]
+synonyms:
+  - file size
+  - byte formatter
+  - size formatter
+use-cases:
+  - human readable bytes
+  - storage size
+  - download size
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/format-bytes.md
+++ b/packages/webawesome/docs/docs/components/format-bytes.md
@@ -3,6 +3,8 @@ title: Format Bytes
 description: Formats a number as a human readable bytes value.
 layout: component
 category: Utilities
+synonyms: ["file size", "byte formatter", "size formatter"]
+use-cases: ["human readable bytes", "storage size", "download size"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/format-date.md
+++ b/packages/webawesome/docs/docs/components/format-date.md
@@ -3,8 +3,14 @@ title: Format Date
 description: Formats a date/time using the specified locale and options.
 layout: component
 category: Utilities
-synonyms: ["date formatter", "time formatter", "datetime"]
-use-cases: ["localized date", "date display", "timestamp"]
+synonyms:
+  - date formatter
+  - time formatter
+  - datetime
+use-cases:
+  - localized date
+  - date display
+  - timestamp
 ---
 
 Localization is handled by the browser's [`Intl.DateTimeFormat` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat). No language packs are required.

--- a/packages/webawesome/docs/docs/components/format-date.md
+++ b/packages/webawesome/docs/docs/components/format-date.md
@@ -3,6 +3,8 @@ title: Format Date
 description: Formats a date/time using the specified locale and options.
 layout: component
 category: Utilities
+synonyms: ["date formatter", "time formatter", "datetime"]
+use-cases: ["localized date", "date display", "timestamp"]
 ---
 
 Localization is handled by the browser's [`Intl.DateTimeFormat` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat). No language packs are required.

--- a/packages/webawesome/docs/docs/components/format-number.md
+++ b/packages/webawesome/docs/docs/components/format-number.md
@@ -3,8 +3,14 @@ title: Format Number
 description: Formats a number using the specified locale and options.
 layout: component
 category: Utilities
-synonyms: ["number formatter", "currency", "percent"]
-use-cases: ["localized number", "decimal format", "currency display"]
+synonyms:
+  - number formatter
+  - currency
+  - percent
+use-cases:
+  - localized number
+  - decimal format
+  - currency display
 ---
 
 Localization is handled by the browser's [`Intl.NumberFormat` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat). No language packs are required.

--- a/packages/webawesome/docs/docs/components/format-number.md
+++ b/packages/webawesome/docs/docs/components/format-number.md
@@ -3,6 +3,8 @@ title: Format Number
 description: Formats a number using the specified locale and options.
 layout: component
 category: Utilities
+synonyms: ["number formatter", "currency", "percent"]
+use-cases: ["localized number", "decimal format", "currency display"]
 ---
 
 Localization is handled by the browser's [`Intl.NumberFormat` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat). No language packs are required.

--- a/packages/webawesome/docs/docs/components/icon.md
+++ b/packages/webawesome/docs/docs/components/icon.md
@@ -3,6 +3,8 @@ title: Icon
 description: Icons are symbols that can be used to represent various options within an application.
 layout: component
 category: Imagery
+synonyms: ["symbol", "glyph", "pictogram", "fa icon"]
+use-cases: ["icon button", "status icon", "navigation icon"]
 ---
 
 Web Awesome comes bundled with over 2,000 free icons courtesy of [Font Awesome](https://fontawesome.com/). These icons are part of the `default` icon library. Font Awesome Pro users can unlock additional icon families. Or, if you prefer, you can register your own [custom icon library](#icon-library).

--- a/packages/webawesome/docs/docs/components/icon.md
+++ b/packages/webawesome/docs/docs/components/icon.md
@@ -3,8 +3,15 @@ title: Icon
 description: Icons are symbols that can be used to represent various options within an application.
 layout: component
 category: Imagery
-synonyms: ["symbol", "glyph", "pictogram", "fa icon"]
-use-cases: ["icon button", "status icon", "navigation icon"]
+synonyms:
+  - symbol
+  - glyph
+  - pictogram
+  - fa icon
+use-cases:
+  - icon button
+  - status icon
+  - navigation icon
 ---
 
 Web Awesome comes bundled with over 2,000 free icons courtesy of [Font Awesome](https://fontawesome.com/). These icons are part of the `default` icon library. Font Awesome Pro users can unlock additional icon families. Or, if you prefer, you can register your own [custom icon library](#icon-library).

--- a/packages/webawesome/docs/docs/components/include.md
+++ b/packages/webawesome/docs/docs/components/include.md
@@ -3,6 +3,8 @@ title: Include
 description: Includes give you the power to embed external HTML files into the page.
 layout: component
 category: Utilities
+synonyms: ["html include", "embed", "html import"]
+use-cases: ["external content", "partial", "server-side include"]
 ---
 
 Included files are asynchronously requested using `window.fetch()`. Requests are cached, so the same file can be included multiple times, but only one request will be made.

--- a/packages/webawesome/docs/docs/components/include.md
+++ b/packages/webawesome/docs/docs/components/include.md
@@ -3,8 +3,14 @@ title: Include
 description: Includes give you the power to embed external HTML files into the page.
 layout: component
 category: Utilities
-synonyms: ["html include", "embed", "html import"]
-use-cases: ["external content", "partial", "server-side include"]
+synonyms:
+  - html include
+  - embed
+  - html import
+use-cases:
+  - external content
+  - partial
+  - server-side include
 ---
 
 Included files are asynchronously requested using `window.fetch()`. Requests are cached, so the same file can be included multiple times, but only one request will be made.

--- a/packages/webawesome/docs/docs/components/input.md
+++ b/packages/webawesome/docs/docs/components/input.md
@@ -3,8 +3,17 @@ title: Input
 description: Inputs collect data from the user.
 layout: component
 category: Form Controls
-synonyms: ["text field", "text box", "form field", "text input"]
-use-cases: ["form input", "search box", "email field", "password field", "url field"]
+synonyms:
+  - text field
+  - text box
+  - form field
+  - text input
+use-cases:
+  - form input
+  - search box
+  - email field
+  - password field
+  - url field
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/input.md
+++ b/packages/webawesome/docs/docs/components/input.md
@@ -3,6 +3,8 @@ title: Input
 description: Inputs collect data from the user.
 layout: component
 category: Form Controls
+synonyms: ["text field", "text box", "form field", "text input"]
+use-cases: ["form input", "search box", "email field", "password field", "url field"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/intersection-observer.md
+++ b/packages/webawesome/docs/docs/components/intersection-observer.md
@@ -3,8 +3,14 @@ title: Intersection Observer
 description: Tracks immediate child elements and fires events as they move in and out of view.
 layout: component
 category: Utilities
-synonyms: ["scroll spy", "lazy load trigger", "viewport observer"]
-use-cases: ["infinite scroll", "scroll tracking", "element visibility"]
+synonyms:
+  - scroll spy
+  - lazy load trigger
+  - viewport observer
+use-cases:
+  - infinite scroll
+  - scroll tracking
+  - element visibility
 ---
 
 This component leverages the [IntersectionObserver API](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver) to track when its direct children enter or leave a designated root element. The `wa-intersect` event fires whenever elements cross the visibility threshold.

--- a/packages/webawesome/docs/docs/components/intersection-observer.md
+++ b/packages/webawesome/docs/docs/components/intersection-observer.md
@@ -3,6 +3,8 @@ title: Intersection Observer
 description: Tracks immediate child elements and fires events as they move in and out of view.
 layout: component
 category: Utilities
+synonyms: ["scroll spy", "lazy load trigger", "viewport observer"]
+use-cases: ["infinite scroll", "scroll tracking", "element visibility"]
 ---
 
 This component leverages the [IntersectionObserver API](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver) to track when its direct children enter or leave a designated root element. The `wa-intersect` event fires whenever elements cross the visibility threshold.

--- a/packages/webawesome/docs/docs/components/markdown.md
+++ b/packages/webawesome/docs/docs/components/markdown.md
@@ -3,6 +3,8 @@ title: Markdown
 description: A declarative utility that renders markdown in plain ol' HTML pages.
 layout: component
 category: Utilities
+synonyms: ["md", "markdown renderer", "rich text"]
+use-cases: ["markdown display", "markdown preview", "content rendering"]
 ---
 
 The markdown component turns raw markdown into rendered HTML using the [Marked](https://marked.js.org/) library. Indentation is handled automatically. You can nest your markdown at any depth to match the surrounding HTML structure and the common leading whitespace will be stripped before parsing.

--- a/packages/webawesome/docs/docs/components/markdown.md
+++ b/packages/webawesome/docs/docs/components/markdown.md
@@ -3,8 +3,14 @@ title: Markdown
 description: A declarative utility that renders markdown in plain ol' HTML pages.
 layout: component
 category: Utilities
-synonyms: ["md", "markdown renderer", "rich text"]
-use-cases: ["markdown display", "markdown preview", "content rendering"]
+synonyms:
+  - md
+  - markdown renderer
+  - rich text
+use-cases:
+  - markdown display
+  - markdown preview
+  - content rendering
 ---
 
 The markdown component turns raw markdown into rendered HTML using the [Marked](https://marked.js.org/) library. Indentation is handled automatically. You can nest your markdown at any depth to match the surrounding HTML structure and the common leading whitespace will be stripped before parsing.

--- a/packages/webawesome/docs/docs/components/mutation-observer.md
+++ b/packages/webawesome/docs/docs/components/mutation-observer.md
@@ -3,8 +3,14 @@ title: Mutation Observer
 description: The Mutation Observer component offers a thin, declarative interface to the MutationObserver API.
 layout: component
 category: Utilities
-synonyms: ["dom watcher", "dom observer", "change detector"]
-use-cases: ["dom changes", "attribute watcher", "child list observer"]
+synonyms:
+  - dom watcher
+  - dom observer
+  - change detector
+use-cases:
+  - dom changes
+  - attribute watcher
+  - child list observer
 ---
 
 The mutation observer will report changes to the content it wraps through the `wa-mutation` event. When emitted, a collection of [MutationRecord](https://developer.mozilla.org/en-US/docs/Web/API/MutationRecord) objects will be attached to `event.detail` that contains information about how it changed.

--- a/packages/webawesome/docs/docs/components/mutation-observer.md
+++ b/packages/webawesome/docs/docs/components/mutation-observer.md
@@ -3,6 +3,8 @@ title: Mutation Observer
 description: The Mutation Observer component offers a thin, declarative interface to the MutationObserver API.
 layout: component
 category: Utilities
+synonyms: ["dom watcher", "dom observer", "change detector"]
+use-cases: ["dom changes", "attribute watcher", "child list observer"]
 ---
 
 The mutation observer will report changes to the content it wraps through the `wa-mutation` event. When emitted, a collection of [MutationRecord](https://developer.mozilla.org/en-US/docs/Web/API/MutationRecord) objects will be attached to `event.detail` that contains information about how it changed.

--- a/packages/webawesome/docs/docs/components/number-input.md
+++ b/packages/webawesome/docs/docs/components/number-input.md
@@ -3,6 +3,8 @@ title: Number Input
 description: Number inputs allow users to enter and edit numeric values with optional stepper buttons.
 layout: component
 category: Form Controls
+synonyms: ["numeric input", "stepper", "spin button", "counter"]
+use-cases: ["quantity selector", "increment decrement", "numeric field"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/number-input.md
+++ b/packages/webawesome/docs/docs/components/number-input.md
@@ -3,8 +3,15 @@ title: Number Input
 description: Number inputs allow users to enter and edit numeric values with optional stepper buttons.
 layout: component
 category: Form Controls
-synonyms: ["numeric input", "stepper", "spin button", "counter"]
-use-cases: ["quantity selector", "increment decrement", "numeric field"]
+synonyms:
+  - numeric input
+  - stepper
+  - spin button
+  - counter
+use-cases:
+  - quantity selector
+  - increment decrement
+  - numeric field
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/option.md
+++ b/packages/webawesome/docs/docs/components/option.md
@@ -3,6 +3,8 @@ title: Option
 description: Options define the selectable items within various form controls such as select.
 layout: component
 category: Form Controls
+synonyms: ["select option", "list option", "choice"]
+use-cases: ["dropdown option", "select item", "pick list item"]
 ---
 
 This component must be used as a child of `<wa-select>`. Please see the [Select docs](/docs/components/select) to see examples of this component in action.

--- a/packages/webawesome/docs/docs/components/option.md
+++ b/packages/webawesome/docs/docs/components/option.md
@@ -3,8 +3,14 @@ title: Option
 description: Options define the selectable items within various form controls such as select.
 layout: component
 category: Form Controls
-synonyms: ["select option", "list option", "choice"]
-use-cases: ["dropdown option", "select item", "pick list item"]
+synonyms:
+  - select option
+  - list option
+  - choice
+use-cases:
+  - dropdown option
+  - select item
+  - pick list item
 ---
 
 This component must be used as a child of `<wa-select>`. Please see the [Select docs](/docs/components/select) to see examples of this component in action.

--- a/packages/webawesome/docs/docs/components/page.md
+++ b/packages/webawesome/docs/docs/components/page.md
@@ -3,6 +3,8 @@ title: Page
 description: Pages offer an easy way to scaffold entire page layouts using minimal markup.
 layout: component
 category: Organization
+synonyms: ["layout", "page layout", "scaffold", "shell"]
+use-cases: ["app layout", "page structure", "content layout", "sidebar layout"]
 ---
 
 The page component is designed to power full webpages. It is flexible enough to handle most modern designs and includes a simple mechanism for handling desktop and mobile navigation.

--- a/packages/webawesome/docs/docs/components/page.md
+++ b/packages/webawesome/docs/docs/components/page.md
@@ -3,8 +3,16 @@ title: Page
 description: Pages offer an easy way to scaffold entire page layouts using minimal markup.
 layout: component
 category: Organization
-synonyms: ["layout", "page layout", "scaffold", "shell"]
-use-cases: ["app layout", "page structure", "content layout", "sidebar layout"]
+synonyms:
+  - layout
+  - page layout
+  - scaffold
+  - shell
+use-cases:
+  - app layout
+  - page structure
+  - content layout
+  - sidebar layout
 ---
 
 The page component is designed to power full webpages. It is flexible enough to handle most modern designs and includes a simple mechanism for handling desktop and mobile navigation.

--- a/packages/webawesome/docs/docs/components/popover.md
+++ b/packages/webawesome/docs/docs/components/popover.md
@@ -3,8 +3,15 @@ title: Popover
 description: Popovers display interactive content when their anchor element is clicked.
 layout: component
 category: Utilities
-synonyms: ["popup content", "info popup", "interactive popup"]
-use-cases: ["rich tooltip", "hover card", "info popover", "click popup"]
+synonyms:
+  - popup content
+  - info popup
+  - interactive popup
+use-cases:
+  - rich tooltip
+  - hover card
+  - info popover
+  - click popup
 ---
 
 Popovers display interactive content when their anchor element is clicked. Unlike [tooltips](/docs/components/tooltip), popovers can contain links, buttons, and form controls. They appear without an overlay and will close when you click outside or press [[Escape]]. Only one popover can be open at a time.

--- a/packages/webawesome/docs/docs/components/popover.md
+++ b/packages/webawesome/docs/docs/components/popover.md
@@ -3,6 +3,8 @@ title: Popover
 description: Popovers display interactive content when their anchor element is clicked.
 layout: component
 category: Utilities
+synonyms: ["popup content", "info popup", "interactive popup"]
+use-cases: ["rich tooltip", "hover card", "info popover", "click popup"]
 ---
 
 Popovers display interactive content when their anchor element is clicked. Unlike [tooltips](/docs/components/tooltip), popovers can contain links, buttons, and form controls. They appear without an overlay and will close when you click outside or press [[Escape]]. Only one popover can be open at a time.

--- a/packages/webawesome/docs/docs/components/popup.md
+++ b/packages/webawesome/docs/docs/components/popup.md
@@ -3,6 +3,8 @@ title: Popup
 description: 'Popup is a utility that lets you declaratively anchor "popup" containers to another element.'
 layout: component
 category: Utilities
+synonyms: ["floating element", "anchor", "positioned element"]
+use-cases: ["tooltip anchor", "dropdown anchor", "floating UI"]
 ---
 
 This component's name is inspired by [`<popup>`](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/Popup/explainer.md). It uses [Floating UI](https://floating-ui.com/) under the hood to provide a well-tested, lightweight, and fully declarative positioning utility for tooltips, dropdowns, and more.

--- a/packages/webawesome/docs/docs/components/popup.md
+++ b/packages/webawesome/docs/docs/components/popup.md
@@ -3,8 +3,14 @@ title: Popup
 description: 'Popup is a utility that lets you declaratively anchor "popup" containers to another element.'
 layout: component
 category: Utilities
-synonyms: ["floating element", "anchor", "positioned element"]
-use-cases: ["tooltip anchor", "dropdown anchor", "floating UI"]
+synonyms:
+  - floating element
+  - anchor
+  - positioned element
+use-cases:
+  - tooltip anchor
+  - dropdown anchor
+  - floating UI
 ---
 
 This component's name is inspired by [`<popup>`](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/Popup/explainer.md). It uses [Floating UI](https://floating-ui.com/) under the hood to provide a well-tested, lightweight, and fully declarative positioning utility for tooltips, dropdowns, and more.

--- a/packages/webawesome/docs/docs/components/progress-bar.md
+++ b/packages/webawesome/docs/docs/components/progress-bar.md
@@ -3,6 +3,8 @@ title: Progress Bar
 description: Progress bars are used to show the status of an ongoing operation.
 layout: component
 category: Feedback & Status
+synonyms: ["loading bar", "progress indicator", "status bar"]
+use-cases: ["upload progress", "download progress", "step progress"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/progress-bar.md
+++ b/packages/webawesome/docs/docs/components/progress-bar.md
@@ -3,8 +3,14 @@ title: Progress Bar
 description: Progress bars are used to show the status of an ongoing operation.
 layout: component
 category: Feedback & Status
-synonyms: ["loading bar", "progress indicator", "status bar"]
-use-cases: ["upload progress", "download progress", "step progress"]
+synonyms:
+  - loading bar
+  - progress indicator
+  - status bar
+use-cases:
+  - upload progress
+  - download progress
+  - step progress
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/progress-ring.md
+++ b/packages/webawesome/docs/docs/components/progress-ring.md
@@ -3,8 +3,14 @@ title: Progress Ring
 description: Progress rings are used to show the progress of a determinate operation in a circular fashion.
 layout: component
 category: Feedback & Status
-synonyms: ["circular progress", "donut chart", "radial progress"]
-use-cases: ["loading spinner", "circular loader", "completion ring"]
+synonyms:
+  - circular progress
+  - donut chart
+  - radial progress
+use-cases:
+  - loading spinner
+  - circular loader
+  - completion ring
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/progress-ring.md
+++ b/packages/webawesome/docs/docs/components/progress-ring.md
@@ -3,6 +3,8 @@ title: Progress Ring
 description: Progress rings are used to show the progress of a determinate operation in a circular fashion.
 layout: component
 category: Feedback & Status
+synonyms: ["circular progress", "donut chart", "radial progress"]
+use-cases: ["loading spinner", "circular loader", "completion ring"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/qr-code.md
+++ b/packages/webawesome/docs/docs/components/qr-code.md
@@ -3,6 +3,8 @@ title: QR Code
 description: Generates a QR code and renders it using the Canvas API.
 layout: component
 category: Actions
+synonyms: ["barcode", "quick response code"]
+use-cases: ["scan code", "share link", "payment code"]
 ---
 
 QR codes are useful for providing small pieces of information to users who can quickly scan them with a smartphone. Most smartphones have built-in QR code scanners, so simply pointing the camera at a QR code will decode it and allow the user to visit a website, dial a phone number, read a message, etc.

--- a/packages/webawesome/docs/docs/components/qr-code.md
+++ b/packages/webawesome/docs/docs/components/qr-code.md
@@ -3,8 +3,13 @@ title: QR Code
 description: Generates a QR code and renders it using the Canvas API.
 layout: component
 category: Actions
-synonyms: ["barcode", "quick response code"]
-use-cases: ["scan code", "share link", "payment code"]
+synonyms:
+  - barcode
+  - quick response code
+use-cases:
+  - scan code
+  - share link
+  - payment code
 ---
 
 QR codes are useful for providing small pieces of information to users who can quickly scan them with a smartphone. Most smartphones have built-in QR code scanners, so simply pointing the camera at a QR code will decode it and allow the user to visit a website, dial a phone number, read a message, etc.

--- a/packages/webawesome/docs/docs/components/radio-group.md
+++ b/packages/webawesome/docs/docs/components/radio-group.md
@@ -3,6 +3,8 @@ title: Radio Group
 description: Radio groups are used to group multiple radios so they function as a single form control.
 layout: component
 category: Form Controls
+synonyms: ["radio buttons", "option group", "button group"]
+use-cases: ["single select group", "exclusive options"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/radio-group.md
+++ b/packages/webawesome/docs/docs/components/radio-group.md
@@ -3,8 +3,13 @@ title: Radio Group
 description: Radio groups are used to group multiple radios so they function as a single form control.
 layout: component
 category: Form Controls
-synonyms: ["radio buttons", "option group", "button group"]
-use-cases: ["single select group", "exclusive options"]
+synonyms:
+  - radio buttons
+  - option group
+  - button group
+use-cases:
+  - single select group
+  - exclusive options
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/radio.md
+++ b/packages/webawesome/docs/docs/components/radio.md
@@ -3,8 +3,12 @@ title: Radio
 description: Radios allow the user to select a single option from a group.
 layout: component
 category: Form Controls
-synonyms: ["radio button", "option button"]
-use-cases: ["single select", "exclusive choice"]
+synonyms:
+  - radio button
+  - option button
+use-cases:
+  - single select
+  - exclusive choice
 ---
 
 This component must be used as a child of `<wa-radio-group>`. Please see the [Radio Group docs](/docs/components/radio-group) to see examples of this component in action.

--- a/packages/webawesome/docs/docs/components/radio.md
+++ b/packages/webawesome/docs/docs/components/radio.md
@@ -3,6 +3,8 @@ title: Radio
 description: Radios allow the user to select a single option from a group.
 layout: component
 category: Form Controls
+synonyms: ["radio button", "option button"]
+use-cases: ["single select", "exclusive choice"]
 ---
 
 This component must be used as a child of `<wa-radio-group>`. Please see the [Radio Group docs](/docs/components/radio-group) to see examples of this component in action.

--- a/packages/webawesome/docs/docs/components/rating.md
+++ b/packages/webawesome/docs/docs/components/rating.md
@@ -3,6 +3,8 @@ title: Rating
 description: Ratings give users a way to quickly view and provide feedback.
 layout: component
 category: Form Controls
+synonyms: ["stars", "star rating", "review"]
+use-cases: ["feedback", "score", "5 stars", "thumbs up"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/rating.md
+++ b/packages/webawesome/docs/docs/components/rating.md
@@ -3,8 +3,15 @@ title: Rating
 description: Ratings give users a way to quickly view and provide feedback.
 layout: component
 category: Form Controls
-synonyms: ["stars", "star rating", "review"]
-use-cases: ["feedback", "score", "5 stars", "thumbs up"]
+synonyms:
+  - stars
+  - star rating
+  - review
+use-cases:
+  - feedback
+  - score
+  - 5 stars
+  - thumbs up
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/relative-time.md
+++ b/packages/webawesome/docs/docs/components/relative-time.md
@@ -3,8 +3,15 @@ title: Relative Time
 description: Outputs a localized time phrase relative to the current date and time.
 layout: component
 category: Utilities
-synonyms: ["time ago", "timeago", "moment", "from now"]
-use-cases: ["posted ago", "last updated", "time since"]
+synonyms:
+  - time ago
+  - timeago
+  - moment
+  - from now
+use-cases:
+  - posted ago
+  - last updated
+  - time since
 ---
 
 Localization is handled by the browser's [`Intl.RelativeTimeFormat` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat). No language packs are required.

--- a/packages/webawesome/docs/docs/components/relative-time.md
+++ b/packages/webawesome/docs/docs/components/relative-time.md
@@ -3,6 +3,8 @@ title: Relative Time
 description: Outputs a localized time phrase relative to the current date and time.
 layout: component
 category: Utilities
+synonyms: ["time ago", "timeago", "moment", "from now"]
+use-cases: ["posted ago", "last updated", "time since"]
 ---
 
 Localization is handled by the browser's [`Intl.RelativeTimeFormat` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat). No language packs are required.

--- a/packages/webawesome/docs/docs/components/resize-observer.md
+++ b/packages/webawesome/docs/docs/components/resize-observer.md
@@ -3,8 +3,14 @@ title: Resize Observer
 description: The Resize Observer component offers a thin, declarative interface to the ResizeObserver API.
 layout: component
 category: Utilities
-synonyms: ["size watcher", "resize listener", "dimension observer"]
-use-cases: ["responsive component", "size tracking", "container query"]
+synonyms:
+  - size watcher
+  - resize listener
+  - dimension observer
+use-cases:
+  - responsive component
+  - size tracking
+  - container query
 ---
 
 The resize observer will report changes to the dimensions of the elements it wraps through the `wa-resize` event. When emitted, a collection of [`ResizeObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry) objects will be attached to `event.detail` that contains the target element and information about its dimensions.

--- a/packages/webawesome/docs/docs/components/resize-observer.md
+++ b/packages/webawesome/docs/docs/components/resize-observer.md
@@ -3,6 +3,8 @@ title: Resize Observer
 description: The Resize Observer component offers a thin, declarative interface to the ResizeObserver API.
 layout: component
 category: Utilities
+synonyms: ["size watcher", "resize listener", "dimension observer"]
+use-cases: ["responsive component", "size tracking", "container query"]
 ---
 
 The resize observer will report changes to the dimensions of the elements it wraps through the `wa-resize` event. When emitted, a collection of [`ResizeObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry) objects will be attached to `event.detail` that contains the target element and information about its dimensions.

--- a/packages/webawesome/docs/docs/components/scroller.md
+++ b/packages/webawesome/docs/docs/components/scroller.md
@@ -3,6 +3,8 @@ title: Scroller
 description: Scrollers create an accessible container while providing visual cues that help users identify and navigate through content that scrolls.
 layout: component
 category: Organization
+synonyms: ["scrollable", "scroll container", "overflow"]
+use-cases: ["horizontal scroll", "scroll area", "scrollable list"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/scroller.md
+++ b/packages/webawesome/docs/docs/components/scroller.md
@@ -3,8 +3,14 @@ title: Scroller
 description: Scrollers create an accessible container while providing visual cues that help users identify and navigate through content that scrolls.
 layout: component
 category: Organization
-synonyms: ["scrollable", "scroll container", "overflow"]
-use-cases: ["horizontal scroll", "scroll area", "scrollable list"]
+synonyms:
+  - scrollable
+  - scroll container
+  - overflow
+use-cases:
+  - horizontal scroll
+  - scroll area
+  - scrollable list
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/select.md
+++ b/packages/webawesome/docs/docs/components/select.md
@@ -3,8 +3,17 @@ title: Select
 description: Selects allow you to choose items from a menu of predefined options.
 layout: component
 category: Form Controls
-synonyms: ["dropdown select", "combobox", "picker", "chooser", "pulldown"]
-use-cases: ["form select", "option picker", "single select", "multi select"]
+synonyms:
+  - dropdown select
+  - combobox
+  - picker
+  - chooser
+  - pulldown
+use-cases:
+  - form select
+  - option picker
+  - single select
+  - multi select
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/select.md
+++ b/packages/webawesome/docs/docs/components/select.md
@@ -3,6 +3,8 @@ title: Select
 description: Selects allow you to choose items from a menu of predefined options.
 layout: component
 category: Form Controls
+synonyms: ["dropdown select", "combobox", "picker", "chooser", "pulldown"]
+use-cases: ["form select", "option picker", "single select", "multi select"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/skeleton.md
+++ b/packages/webawesome/docs/docs/components/skeleton.md
@@ -3,8 +3,15 @@ title: Skeleton
 description: Skeletons are used to provide a visual representation of where content will eventually be drawn.
 layout: component
 category: Feedback & Status
-synonyms: ["placeholder", "shimmer", "loading placeholder", "ghost"]
-use-cases: ["content loader", "skeleton screen", "loading state"]
+synonyms:
+  - placeholder
+  - shimmer
+  - loading placeholder
+  - ghost
+use-cases:
+  - content loader
+  - skeleton screen
+  - loading state
 ---
 
 These are simple containers for scaffolding layouts that mimic what users will see when content has finished loading. This prevents large areas of empty space during asynchronous operations.

--- a/packages/webawesome/docs/docs/components/skeleton.md
+++ b/packages/webawesome/docs/docs/components/skeleton.md
@@ -3,6 +3,8 @@ title: Skeleton
 description: Skeletons are used to provide a visual representation of where content will eventually be drawn.
 layout: component
 category: Feedback & Status
+synonyms: ["placeholder", "shimmer", "loading placeholder", "ghost"]
+use-cases: ["content loader", "skeleton screen", "loading state"]
 ---
 
 These are simple containers for scaffolding layouts that mimic what users will see when content has finished loading. This prevents large areas of empty space during asynchronous operations.

--- a/packages/webawesome/docs/docs/components/slider.md
+++ b/packages/webawesome/docs/docs/components/slider.md
@@ -3,8 +3,16 @@ title: Slider
 description: Ranges allow the user to select a single value within a given range using a slider.
 layout: component
 category: Form Controls
-synonyms: ["range", "range slider", "range input", "scrubber"]
-use-cases: ["volume control", "price range", "filter range", "seek bar"]
+synonyms:
+  - range
+  - range slider
+  - range input
+  - scrubber
+use-cases:
+  - volume control
+  - price range
+  - filter range
+  - seek bar
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/slider.md
+++ b/packages/webawesome/docs/docs/components/slider.md
@@ -3,6 +3,8 @@ title: Slider
 description: Ranges allow the user to select a single value within a given range using a slider.
 layout: component
 category: Form Controls
+synonyms: ["range", "range slider", "range input", "scrubber"]
+use-cases: ["volume control", "price range", "filter range", "seek bar"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/spinner.md
+++ b/packages/webawesome/docs/docs/components/spinner.md
@@ -3,8 +3,15 @@ title: Spinner
 description: Spinners are used to show the progress of an indeterminate operation.
 layout: component
 category: Feedback & Status
-synonyms: ["loading", "loader", "busy indicator", "throbber"]
-use-cases: ["loading animation", "indeterminate progress", "ajax loader"]
+synonyms:
+  - loading
+  - loader
+  - busy indicator
+  - throbber
+use-cases:
+  - loading animation
+  - indeterminate progress
+  - ajax loader
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/spinner.md
+++ b/packages/webawesome/docs/docs/components/spinner.md
@@ -3,6 +3,8 @@ title: Spinner
 description: Spinners are used to show the progress of an indeterminate operation.
 layout: component
 category: Feedback & Status
+synonyms: ["loading", "loader", "busy indicator", "throbber"]
+use-cases: ["loading animation", "indeterminate progress", "ajax loader"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/split-panel.md
+++ b/packages/webawesome/docs/docs/components/split-panel.md
@@ -3,8 +3,15 @@ title: Split Panel
 description: Split panels display two adjacent panels, allowing the user to reposition them.
 layout: component
 category: Organization
-synonyms: ['resizable panels', 'pane splitter', 'split view', 'splitter']
-use-cases: ['code editor layout', 'side by side', 'resizable columns']
+synonyms:
+  - resizable panels
+  - pane splitter
+  - split view
+  - splitter
+use-cases:
+  - code editor layout
+  - side by side
+  - resizable columns
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/split-panel.md
+++ b/packages/webawesome/docs/docs/components/split-panel.md
@@ -3,8 +3,8 @@ title: Split Panel
 description: Split panels display two adjacent panels, allowing the user to reposition them.
 layout: component
 category: Organization
-synonyms: ["resizable panels", "pane splitter", "split view"]
-use-cases: ["code editor layout", "side by side", "resizable columns"]
+synonyms: ['resizable panels', 'pane splitter', 'split view', 'splitter']
+use-cases: ['code editor layout', 'side by side', 'resizable columns']
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/split-panel.md
+++ b/packages/webawesome/docs/docs/components/split-panel.md
@@ -3,6 +3,8 @@ title: Split Panel
 description: Split panels display two adjacent panels, allowing the user to reposition them.
 layout: component
 category: Organization
+synonyms: ["resizable panels", "pane splitter", "split view"]
+use-cases: ["code editor layout", "side by side", "resizable columns"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/switch.md
+++ b/packages/webawesome/docs/docs/components/switch.md
@@ -3,6 +3,8 @@ title: Switch
 description: Switches allow the user to toggle an option on or off.
 layout: component
 category: Form Controls
+synonyms: ["toggle", "toggle switch", "on off"]
+use-cases: ["boolean toggle", "setting toggle", "dark mode toggle"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/switch.md
+++ b/packages/webawesome/docs/docs/components/switch.md
@@ -3,8 +3,14 @@ title: Switch
 description: Switches allow the user to toggle an option on or off.
 layout: component
 category: Form Controls
-synonyms: ["toggle", "toggle switch", "on off"]
-use-cases: ["boolean toggle", "setting toggle", "dark mode toggle"]
+synonyms:
+  - toggle
+  - toggle switch
+  - on off
+use-cases:
+  - boolean toggle
+  - setting toggle
+  - dark mode toggle
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/tab-group.md
+++ b/packages/webawesome/docs/docs/components/tab-group.md
@@ -3,6 +3,8 @@ title: Tab Group
 description: Tab groups organize content into a container that shows one section at a time.
 layout: component
 category: Navigation
+synonyms: ["tabs", "tabbed interface", "tab bar", "tab panel", "tab set"]
+use-cases: ["tabbed content", "tab navigation", "settings tabs"]
 ---
 
 Tab groups make use of [tabs](/docs/components/tab) and [tab panels](/docs/components/tab-panel). Each panel should have a name that's unique within the tab group, and tabs should have a `panel` attribute that points to the respective panel's name.

--- a/packages/webawesome/docs/docs/components/tab-group.md
+++ b/packages/webawesome/docs/docs/components/tab-group.md
@@ -3,8 +3,16 @@ title: Tab Group
 description: Tab groups organize content into a container that shows one section at a time.
 layout: component
 category: Navigation
-synonyms: ["tabs", "tabbed interface", "tab bar", "tab panel", "tab set"]
-use-cases: ["tabbed content", "tab navigation", "settings tabs"]
+synonyms:
+  - tabs
+  - tabbed interface
+  - tab bar
+  - tab panel
+  - tab set
+use-cases:
+  - tabbed content
+  - tab navigation
+  - settings tabs
 ---
 
 Tab groups make use of [tabs](/docs/components/tab) and [tab panels](/docs/components/tab-panel). Each panel should have a name that's unique within the tab group, and tabs should have a `panel` attribute that points to the respective panel's name.

--- a/packages/webawesome/docs/docs/components/tab-panel.md
+++ b/packages/webawesome/docs/docs/components/tab-panel.md
@@ -3,6 +3,8 @@ title: Tab Panel
 description: Tab panels are used inside tab groups to display tabbed content.
 layout: component
 category: Navigation
+synonyms: ["tab content", "tab pane"]
+use-cases: ["tab body", "tab section"]
 ---
 
 This component must be used as a child of `<wa-tab-group>`. Please see the [Tab Group docs](/docs/components/tab-group) to see examples of this component in action.

--- a/packages/webawesome/docs/docs/components/tab-panel.md
+++ b/packages/webawesome/docs/docs/components/tab-panel.md
@@ -3,8 +3,12 @@ title: Tab Panel
 description: Tab panels are used inside tab groups to display tabbed content.
 layout: component
 category: Navigation
-synonyms: ["tab content", "tab pane"]
-use-cases: ["tab body", "tab section"]
+synonyms:
+  - tab content
+  - tab pane
+use-cases:
+  - tab body
+  - tab section
 ---
 
 This component must be used as a child of `<wa-tab-group>`. Please see the [Tab Group docs](/docs/components/tab-group) to see examples of this component in action.

--- a/packages/webawesome/docs/docs/components/tab.md
+++ b/packages/webawesome/docs/docs/components/tab.md
@@ -3,6 +3,8 @@ title: Tab
 description: Tabs are used inside tab groups to represent and activate tab panels.
 layout: component
 category: Navigation
+synonyms: ["tab button", "tab header"]
+use-cases: ["tab label", "tab trigger"]
 ---
 
 This component must be used as a child of `<wa-tab-group>`. Please see the [Tab Group docs](/docs/components/tab-group) to see examples of this component in action.

--- a/packages/webawesome/docs/docs/components/tab.md
+++ b/packages/webawesome/docs/docs/components/tab.md
@@ -3,8 +3,12 @@ title: Tab
 description: Tabs are used inside tab groups to represent and activate tab panels.
 layout: component
 category: Navigation
-synonyms: ["tab button", "tab header"]
-use-cases: ["tab label", "tab trigger"]
+synonyms:
+  - tab button
+  - tab header
+use-cases:
+  - tab label
+  - tab trigger
 ---
 
 This component must be used as a child of `<wa-tab-group>`. Please see the [Tab Group docs](/docs/components/tab-group) to see examples of this component in action.

--- a/packages/webawesome/docs/docs/components/tag.md
+++ b/packages/webawesome/docs/docs/components/tag.md
@@ -3,8 +3,17 @@ title: Tag
 description: Tags are used as labels to organize things or to indicate a selection.
 layout: component
 category: Feedback & Status
-synonyms: ["chip", "label", "pill", "token", "badge"]
-use-cases: ["filter tag", "removable tag", "category label", "keyword"]
+synonyms:
+  - chip
+  - label
+  - pill
+  - token
+  - badge
+use-cases:
+  - filter tag
+  - removable tag
+  - category label
+  - keyword
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/tag.md
+++ b/packages/webawesome/docs/docs/components/tag.md
@@ -3,6 +3,8 @@ title: Tag
 description: Tags are used as labels to organize things or to indicate a selection.
 layout: component
 category: Feedback & Status
+synonyms: ["chip", "label", "pill", "token", "badge"]
+use-cases: ["filter tag", "removable tag", "category label", "keyword"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/textarea.md
+++ b/packages/webawesome/docs/docs/components/textarea.md
@@ -3,8 +3,15 @@ title: Textarea
 description: Textareas collect data from the user and allow multiple lines of text.
 layout: component
 category: Form Controls
-synonyms: ["text area", "multiline input", "text box"]
-use-cases: ["comment box", "message input", "description field", "code input"]
+synonyms:
+  - text area
+  - multiline input
+  - text box
+use-cases:
+  - comment box
+  - message input
+  - description field
+  - code input
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/textarea.md
+++ b/packages/webawesome/docs/docs/components/textarea.md
@@ -3,6 +3,8 @@ title: Textarea
 description: Textareas collect data from the user and allow multiple lines of text.
 layout: component
 category: Form Controls
+synonyms: ["text area", "multiline input", "text box"]
+use-cases: ["comment box", "message input", "description field", "code input"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/tooltip.md
+++ b/packages/webawesome/docs/docs/components/tooltip.md
@@ -3,8 +3,15 @@ title: Tooltip
 description: Tooltips display additional information based on a specific action.
 layout: component
 category: Feedback & Status
-synonyms: ["hint", "hover text", "info bubble", "title attribute"]
-use-cases: ["help text", "contextual help", "hover info"]
+synonyms:
+  - hint
+  - hover text
+  - info bubble
+  - title attribute
+use-cases:
+  - help text
+  - contextual help
+  - hover info
 ---
 
 A tooltip's target is based on the `for` attribute which points to an element id.

--- a/packages/webawesome/docs/docs/components/tooltip.md
+++ b/packages/webawesome/docs/docs/components/tooltip.md
@@ -3,6 +3,8 @@ title: Tooltip
 description: Tooltips display additional information based on a specific action.
 layout: component
 category: Feedback & Status
+synonyms: ["hint", "hover text", "info bubble", "title attribute"]
+use-cases: ["help text", "contextual help", "hover info"]
 ---
 
 A tooltip's target is based on the `for` attribute which points to an element id.

--- a/packages/webawesome/docs/docs/components/tree-item.md
+++ b/packages/webawesome/docs/docs/components/tree-item.md
@@ -3,8 +3,14 @@ title: Tree Item
 description: A tree item serves as a hierarchical node that lives inside a tree.
 layout: component
 category: Navigation
-synonyms: ["tree node", "tree leaf", "tree branch"]
-use-cases: ["file node", "folder", "nested item"]
+synonyms:
+  - tree node
+  - tree leaf
+  - tree branch
+use-cases:
+  - file node
+  - folder
+  - nested item
 ---
 
 This component must be used as a child of `<wa-tree>`. Please see the [Tree docs](/docs/components/tree) to see examples of this component in action.

--- a/packages/webawesome/docs/docs/components/tree-item.md
+++ b/packages/webawesome/docs/docs/components/tree-item.md
@@ -3,6 +3,8 @@ title: Tree Item
 description: A tree item serves as a hierarchical node that lives inside a tree.
 layout: component
 category: Navigation
+synonyms: ["tree node", "tree leaf", "tree branch"]
+use-cases: ["file node", "folder", "nested item"]
 ---
 
 This component must be used as a child of `<wa-tree>`. Please see the [Tree docs](/docs/components/tree) to see examples of this component in action.

--- a/packages/webawesome/docs/docs/components/tree.md
+++ b/packages/webawesome/docs/docs/components/tree.md
@@ -3,8 +3,16 @@ title: Tree
 description: Trees allow you to display a hierarchical list of selectable tree items. Items with children can be expanded and collapsed as desired by the user.
 layout: component
 category: Navigation
-synonyms: ["treeview", "tree view", "file tree", "hierarchy"]
-use-cases: ["file browser", "directory tree", "nested list", "org chart"]
+synonyms:
+  - treeview
+  - tree view
+  - file tree
+  - hierarchy
+use-cases:
+  - file browser
+  - directory tree
+  - nested list
+  - org chart
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/tree.md
+++ b/packages/webawesome/docs/docs/components/tree.md
@@ -3,6 +3,8 @@ title: Tree
 description: Trees allow you to display a hierarchical list of selectable tree items. Items with children can be expanded and collapsed as desired by the user.
 layout: component
 category: Navigation
+synonyms: ["treeview", "tree view", "file tree", "hierarchy"]
+use-cases: ["file browser", "directory tree", "nested list", "org chart"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/zoomable-frame.md
+++ b/packages/webawesome/docs/docs/components/zoomable-frame.md
@@ -3,6 +3,8 @@ title: Zoomable Frame
 description: Zoomable frames render iframe content with zoom and interaction controls.
 layout: component
 category: Imagery
+synonyms: ["iframe zoom", "preview frame", "minimap"]
+use-cases: ["component preview", "responsive preview", "scaled iframe"]
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/zoomable-frame.md
+++ b/packages/webawesome/docs/docs/components/zoomable-frame.md
@@ -3,8 +3,14 @@ title: Zoomable Frame
 description: Zoomable frames render iframe content with zoom and interaction controls.
 layout: component
 category: Imagery
-synonyms: ["iframe zoom", "preview frame", "minimap"]
-use-cases: ["component preview", "responsive preview", "scaled iframe"]
+synonyms:
+  - iframe zoom
+  - preview frame
+  - minimap
+use-cases:
+  - component preview
+  - responsive preview
+  - scaled iframe
 ---
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/customizing.md
+++ b/packages/webawesome/docs/docs/customizing.md
@@ -2,8 +2,16 @@
 title: Customizing
 description: Learn how to customize Web Awesome through themes, parts, and custom properties.
 layout: page-outline
-synonyms: ["theming", "styling", "custom styles", "override"]
-use-cases: ["css custom properties", "css variables", "design tokens", "brand"]
+synonyms:
+  - theming
+  - styling
+  - custom styles
+  - override
+use-cases:
+  - css custom properties
+  - css variables
+  - design tokens
+  - brand
 ---
 
 You can customize the look and feel of Web Awesome at a high level with themes. For more advanced customizations, you can make use of CSS parts and custom properties to target individual components.

--- a/packages/webawesome/docs/docs/customizing.md
+++ b/packages/webawesome/docs/docs/customizing.md
@@ -2,6 +2,8 @@
 title: Customizing
 description: Learn how to customize Web Awesome through themes, parts, and custom properties.
 layout: page-outline
+synonyms: ["theming", "styling", "custom styles", "override"]
+use-cases: ["css custom properties", "css variables", "design tokens", "brand"]
 ---
 
 You can customize the look and feel of Web Awesome at a high level with themes. For more advanced customizations, you can make use of CSS parts and custom properties to target individual components.

--- a/packages/webawesome/docs/docs/form-controls.md
+++ b/packages/webawesome/docs/docs/form-controls.md
@@ -2,8 +2,14 @@
 title: Form Controls
 description: Using Web Awesome form controls.
 layout: page-outline
-synonyms: ["forms", "form elements", "validation"]
-use-cases: ["form handling", "form data", "constraint validation"]
+synonyms:
+  - forms
+  - form elements
+  - validation
+use-cases:
+  - form handling
+  - form data
+  - constraint validation
 ---
 
 Web Awesome form controls are form-associated custom elements, meaning they will submit with forms just like native `<form>` controls. They also support constraint validation, which is the platform's version of client-side form validation.

--- a/packages/webawesome/docs/docs/form-controls.md
+++ b/packages/webawesome/docs/docs/form-controls.md
@@ -2,6 +2,8 @@
 title: Form Controls
 description: Using Web Awesome form controls.
 layout: page-outline
+synonyms: ["forms", "form elements", "validation"]
+use-cases: ["form handling", "form data", "constraint validation"]
 ---
 
 Web Awesome form controls are form-associated custom elements, meaning they will submit with forms just like native `<form>` controls. They also support constraint validation, which is the platform's version of client-side form validation.

--- a/packages/webawesome/docs/docs/frameworks.md
+++ b/packages/webawesome/docs/docs/frameworks.md
@@ -2,6 +2,8 @@
 title: Frameworks
 description: Using Web Awesome with frameworks.
 layout: page-outline
+synonyms: ["integrations", "libraries", "spa"]
+use-cases: ["react", "vue", "angular", "svelte", "next.js"]
 ---
 
 Web Awesome is designed to work in harmony with various frameworks. We have documented some of the most common ones including setup and limitations. Individual frameworks can be found down below:

--- a/packages/webawesome/docs/docs/frameworks.md
+++ b/packages/webawesome/docs/docs/frameworks.md
@@ -2,8 +2,16 @@
 title: Frameworks
 description: Using Web Awesome with frameworks.
 layout: page-outline
-synonyms: ["integrations", "libraries", "spa"]
-use-cases: ["react", "vue", "angular", "svelte", "next.js"]
+synonyms:
+  - integrations
+  - libraries
+  - spa
+use-cases:
+  - react
+  - vue
+  - angular
+  - svelte
+  - next.js
 ---
 
 Web Awesome is designed to work in harmony with various frameworks. We have documented some of the most common ones including setup and limitations. Individual frameworks can be found down below:

--- a/packages/webawesome/docs/docs/localization.md
+++ b/packages/webawesome/docs/docs/localization.md
@@ -2,8 +2,16 @@
 title: Localization
 description: Discover how to localize Web Awesome with minimal effort.
 layout: page-outline
-synonyms: ["i18n", "internationalization", "l10n", "translation"]
-use-cases: ["language", "locale", "rtl", "right to left"]
+synonyms:
+  - i18n
+  - internationalization
+  - l10n
+  - translation
+use-cases:
+  - language
+  - locale
+  - rtl
+  - right to left
 ---
 
 Components can be localized by importing the appropriate translation file and setting the desired [`lang`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang) and/or [`dir`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir) attributes on the `<html>` element. Here's an example that renders Web Awesome components in Spanish.

--- a/packages/webawesome/docs/docs/localization.md
+++ b/packages/webawesome/docs/docs/localization.md
@@ -2,6 +2,8 @@
 title: Localization
 description: Discover how to localize Web Awesome with minimal effort.
 layout: page-outline
+synonyms: ["i18n", "internationalization", "l10n", "translation"]
+use-cases: ["language", "locale", "rtl", "right to left"]
 ---
 
 Components can be localized by importing the appropriate translation file and setting the desired [`lang`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang) and/or [`dir`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/dir) attributes on the `<html>` element. Here's an example that renders Web Awesome components in Spanish.

--- a/packages/webawesome/docs/docs/tokens/borders.md
+++ b/packages/webawesome/docs/docs/tokens/borders.md
@@ -1,6 +1,8 @@
 ---
 title: Borders
 description: Change the edges and corners of your components with Web Awesome's border properties.
+synonyms: ["border", "outline", "stroke"]
+use-cases: ["border width", "border style", "border color"]
 ---
 
 ## Style

--- a/packages/webawesome/docs/docs/tokens/borders.md
+++ b/packages/webawesome/docs/docs/tokens/borders.md
@@ -1,8 +1,14 @@
 ---
 title: Borders
 description: Change the edges and corners of your components with Web Awesome's border properties.
-synonyms: ["border", "outline", "stroke"]
-use-cases: ["border width", "border style", "border color"]
+synonyms:
+  - border
+  - outline
+  - stroke
+use-cases:
+  - border width
+  - border style
+  - border color
 ---
 
 ## Style

--- a/packages/webawesome/docs/docs/tokens/color.md
+++ b/packages/webawesome/docs/docs/tokens/color.md
@@ -2,8 +2,14 @@
 title: Color
 description: Ensure consistent use of color and readable contrast with Web Awesome's color properties.
 hasOutline: true
-synonyms: ["palette", "color system", "color tokens"]
-use-cases: ["theme colors", "brand palette", "semantic colors"]
+synonyms:
+  - palette
+  - color system
+  - color tokens
+use-cases:
+  - theme colors
+  - brand palette
+  - semantic colors
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/tokens/color.md
+++ b/packages/webawesome/docs/docs/tokens/color.md
@@ -2,6 +2,8 @@
 title: Color
 description: Ensure consistent use of color and readable contrast with Web Awesome's color properties.
 hasOutline: true
+synonyms: ["palette", "color system", "color tokens"]
+use-cases: ["theme colors", "brand palette", "semantic colors"]
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/tokens/component-groups.md
+++ b/packages/webawesome/docs/docs/tokens/component-groups.md
@@ -3,6 +3,8 @@ title: Component Groups
 description: Style groups of components that share similar qualities with these Web Awesome custom properties.
 order: 9999
 layout: page-outline
+synonyms: ["component tokens", "group tokens"]
+use-cases: ["shared tokens", "token sets"]
 ---
 
 For components that share similar qualities, Web Awesome includes custom properties to change the appearance of these related components all at once.

--- a/packages/webawesome/docs/docs/tokens/component-groups.md
+++ b/packages/webawesome/docs/docs/tokens/component-groups.md
@@ -3,8 +3,12 @@ title: Component Groups
 description: Style groups of components that share similar qualities with these Web Awesome custom properties.
 order: 9999
 layout: page-outline
-synonyms: ["component tokens", "group tokens"]
-use-cases: ["shared tokens", "token sets"]
+synonyms:
+  - component tokens
+  - group tokens
+use-cases:
+  - shared tokens
+  - token sets
 ---
 
 For components that share similar qualities, Web Awesome includes custom properties to change the appearance of these related components all at once.

--- a/packages/webawesome/docs/docs/tokens/focus.md
+++ b/packages/webawesome/docs/docs/tokens/focus.md
@@ -1,8 +1,14 @@
 ---
 title: Focus
 description: Configure recognizable focus states with Web Awesome's focus properties.
-synonyms: ["focus ring", "focus outline", "focus visible"]
-use-cases: ["keyboard focus", "accessibility focus", "tab focus"]
+synonyms:
+  - focus ring
+  - focus outline
+  - focus visible
+use-cases:
+  - keyboard focus
+  - accessibility focus
+  - tab focus
 ---
 
 A consistent focus ring helps with predictable keyboard navigation. Together with [`--wa-color-focus`](/docs/tokens/color/#interactions), these tokens create a uniform focus state for Web Awesome components.

--- a/packages/webawesome/docs/docs/tokens/focus.md
+++ b/packages/webawesome/docs/docs/tokens/focus.md
@@ -1,6 +1,8 @@
 ---
 title: Focus
 description: Configure recognizable focus states with Web Awesome's focus properties.
+synonyms: ["focus ring", "focus outline", "focus visible"]
+use-cases: ["keyboard focus", "accessibility focus", "tab focus"]
 ---
 
 A consistent focus ring helps with predictable keyboard navigation. Together with [`--wa-color-focus`](/docs/tokens/color/#interactions), these tokens create a uniform focus state for Web Awesome components.

--- a/packages/webawesome/docs/docs/tokens/shadows.md
+++ b/packages/webawesome/docs/docs/tokens/shadows.md
@@ -1,6 +1,8 @@
 ---
 title: Shadows
 description: Elevate your components with Web Awesome's shadow properties.
+synonyms: ["box shadow", "elevation", "depth"]
+use-cases: ["drop shadow", "card shadow", "overlay shadow"]
 ---
 
 Shadows indicate elevation and, often, interactivity. Web Awesome offers highly modular shadow properties to easily create custom shadow effects or transform elements based on specific shadow qualities. Together with [`--wa-color-shadow`](/docs/tokens/color/#shadow), these tokens create realistic shadows for Web Awesome components.

--- a/packages/webawesome/docs/docs/tokens/shadows.md
+++ b/packages/webawesome/docs/docs/tokens/shadows.md
@@ -1,8 +1,14 @@
 ---
 title: Shadows
 description: Elevate your components with Web Awesome's shadow properties.
-synonyms: ["box shadow", "elevation", "depth"]
-use-cases: ["drop shadow", "card shadow", "overlay shadow"]
+synonyms:
+  - box shadow
+  - elevation
+  - depth
+use-cases:
+  - drop shadow
+  - card shadow
+  - overlay shadow
 ---
 
 Shadows indicate elevation and, often, interactivity. Web Awesome offers highly modular shadow properties to easily create custom shadow effects or transform elements based on specific shadow qualities. Together with [`--wa-color-shadow`](/docs/tokens/color/#shadow), these tokens create realistic shadows for Web Awesome components.

--- a/packages/webawesome/docs/docs/tokens/space.md
+++ b/packages/webawesome/docs/docs/tokens/space.md
@@ -1,6 +1,8 @@
 ---
 title: Space
 description: Lock down consistent spacing Web Awesome's space properties.
+synonyms: ["spacing", "spacing scale", "whitespace"]
+use-cases: ["padding", "margin", "gap", "spacing tokens"]
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/tokens/space.md
+++ b/packages/webawesome/docs/docs/tokens/space.md
@@ -1,8 +1,15 @@
 ---
 title: Space
 description: Lock down consistent spacing Web Awesome's space properties.
-synonyms: ["spacing", "spacing scale", "whitespace"]
-use-cases: ["padding", "margin", "gap", "spacing tokens"]
+synonyms:
+  - spacing
+  - spacing scale
+  - whitespace
+use-cases:
+  - padding
+  - margin
+  - gap
+  - spacing tokens
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/tokens/transitions.md
+++ b/packages/webawesome/docs/docs/tokens/transitions.md
@@ -1,6 +1,8 @@
 ---
 title: Transitions
 description: Customize your theme's built-in transitions with Web Awesome's transition properties.
+synonyms: ["animation timing", "easing", "duration"]
+use-cases: ["transition speed", "motion tokens"]
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/tokens/transitions.md
+++ b/packages/webawesome/docs/docs/tokens/transitions.md
@@ -1,8 +1,13 @@
 ---
 title: Transitions
 description: Customize your theme's built-in transitions with Web Awesome's transition properties.
-synonyms: ["animation timing", "easing", "duration"]
-use-cases: ["transition speed", "motion tokens"]
+synonyms:
+  - animation timing
+  - easing
+  - duration
+use-cases:
+  - transition speed
+  - motion tokens
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/tokens/typography.md
+++ b/packages/webawesome/docs/docs/tokens/typography.md
@@ -2,8 +2,15 @@
 title: Typography
 description: Get consistent font styles and vertical rhythm with Web Awesome's typography properties.
 layout: page-outline
-synonyms: ["fonts", "type scale", "font size"]
-use-cases: ["font family", "line height", "font weight", "text tokens"]
+synonyms:
+  - fonts
+  - type scale
+  - font size
+use-cases:
+  - font family
+  - line height
+  - font weight
+  - text tokens
 ---
 
 ## Font Family

--- a/packages/webawesome/docs/docs/tokens/typography.md
+++ b/packages/webawesome/docs/docs/tokens/typography.md
@@ -2,6 +2,8 @@
 title: Typography
 description: Get consistent font styles and vertical rhythm with Web Awesome's typography properties.
 layout: page-outline
+synonyms: ["fonts", "type scale", "font size"]
+use-cases: ["font family", "line height", "font weight", "text tokens"]
 ---
 
 ## Font Family

--- a/packages/webawesome/docs/docs/usage.md
+++ b/packages/webawesome/docs/docs/usage.md
@@ -2,6 +2,8 @@
 title: Usage
 description: Learn more about using custom elements.
 layout: page-outline
+synonyms: ["getting started", "install", "setup", "quickstart"]
+use-cases: ["cdn", "npm install", "import", "autoloader"]
 ---
 
 Web Awesome components are just regular HTML elements, or [custom elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements) to be precise. You can use them like any other element. Each component has detailed documentation that describes its full API, including properties, events, methods, and more.

--- a/packages/webawesome/docs/docs/usage.md
+++ b/packages/webawesome/docs/docs/usage.md
@@ -2,8 +2,16 @@
 title: Usage
 description: Learn more about using custom elements.
 layout: page-outline
-synonyms: ["getting started", "install", "setup", "quickstart"]
-use-cases: ["cdn", "npm install", "import", "autoloader"]
+synonyms:
+  - getting started
+  - install
+  - setup
+  - quickstart
+use-cases:
+  - cdn
+  - npm install
+  - import
+  - autoloader
 ---
 
 Web Awesome components are just regular HTML elements, or [custom elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements) to be precise. You can use them like any other element. Each component has detailed documentation that describes its full API, including properties, events, methods, and more.

--- a/packages/webawesome/docs/docs/utilities/align-items.md
+++ b/packages/webawesome/docs/docs/utilities/align-items.md
@@ -3,6 +3,8 @@ title: Align Items
 description: Control cross-axis alignment in flex and grid containers with align-items and align-self utility classes.
 layout: docs
 tags: layoutUtilities
+synonyms: ["vertical align", "cross axis", "align"]
+use-cases: ["flex align", "grid align", "center vertically"]
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/utilities/align-items.md
+++ b/packages/webawesome/docs/docs/utilities/align-items.md
@@ -3,8 +3,14 @@ title: Align Items
 description: Control cross-axis alignment in flex and grid containers with align-items and align-self utility classes.
 layout: docs
 tags: layoutUtilities
-synonyms: ["vertical align", "cross axis", "align"]
-use-cases: ["flex align", "grid align", "center vertically"]
+synonyms:
+  - vertical align
+  - cross axis
+  - align
+use-cases:
+  - flex align
+  - grid align
+  - center vertically
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/utilities/cluster.md
+++ b/packages/webawesome/docs/docs/utilities/cluster.md
@@ -3,6 +3,8 @@ title: Cluster
 description: 'Use the `wa-cluster` class to arrange elements inline with even spacing, allowing items to wrap when space is limited.'
 layout: docs
 tags: layoutUtilities
+synonyms: ['inline group', 'horizontal group', 'tag group', 'flow layout']
+use-cases: ['button row', 'tag list', 'chip group', 'inline list', 'pill group']
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/utilities/cluster.md
+++ b/packages/webawesome/docs/docs/utilities/cluster.md
@@ -3,8 +3,17 @@ title: Cluster
 description: 'Use the `wa-cluster` class to arrange elements inline with even spacing, allowing items to wrap when space is limited.'
 layout: docs
 tags: layoutUtilities
-synonyms: ['inline group', 'horizontal group', 'tag group', 'flow layout']
-use-cases: ['button row', 'tag list', 'chip group', 'inline list', 'pill group']
+synonyms:
+  - inline group
+  - horizontal group
+  - tag group
+  - flow layout
+use-cases:
+  - button row
+  - tag list
+  - chip group
+  - inline list
+  - pill group
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/utilities/color.md
+++ b/packages/webawesome/docs/docs/utilities/color.md
@@ -3,6 +3,8 @@ title: Color Variants
 description: Color utilities allow you to apply the brand, neutral, success, warning, and danger colors from your theme to any element.
 layout: docs
 tags: styleUtilities
+synonyms: ['text color', 'foreground color', 'colour', 'color utility', 'semantic color']
+use-cases: ['brand color', 'status color', 'theme color', 'background color', 'danger color', 'success color']
 ---
 
 Some Web Awesome components, like `<wa-button>`, allow you to change the color by using a `variant` attribute:

--- a/packages/webawesome/docs/docs/utilities/color.md
+++ b/packages/webawesome/docs/docs/utilities/color.md
@@ -3,8 +3,19 @@ title: Color Variants
 description: Color utilities allow you to apply the brand, neutral, success, warning, and danger colors from your theme to any element.
 layout: docs
 tags: styleUtilities
-synonyms: ['text color', 'foreground color', 'colour', 'color utility', 'semantic color']
-use-cases: ['brand color', 'status color', 'theme color', 'background color', 'danger color', 'success color']
+synonyms:
+  - text color
+  - foreground color
+  - colour
+  - color utility
+  - semantic color
+use-cases:
+  - brand color
+  - status color
+  - theme color
+  - background color
+  - danger color
+  - success color
 ---
 
 Some Web Awesome components, like `<wa-button>`, allow you to change the color by using a `variant` attribute:

--- a/packages/webawesome/docs/docs/utilities/flank.md
+++ b/packages/webawesome/docs/docs/utilities/flank.md
@@ -3,8 +3,14 @@ title: Flank
 description: 'Use the `wa-flank` class to position two items side-by-side, with one item positioned alongside, or _flanking_, content that stretches to fill the available space.'
 layout: docs
 tags: layoutUtilities
-synonyms: ["media object", "side by side", "horizontal layout"]
-use-cases: ["icon and text", "image and content", "avatar with text"]
+synonyms:
+  - media object
+  - side by side
+  - horizontal layout
+use-cases:
+  - icon and text
+  - image and content
+  - avatar with text
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/utilities/flank.md
+++ b/packages/webawesome/docs/docs/utilities/flank.md
@@ -3,6 +3,8 @@ title: Flank
 description: 'Use the `wa-flank` class to position two items side-by-side, with one item positioned alongside, or _flanking_, content that stretches to fill the available space.'
 layout: docs
 tags: layoutUtilities
+synonyms: ["media object", "side by side", "horizontal layout"]
+use-cases: ["icon and text", "image and content", "avatar with text"]
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/utilities/flex-wrap.md
+++ b/packages/webawesome/docs/docs/utilities/flex-wrap.md
@@ -3,8 +3,15 @@ title: Flex Wrap
 description: Flex wrap utilities specify how items within flex containers wrap.
 layout: docs
 tags: layoutUtilities
-synonyms: ['wrapping', 'flow', 'line wrap']
-use-cases: ['responsive wrap', 'multi-line flex', 'flex wrap reverse', 'nowrap']
+synonyms:
+  - wrapping
+  - flow
+  - line wrap
+use-cases:
+  - responsive wrap
+  - multi-line flex
+  - flex wrap reverse
+  - nowrap
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/utilities/flex-wrap.md
+++ b/packages/webawesome/docs/docs/utilities/flex-wrap.md
@@ -3,6 +3,8 @@ title: Flex Wrap
 description: Flex wrap utilities specify how items within flex containers wrap.
 layout: docs
 tags: layoutUtilities
+synonyms: ['wrapping', 'flow', 'line wrap']
+use-cases: ['responsive wrap', 'multi-line flex', 'flex wrap reverse', 'nowrap']
 ---
 
 <style>
@@ -36,8 +38,8 @@ tags: layoutUtilities
 
 Web Awesome includes classes to set the `flex-wrap` property of flex containers. Use them alongside other Web Awesome layout utilities, like [cluster](/docs/utilities/cluster) or [split](/docs/utilities/split), to specify how items in the container wrap.
 
-| Class Name             | `flex-wrap` Value | Preview                                                                                                                                                                            |
-| ---------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `wa-flex-wrap`         | `wrap`            | <div class="wa-cluster wa-gap-2xs wa-flex-wrap preview-wrapper"><div class="preview-block"></div><div class="preview-block"></div><div class="preview-block"></div></div>          |
-| `wa-flex-nowrap`       | `nowrap`          | <div class="wa-cluster wa-gap-2xs wa-flex-nowrap preview-wrapper"><div class="preview-block"></div><div class="preview-block"></div><div class="preview-block"></div></div>        |
-| `wa-flex-wrap-reverse` | `wrap-reverse`    | <div class="wa-cluster wa-gap-2xs wa-flex-wrap-reverse preview-wrapper"><div class="preview-block"></div><div class="preview-block"></div><div class="preview-block"></div></div>  |
+| Class Name             | `flex-wrap` Value | Preview                                                                                                                                                                           |
+| ---------------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `wa-flex-wrap`         | `wrap`            | <div class="wa-cluster wa-gap-2xs wa-flex-wrap preview-wrapper"><div class="preview-block"></div><div class="preview-block"></div><div class="preview-block"></div></div>         |
+| `wa-flex-nowrap`       | `nowrap`          | <div class="wa-cluster wa-gap-2xs wa-flex-nowrap preview-wrapper"><div class="preview-block"></div><div class="preview-block"></div><div class="preview-block"></div></div>       |
+| `wa-flex-wrap-reverse` | `wrap-reverse`    | <div class="wa-cluster wa-gap-2xs wa-flex-wrap-reverse preview-wrapper"><div class="preview-block"></div><div class="preview-block"></div><div class="preview-block"></div></div> |

--- a/packages/webawesome/docs/docs/utilities/fouce.md
+++ b/packages/webawesome/docs/docs/utilities/fouce.md
@@ -3,6 +3,8 @@ title: Reducing FOUCE
 description: Utility to improve the loading experience by hiding non-prerendered custom elements until they are registered.
 layout: docs
 tags: styleUtilities
+synonyms: ['flash of unstyled content', 'custom element flash', 'FOUC', 'CLS']
+use-cases: ['component loading flash', 'undefined element', 'hydration flash', 'layout shift']
 ---
 
 Often, components are shown before their logic and styles have had a chance to load, also known as a [Flash of Undefined Custom Elements](https://www.abeautifulsite.net/posts/flash-of-undefined-custom-elements/).

--- a/packages/webawesome/docs/docs/utilities/fouce.md
+++ b/packages/webawesome/docs/docs/utilities/fouce.md
@@ -3,8 +3,16 @@ title: Reducing FOUCE
 description: Utility to improve the loading experience by hiding non-prerendered custom elements until they are registered.
 layout: docs
 tags: styleUtilities
-synonyms: ['flash of unstyled content', 'custom element flash', 'FOUC', 'CLS']
-use-cases: ['component loading flash', 'undefined element', 'hydration flash', 'layout shift']
+synonyms:
+  - flash of unstyled content
+  - custom element flash
+  - FOUC
+  - CLS
+use-cases:
+  - component loading flash
+  - undefined element
+  - hydration flash
+  - layout shift
 ---
 
 Often, components are shown before their logic and styles have had a chance to load, also known as a [Flash of Undefined Custom Elements](https://www.abeautifulsite.net/posts/flash-of-undefined-custom-elements/).

--- a/packages/webawesome/docs/docs/utilities/frame.md
+++ b/packages/webawesome/docs/docs/utilities/frame.md
@@ -3,8 +3,14 @@ title: Frame
 description: 'Use the `wa-frame` class to create a responsive container with consistent proportions to enclose content.'
 layout: docs
 tags: layoutUtilities
-synonyms: ["aspect ratio", "media frame", "ratio box"]
-use-cases: ["video frame", "image container", "responsive embed"]
+synonyms:
+  - aspect ratio
+  - media frame
+  - ratio box
+use-cases:
+  - video frame
+  - image container
+  - responsive embed
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/utilities/frame.md
+++ b/packages/webawesome/docs/docs/utilities/frame.md
@@ -3,6 +3,8 @@ title: Frame
 description: 'Use the `wa-frame` class to create a responsive container with consistent proportions to enclose content.'
 layout: docs
 tags: layoutUtilities
+synonyms: ["aspect ratio", "media frame", "ratio box"]
+use-cases: ["video frame", "image container", "responsive embed"]
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/utilities/gap.md
+++ b/packages/webawesome/docs/docs/utilities/gap.md
@@ -3,6 +3,8 @@ title: Gap
 description: Gap utilities set the gap property of flex and grid containers, like other Web Awesome layout utilities.
 layout: docs
 tags: layoutUtilities
+synonyms: ["spacing", "gutter", "margin", "space between"]
+use-cases: ["flex gap", "grid gap", "element spacing"]
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/utilities/gap.md
+++ b/packages/webawesome/docs/docs/utilities/gap.md
@@ -3,8 +3,15 @@ title: Gap
 description: Gap utilities set the gap property of flex and grid containers, like other Web Awesome layout utilities.
 layout: docs
 tags: layoutUtilities
-synonyms: ["spacing", "gutter", "margin", "space between"]
-use-cases: ["flex gap", "grid gap", "element spacing"]
+synonyms:
+  - spacing
+  - gutter
+  - margin
+  - space between
+use-cases:
+  - flex gap
+  - grid gap
+  - element spacing
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/utilities/grid.md
+++ b/packages/webawesome/docs/docs/utilities/grid.md
@@ -3,8 +3,15 @@ title: Grid
 description: 'Use the `wa-grid` class to arrange elements into rows and columns that automatically adapt to the available space.'
 layout: docs
 tags: layoutUtilities
-synonyms: ["columns", "layout grid", "css grid"]
-use-cases: ["responsive grid", "card grid", "auto grid", "masonry"]
+synonyms:
+  - columns
+  - layout grid
+  - css grid
+use-cases:
+  - responsive grid
+  - card grid
+  - auto grid
+  - masonry
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/utilities/grid.md
+++ b/packages/webawesome/docs/docs/utilities/grid.md
@@ -3,6 +3,8 @@ title: Grid
 description: 'Use the `wa-grid` class to arrange elements into rows and columns that automatically adapt to the available space.'
 layout: docs
 tags: layoutUtilities
+synonyms: ["columns", "layout grid", "css grid"]
+use-cases: ["responsive grid", "card grid", "auto grid", "masonry"]
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/utilities/justify-content.md
+++ b/packages/webawesome/docs/docs/utilities/justify-content.md
@@ -3,8 +3,14 @@ title: Justify Content
 description: Justify content utilities determine how space is distributed between items in flex and grid containers.
 layout: docs
 tags: layoutUtilities
-synonyms: ["horizontal align", "main axis", "distribute"]
-use-cases: ["flex justify", "space between", "center horizontally"]
+synonyms:
+  - horizontal align
+  - main axis
+  - distribute
+use-cases:
+  - flex justify
+  - space between
+  - center horizontally
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/utilities/justify-content.md
+++ b/packages/webawesome/docs/docs/utilities/justify-content.md
@@ -3,6 +3,8 @@ title: Justify Content
 description: Justify content utilities determine how space is distributed between items in flex and grid containers.
 layout: docs
 tags: layoutUtilities
+synonyms: ["horizontal align", "main axis", "distribute"]
+use-cases: ["flex justify", "space between", "center horizontally"]
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/utilities/native.md
+++ b/packages/webawesome/docs/docs/utilities/native.md
@@ -3,6 +3,8 @@ title: Native Styles
 description: Native styles apply your theme to native HTML elements so they match the look and feel of Web Awesome components.
 layout: page-outline
 tags: styleUtilities
+synonyms: ['browser default', 'native styles', 'global styles']
+use-cases: ['native HTML', 'style native elements', 'reset', 'default styles']
 ---
 
 Native styles use design tokens to spruce up native HTML elements so that they match the look and feel of your theme. While these native styles are completely optional, they're a great starting point for a cohesive design and a huge help when using a combination of native elements and Web Awesome components in your project.
@@ -36,8 +38,9 @@ Or, if you only want styles for native elements, import a theme and native style
 import '@awesome.me/webawesome/dist/styles/themes/default.css';
 import '@awesome.me/webawesome/dist/styles/native.css';
 ```
+
 {% endmarkdown %}
-  </wa-tab-panel>
+</wa-tab-panel>
 
   <wa-tab-panel name="self-hosted">
 {% markdown %}
@@ -53,8 +56,9 @@ Or, if you only want styles for native elements, include a theme and native styl
 <link rel="stylesheet" href="/dist/styles/themes/default.css" />
 <link rel="stylesheet" href="/dist/styles/native.css" />
 ```
+
 {% endmarkdown %}
-  </wa-tab-panel>
+</wa-tab-panel>
 </wa-tab-group>
 
 You can additionally include any pre-made [theme](/docs/themes/) or [color palette](/docs/color-palettes/) to change the look of native elements.
@@ -146,8 +150,8 @@ Create paragraphs with `<p>`. Paragraphs inherit the default text styles set on 
 </p>
 
 <p>
-  You can have as many paragraphs as you need and they'll maintain consistent spacing between them. Native styles
-  ensure everything stays readable and well-proportioned, no matter how much content you throw at it.
+  You can have as many paragraphs as you need and they'll maintain consistent spacing between them. Native styles ensure
+  everything stays readable and well-proportioned, no matter how much content you throw at it.
 </p>
 ```
 

--- a/packages/webawesome/docs/docs/utilities/native.md
+++ b/packages/webawesome/docs/docs/utilities/native.md
@@ -3,8 +3,15 @@ title: Native Styles
 description: Native styles apply your theme to native HTML elements so they match the look and feel of Web Awesome components.
 layout: page-outline
 tags: styleUtilities
-synonyms: ['browser default', 'native styles', 'global styles']
-use-cases: ['native HTML', 'style native elements', 'reset', 'default styles']
+synonyms:
+  - browser default
+  - native styles
+  - global styles
+use-cases:
+  - native HTML
+  - style native elements
+  - reset
+  - default styles
 ---
 
 Native styles use design tokens to spruce up native HTML elements so that they match the look and feel of your theme. While these native styles are completely optional, they're a great starting point for a cohesive design and a huge help when using a combination of native elements and Web Awesome components in your project.

--- a/packages/webawesome/docs/docs/utilities/rounding.md
+++ b/packages/webawesome/docs/docs/utilities/rounding.md
@@ -3,6 +3,8 @@ title: Rounding Utilities
 description: Border radius utilities set an element's border radius property.
 layout: docs
 tags: styleUtilities
+synonyms: ["border radius", "rounded corners", "pill shape"]
+use-cases: ["rounded", "circle", "pill button"]
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/utilities/rounding.md
+++ b/packages/webawesome/docs/docs/utilities/rounding.md
@@ -3,8 +3,14 @@ title: Rounding Utilities
 description: Border radius utilities set an element's border radius property.
 layout: docs
 tags: styleUtilities
-synonyms: ["border radius", "rounded corners", "pill shape"]
-use-cases: ["rounded", "circle", "pill button"]
+synonyms:
+  - border radius
+  - rounded corners
+  - pill shape
+use-cases:
+  - rounded
+  - circle
+  - pill button
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/utilities/split.md
+++ b/packages/webawesome/docs/docs/utilities/split.md
@@ -3,8 +3,14 @@ title: Split
 description: 'Use the `wa-split` class to distribute two or more items evenly across available space, either in a row or a column.'
 layout: docs
 tags: layoutUtilities
-synonyms: ["holy grail", "sidebar layout", "main aside"]
-use-cases: ["two column", "content sidebar", "layout split"]
+synonyms:
+  - holy grail
+  - sidebar layout
+  - main aside
+use-cases:
+  - two column
+  - content sidebar
+  - layout split
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/utilities/split.md
+++ b/packages/webawesome/docs/docs/utilities/split.md
@@ -3,6 +3,8 @@ title: Split
 description: 'Use the `wa-split` class to distribute two or more items evenly across available space, either in a row or a column.'
 layout: docs
 tags: layoutUtilities
+synonyms: ["holy grail", "sidebar layout", "main aside"]
+use-cases: ["two column", "content sidebar", "layout split"]
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/utilities/stack.md
+++ b/packages/webawesome/docs/docs/utilities/stack.md
@@ -3,8 +3,15 @@ title: Stack
 description: 'Use `wa-stack` to arrange elements in the block direction with even spacing.'
 layout: docs
 tags: layoutUtilities
-synonyms: ['vertical stack', 'vstack', 'column layout']
-use-cases: ['vertical spacing', 'stacked layout', 'card stack', 'vertical rhythm']
+synonyms:
+  - vertical stack
+  - vstack
+  - column layout
+use-cases:
+  - vertical spacing
+  - stacked layout
+  - card stack
+  - vertical rhythm
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/utilities/stack.md
+++ b/packages/webawesome/docs/docs/utilities/stack.md
@@ -3,6 +3,8 @@ title: Stack
 description: 'Use `wa-stack` to arrange elements in the block direction with even spacing.'
 layout: docs
 tags: layoutUtilities
+synonyms: ['vertical stack', 'vstack', 'column layout']
+use-cases: ['vertical spacing', 'stacked layout', 'card stack', 'vertical rhythm']
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/utilities/text.md
+++ b/packages/webawesome/docs/docs/utilities/text.md
@@ -3,8 +3,15 @@ title: Text
 description: Text utility classes use custom properties from your Web Awesome theme and other standard CSS properties to style text elements on the fly.
 layout: docs
 tags: styleUtilities
-synonyms: ["typography", "font", "text style"]
-use-cases: ["text size", "text align", "text weight", "truncate"]
+synonyms:
+  - typography
+  - font
+  - text style
+use-cases:
+  - text size
+  - text align
+  - text weight
+  - truncate
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/utilities/text.md
+++ b/packages/webawesome/docs/docs/utilities/text.md
@@ -3,6 +3,8 @@ title: Text
 description: Text utility classes use custom properties from your Web Awesome theme and other standard CSS properties to style text elements on the fly.
 layout: docs
 tags: styleUtilities
+synonyms: ["typography", "font", "text style"]
+use-cases: ["text size", "text align", "text weight", "truncate"]
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/utilities/visually-hidden.md
+++ b/packages/webawesome/docs/docs/utilities/visually-hidden.md
@@ -3,6 +3,8 @@ title: Visually Hidden
 description: The visually hidden utility makes content accessible to assistive devices without displaying it on the screen.
 layout: docs
 tags: styleUtilities
+synonyms: ["screen reader only", "sr-only", "accessible hide"]
+use-cases: ["a11y hide", "skip link", "assistive text"]
 ---
 
 > "There are real world situations where visually hiding content may be appropriate, while the content should remain available to assistive technologies, such as screen readers. For instance, hiding a search field's label as a common magnifying glass icon is used in its stead."

--- a/packages/webawesome/docs/docs/utilities/visually-hidden.md
+++ b/packages/webawesome/docs/docs/utilities/visually-hidden.md
@@ -3,8 +3,14 @@ title: Visually Hidden
 description: The visually hidden utility makes content accessible to assistive devices without displaying it on the screen.
 layout: docs
 tags: styleUtilities
-synonyms: ["screen reader only", "sr-only", "accessible hide"]
-use-cases: ["a11y hide", "skip link", "assistive text"]
+synonyms:
+  - screen reader only
+  - sr-only
+  - accessible hide
+use-cases:
+  - a11y hide
+  - skip link
+  - assistive text
 ---
 
 > "There are real world situations where visually hiding content may be appropriate, while the content should remain available to assistive technologies, such as screen readers. For instance, hiding a search field's label as a common magnifying glass icon is used in its stead."


### PR DESCRIPTION
This work adds `synonyms` and `use-cases` front matter fields to doc pages so the site search can find components by alternative terms. Searching "modal" now finds Dialog, "sidebar" finds Drawer, "accordion" finds Details, etc.

## How it works
The search plugin indexes two new fields at build time with tiered boost weights:
- **Synonyms** (boost 14) — terms that ARE this component by another name (e.g., "modal" for Dialog)
- **Use-cases** (boost 6) — terms describing WHY you'd reach for it (e.g., "cookie consent" for Dialog)
Existing search ranking is preserved. Title matches (20) still rank highest, synonyms slot between title and headings (10), and use-cases slot between headings and body content (1).

## Changes
- `docs/_plugins/search.js` — caches front matter keywords in the preprocessor, merges with HTML data in the transform, adds `s`/`u` fields to MiniSearch index, fixes incremental build cache for the new data format
- `docs/assets/scripts/search.js` — adds new fields to `loadJSON` and sets boost weights
- 89 doc files — curated `synonyms` and `use-cases` for all components, utilities, tokens, and general docs
- 
## Before/after
| Query | Before | After |
|-------|--------|-------|
| sidebar | no results | Drawer |
| accordion | Format Date | Details |
| lightbox | no results | Dialog |
| combobox | Popup | Select |
| offcanvas | no results | Drawer |
| loader | Installation | Spinner |
| dropdown | Dropdown only | Dropdown + Select |
| popup | Popup only | Popup + Dialog |