### PR TITLE
Improve Local DX

### DIFF
--- a/packages/webawesome/scripts/build.js
+++ b/packages/webawesome/scripts/build.js
@@ -467,7 +467,14 @@ export async function build(options = {}) {
 
             reload();
           } catch (err) {
-            console.error(chalk.red(err));
+            const inner = err?.cause || err?.originalError;
+            const innerStr = inner?.stack || inner?.message;
+            const outer = err?.message;
+            const out =
+              innerStr && outer && !innerStr.includes(outer)
+                ? `${outer}\n\n${innerStr}`
+                : innerStr || err?.stack || outer || String(err);
+            console.error(chalk.red(out));
 
             if (!isDeveloping) {
               process.exit(1);

--- a/packages/webawesome/scripts/build.js
+++ b/packages/webawesome/scripts/build.js
@@ -16,7 +16,7 @@ import copy from 'recursive-copy';
 import { SimulateWebAwesomeApp } from '../docs/_utils/simulate-webawesome-app.js';
 import { generateDocs } from './docs.js';
 import { generateLlmsTxtFile } from './llms.js';
-import { getCdnDir, getDistDir, getDocsDir, getRootDir, getSiteDir } from './utils.js';
+import { formatError, getCdnDir, getDistDir, getDocsDir, getRootDir, getSiteDir } from './utils.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -467,14 +467,7 @@ export async function build(options = {}) {
 
             reload();
           } catch (err) {
-            const inner = err?.cause || err?.originalError;
-            const innerStr = inner?.stack || inner?.message;
-            const outer = err?.message;
-            const out =
-              innerStr && outer && !innerStr.includes(outer)
-                ? `${outer}\n\n${innerStr}`
-                : innerStr || err?.stack || outer || String(err);
-            console.error(chalk.red(out));
+            console.error(chalk.red(formatError(err)));
 
             if (!isDeveloping) {
               process.exit(1);

--- a/packages/webawesome/scripts/docs.js
+++ b/packages/webawesome/scripts/docs.js
@@ -91,13 +91,16 @@ export async function generateDocs(options = {}) {
   function stubConsole(key) {
     const originalFn = console[key];
     console[key] = function (...args) {
-      outputs[key].push(...args);
+      outputs[key].push(args);
     };
     return originalFn;
   }
 
   // Works around a bug in 11ty where it still prints warnings despite the logger being overriden and in quietMode.
   const originalWarn = stubConsole('warn');
+  const restoreConsole = () => {
+    console.warn = originalWarn;
+  };
 
   let output = '';
 
@@ -146,9 +149,21 @@ export async function generateDocs(options = {}) {
       console.log(`Writing the docs ${output}`);
     }
   } catch (error) {
-    console.warn = originalWarn;
+    if (outputs.warn.length > 0) {
+      console.error(chalk.yellow('\n11ty warnings captured during build:'));
+      for (const args of outputs.warn) {
+        console.error(chalk.yellow('  ' + args.map(a => a?.stack || a?.message || a).join(' ')));
+      }
+    }
 
-    console.error('\n\n' + chalk.red(error.cause) + '\n');
+    const inner = error?.cause || error?.originalError;
+    const innerStr = inner?.stack || inner?.message;
+    const outer = error?.message;
+    const out =
+      innerStr && outer && !innerStr.includes(outer)
+        ? `${outer}\n\n${innerStr}`
+        : innerStr || error?.stack || outer || String(error);
+    console.error('\n\n' + chalk.red(out) + '\n');
 
     if (spinner) {
       spinner.fail(chalk.red(`Error while writing the docs.`));
@@ -159,6 +174,8 @@ export async function generateDocs(options = {}) {
     if (!isDeveloping) {
       process.exit(1);
     }
+  } finally {
+    restoreConsole();
   }
 }
 

--- a/packages/webawesome/scripts/docs.js
+++ b/packages/webawesome/scripts/docs.js
@@ -5,7 +5,7 @@ import copy from 'recursive-copy';
 import chalk from 'chalk';
 import { deleteAsync } from 'del';
 import { join } from 'path';
-import { getCdnDir, getDocsDir, getEleventyConfigPath, getSiteDir } from './utils.js';
+import { formatError, getCdnDir, getDocsDir, getEleventyConfigPath, getSiteDir } from './utils.js';
 
 let eleventyBuildResolver;
 let eleventyBuildPromise;
@@ -156,14 +156,7 @@ export async function generateDocs(options = {}) {
       }
     }
 
-    const inner = error?.cause || error?.originalError;
-    const innerStr = inner?.stack || inner?.message;
-    const outer = error?.message;
-    const out =
-      innerStr && outer && !innerStr.includes(outer)
-        ? `${outer}\n\n${innerStr}`
-        : innerStr || error?.stack || outer || String(error);
-    console.error('\n\n' + chalk.red(out) + '\n');
+    console.error('\n\n' + chalk.red(formatError(error)) + '\n');
 
     if (spinner) {
       spinner.fail(chalk.red(`Error while writing the docs.`));

--- a/packages/webawesome/scripts/docs.js
+++ b/packages/webawesome/scripts/docs.js
@@ -152,7 +152,7 @@ export async function generateDocs(options = {}) {
     if (outputs.warn.length > 0) {
       console.error(chalk.yellow('\n11ty warnings captured during build:'));
       for (const args of outputs.warn) {
-        console.error(chalk.yellow('  ' + args.map(a => a?.stack || a?.message || a).join(' ')));
+        console.error(chalk.yellow('  ' + args.map(a => a?.message || a?.stack || String(a)).join(' ')));
       }
     }
 

--- a/packages/webawesome/scripts/utils.js
+++ b/packages/webawesome/scripts/utils.js
@@ -14,14 +14,15 @@ export const getSiteDir = () => process.env.SITE_DIR || join(getRootDir(), '_sit
 export const getEleventyConfigPath = () => process.env.ELEVENTY_CONFIG_PATH || join(getDocsDir(), '.eleventy.js');
 
 /**
- * Formats an error for display in dev terminals. Falls through
- * `cause → originalError → message → stack`, since 11ty stores its
- * useful detail (file path, line, column) on `originalError` —
- * `cause` is almost always empty.
+ * Formats an error for display in dev terminals. 11ty wraps template
+ * failures in a TemplateContentRenderError whose `originalError` carries
+ * the actionable detail (file path, line, column). For the inner error
+ * we prefer `.message` over `.stack` because the message already has
+ * everything useful and the stack adds many lines of internal frames.
  */
 export function formatError(err) {
-  const inner = err?.cause || err?.originalError;
-  const innerStr = inner?.stack || inner?.message;
+  const inner = err?.originalError || err?.cause;
+  const innerStr = inner?.message || inner?.stack;
   const outer = err?.message;
   return innerStr && outer && !innerStr.includes(outer)
     ? `${outer}\n\n${innerStr}`

--- a/packages/webawesome/scripts/utils.js
+++ b/packages/webawesome/scripts/utils.js
@@ -14,6 +14,21 @@ export const getSiteDir = () => process.env.SITE_DIR || join(getRootDir(), '_sit
 export const getEleventyConfigPath = () => process.env.ELEVENTY_CONFIG_PATH || join(getDocsDir(), '.eleventy.js');
 
 /**
+ * Formats an error for display in dev terminals. Falls through
+ * `cause → originalError → message → stack`, since 11ty stores its
+ * useful detail (file path, line, column) on `originalError` —
+ * `cause` is almost always empty.
+ */
+export function formatError(err) {
+  const inner = err?.cause || err?.originalError;
+  const innerStr = inner?.stack || inner?.message;
+  const outer = err?.message;
+  return innerStr && outer && !innerStr.includes(outer)
+    ? `${outer}\n\n${innerStr}`
+    : innerStr || err?.stack || outer || String(err);
+}
+
+/**
  * Runs a script and returns a promise that resolves with the content of stdout when the script exits or rejects with
  * the content of stderr when the script exits with an error.
  */


### PR DESCRIPTION
If you've ever seen `undefined ✖ Error while writing the docs`. while running npm start and felt mildly betrayed, this branch is for you. 

A template syntax error was logging the wrong field — Eleventy puts the useful detail (file path, line, column) on `originalError`, but the build script was reading `cause`, which is almost always empty. 

Now you get the actual file, line, and parser message, plus any 11ty warnings the build captured along the way (previously thrown out). The same fix applies to the watch-mode rebuild handler in `build.js`, so saving a broken template during dev gives you the same useful output. 

Touches `scripts/docs.js` and `scripts/build.js`. All changes live in error paths — successful builds aren't affected.