### PR TITLE
Sync Up Page Wrapper Naming

### DIFF
--- a/packages/webawesome/docs/_includes/nav-products.njk
+++ b/packages/webawesome/docs/_includes/nav-products.njk
@@ -1,4 +1,4 @@
-<div class="wrapper-nav-products">
+<div class="page-nav-products">
   <nav class="nav-products nav-products-full content-container" aria-label="Awesomeverse Products + Links">
     <div class="nav-products-primary wa-split wa-align-items-stretch">
       <div class="wa-cluster wa-align-items-stretch wa-gap-0">

--- a/packages/webawesome/docs/_includes/slot-banner-ba-kickstarter.njk
+++ b/packages/webawesome/docs/_includes/slot-banner-ba-kickstarter.njk
@@ -1,6 +1,6 @@
 {% raw %}
 {% if isBuildAwesomePromoActive %}
-<div slot="banner" class="wrapper-banner">
+<div slot="banner" class="page-banner">
   <div class="banner banner-ba-kickstarter brand-build-awesome content-container">
     <wa-callout appearance="accent" variant="brand" size="s">
       <wa-icon slot="icon" src="/assets/images/logo-build-awesome-icon.svg" class="banner-icon"style="--logo-icon-fill: var(--wa-color-neutral-fill-loud);"></wa-icon>

--- a/packages/webawesome/docs/_includes/slot-subheader.njk
+++ b/packages/webawesome/docs/_includes/slot-subheader.njk
@@ -1,6 +1,6 @@
 {# wa-page slot="subheader": toggle, shortcut links, mobile logo, account #}
-<div slot="subheader" class="wrapper-page-subheader">
-  <div class="page-subheader wa-split content-container">
+<div slot="subheader" class="page-subheader">
+  <div class="subheader wa-split content-container">
     <div class="wa-cluster wa-gap-2xs">
       {% include "nav-toggle.njk" %}
       {% include "subheader-links.njk" %}

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -193,7 +193,7 @@
   }
 
   /*  products nav */
-  .wrapper-nav-products {
+  .page-nav-products {
     background-color: var(--nav-products-bg, var(--wa-color-surface-lowered));
     /* inline padding handled by .content-container on inner .nav-products-full */
     padding-block-start: var(--wa-space-xs);
@@ -221,7 +221,7 @@
     }
   }
 
-  wa-page:has(.wrapper-nav-products, .nav-products-drawer) {
+  wa-page:has(.page-nav-products, .nav-products-drawer) {
     &:has(.product-web-awesome:hover) {
       --nav-products-bg: var(--nav-products-fill-quiet-web);
     }
@@ -286,7 +286,7 @@
 
     /* Narrow (≤ 80ch): compact header with logo */
     @container header (inline-size <= 80ch) {
-      .wrapper-nav-products {
+      .page-nav-products {
         display: none;
       }
     }


### PR DESCRIPTION
This work aligns wrapper class naming for banner, subheader, and nav-products with the `.page-[sectionName]` convention.

  ## Why
  The wrapper components were using `.wrapper-banner`, `.wrapper-page-subheader`, and `.wrapper-nav-products` — an inconsistent mix that didn't
   match the convention used elsewhere for wa-page slot wrappers.

  ## What's in this PR
  - `.wrapper-banner` → `.page-banner`
  - `.wrapper-page-subheader` → `.page-subheader` (inner `.page-subheader` → `.subheader`)
  - `.wrapper-nav-products` → `.page-nav-products`
  - Updates the corresponding selectors in utils.css
  - Templates updated: `slot-banner-ba-kickstarter.njk`, `slot-subheader.njk`, `nav-products.njk`