### PR TITLE
Updated text-wrap property

### DIFF
--- a/packages/webawesome/src/styles/native.css
+++ b/packages/webawesome/src/styles/native.css
@@ -109,7 +109,7 @@
   }
 
   p {
-    text-wrap: pretty;
+    text-wrap: wrap;
   }
 
   blockquote {

--- a/packages/webawesome/src/styles/native.css
+++ b/packages/webawesome/src/styles/native.css
@@ -111,7 +111,11 @@
   p {
     text-wrap: wrap;
   }
-
+  @supports (text-wrap: pretty) {
+    p {
+      text-wrap: pretty;
+    }
+  }
   blockquote {
     padding: var(--wa-space-xl);
 


### PR DESCRIPTION
This is a fix for #2331 

In `native.css` we are using `text-wrap: pretty` for all `p` elements. That property is not yet supported in Firefox:
https://caniuse.com/mdn-css_properties_text-wrap_pretty

So I reverted it to `wrap` which according to [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/text-wrap#pretty) will give us more or less the result we want

Before
<img width="1201" height="665" alt="Screenshot 2026-05-06 at 12 07 36 AM" src="https://github.com/user-attachments/assets/8ba705df-4b3d-47c0-be72-3b111a3c7f09" />

After


<img width="1267" height="719" alt="Screenshot 2026-05-06 at 12 07 45 AM" src="https://github.com/user-attachments/assets/c7affc2f-1561-4a6b-9bbb-30459345ff47" />
