### PR TITLE
Docs: Use Free Icons in Examples (When Possible)

### DIFF
--- a/packages/webawesome/docs/docs/components/badge.md
+++ b/packages/webawesome/docs/docs/components/badge.md
@@ -133,16 +133,16 @@ Use the `start` and `end` slots to add presentational elements like `<wa-icon>` 
 
 ```html {.example}
 <wa-badge>
-  <wa-icon slot="start" name="acorn"></wa-icon>
+  <wa-icon slot="start" name="seedling"></wa-icon>
   Start
 </wa-badge>
 <wa-badge>
-  <wa-icon slot="end" name="tree-deciduous"></wa-icon>
+  <wa-icon slot="end" name="tree"></wa-icon>
   End
 </wa-badge>
 <wa-badge>
   <wa-icon slot="start" name="cow"></wa-icon>
-  <wa-icon slot="end" name="ufo-beam"></wa-icon>
+  <wa-icon slot="end" name="meteor"></wa-icon>
   Both
 </wa-badge>
 ```

--- a/packages/webawesome/docs/docs/components/breadcrumb.md
+++ b/packages/webawesome/docs/docs/components/breadcrumb.md
@@ -56,7 +56,7 @@ Use the `start` and `end` slots to add presentational elements like `<wa-icon>` 
   </wa-breadcrumb-item>
   <wa-breadcrumb-item>Articles</wa-breadcrumb-item>
   <wa-breadcrumb-item>
-    <wa-icon slot="end" name="tree-palm"></wa-icon>
+    <wa-icon slot="end" name="umbrella-beach"></wa-icon>
     Traveling
   </wa-breadcrumb-item>
 </wa-breadcrumb>

--- a/packages/webawesome/docs/docs/components/callout.md
+++ b/packages/webawesome/docs/docs/components/callout.md
@@ -18,7 +18,7 @@ use-cases:
 
 ```html {.example}
 <wa-callout>
-  <wa-icon slot="icon" name="circle-info" variant="regular"></wa-icon>
+  <wa-icon slot="icon" name="circle-info"></wa-icon>
   This is a standard callout. You can customize its content and even the icon.
 </wa-callout>
 ```
@@ -31,7 +31,7 @@ Set the `variant` attribute to change the callout's variant.
 
 ```html {.example}
 <wa-callout variant="brand">
-  <wa-icon slot="icon" name="circle-info" variant="regular"></wa-icon>
+  <wa-icon slot="icon" name="circle-info"></wa-icon>
   <strong>This is super informative</strong><br />
   You can tell by how pretty the callout is.
 </wa-callout>
@@ -47,7 +47,7 @@ Set the `variant` attribute to change the callout's variant.
 <br />
 
 <wa-callout variant="neutral">
-  <wa-icon slot="icon" name="gear" variant="regular"></wa-icon>
+  <wa-icon slot="icon" name="gear"></wa-icon>
   <strong>Your settings have been updated</strong><br />
   Settings will take effect on next login.
 </wa-callout>
@@ -55,7 +55,7 @@ Set the `variant` attribute to change the callout's variant.
 <br />
 
 <wa-callout variant="warning">
-  <wa-icon slot="icon" name="triangle-exclamation" variant="regular"></wa-icon>
+  <wa-icon slot="icon" name="triangle-exclamation"></wa-icon>
   <strong>Your session has ended</strong><br />
   Please login again to continue.
 </wa-callout>
@@ -63,7 +63,7 @@ Set the `variant` attribute to change the callout's variant.
 <br />
 
 <wa-callout variant="danger">
-  <wa-icon slot="icon" name="circle-exclamation" variant="regular"></wa-icon>
+  <wa-icon slot="icon" name="circle-exclamation"></wa-icon>
   <strong>Your account has been deleted</strong><br />
   We're very sorry to see you go!
 </wa-callout>
@@ -82,28 +82,28 @@ Use the `appearance` attribute to change the callout's visual appearance (the de
 <br />
 
 <wa-callout variant="brand" appearance="filled-outlined">
-  <wa-icon slot="icon" name="fill-drip" variant="regular"></wa-icon>
+  <wa-icon slot="icon" name="fill-drip"></wa-icon>
   This callout is both <strong>filled</strong> and <strong>outlined</strong>
 </wa-callout>
 
 <br />
 
 <wa-callout variant="brand" appearance="filled">
-  <wa-icon slot="icon" name="fill" variant="regular"></wa-icon>
+  <wa-icon slot="icon" name="fill"></wa-icon>
   This callout is only <strong>filled</strong>
 </wa-callout>
 
 <br />
 
 <wa-callout variant="brand" appearance="outlined">
-  <wa-icon slot="icon" name="lines-leaning" variant="regular"></wa-icon>
+  <wa-icon slot="icon" name="lines-leaning"></wa-icon>
   Here's an <strong>outlined</strong> callout
 </wa-callout>
 
 <br />
 
 <wa-callout variant="brand" appearance="plain">
-  <wa-icon slot="icon" name="font" variant="regular"></wa-icon>
+  <wa-icon slot="icon" name="font"></wa-icon>
   No bells and whistles on this <strong>plain</strong> callout
 </wa-callout>
 ```
