### PR TITLE
Add beforeinput event

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -17,6 +17,7 @@
     "autoloader",
     "autoloading",
     "autoplay",
+    "beforeinput",
     "bezier",
     "Blockquotes",
     "boxicons",

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -14,6 +14,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 
 <small>TBD</small>
 
+- Added `beforeinput` event to `<wa-number-input>` stepper buttons so value changes can be cancelled with `event.preventDefault()`
 - Fixed a bug in `<wa-checkbox>` where the `value` property returned `null` instead of `'on'` when unchecked
 - Fixed a bug in `<wa-rating>` where disabling via a `<fieldset>` did not properly restore the enabled state when the fieldset was re-enabled
 - Fixed a bug in `<wa-zoomable-frame>` where zoom control buttons did not properly update their disabled state after zoom levels were parsed

--- a/packages/webawesome/src/components/number-input/number-input.test.ts
+++ b/packages/webawesome/src/components/number-input/number-input.test.ts
@@ -306,6 +306,103 @@ describe('<wa-number-input>', () => {
 
           expect(decrementButton.disabled).to.be.true;
         });
+
+        it('should emit beforeinput when increment button is clicked', async () => {
+          const el = await fixture<WaNumberInput>(html` <wa-number-input value="5"></wa-number-input> `);
+          const incrementButton = el.shadowRoot!.querySelector<HTMLButtonElement>('[part~="stepper-increment"]')!;
+          const beforeInputHandler = sinon.spy();
+
+          el.addEventListener('beforeinput', beforeInputHandler);
+          incrementButton.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+          await el.updateComplete;
+
+          expect(beforeInputHandler).to.have.been.calledOnce;
+        });
+
+        it('should emit beforeinput when decrement button is clicked', async () => {
+          const el = await fixture<WaNumberInput>(html` <wa-number-input value="5"></wa-number-input> `);
+          const decrementButton = el.shadowRoot!.querySelector<HTMLButtonElement>('[part~="stepper-decrement"]')!;
+          const beforeInputHandler = sinon.spy();
+
+          el.addEventListener('beforeinput', beforeInputHandler);
+          decrementButton.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+          await el.updateComplete;
+
+          expect(beforeInputHandler).to.have.been.calledOnce;
+        });
+
+        it('should prevent value change when beforeinput is cancelled', async () => {
+          const el = await fixture<WaNumberInput>(html` <wa-number-input value="5"></wa-number-input> `);
+          const incrementButton = el.shadowRoot!.querySelector<HTMLButtonElement>('[part~="stepper-increment"]')!;
+
+          el.addEventListener('beforeinput', (event: Event) => event.preventDefault());
+          incrementButton.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+          await el.updateComplete;
+
+          expect(el.value).to.equal('5');
+        });
+
+        it('should not emit input or change when beforeinput is cancelled', async () => {
+          const el = await fixture<WaNumberInput>(html` <wa-number-input value="5"></wa-number-input> `);
+          const incrementButton = el.shadowRoot!.querySelector<HTMLButtonElement>('[part~="stepper-increment"]')!;
+          const inputHandler = sinon.spy();
+          const changeHandler = sinon.spy();
+
+          el.addEventListener('beforeinput', (event: Event) => event.preventDefault());
+          el.addEventListener('input', inputHandler);
+          el.addEventListener('change', changeHandler);
+          incrementButton.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+          await el.updateComplete;
+
+          expect(inputHandler).to.not.have.been.called;
+          expect(changeHandler).to.not.have.been.called;
+        });
+
+        it('should not emit beforeinput when disabled', async () => {
+          const el = await fixture<WaNumberInput>(html` <wa-number-input value="5" disabled></wa-number-input> `);
+          const incrementButton = el.shadowRoot!.querySelector<HTMLButtonElement>('[part~="stepper-increment"]')!;
+          const beforeInputHandler = sinon.spy();
+
+          el.addEventListener('beforeinput', beforeInputHandler);
+          incrementButton.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+          await el.updateComplete;
+
+          expect(beforeInputHandler).to.not.have.been.called;
+        });
+
+        it('should not emit beforeinput when readonly', async () => {
+          const el = await fixture<WaNumberInput>(html` <wa-number-input value="5" readonly></wa-number-input> `);
+          const incrementButton = el.shadowRoot!.querySelector<HTMLButtonElement>('[part~="stepper-increment"]')!;
+          const beforeInputHandler = sinon.spy();
+
+          el.addEventListener('beforeinput', beforeInputHandler);
+          incrementButton.dispatchEvent(new PointerEvent('pointerup', { bubbles: true }));
+          await el.updateComplete;
+
+          expect(beforeInputHandler).to.not.have.been.called;
+        });
+
+        it('should not emit beforeinput when stepUp() is called programmatically', async () => {
+          const el = await fixture<WaNumberInput>(html` <wa-number-input value="5"></wa-number-input> `);
+          const beforeInputHandler = sinon.spy();
+
+          el.addEventListener('beforeinput', beforeInputHandler);
+          el.stepUp();
+          await el.updateComplete;
+
+          expect(beforeInputHandler).to.not.have.been.called;
+        });
+
+        it('should not emit beforeinput when stepDown() is called programmatically', async () => {
+          const el = await fixture<WaNumberInput>(html` <wa-number-input value="5"></wa-number-input> `);
+          const beforeInputHandler = sinon.spy();
+
+          el.addEventListener('beforeinput', beforeInputHandler);
+          el.stepDown();
+          await el.updateComplete;
+
+          expect(beforeInputHandler).to.not.have.been.called;
+        });
       });
 
       describe('min and max constraints', () => {

--- a/packages/webawesome/src/components/number-input/number-input.ts
+++ b/packages/webawesome/src/components/number-input/number-input.ts
@@ -33,6 +33,8 @@ import styles from './number-input.styles.js';
  * @event change - Emitted when an alteration to the control's value is committed by the user.
  * @event focus - Emitted when the control gains focus.
  * @event input - Emitted when the control receives input.
+ * @event beforeinput - Emitted before the value changes. Can be cancelled with `event.preventDefault()` to prevent the
+ *  value from changing.
  * @event wa-invalid - Emitted when the form control has been checked for validity and its constraints aren't satisfied.
  *
  * @csspart label - The label element.
@@ -199,6 +201,10 @@ export default class WaNumberInput extends WebAwesomeFormAssociatedElement {
 
   private handleStepperPointerUp(direction: 'up' | 'down', event: PointerEvent) {
     if (this.disabled || this.readonly) return;
+
+    const beforeInputEvent = new InputEvent('beforeinput', { bubbles: true, cancelable: true, composed: true });
+    this.dispatchEvent(beforeInputEvent);
+    if (beforeInputEvent.defaultPrevented) return;
 
     if (direction === 'up') {
       this.input.stepUp();


### PR DESCRIPTION
Adds the `beforeinput` event to `<wa-number-input>` which mirrors native `<input type="number">` behavior.

Fixes #2296