### PR TITLE
Update localize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1880,12 +1880,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@konnorr/qr-creator": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@konnorr/qr-creator/-/qr-creator-1.0.1.tgz",
-      "integrity": "sha512-EmRR9rny1ENBtQy7TLOguO/79h1EpzXUmqIdMTGp2BW8NkZtRRPr5hmQcE+n9QXYo4T8NjcaJ14hnZg+s/+K+A==",
-      "license": "MIT"
-    },
     "node_modules/@kurkle/color": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
@@ -2868,9 +2862,10 @@
       }
     },
     "node_modules/@shoelace-style/localize": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@shoelace-style/localize/-/localize-3.2.1.tgz",
-      "integrity": "sha512-r4C9C/5kSfMBIr0D9imvpRdCNXtUNgyYThc4YlS6K5Hchv1UyxNQ9mxwj+BTRH2i1Neits260sR3OjKMnplsFA=="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@shoelace-style/localize/-/localize-3.2.2.tgz",
+      "integrity": "sha512-h3+2/cFWGaw3KQUwintkP4Cy3PtrVW//ysr9DM5nOfIXYekgrHwsELk/nyxc8hmjVP/Kcon7KCzvUtSwUBipfQ==",
+      "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
       "version": "0.7.0",
@@ -14830,7 +14825,7 @@
         "@floating-ui/dom": "^1.6.13",
         "@lit/react": "^1.0.8",
         "@shoelace-style/animations": "^1.2.0",
-        "@shoelace-style/localize": "^3.2.1",
+        "@shoelace-style/localize": "^3.2.2",
         "composed-offset-position": "^0.0.6",
         "lit": "^3.2.1",
         "marked": "^11.2.0",
@@ -14857,7 +14852,6 @@
       "dependencies": {
         "@ctrl/tinycolor": "4.1.0",
         "@floating-ui/dom": "^1.6.13",
-        "@konnorr/qr-creator": "^1.0.1",
         "@lit/react": "^1.0.8",
         "@shoelace-style/animations": "^1.2.0",
         "@shoelace-style/localize": "^3.2.1",

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -25,6 +25,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug in `<wa-dropdown-item>` where disabled items in a submenu showed a pointer cursor instead of the default cursor [issue:2276]
 - Fixed a bug in `<wa-dropdown-item>` where items with an open submenu did not show a selection state
 - Refactored component tests across core and pro packages to follow a consistent structure with improved coverage
+- Updated `@shoelace-style/localize` to 3.2.2 to prevent Chrome translations from throwing errors [issue:2322]
 - Updated TypeScript to 5.9.3
 
 ## 3.5.0

--- a/packages/webawesome/package.json
+++ b/packages/webawesome/package.json
@@ -84,7 +84,7 @@
     "@floating-ui/dom": "^1.6.13",
     "@lit/react": "^1.0.8",
     "@shoelace-style/animations": "^1.2.0",
-    "@shoelace-style/localize": "^3.2.1",
+    "@shoelace-style/localize": "^3.2.2",
     "composed-offset-position": "^0.0.6",
     "lit": "^3.2.1",
     "marked": "^11.2.0",


### PR DESCRIPTION
This PR updates `@shoelace-style/localize` to the latest version, which prevents errors from being throw in the console when invalid language codes are passed.

The actual bug was fixed upstream: https://github.com/shoelace-style/localize/commit/d888d8d0d8aa8cd62a0d0180b73dfc7fb9e925b0

Closes #2322