### PR TITLE
Consistently Set Vertical Spacing on Main Content

### DIFF
--- a/packages/webawesome/docs/_includes/base.njk
+++ b/packages/webawesome/docs/_includes/base.njk
@@ -87,7 +87,7 @@
     {% block pageMainHeader %}{% endblock %}
 
     {# wa-page-based Main Content (default) #}
-    <main id="content">
+    <main id="content"{% if not hasFlushMain %} class="content-container"{% endif %}>
       {# Expandable outline #}
       {% if hasOutline %}
       <nav id="outline-expandable">

--- a/packages/webawesome/docs/_includes/base.njk
+++ b/packages/webawesome/docs/_includes/base.njk
@@ -86,7 +86,11 @@
     {# wa-page-based Main Header #}
     {% block pageMainHeader %}{% endblock %}
 
-    {# wa-page-based Main Content (default) #}
+    {# wa-page-based Main Content (default).
+     # Pages opt out of the default sizing/spacing by setting
+     # `hasFlushMain: true` in their front matter — <main> then
+     # renders without .content-container so the page can handle
+     # its own layout (used by full-bleed marketing pages, etc.). #}
     <main id="content"{% if not hasFlushMain %} class="content-container"{% endif %}>
       {# Expandable outline #}
       {% if hasOutline %}

--- a/packages/webawesome/docs/_includes/nav-products.njk
+++ b/packages/webawesome/docs/_includes/nav-products.njk
@@ -1,5 +1,5 @@
 <div class="wrapper-nav-products">
-  <nav class="nav-products nav-products-full" aria-label="Awesomeverse Products + Links">
+  <nav class="nav-products nav-products-full content-container" aria-label="Awesomeverse Products + Links">
     <div class="nav-products-primary wa-split wa-align-items-stretch">
       <div class="wa-cluster wa-align-items-stretch wa-gap-0">
         <a href="/" class="product product-web-awesome product-active" aria-label="Web Awesome" data-track-event="navigation:product_link_click" data-track-destination="web-awesome" data-track-context="products_nav">

--- a/packages/webawesome/docs/_includes/slot-banner-ba-kickstarter.njk
+++ b/packages/webawesome/docs/_includes/slot-banner-ba-kickstarter.njk
@@ -1,7 +1,7 @@
 {% raw %}
 {% if isBuildAwesomePromoActive %}
 <div slot="banner" class="wrapper-banner">
-  <div class="banner banner-ba-kickstarter brand-build-awesome">
+  <div class="banner banner-ba-kickstarter brand-build-awesome content-container">
     <wa-callout appearance="accent" variant="brand" size="s">
       <wa-icon slot="icon" src="/assets/images/logo-build-awesome-icon.svg" class="banner-icon"style="--logo-icon-fill: var(--wa-color-neutral-fill-loud);"></wa-icon>
       <div class="wa-flank:end">

--- a/packages/webawesome/docs/_includes/slot-subheader.njk
+++ b/packages/webawesome/docs/_includes/slot-subheader.njk
@@ -1,6 +1,6 @@
 {# wa-page slot="subheader": toggle, shortcut links, mobile logo, account #}
 <div slot="subheader" class="wrapper-page-subheader">
-  <div class="page-subheader wa-split">
+  <div class="page-subheader wa-split content-container">
     <div class="wa-cluster wa-gap-2xs">
       {% include "nav-toggle.njk" %}
       {% include "subheader-links.njk" %}

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -84,7 +84,7 @@
 
   /* line-length */
   .line-length {
-    max-width: var(--line-length, none);
+    max-inline-size: var(--line-length, none);
   }
 
   .line-length-xs {

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -166,7 +166,9 @@
   wa-page > [slot='banner'] {
     /* match nav-products background color */
     background-color: var(--nav-products-bg, var(--wa-color-surface-lowered));
-    padding: var(--wa-space-l) var(--content-padding-inline);
+    /* inline padding handled by .content-container on inner .banner */
+    padding-block: var(--wa-space-l);
+    padding-inline: 0;
     transition: background-color var(--wa-transition-slow) var(--wa-transition-easing);
 
     .banner {
@@ -188,8 +190,9 @@
   /*  products nav */
   .wrapper-nav-products {
     background-color: var(--nav-products-bg, var(--wa-color-surface-lowered));
+    /* inline padding handled by .content-container on inner .nav-products-full */
     padding-block-start: var(--wa-space-xs);
-    padding-inline: var(--content-padding-inline);
+    padding-inline: 0;
     inline-size: 100%;
     transition: background-color var(--wa-transition-slow) var(--wa-transition-easing);
   }
@@ -291,7 +294,9 @@
   wa-page > [slot='subheader'] {
     background-color: var(--wa-color-surface-default);
     border-bottom: var(--wa-border-style) var(--wa-panel-border-width) var(--wa-color-surface-border);
-    padding: var(--wa-space-xs) var(--content-padding-inline);
+    /* inline padding handled by .content-container on inner .page-subheader */
+    padding-block: var(--wa-space-xs);
+    padding-inline: 0;
     container-type: inline-size;
     container-name: subheader;
 

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -48,12 +48,12 @@
    * redefinition). Scoped overrides like `.page-footer .content-container { ... }`
    * are fine — only base-class redefinition is forbidden.
    *
-   * Override per-instance width via the `--max-width` custom property:
-   *   main { --max-width: var(--content-width-xs); }
+   * Override per-instance width via the `--max-inline-size` custom property:
+   *   main { --max-inline-size: var(--content-width-xs); }
    */
   .content-container {
     margin-inline: auto;
-    max-inline-size: var(--max-width, var(--content-width-l));
+    max-inline-size: var(--max-inline-size, var(--content-width-l));
     padding-inline: var(--content-padding-inline);
   }
 
@@ -170,7 +170,7 @@
     padding-block: var(--wa-space-l);
     padding-inline: 0;
     /* default to full-width in webawesome docs; pro overrides to --content-width-l */
-    --max-width: 100%;
+    --max-inline-size: 100%;
     transition: background-color var(--wa-transition-slow) var(--wa-transition-easing);
 
     .banner {
@@ -197,7 +197,7 @@
     padding-inline: 0;
     inline-size: 100%;
     /* default to full-width in webawesome docs; pro overrides to --content-width-l */
-    --max-width: 100%;
+    --max-inline-size: 100%;
     transition: background-color var(--wa-transition-slow) var(--wa-transition-easing);
   }
 
@@ -302,7 +302,7 @@
     padding-block: var(--wa-space-xs);
     padding-inline: 0;
     /* default to full-width in webawesome docs; pro overrides to --content-width-l */
-    --max-width: 100%;
+    --max-inline-size: 100%;
     container-type: inline-size;
     container-name: subheader;
 

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -169,6 +169,8 @@
     /* inline padding handled by .content-container on inner .banner */
     padding-block: var(--wa-space-l);
     padding-inline: 0;
+    /* default to full-width in webawesome docs; pro overrides to --content-width-l */
+    --max-width: 100%;
     transition: background-color var(--wa-transition-slow) var(--wa-transition-easing);
 
     .banner {
@@ -194,6 +196,8 @@
     padding-block-start: var(--wa-space-xs);
     padding-inline: 0;
     inline-size: 100%;
+    /* default to full-width in webawesome docs; pro overrides to --content-width-l */
+    --max-width: 100%;
     transition: background-color var(--wa-transition-slow) var(--wa-transition-easing);
   }
 
@@ -297,6 +301,8 @@
     /* inline padding handled by .content-container on inner .page-subheader */
     padding-block: var(--wa-space-xs);
     padding-inline: 0;
+    /* default to full-width in webawesome docs; pro overrides to --content-width-l */
+    --max-width: 100%;
     container-type: inline-size;
     container-name: subheader;
 

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -38,11 +38,41 @@
   }
 
   /* #region layout utilities */
+
+  /*
+   * .content-container — CANONICAL DEFINITION
+   *
+   * Default sizing/centering primitive for main content areas across the
+   * Web Awesome ecosystem (app, marketing, docs). DO NOT redefine this
+   * class anywhere else (no shadow rules in pro site.css base, no app.css
+   * redefinition). Scoped overrides like `.page-footer .content-container { ... }`
+   * are fine — only base-class redefinition is forbidden.
+   *
+   * Override per-instance width via the `--max-width` custom property:
+   *   main { --max-width: var(--content-width-xs); }
+   */
   .content-container {
     margin-inline: auto;
-    max-width: var(--max-width, var(--content-width-l));
+    max-inline-size: var(--max-width, var(--content-width-l));
     padding-inline: var(--content-padding-inline);
   }
+
+  /* Default main content vertical spacing.
+   * Applies when <main> opts into the default sizing pattern via class.
+   * Pages opt out by setting front matter `hasFlushMain: true`, which causes
+   * the layout to omit the class entirely (no spacing, no container). */
+  wa-page > main.content-container {
+    padding-block: var(--wa-space-4xl);
+  }
+
+  /* Neutralize wa-page's shadow-DOM `::slotted(main) { padding: var(--wa-space-3xl) }`
+   * on flush pages. When a page sets `hasFlushMain: true`, <main> renders without
+   * the .content-container class — this rule ensures the page is fully flush,
+   * not inheriting the component's default padding. */
+  wa-page > main:not(.content-container) {
+    padding: 0;
+  }
+
   /* #endregion */
 
   /* #region Text utilities */


### PR DESCRIPTION
Top/Bottom spacing on our views' main content was inconsistent — some pages set it via inline `<style>`, others via custom panels, others not at all. The wrapper components were each hand-rolling their own max-width and centering. 

This PR does the following...
- makes `.content-container` the canonical class for... well... containing content
- then gives every page the same spacing baseline

### What's Changed
  - `.content-container`switches to use logical `max-inline-size`
  -  `base.njk` adds `class="content-container"` to `<main>` unless the page sets `hasFlushMain: true` (allowing for no vertical spacing)
  - `wa-page > main.content-container { padding-block: var(--wa-space-4xl) }` (adding the consistent ~64px top/bottom vertical spacing)
  -  Some CSS guards so that flush pages stay fully flush
  - Wrapper components (banner, subheader, nav-products) now use `.content-container` for sizing — they default to full-width in free docs.
  -   Renaming `--max-width` property to `--max-inline-size`

### Companion PRs
- https://github.com/shoelace-style/webawesome-pro/pull/199
- https://github.com/shoelace-style/webawesome-app/pull/357