### PR TITLE
Fix submenu selection styles

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -23,6 +23,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug in `<wa-file-input>` that incorrectly exposed a `file-icon` slot that never worked as described [issue:2294]
 - Fixed React imports to point directly to each component's `index.js` file [issue:2293]
 - Fixed a bug in `<wa-dropdown-item>` where disabled items in a submenu showed a pointer cursor instead of the default cursor [issue:2276]
+- Fixed a bug in `<wa-dropdown-item>` where items with an open submenu did not show a selection state
 - Refactored component tests across core and pro packages to follow a consistent structure with improved coverage
 
 ## 3.5.0

--- a/packages/webawesome/src/components/dropdown-item/dropdown-item.styles.ts
+++ b/packages/webawesome/src/components/dropdown-item/dropdown-item.styles.ts
@@ -22,6 +22,10 @@ export default css`
     }
   }
 
+  :host(:state(submenu-open)) {
+    background-color: var(--wa-color-neutral-fill-normal);
+  }
+
   :host(:focus-visible) {
     z-index: 1;
     outline: var(--wa-focus-ring);
@@ -47,6 +51,7 @@ export default css`
     }
   }
 
+  :host([variant='danger']:state(submenu-open)),
   :host([variant='danger']:focus-visible) {
     background-color: var(--wa-color-danger-fill-normal);
     color: var(--wa-color-danger-on-normal);


### PR DESCRIPTION
This PR adds the same visual treatment as when menu item's are hovered when a submenu is active. Fixes #2279.

<img width="1129" height="531" alt="CleanShot 2026-04-20 at 13 34 17@2x" src="https://github.com/user-attachments/assets/2067205b-6aa7-437e-b505-0cec430615da" />
