### PR TITLE
Abstract Background-Based Styling in `utils.css`

### DIFF
--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -795,33 +795,13 @@
     background-size: var(--dot-spacing) var(--dot-spacing);
   }
 
-  /* Bottom fade mask; --wa-fade-mask-base on self/ancestor. With background-wa-pattern, masks ::after. */
+  /* Bottom fade mask. Composes with .background-wa-pattern (masks the ::after decoration only); on any
+   * other element, masks the host (content fades too). Mask reads alpha, so color is irrelevant. */
   .wa-mask-fade-below:not(.background-wa-pattern),
   .background-wa-pattern.wa-mask-fade-below::after {
-    --wa-fade-mask-show: var(--wa-fade-mask-base, var(--wa-color-surface-default));
-    --wa-fade-mask-hide: transparent;
-    --wa-fade-mask-fade-start: 60%;
-    --wa-fade-mask-fade-length: 35%;
-    -webkit-mask-image: linear-gradient(
-      to bottom,
-      var(--wa-fade-mask-show) 0%,
-      var(--wa-fade-mask-show) var(--wa-fade-mask-fade-start),
-      var(--wa-fade-mask-hide) calc(var(--wa-fade-mask-fade-start) + var(--wa-fade-mask-fade-length))
-    );
-    mask-image: linear-gradient(
-      to bottom,
-      var(--wa-fade-mask-show) 0%,
-      var(--wa-fade-mask-show) var(--wa-fade-mask-fade-start),
-      var(--wa-fade-mask-hide) calc(var(--wa-fade-mask-fade-start) + var(--wa-fade-mask-fade-length))
-    );
-  }
-
-  @supports (color: rgb(from red r g b)) {
-    .wa-mask-fade-below:not(.background-wa-pattern),
-    .background-wa-pattern.wa-mask-fade-below::after {
-      --wa-fade-mask-show: rgb(from var(--wa-fade-mask-base, var(--wa-color-surface-default)) r g b / 1);
-      --wa-fade-mask-hide: rgb(from var(--wa-fade-mask-base, var(--wa-color-surface-default)) r g b / 0);
-    }
+    --wa-mask-fade-start: 60%;
+    --wa-mask-fade-end: 95%;
+    mask-image: linear-gradient(to bottom, #000 var(--wa-mask-fade-start), transparent var(--wa-mask-fade-end));
   }
 
   /* wa illustration background pattern */

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -831,6 +831,7 @@
   /* wa illustration background pattern */
   .background-wa-pattern {
     --background-pattern-size: auto;
+    --background-pattern-position: 0 0;
     position: relative;
 
     & > * {
@@ -845,6 +846,7 @@
       background-image: var(--background-pattern-image, url('/assets/images/bg-wa-pattern.svg'));
       background-repeat: repeat;
       background-size: var(--background-pattern-size);
+      background-position: var(--background-pattern-position);
       content: '';
       opacity: var(--background-pattern-opacity, 0.3);
       z-index: 0;

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -795,8 +795,42 @@
     background-size: var(--dot-spacing) var(--dot-spacing);
   }
 
+  /* Bottom fade mask; --wa-fade-mask-base on self/ancestor. With background-wa-pattern, masks ::after. */
+  .wa-mask-fade-below:not(.background-wa-pattern),
+  .background-wa-pattern.wa-mask-fade-below::after {
+    --wa-fade-mask-show: var(--wa-fade-mask-base, var(--wa-color-surface-default));
+    --wa-fade-mask-hide: transparent;
+    --wa-fade-mask-fade-start: 60%;
+    --wa-fade-mask-fade-length: 35%;
+    -webkit-mask-image: linear-gradient(
+      to bottom,
+      var(--wa-fade-mask-show) 0%,
+      var(--wa-fade-mask-show) var(--wa-fade-mask-fade-start),
+      var(--wa-fade-mask-hide) calc(var(--wa-fade-mask-fade-start) + var(--wa-fade-mask-fade-length))
+    );
+    mask-image: linear-gradient(
+      to bottom,
+      var(--wa-fade-mask-show) 0%,
+      var(--wa-fade-mask-show) var(--wa-fade-mask-fade-start),
+      var(--wa-fade-mask-hide) calc(var(--wa-fade-mask-fade-start) + var(--wa-fade-mask-fade-length))
+    );
+    -webkit-mask-size: 100% 100%;
+    mask-size: 100% 100%;
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+  }
+
+  @supports (color: rgb(from red r g b)) {
+    .wa-mask-fade-below:not(.background-wa-pattern),
+    .background-wa-pattern.wa-mask-fade-below::after {
+      --wa-fade-mask-show: rgb(from var(--wa-fade-mask-base, var(--wa-color-surface-default)) r g b / 1);
+      --wa-fade-mask-hide: rgb(from var(--wa-fade-mask-base, var(--wa-color-surface-default)) r g b / 0);
+    }
+  }
+
   /* wa illustration background pattern */
   .background-wa-pattern {
+    --background-pattern-size: auto;
     position: relative;
 
     & > * {
@@ -810,6 +844,7 @@
       background-color: var(--background-pattern-color, transparent);
       background-image: var(--background-pattern-image, url('/assets/images/bg-wa-pattern.svg'));
       background-repeat: repeat;
+      background-size: var(--background-pattern-size);
       content: '';
       opacity: var(--background-pattern-opacity, 0.3);
       z-index: 0;

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -814,10 +814,6 @@
       var(--wa-fade-mask-show) var(--wa-fade-mask-fade-start),
       var(--wa-fade-mask-hide) calc(var(--wa-fade-mask-fade-start) + var(--wa-fade-mask-fade-length))
     );
-    -webkit-mask-size: 100% 100%;
-    mask-size: 100% 100%;
-    -webkit-mask-repeat: no-repeat;
-    mask-repeat: no-repeat;
   }
 
   @supports (color: rgb(from red r g b)) {


### PR DESCRIPTION
This work improves some of our background-based utilities in `utils.css`.

  - Adds a wa-mask-fade-below utility class that applies a bottom-edge fade mask, working on both standalone elements and .background-wa-pattern      
  pseudo-elements
  - Adds --background-pattern-size and --background-pattern-position custom properties to .background-wa-pattern for controlling the pattern's size   
  and position                                                                                                                                        
  - Uses relative color syntax (@supports) for cleaner opacity transitions when the browser supports it