@@ -114,21 +114,21 @@ Use the `size` attribute to change a callout's size.
 
 ```html {.example}
 <wa-callout size="large">
-  <wa-icon slot="icon" name="circle-info" variant="regular"></wa-icon>
+  <wa-icon slot="icon" name="circle-info"></wa-icon>
   This is meant to be very emphasized.
 </wa-callout>
 
 <br />
 
 <wa-callout size="medium">
-  <wa-icon slot="icon" name="circle-info" variant="regular"></wa-icon>
+  <wa-icon slot="icon" name="circle-info"></wa-icon>
   Normal-sized callout.
 </wa-callout>
 
 <br />
 
 <wa-callout size="small">
-  <wa-icon slot="icon" name="circle-info" variant="regular"></wa-icon>
+  <wa-icon slot="icon" name="circle-info"></wa-icon>
   Just a small tip!
 </wa-callout>
 ```

--- a/packages/webawesome/docs/docs/components/callout.md
+++ b/packages/webawesome/docs/docs/components/callout.md
@@ -39,7 +39,7 @@ Set the `variant` attribute to change the callout's variant.
 <br />
 
 <wa-callout variant="success">
-  <wa-icon slot="icon" name="circle-check" variant="regular"></wa-icon>
+  <wa-icon slot="icon" name="circle-check"></wa-icon>
   <strong>Your changes have been saved</strong><br />
   You can safely exit the app now.
 </wa-callout>

