### PR TITLE
fix icon button width when caret is applied

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -17,6 +17,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug in `<wa-checkbox>` where the `value` property returned `null` instead of `'on'` when unchecked
 - Fixed a bug in `<wa-rating>` where disabling via a `<fieldset>` did not properly restore the enabled state when the fieldset was re-enabled
 - Fixed a bug in `<wa-zoomable-frame>` where zoom control buttons did not properly update their disabled state after zoom levels were parsed
+- Fixed a bug in `<wa-button>` where icon-only buttons with `with-caret` were sized as a square, causing the caret to overflow
 - Refactored component tests across core and pro packages to follow a consistent structure with improved coverage
 
 ## 3.5.0

--- a/packages/webawesome/src/components/button/button.styles.ts
+++ b/packages/webawesome/src/components/button/button.styles.ts
@@ -226,8 +226,11 @@ export default css`
     aspect-ratio: 1;
   }
 
-  .button.is-icon-button:has(wa-icon) {
+  /* Icon buttons with a caret need to grow to fit both the icon and the caret */
+  .button.is-icon-button.caret {
     width: auto;
+    aspect-ratio: auto;
+    min-width: var(--wa-form-control-height);
   }
 
   /* Pill modifier */


### PR DESCRIPTION
Fixes a problem where the width of the icon button didn't expand when the caret attribute was present. The bug was only visually present in Firefox.

Before:

<img width="707" height="385" alt="image" src="https://github.com/user-attachments/assets/e8cec895-3df8-4b2a-a271-d03166de0269" />

After:

<img width="1518" height="624" alt="CleanShot 2026-04-16 at 08 21 15@2x" src="https://github.com/user-attachments/assets/dba1f38e-070a-4ba0-8457-732b51a7dda8" />

Mentioned in: https://discord.com/channels/739437527907303535/1491772882655641671