### PR TITLE
fix: remove underline on hover from planned badge links in sidebar

### DIFF
--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -681,6 +681,12 @@
       &:hover {
         text-decoration: underline;
       }
+
+	&:has(wa-badge.planned) {
+         &:hover {
+          text-decoration: none;
+         }
+  }
     }
 
     li wa-badge::part(base) {
@@ -743,6 +749,7 @@
 
   #sidebar .is-planned {
     color: var(--wa-color-text-quiet);
+    text-decoration: none;
   }
 
   #sidebar-close-button {


### PR DESCRIPTION
## Problem
When hovering over a "Planned" badge in the sidebar, an unwanted underline appears. This is because the `li a:hover` rule applies `text-decoration: underline` to the anchor tag wrapping the badge.

## Fix
Added a nested `:has()` selector inside the existing `li a` rule in `utils.css` to prevent underline specifically for anchors containing a planned badge:

```css
li a {
  /* ...existing styles... */

  &:has(wa-badge.planned) {
    &:hover {
      text-decoration: none;
    }
  }
}
```
## Before
<img width="390" height="372" alt="Before" src="https://github.com/user-attachments/assets/bcf122d9-a189-4da8-a6de-add1cc6fc138" />


## After
<img width="400" height="338" alt="After" src="https://github.com/user-attachments/assets/cfa7d8f5-4af2-4727-a7a6-32201dc0e43e" />

## Testing
- Hover over "Planned" badge in sidebar — no underline appears
- Regular sidebar links still show underline on hover (existing behavior preserved)

Fixes #2302