### PR TITLE
Docs: Improve Prose Rhythm and Typography

### DIFF
--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -99,6 +99,71 @@ wa-page > main:has(.modern-card-list) {
   max-inline-size: var(--content-width-m);
 }
 
+/* Prose rhythm — replaces the wa-native layer's uniform `--wa-content-spacing`
+   between block siblings with hierarchical, asymmetric margins. Unlayered so
+   it wins via cascade order; re-check if this file ever joins a layer. */
+#content {
+  /* Headings hug what they introduce: generous above, tight below. */
+
+  * + h2 {
+    margin-block-start: var(--wa-space-2xl);
+  }
+  h2:has(+ *) {
+    margin-block-end: var(--wa-space-s);
+  }
+
+  * + h3 {
+    margin-block-start: var(--wa-space-xl);
+  }
+  h3:has(+ *) {
+    margin-block-end: var(--wa-space-s);
+  }
+
+  :is(h4, h5, h6):has(+ *) {
+    margin-block-end: var(--wa-space-xs);
+  }
+
+  /* Prevents stacked top + bottom margins on back-to-back headings. */
+  h2 + :is(h3, h4),
+  h3 + h4 {
+    margin-block-start: var(--wa-space-m);
+  }
+
+  :is(ul, ol) > li:has(+ li) {
+    margin-block-end: var(--wa-space-2xs);
+  }
+
+  /* Slight optical tracking; only the larger sizes need it. */
+  :is(h1, h2) {
+    letter-spacing: -0.01em;
+  }
+
+  /* `<hr>` marks a topic shift. Its own margin defines the gap; the heading
+     or paragraph that follows shouldn't double-stack on top. */
+  hr {
+    margin-block: var(--wa-space-xl);
+  }
+  hr + :is(h1, h2, h3, h4, h5, h6) {
+    margin-block-start: 0;
+  }
+
+  /* Major non-text blocks get more breathing room than running prose, but
+     headings still hug — so the top-margin rule only applies after non-heading
+     siblings. */
+  :is(pre, figure, table, blockquote, wa-callout, .code-example):has(+ *) {
+    margin-block-end: var(--wa-space-xl);
+  }
+
+  :not(h1, h2, h3, h4, h5, h6) + :is(pre, figure, table, blockquote, wa-callout, .code-example) {
+    margin-block-start: var(--wa-space-xl);
+  }
+
+  /* Visually heavy blocks still deserve a minimum breath after a heading. */
+  :is(h1, h2, h3, h4, h5, h6) + :is(pre, figure, table, blockquote, wa-callout, .code-example) {
+    margin-block-start: var(--wa-space-m);
+  }
+}
+
 h1.title {
   wa-badge {
     vertical-align: middle;
@@ -131,8 +196,6 @@ h1.title {
 
 /* Callouts in content */
 #content > wa-callout {
-  margin-block-end: var(--wa-content-spacing);
-
   &[variant='brand'] code {
     background-color: color-mix(in oklab, var(--wa-color-brand-fill-soft), black 2.5%);
   }
@@ -374,6 +437,8 @@ wa-scroller:has(.component-table) {
 }
 
 .component-table {
+  font-variant-numeric: tabular-nums;
+
   .table-name {
     white-space: nowrap;
   }

--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -141,7 +141,7 @@ wa-page > main:has(.modern-card-list) {
   /* `<hr>` marks a topic shift. Its own margin defines the gap; the heading
      or paragraph that follows shouldn't double-stack on top. */
   hr {
-    margin-block: var(--wa-space-xl);
+    margin-block: var(--wa-space-3xl);
   }
   hr + :is(h1, h2, h3, h4, h5, h6) {
     margin-block-start: 0;


### PR DESCRIPTION
Web Awesome's native typography sets a uniform 24px gap below every block-level element — `h1–h6`, `p`, `ul`, `pre`, `figure`, all sharing the same `--wa-content-spacing`. In long-form docs copy, that uniformity made everything feel structurally flat: a major section break read the same as the next sentence. 

This PR adds a "Prose rhythm" block to `docs.css` (scoped to `#content`) that replaces the uniform gap with hierarchical, asymmetric rhythm. All values use existing `--wa-space-*` tokens.

### Heading Rhythm
Headings now hug the content they introduce. `h2` gets 40px above and 12px below; `h3` gets 32px above and 12px below; `h4–h6` keep their default top margin and tighten the bottom to 8px. Consecutive headings (e.g., an `h2` immediately followed by an `h3` with no body between) tighten to 16px so they don't double-space.

### Section Breaks and Major Non-Text Blocks
`<hr>` becomes a true section divider with 48px of breathing room on each side — the strongest visual break in the rhythm. Major content blocks (`<pre>`, `<figure>`, `<table>`, `<blockquote>`, `<wa-callout>`, `.code-example`) get 32px above and below when sitting between paragraphs. When they immediately follow a heading, they get a 16px minimum gap so the heading still hugs the block while the block keeps the air it deserves.

### Polish
Multi-line list items get 4px of breath between siblings. Display headings (`h1`, `h2`) get a hair of negative letter-tracking (`-0.01em`) for a tighter optical fit. Component API tables get `font-variant-numeric: tabular-nums` so numeric columns align cleanly.

### Screenies

| Before | After |
|--------|--------|
| <img width="3024" height="1732" alt="image" src="https://github.com/user-attachments/assets/b709b1aa-1c3e-41fa-8037-5f1574c7af26" /> | <img width="3024" height="1732" alt="image" src="https://github.com/user-attachments/assets/3404d736-49dc-4b2d-9876-db5344bdbfd9" /> |
| <img width="3024" height="1732" alt="image" src="https://github.com/user-attachments/assets/2e94d900-501f-4f70-8007-113b09569038" /> | <img width="3024" height="1732" alt="image" src="https://github.com/user-attachments/assets/05465c5f-b162-4ebe-aedf-dca893755447" /> |
### Implementation
The block is scoped to `#content` and uses sibling combinators (`* + h2`) so first-on-page elements don't pick up extraneous top margins. The rules are unlayered, which lets them cleanly override `native.css`'s `wa-native` layer via cascade order.