### PR TITLE
Fix broken example in markdown component

### DIFF
--- a/packages/webawesome/docs/docs/components/markdown.md
+++ b/packages/webawesome/docs/docs/components/markdown.md
@@ -132,8 +132,9 @@ All `<wa-markdown>` instances share a single [Marked](https://marked.js.org/usin
 
   // Customize the link renderer to open links in a new tab
   const renderer = {
-    link({ href, text }) {
-      return `<a href="${href}" target="_blank" rel="noopener">${text}</a>`;
+    link(href, title, text) {
+      const titleAttr = title ? ` title="${title}"` : '';
+      return `<a href="${href}"${titleAttr} target="_blank" rel="noopener">${text}</a>`;
     }
   };
 


### PR DESCRIPTION
Fixes #2327, which was a docs bug not a component bug.

<img width="1530" height="636" alt="CleanShot 2026-04-23 at 11 39 53@2x" src="https://github.com/user-attachments/assets/b6eeb1ff-b222-4165-86e2-c7d9f2645aed" />
