### PR TITLE
Remove Redundant `wa-gap-m` from Layout Utilities

### DIFF
--- a/packages/webawesome/docs/docs/frameworks.md
+++ b/packages/webawesome/docs/docs/frameworks.md
@@ -21,7 +21,7 @@ Select your framework below to get started.
 <div class="wa-grid" style="--min-column-size: 20ch;">
   <a href="/docs/frameworks/angular" class="wa-link-plain">
     <wa-card appearance="outlined" style="height: 100%;">
-      <div class="wa-stack wa-align-items-center wa-gap-m">
+      <div class="wa-stack wa-align-items-center">
         <wa-icon name="angular" family="brands" style="font-size: var(--wa-font-size-4xl); color: #dd0031;"></wa-icon>
         <span class="wa-heading-m">Angular</span>
       </div>
@@ -29,7 +29,7 @@ Select your framework below to get started.
   </a>
   <a href="/docs/frameworks/react" class="wa-link-plain">
     <wa-card appearance="outlined" style="height: 100%;">
-      <div class="wa-stack wa-align-items-center wa-gap-m">
+      <div class="wa-stack wa-align-items-center">
         <wa-icon name="react" family="brands" style="font-size: var(--wa-font-size-4xl); color: #61dafb;"></wa-icon>
         <span class="wa-heading-m">React</span>
       </div>
@@ -37,7 +37,7 @@ Select your framework below to get started.
   </a>
   <a href="/docs/frameworks/svelte" class="wa-link-plain">
     <wa-card appearance="outlined" style="height: 100%;">
-      <div class="wa-stack wa-align-items-center wa-gap-m">
+      <div class="wa-stack wa-align-items-center">
         <wa-icon src="/assets/images/svelte.svg" style="font-size: var(--wa-font-size-4xl); color: #ff3e00;"></wa-icon>
         <span class="wa-heading-m">Svelte</span>
       </div>
@@ -45,7 +45,7 @@ Select your framework below to get started.
   </a>
   <a href="/docs/frameworks/vue" class="wa-link-plain">
     <wa-card appearance="outlined" style="height: 100%;">
-      <div class="wa-stack wa-align-items-center wa-gap-m">
+      <div class="wa-stack wa-align-items-center">
         <wa-icon name="vuejs" family="brands" style="font-size: var(--wa-font-size-4xl); color: #41b883;"></wa-icon>
         <span class="wa-heading-m">Vue 3</span>
       </div>
@@ -53,7 +53,7 @@ Select your framework below to get started.
   </a>
   <a href="/docs/frameworks/vue-2" class="wa-link-plain">
     <wa-card appearance="outlined" style="height: 100%;">
-      <div class="wa-stack wa-align-items-center wa-gap-m">
+      <div class="wa-stack wa-align-items-center">
         <wa-icon name="vuejs" family="brands" style="font-size: var(--wa-font-size-4xl); color: #41b883;"></wa-icon>
         <span class="wa-heading-m">Vue 2</span>
       </div>

--- a/packages/webawesome/docs/docs/utilities/gap.md
+++ b/packages/webawesome/docs/docs/utilities/gap.md
@@ -37,8 +37,8 @@ Every class besides `wa-gap-0` corresponds to one of the [`--wa-space-*`](/docs/
 
 ## Gap Classes
 
-| Class Name   | `gap` Value      | Preview                                                                                                     |
-| ------------ | ---------------- | ----------------------------------------------------------------------------------------------------------- |
+| Class Name   | `gap` Value      | Preview                                                                                                                     |
+| ------------ | ---------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `wa-gap-0`   | `0`              | <div class="preview-wrapper wa-cluster wa-gap-0"><div class="preview-block"></div><div class="preview-block"></div></div>   |
 | `wa-gap-3xs` | `--wa-space-3xs` | <div class="preview-wrapper wa-cluster wa-gap-3xs"><div class="preview-block"></div><div class="preview-block"></div></div> |
 | `wa-gap-2xs` | `--wa-space-2xs` | <div class="preview-wrapper wa-cluster wa-gap-2xs"><div class="preview-block"></div><div class="preview-block"></div></div> |


### PR DESCRIPTION
This work strips wa-gap-m from layout utility wrappers (wa-stack, wa-cluster, wa-grid) where it's already the default gap size. The demo row in gap.md's class table keeps its wa-gap-m, since the row is labeled wa-gap-m and exists to demonstrate that exact class.

### Companion PRs
- https://github.com/shoelace-style/webawesome-pro/pull/196
- https://github.com/shoelace-style/webawesome-app/pull/355