### PR TITLE
Remove `line-height` from buttons

### DIFF
--- a/packages/webawesome/src/components/button/button.styles.ts
+++ b/packages/webawesome/src/components/button/button.styles.ts
@@ -37,7 +37,6 @@ export default css`
     font-family: inherit;
     font-size: inherit;
     font-weight: var(--wa-font-weight-action);
-    line-height: calc(var(--wa-form-control-height) - var(--wa-form-control-border-width) * 2);
     height: var(--wa-form-control-height);
     width: 100%;
 

--- a/packages/webawesome/src/styles/native.css
+++ b/packages/webawesome/src/styles/native.css
@@ -601,7 +601,6 @@
       font-family: inherit;
       font-size: var(--wa-form-control-value-font-size);
       font-weight: var(--wa-font-weight-action);
-      line-height: calc(var(--wa-form-control-height) - var(--border-width) * 2);
       text-decoration: none;
       vertical-align: middle;
       white-space: nowrap;


### PR DESCRIPTION
For buttons, we currently set `line-height: calc(var(--wa-form-control-height) - var(--wa-form-control-border-width) * 2);`, which causes trouble for buttons with complex content (see below). Since buttons are `inline-flex` containers and already center content in both directions, `line-height` doesn't seem to be necessary.

This PR removes the property from `wa-button` and native buttons. I haven't seen any ill effects from doing so, but please give a shout if I'm missing something.

---

**Before**
<img width="1292" height="386" alt="Screenshot 2026-05-06 at 5 00 11 PM" src="https://github.com/user-attachments/assets/ac35b815-626b-4be6-b26f-e2f8c210a114" />

**After**
<img width="1292" height="330" alt="Screenshot 2026-05-06 at 5 02 03 PM" src="https://github.com/user-attachments/assets/b3dcf43e-3284-4fb7-be4b-2cb4d7aa74f1" />
