### PR TITLE
Additional Emphasis on Current View in Docs Sidebar

### DIFF
--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -696,6 +696,21 @@
     wa-button#search-trigger::part(base) {
       justify-content: flex-start; /* align search trigger button content to start */
     }
+
+    /* current page: accent line replacing the section's left rail */
+    li:has(> .current),
+    li:has(> .wa-split > .current) {
+      position: relative;
+
+      &::before {
+        content: '';
+        position: absolute;
+        inset-block: calc(-1 * var(--wa-space-2xs));
+        inset-inline-start: calc(-1 * var(--wa-space-m) - var(--wa-border-width-s));
+        width: var(--wa-border-width-s);
+        background: var(--wa-color-brand-on-quiet);
+      }
+    }
   }
 
   #sidebar .is-planned {


### PR DESCRIPTION
Per the good suggestion in https://github.com/shoelace-style/webawesome/discussions/2346, this adds an additional visual indicator to the current item in our Docs sidebar.

| Before | After |
|--------|--------|
| <img width="1368" height="1540" alt="image" src="https://github.com/user-attachments/assets/2f510136-c1f1-422c-a6cc-5072bc8fdd49" /> | <img width="1368" height="1540" alt="image" src="https://github.com/user-attachments/assets/94240c4e-12e3-4109-8f5f-ddb3a0149c2d" /> | 