### PR TITLE
Add warning for FA Pro users

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -14,6 +14,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 
 <small>TBD</small>
 
+- Added a console warning in `<wa-icon>` when a Font Awesome Pro icon is requested via the free CDN without a kit code
 - Fixed a bug in `<wa-checkbox>` where the `value` property returned `null` instead of `'on'` when unchecked
 - Fixed a bug in `<wa-rating>` where disabling via a `<fieldset>` did not properly restore the enabled state when the fieldset was re-enabled
 - Fixed a bug in `<wa-zoomable-frame>` where zoom control buttons did not properly update their disabled state after zoom levels were parsed

--- a/packages/webawesome/src/components/icon/icon.ts
+++ b/packages/webawesome/src/components/icon/icon.ts
@@ -195,7 +195,10 @@ export default class WaIcon extends WebAwesomeElement {
 
     try {
       fileData = await fetch(url, { mode: 'cors' });
-      if (!fileData.ok) return fileData.status === 410 ? CACHEABLE_ERROR : RETRYABLE_ERROR;
+      if (!fileData.ok) {
+        library?.onFetchError?.(url, fileData.status, this);
+        return fileData.status === 410 ? CACHEABLE_ERROR : RETRYABLE_ERROR;
+      }
     } catch {
       return RETRYABLE_ERROR;
     }

--- a/packages/webawesome/src/components/icon/library.default.ts
+++ b/packages/webawesome/src/components/icon/library.default.ts
@@ -2,6 +2,10 @@ import { getIconPath, getKitCode } from '../../utilities/base-path.js';
 import type { IconLibrary } from './library.js';
 
 const FA_VERSION = '7.2.0';
+const FREE_CDN_HOST = 'ka-f.fontawesome.com';
+const PRO_CDN_HOST = 'ka-p.fontawesome.com';
+
+let hasWarnedAboutProKitCode = false;
 
 /** Returns the folder name used by Font Awesome for a given icon family and variant combination. */
 export function getIconFolder(_name: string, family: string, variant: string) {
@@ -134,14 +138,31 @@ function getIconUrl(name: string, family: string, variant: string) {
   const isPro = kitCode.length > 0;
 
   return isPro
-    ? `https://ka-p.fontawesome.com/releases/v${FA_VERSION}/svgs/${folder}/${name}.svg?token=${encodeURIComponent(kitCode)}`
-    : `https://ka-f.fontawesome.com/releases/v${FA_VERSION}/svgs/${folder}/${name}.svg`;
+    ? `https://${PRO_CDN_HOST}/releases/v${FA_VERSION}/svgs/${folder}/${name}.svg?token=${encodeURIComponent(kitCode)}`
+    : `https://${FREE_CDN_HOST}/releases/v${FA_VERSION}/svgs/${folder}/${name}.svg`;
 }
 
 const library: IconLibrary = {
   name: 'default',
   resolver: (name: string, family = 'classic', variant = 'solid') => {
     return getIconUrl(name, family, variant);
+  },
+  onFetchError: (url, status, hostEl) => {
+    // A 403 from the free Font Awesome CDN indicates a Pro icon was requested without a kit code. Requests made with a
+    // kit code go to the Pro CDN, and self-hosted setups use a custom icon base, so this check skips those cases.
+    if (hasWarnedAboutProKitCode) return;
+    if (status !== 403) return;
+    if (!url.includes(FREE_CDN_HOST)) return;
+
+    hasWarnedAboutProKitCode = true;
+    setTimeout(() => {
+      console.warn(
+        `A Font Awesome Pro icon was requested without a kit code (other icons may be affected). ` +
+          `Add your kit code to load Pro icons via CDN. ` +
+          `See https://webawesome.com/docs/#using-font-awesome-pro-and-pro for details.`,
+        hostEl,
+      );
+    }, 500); // this helps the warning show BELOW the 403 errors so it's not buried when multiple icons are requested
   },
   mutator: (svg, hostEl) => {
     // Duotone families

--- a/packages/webawesome/src/components/icon/library.ts
+++ b/packages/webawesome/src/components/icon/library.ts
@@ -10,11 +10,7 @@ export type IconLibraryResolver = (
   autoWidth: boolean,
 ) => string | Promise<string>;
 export type IconLibraryMutator = (svg: SVGElement, hostElement?: IconLibraryHostElement) => void;
-export type IconLibraryFetchErrorHandler = (
-  url: string,
-  status: number,
-  hostElement: IconLibraryHostElement,
-) => void;
+export type IconLibraryFetchErrorHandler = (url: string, status: number, hostElement: IconLibraryHostElement) => void;
 export interface IconLibrary {
   name: string;
   resolver: IconLibraryResolver;

--- a/packages/webawesome/src/components/icon/library.ts
+++ b/packages/webawesome/src/components/icon/library.ts
@@ -10,11 +10,17 @@ export type IconLibraryResolver = (
   autoWidth: boolean,
 ) => string | Promise<string>;
 export type IconLibraryMutator = (svg: SVGElement, hostElement?: IconLibraryHostElement) => void;
+export type IconLibraryFetchErrorHandler = (
+  url: string,
+  status: number,
+  hostElement: IconLibraryHostElement,
+) => void;
 export interface IconLibrary {
   name: string;
   resolver: IconLibraryResolver;
   mutator?: IconLibraryMutator;
   spriteSheet?: boolean;
+  onFetchError?: IconLibraryFetchErrorHandler;
 }
 
 let defaultIconFamily = 'classic';
@@ -44,6 +50,7 @@ export function registerIconLibrary(name: string, options: Omit<IconLibrary, 'na
     resolver: options.resolver,
     mutator: options.mutator,
     spriteSheet: options.spriteSheet,
+    onFetchError: options.onFetchError,
   });
 
   // Redraw watched icons


### PR DESCRIPTION
This warning is designed to detect when users try to use Font Awesome Pro icons with `<wa-icon>` without setting a kit code and help them get things working. It relies on some less than perfect heuristics, though.

This isn't using a manifest of pro icons so it currently relies on the request domain (`ka-f.fontawesome.com`) to return a 403 which can mean one of two things:
  - It's a Pro icon (expected)
  - It's an invalid icon name, e.g.: https://ka-f.fontawesome.com/releases/v7.2.0/svgs/regular/blah.svg (403 response)

The warning only fires once per page load, even if many icons are affected, to avoid flooding the console. It's scoped to the default icon library so custom libraries and `src` URLs won't trigger it. Users who provide a kit code hit `ka-p.fontawesome.com` instead, and users who self-host don't hit the FA CDN at all, so both cases are naturally excluded.

The warning is intentionally delayed by half a second so it appears below 403 errors in the console instead of getting buried when multiple icons are requested on page load.

I worry mostly about invalid icon names being a problem, so it's probably necessary to get an icon manifest. BUT that would be a lot of bytes, even if we only included free icon names.

Ideally, the CDN would reply with a 404 instead of a 403 but this check probably happens at a higher layer, e.g. during token validation.