--- a/packages/webawesome/docs/docs/components/icon.md
+++ b/packages/webawesome/docs/docs/components/icon.md
@@ -17,7 +17,7 @@ use-cases:
 Web Awesome comes bundled with over 2,000 free icons courtesy of [Font Awesome](https://fontawesome.com/). These icons are part of the `default` icon library. Font Awesome Pro users can unlock additional icon families. Or, if you prefer, you can register your own [custom icon library](#icon-library).
 
 ```html {.example}
-<wa-icon name="face-awesome" variant="light" label="Awesome" style="font-size: 2em;"></wa-icon>
+<wa-icon name="star" label="Star" style="font-size: 2em;"></wa-icon>
 ```
 
 :::info
@@ -116,10 +116,10 @@ Without auto-width<br />
 <div style="font-size: 1.5em; color: #193154;">
   <wa-icon family="solid" name="exclamation" style="background: lightsalmon;"></wa-icon>
   <wa-icon family="solid" name="circle-check" style="background: lightsalmon;"></wa-icon>
-  <wa-icon family="solid" name="input-numeric" style="background: lightsalmon;"></wa-icon>
+  <wa-icon family="solid" name="magnifying-glass" style="background: lightsalmon;"></wa-icon>
   <wa-icon family="solid" name="ruler-vertical" style="background: lightsalmon;"></wa-icon>
   <wa-icon family="solid" name="ruler-horizontal" style="background: lightsalmon;"></wa-icon>
-  <wa-icon family="solid" name="airplay" style="background: lightsalmon;"></wa-icon>
+  <wa-icon family="solid" name="envelope" style="background: lightsalmon;"></wa-icon>
 </div>
 
 <br />
@@ -128,10 +128,10 @@ With auto-width<br />
 <div style="font-size: 1.5em; color: #193154;">
   <wa-icon auto-width family="solid" name="exclamation" style="background: lightsalmon;"></wa-icon>
   <wa-icon auto-width family="solid" name="circle-check" style="background: lightsalmon;"></wa-icon>
-  <wa-icon auto-width family="solid" name="input-numeric" style="background: lightsalmon;"></wa-icon>
+  <wa-icon auto-width family="solid" name="magnifying-glass" style="background: lightsalmon;"></wa-icon>
   <wa-icon auto-width family="solid" name="ruler-vertical" style="background: lightsalmon;"></wa-icon>
   <wa-icon auto-width family="solid" name="ruler-horizontal" style="background: lightsalmon;"></wa-icon>
-  <wa-icon auto-width family="solid" name="airplay" style="background: lightsalmon;"></wa-icon>
+  <wa-icon auto-width family="solid" name="envelope" style="background: lightsalmon;"></wa-icon>
 </div>
 ```
 
@@ -182,7 +182,7 @@ Use the `fade` animation to fade an icon in and out visually to grab attention i
 ```html {.example}
 <wa-icon name="triangle-exclamation" animation="fade" label="Fading Warning" style="font-size: 2em;"></wa-icon>
 <wa-icon name="skull-crossbones" animation="fade" label="Fading Danger" style="font-size: 2em;"></wa-icon>
-<wa-icon name="desktop-arrow-down" animation="fade" label="Fading Download" style="font-size: 2em;"></wa-icon>
+<wa-icon name="cloud-arrow-down" animation="fade" label="Fading Download" style="font-size: 2em;"></wa-icon>
 <wa-icon
   name="i-cursor"
   animation="fade"
@@ -196,13 +196,8 @@ Use the `fade` animation to fade an icon in and out visually to grab attention i
 Use the `beat-fade` animation to grab attention by visually scaling and pulsing an icon in and out.
 
 ```html {.example}
-<wa-icon
-  name="triangle-person-digging"
-  animation="beat-fade"
-  label="Beat-Fading Construction"
-  style="font-size: 2em;"
-></wa-icon>
-<wa-icon name="square-exclamation" animation="beat-fade" label="Beat-Fading Alert" style="font-size: 2em;"></wa-icon>
+<wa-icon name="person-digging" animation="beat-fade" label="Beat-Fading Construction" style="font-size: 2em;"></wa-icon>
+<wa-icon name="circle-exclamation" animation="beat-fade" label="Beat-Fading Alert" style="font-size: 2em;"></wa-icon>
 <wa-icon
   name="poo-bolt"
   animation="beat-fade"
@@ -256,7 +251,7 @@ Use the `flip` animation to rotate an icon in 3D space. By default, flip rotates
 ```html {.example}
 <wa-icon name="compact-disc" animation="flip" label="Flipping Compact Disc" style="font-size: 2em;"></wa-icon>
 <wa-icon name="camera-rotate" animation="flip" label="Flipping Camera Rotate" style="font-size: 2em;"></wa-icon>
-<wa-icon name="cassette-tape" animation="flip" label="Flipping Cassette Tape" style="font-size: 2em;"></wa-icon>
+<wa-icon name="sun" animation="flip" label="Flipping Sun" style="font-size: 2em;"></wa-icon>
 <wa-icon
   name="scroll"
   animation="flip"
@@ -310,12 +305,12 @@ Icons inherit their color from the current text color. Thus, you can set the `co
 
 ```html {.example}
 <div class="wa-cluster" style="font-size: 1.5em;">
-  <wa-icon name="strawberry" style="color: salmon;"></wa-icon>
-  <wa-icon name="crab" style="color: coral;"></wa-icon>
+  <wa-icon name="heart" style="color: salmon;"></wa-icon>
+  <wa-icon name="fire" style="color: coral;"></wa-icon>
   <wa-icon name="sun" style="color: gold;"></wa-icon>
   <wa-icon name="leaf" style="color: mediumseagreen;"></wa-icon>
   <wa-icon name="cloud-showers-heavy" style="color: steelblue;"></wa-icon>
-  <wa-icon name="cat-space" style="color: mediumpurple;"></wa-icon>
+  <wa-icon name="hat-wizard" style="color: mediumpurple;"></wa-icon>
 </div>
 ```
 

--- a/packages/webawesome/docs/docs/components/icon.md
+++ b/packages/webawesome/docs/docs/components/icon.md
@@ -251,7 +251,7 @@ Use the `flip` animation to rotate an icon in 3D space. By default, flip rotates
 ```html {.example}
 <wa-icon name="compact-disc" animation="flip" label="Flipping Compact Disc" style="font-size: 2em;"></wa-icon>
 <wa-icon name="camera-rotate" animation="flip" label="Flipping Camera Rotate" style="font-size: 2em;"></wa-icon>
-<wa-icon name="sun" animation="flip" label="Flipping Sun" style="font-size: 2em;"></wa-icon>
+<wa-icon name="compact-disc" animation="flip" label="Flipping Disc" style="font-size: 2em;"></wa-icon>
 <wa-icon
   name="scroll"
   animation="flip"

--- a/packages/webawesome/docs/docs/components/intersection-observer.md
+++ b/packages/webawesome/docs/docs/components/intersection-observer.md
@@ -18,7 +18,7 @@ This component leverages the [IntersectionObserver API](https://developer.mozill
 ```html {.example}
 <div id="intersection__overview">
   <wa-intersection-observer threshold="1" intersect-class="visible">
-    <div class="box"><wa-icon name="bulb"></wa-icon></div>
+    <div class="box"><wa-icon name="lightbulb"></wa-icon></div>
   </wa-intersection-observer>
 </div>
 

--- a/packages/webawesome/docs/docs/resources/contributing.md
+++ b/packages/webawesome/docs/docs/resources/contributing.md
@@ -1,7 +1,7 @@
 ---
 title: Contributing
 description: Web Awesome is an open source project, meaning everyone can use it and contribute to its development.
-layout: page
+layout: page-outline
 ---
 
 Many Web Awesome components are open source, meaning everyone can use them and contribute to their development. When you join our community, you'll find a friendly group of enthusiasts at all experience levels who are willing to chat about anything and everything related to Web Awesome.

--- a/packages/webawesome/docs/docs/resources/contributing.md
+++ b/packages/webawesome/docs/docs/resources/contributing.md
@@ -150,6 +150,10 @@ eleventyExcludeFromCollections: true
 ---
 ```
 
+### Icons in Examples
+
+Documentation examples should use [Font Awesome Free](https://fontawesome.com/search?o=r&m=free) icons by default so users can copy and paste them without needing a Pro kit code. Pro icons are fine in sections that specifically demonstrate Pro features (e.g. Duotone, Sharp, Pro+ icon packs).
+
 ## Best Practices
 
 The following is a non-exhaustive list of conventions, patterns, and best practices we try to follow. As a contributor, we ask that you make a good faith effort to follow them as well. This ensures consistency and maintainability throughout the project.

--- a/packages/webawesome/docs/docs/utilities/grid.md
+++ b/packages/webawesome/docs/docs/utilities/grid.md
@@ -105,7 +105,7 @@ Grids work especially well for card lists and content designed for browsing.
   <wa-card>
     <div class="wa-flank">
       <wa-avatar shape="rounded">
-        <wa-icon slot="icon" name="brain-circuit"></wa-icon>
+        <wa-icon slot="icon" name="microchip"></wa-icon>
       </wa-avatar>
       <div class="wa-stack wa-gap-3xs">
         <span class="wa-caption-xs">Minds Freed</span>
@@ -125,7 +125,7 @@ Grids work especially well for card lists and content designed for browsing.
         <span class="wa-caption-xs">Agents Discovered</span>
         <span class="wa-cluster wa-gap-xs">
           <span class="wa-heading-2xl">3</span>
-          <wa-badge variant="neutral">±0%&nbsp;<wa-icon name="wave-triangle"></wa-icon></wa-badge>
+          <wa-badge variant="neutral">±0%&nbsp;<wa-icon name="minus"></wa-icon></wa-badge>
         </span>
       </div>
     </div>

--- a/packages/webawesome/docs/docs/utilities/native.md
+++ b/packages/webawesome/docs/docs/utilities/native.md
@@ -614,7 +614,7 @@ Wrap form controls in a flex container to arrange them horizontally or verticall
   </label>
   <label><input type="checkbox" checked /> Add whipped butter</label>
   <button>
-    <wa-icon name="pancakes"></wa-icon>
+    <wa-icon name="cookie"></wa-icon>
     Stack 'em up
   </button>
 </form>

--- a/packages/webawesome/docs/docs/utilities/native.md
+++ b/packages/webawesome/docs/docs/utilities/native.md
@@ -614,7 +614,7 @@ Wrap form controls in a flex container to arrange them horizontally or verticall
   </label>
   <label><input type="checkbox" checked /> Add whipped butter</label>
   <button>
-    <wa-icon name="cookie"></wa-icon>
+    <wa-icon name="layer-group"></wa-icon>
     Stack 'em up
   </button>
 </form>

--- a/packages/webawesome/docs/docs/utilities/stack.md
+++ b/packages/webawesome/docs/docs/utilities/stack.md
@@ -49,7 +49,7 @@ Stacks are well suited for forms, text, and ensuring consistent spacing between 
     <wa-icon slot="start" name="envelope" variant="regular"></wa-icon>
   </wa-input>
   <wa-input label="Password" type="password">
-    <wa-icon slot="start" name="lock" variant="regular"></wa-icon>
+    <wa-icon slot="start" name="lock"></wa-icon>
   </wa-input>
   <wa-checkbox>Remember me on this device</wa-checkbox>
   <wa-button appearance="filled">Log In</wa-button>

--- a/packages/webawesome/docs/docs/utilities/visually-hidden.md
+++ b/packages/webawesome/docs/docs/utilities/visually-hidden.md
@@ -34,7 +34,7 @@ In this example, the link will open a new window. Screen readers will announce "
 ```html {.example}
 <a href="https://example.com/" target="_blank">
   Visit External Page
-  <wa-icon name="arrow-up-right-from-square" variant="regular"></wa-icon>
+  <wa-icon name="arrow-up-right-from-square"></wa-icon>
   <span class="wa-visually-hidden">opens in a new window</span>
 </a>
 ```
@@ -65,7 +65,7 @@ Instead, you can hide them visually while keeping them available to screen reade
   class="wa-visually-hidden-label"
   style="margin-block-end: 1rem;"
 >
-  <wa-icon slot="start" name="magnifying-glass" variant="regular"></wa-icon>
+  <wa-icon slot="start" name="magnifying-glass"></wa-icon>
 </wa-input>
 
 <wa-input
@@ -76,7 +76,7 @@ Instead, you can hide them visually while keeping them available to screen reade
   class="wa-visually-hidden-hint"
   style="margin-block-end: 1rem;"
 >
-  <wa-icon slot="start" name="phone" variant="regular"></wa-icon>
+  <wa-icon slot="start" name="phone"></wa-icon>
 </wa-input>
 
 <wa-select
@@ -94,7 +94,7 @@ Instead, you can hide them visually while keeping them available to screen reade
   <wa-option value="wakanda">Wakanda</wa-option>
   <wa-option value="genovia">Genovia</wa-option>
   <wa-option value="elbonia">Elbonia</wa-option>
-  <wa-icon slot="start" name="globe" variant="regular"></wa-icon>
+  <wa-icon slot="start" name="globe"></wa-icon>
 </wa-select>
 
 <wa-input


### PR DESCRIPTION
Based on some good feedback in https://github.com/shoelace-style/webawesome/discussions/2288#discussioncomment-16572341, this work swaps Pro-only Font Awesome icons for Free alternatives in our docs so examples work out of the box for new users without a kit code. 

Pro icons remain in sections that specifically demo Pro features (Duotone, Sharp, Pro+ Packs, etc.).