### PR TITLE
Add `text-wrap`-Based Text Utilities

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -13,6 +13,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 ## Unreleased
 
 - Added the `wa-text-wrap-nowrap` text utility class for preventing text from wrapping
+- Added the `wa-text-wrap-balance` text utility class for evenly distributing text across lines
 
 ## 3.6.0
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -10,6 +10,10 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 
 {% include "changelog-email-signup.njk" %}
 
+## Unreleased
+
+- Added the `wa-text-wrap-nowrap` text utility class for preventing text from wrapping
+
 ## 3.6.0
 
 <small>April 30th, 2026</small>

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -14,6 +14,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 
 - Added the `wa-text-wrap-nowrap` text utility class for preventing text from wrapping
 - Added the `wa-text-wrap-balance` text utility class for evenly distributing text across lines
+- Added the `wa-text-wrap-pretty` text utility class for avoiding orphaned words on the last line (not supported in Firefox)
 
 ## 3.6.0
 

--- a/packages/webawesome/docs/docs/utilities/text.md
+++ b/packages/webawesome/docs/docs/utilities/text.md
@@ -183,6 +183,11 @@ Use `wa-text-wrap-*` classes to control how text wraps across lines. These utili
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `wa-text-wrap-nowrap`  | <div class="wa-text-wrap-nowrap" style="max-width: 40ch; overflow: hidden; text-overflow: ellipsis;">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div> |
 | `wa-text-wrap-balance` | <div class="wa-text-wrap-balance" style="max-width: 40ch;">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div>                                           |
+| `wa-text-wrap-pretty`  | <div class="wa-text-wrap-pretty" style="max-width: 40ch;">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div>                                            |
+
+:::info
+`wa-text-wrap-pretty` is wrapped in an `@supports` rule because Firefox does not yet support `text-wrap: pretty`. In unsupported browsers, the class has no effect and text wraps normally.
+:::
 
 ## Truncation
 

--- a/packages/webawesome/docs/docs/utilities/text.md
+++ b/packages/webawesome/docs/docs/utilities/text.md
@@ -175,10 +175,18 @@ Use single-purpose `wa-color-text-*` classes to apply a given [text color](/docs
 | `wa-color-text-normal` | <div class="wa-color-text-normal">Five boxing wizards</div> |
 | `wa-color-text-link`   | <div class="wa-color-text-link">Five boxing wizards</div>   |
 
+## Wrapping
+
+Use `wa-text-wrap-*` classes to control how text wraps across lines. These utilities apply standard CSS [`text-wrap`](https://developer.mozilla.org/docs/Web/CSS/text-wrap) values.
+
+| Class Name            | Preview                                                                                                                                                                               |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `wa-text-wrap-nowrap` | <div class="wa-text-wrap-nowrap" style="max-width: 40ch; overflow: hidden; text-overflow: ellipsis;">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div> |
+
 ## Truncation
 
 Use the `wa-text-truncate` class to truncate text with an ellipsis instead of letting it overflow or wrap.
 
-| Class Name         | Preview                                                     |
-| ------------------ | ----------------------------------------------------------- |
-| `wa-text-truncate` | <div class="wa-text-truncate" style="max-width: 40ch;">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div>  |
+| Class Name         | Preview                                                                                                                                 |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `wa-text-truncate` | <div class="wa-text-truncate" style="max-width: 40ch;">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div> |

--- a/packages/webawesome/docs/docs/utilities/text.md
+++ b/packages/webawesome/docs/docs/utilities/text.md
@@ -181,7 +181,7 @@ Use `wa-text-wrap-*` classes to control how text wraps across lines. These utili
 
 | Class Name             | Preview                                                                                                                                                                               |
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `wa-text-wrap-nowrap`  | <div class="wa-text-wrap-nowrap" style="max-width: 40ch; overflow: hidden; text-overflow: ellipsis;">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div> |
+| `wa-text-wrap-nowrap`  | <div class="wa-text-wrap-nowrap" style="max-width: 40ch; overflow: hidden;">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div> |
 | `wa-text-wrap-balance` | <div class="wa-text-wrap-balance" style="max-width: 40ch;">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div>                                           |
 | `wa-text-wrap-pretty`  | <div class="wa-text-wrap-pretty" style="max-width: 40ch;">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div>                                            |
 

--- a/packages/webawesome/docs/docs/utilities/text.md
+++ b/packages/webawesome/docs/docs/utilities/text.md
@@ -179,9 +179,10 @@ Use single-purpose `wa-color-text-*` classes to apply a given [text color](/docs
 
 Use `wa-text-wrap-*` classes to control how text wraps across lines. These utilities apply standard CSS [`text-wrap`](https://developer.mozilla.org/docs/Web/CSS/text-wrap) values.
 
-| Class Name            | Preview                                                                                                                                                                               |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `wa-text-wrap-nowrap` | <div class="wa-text-wrap-nowrap" style="max-width: 40ch; overflow: hidden; text-overflow: ellipsis;">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div> |
+| Class Name             | Preview                                                                                                                                                                               |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `wa-text-wrap-nowrap`  | <div class="wa-text-wrap-nowrap" style="max-width: 40ch; overflow: hidden; text-overflow: ellipsis;">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div> |
+| `wa-text-wrap-balance` | <div class="wa-text-wrap-balance" style="max-width: 40ch;">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div>                                           |
 
 ## Truncation
 

--- a/packages/webawesome/src/styles/utilities/text.css
+++ b/packages/webawesome/src/styles/utilities/text.css
@@ -155,6 +155,12 @@
   .wa-text-wrap-balance {
     text-wrap: balance;
   }
+
+  @supports (text-wrap: pretty) {
+    .wa-text-wrap-pretty {
+      text-wrap: pretty;
+    }
+  }
   /* #endregion */
 
   /* #region Links ~~~~~~~ */

--- a/packages/webawesome/src/styles/utilities/text.css
+++ b/packages/webawesome/src/styles/utilities/text.css
@@ -151,6 +151,10 @@
   .wa-text-wrap-nowrap {
     text-wrap: nowrap;
   }
+
+  .wa-text-wrap-balance {
+    text-wrap: balance;
+  }
   /* #endregion */
 
   /* #region Links ~~~~~~~ */

--- a/packages/webawesome/src/styles/utilities/text.css
+++ b/packages/webawesome/src/styles/utilities/text.css
@@ -147,6 +147,10 @@
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+
+  .wa-text-wrap-nowrap {
+    text-wrap: nowrap;
+  }
   /* #endregion */
 
   /* #region Links ~~~~~~~ */


### PR DESCRIPTION
 This work adds three new text utility classes for controlling line wrapping:         
                                                                
1. `wa-text-wrap-nowrap` → `text-wrap: nowrap` (prevents wrapping)
1. `wa-text-wrap-balance` → `text-wrap: balance` (evens out line lengths — best for short text)
1. `wa-text-wrap-pretty` → `text-wrap: pretty` (avoids orphaned single words on the last line)           

### Other Notes             
  - `wa-text-wrap-pretty` is wrapped in `@supports (text-wrap: pretty)` because Firefox does not yet ship the value. In unsupported browsers,  
  the class has no effect and text wraps normally.                                                                                             
  - Names follow the dominant `wa-{property}-{value}` convention used by `wa-align-items-*`, `wa-justify-content-*`, `wa-font-size-*`, etc. —  
  so a reader sees the class and immediately knows it sets `text-wrap`.                                                                        
  - Adds a new **Wrapping** section to the [Text utilities docs page](/docs/utilities/text), placed before **Truncation**.                                                                            
  - Adds a new **Unreleased** changelog section with one entry per utility.  