### PR TITLE
Add Prose Text Utility

### DIFF
--- a/packages/webawesome/docs/_includes/base.njk
+++ b/packages/webawesome/docs/_includes/base.njk
@@ -93,7 +93,7 @@
      # `hasFlushMain: true` in their front matter — <main> then
      # renders without .content-container so the page can handle
      # its own layout (used by full-bleed marketing pages, etc.). #}
-    <main id="content"{% if not hasFlushMain %} class="content-container"{% endif %}>
+    <main id="content"{% if not hasFlushMain %} class="content-container{% if proseContent %} wa-prose{% endif %}"{% endif %}>
       {# Expandable outline #}
       {% if hasOutline %}
       <nav id="outline-expandable">

--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -87,71 +87,37 @@ wa-page > main:has(.modern-card-list) {
   max-inline-size: var(--content-width-m);
 }
 
-/* Prose rhythm — replaces the wa-native layer's uniform `--wa-content-spacing`
-   between block siblings with hierarchical, asymmetric margins. Unlayered so
-   it wins via cascade order; re-check if this file ever joins a layer. */
+/* The docs main column is wider than `wa-prose`'s default 65ch. Anchor the
+   reading-column custom property to the docs token so existing layouts —
+   default, modern-card-list, and page-wide — keep their established widths. */
 #content {
-  /* Headings hug what they introduce: generous above, tight below. */
+  --wa-prose-line-length: var(--content-width-s);
 
-  * + h2 {
-    margin-block-start: var(--wa-space-2xl);
-  }
-  h2:has(+ *) {
-    margin-block-end: var(--wa-space-s);
-  }
+  /* Remap wa-prose's em-based rhythm to the docs' rem-based spacing scale.
+     wa-prose intentionally scales with element font-size, but the docs were
+     authored against the rem-based rhythm and depend on that visual cadence. */
+  --wa-prose-rhythm-2xs: var(--wa-space-2xs);
+  --wa-prose-rhythm-xs: var(--wa-space-xs);
+  --wa-prose-rhythm-s: var(--wa-space-s);
+  --wa-prose-rhythm-m: var(--wa-space-m);
+  --wa-prose-rhythm-l: var(--wa-space-l);
+  --wa-prose-rhythm-xl: var(--wa-space-xl);
+  --wa-prose-rhythm-2xl: var(--wa-space-2xl);
+  --wa-prose-rhythm-3xl: var(--wa-space-3xl);
 
-  * + h3 {
-    margin-block-start: var(--wa-space-xl);
+  /* Extend wa-prose's major-blocks treatment to `.code-example` live demos
+     (wa-prose covers `<details>` natively). */
+  .code-example:has(+ *) {
+    margin-block-end: var(--wa-prose-rhythm-xl);
   }
-  h3:has(+ *) {
-    margin-block-end: var(--wa-space-s);
+  :not(h1, h2, h3, h4, h5, h6) + .code-example {
+    margin-block-start: var(--wa-prose-rhythm-xl);
   }
-
-  :is(h4, h5, h6):has(+ *) {
-    margin-block-end: var(--wa-space-xs);
-  }
-
-  /* Prevents stacked top + bottom margins on back-to-back headings. */
-  h2 + :is(h3, h4),
-  h3 + h4 {
-    margin-block-start: var(--wa-space-m);
-  }
-
-  :is(ul, ol) > li:has(+ li) {
-    margin-block-end: var(--wa-space-2xs);
+  :is(h1, h2, h3, h4, h5, h6) + .code-example {
+    margin-block-start: var(--wa-prose-rhythm-m);
   }
 
-  /* Slight optical tracking; only the larger sizes need it. */
-  :is(h1, h2) {
-    letter-spacing: -0.01em;
-  }
-
-  /* `<hr>` marks a topic shift. Its own margin defines the gap; the heading
-     or paragraph that follows shouldn't double-stack on top. */
-  hr {
-    margin-block: var(--wa-space-3xl);
-  }
-  hr + :is(h1, h2, h3, h4, h5, h6) {
-    margin-block-start: 0;
-  }
-
-  /* Major non-text blocks get more breathing room than running prose, but
-     headings still hug — so the top-margin rule only applies after non-heading
-     siblings. */
-  :is(pre, figure, table, blockquote, wa-callout, .code-example, details):has(+ *) {
-    margin-block-end: var(--wa-space-xl);
-  }
-
-  :not(h1, h2, h3, h4, h5, h6) + :is(pre, figure, table, blockquote, wa-callout, .code-example, details) {
-    margin-block-start: var(--wa-space-xl);
-  }
-
-  /* Visually heavy blocks still deserve a minimum breath after a heading. */
-  :is(h1, h2, h3, h4, h5, h6) + :is(pre, figure, table, blockquote, wa-callout, .code-example, details) {
-    margin-block-start: var(--wa-space-m);
-  }
-
-  /* Treat h2 + `<small><time>` as one header unit. */
+  /* Treat h2 + `<small><time>` as one header unit (changelog releases). */
   h2:has(+ p > small > time) {
     margin-block-end: var(--wa-space-3xs);
   }
@@ -161,11 +127,17 @@ wa-page > main:has(.modern-card-list) {
     color: var(--wa-color-text-quiet);
   }
 
-  /* Subordinate the prerelease version headings inside `<details data-no-outline>`
+  /* Subordinate prerelease version headings inside `<details data-no-outline>`
      so they read as historical, not peer to current releases. */
   details[data-no-outline] h2 {
     font-size: var(--wa-font-size-l);
     margin-block-start: var(--wa-space-l);
+  }
+
+  /* The breadcrumb is navigation, not prose flow — drop wa-prose's
+     previous-sibling top margin on the page title that follows it. */
+  .page-breadcrumbs + h1 {
+    margin-block-start: 0;
   }
 }
 

--- a/packages/webawesome/docs/docs/docs.json
+++ b/packages/webawesome/docs/docs/docs.json
@@ -1,0 +1,3 @@
+{
+  "proseContent": true
+}

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -69,6 +69,7 @@ These are still finding their shape. APIs can change between minor versions, so 
 - Added the `wa-text-wrap-nowrap` text utility class for preventing text from wrapping
 - Added the `wa-text-wrap-balance` text utility class for evenly distributing text across lines
 - Added the `wa-text-wrap-pretty` text utility class for avoiding orphaned words on the last line (not supported in Firefox)
+- Added the `wa-prose` utility class for applying typographic rhythm to long-form content (docs, blog posts, marketing copy).
 
 :::
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -26,6 +26,7 @@ These are still finding their shape. APIs can change between minor versions, so 
 - Added the `wa-text-center` text utility class for centered text alignment
 - Added the `wa-text-end` text utility class for logical (direction-aware) text alignment
 - Added the `wa-text-justify` text utility class for justified text alignment
+- Added the `wa-prose` utility class for applying typographic rhythm to long-form content (docs, blog posts, marketing copy)
 
 :::
 
@@ -69,7 +70,6 @@ These are still finding their shape. APIs can change between minor versions, so 
 - Added the `wa-text-wrap-nowrap` text utility class for preventing text from wrapping
 - Added the `wa-text-wrap-balance` text utility class for evenly distributing text across lines
 - Added the `wa-text-wrap-pretty` text utility class for avoiding orphaned words on the last line (not supported in Firefox)
-- Added the `wa-prose` utility class for applying typographic rhythm to long-form content (docs, blog posts, marketing copy).
 
 :::
 

--- a/packages/webawesome/docs/docs/utilities/prose.md
+++ b/packages/webawesome/docs/docs/utilities/prose.md
@@ -1,0 +1,207 @@
+---
+title: Prose
+description: The wa-prose utility applies hierarchical, asymmetric typographic rhythm to long-form content like documentation, articles, and marketing copy.
+layout: page-outline
+tags: styleUtilities
+synonyms:
+  - prose
+  - longform
+  - article
+  - copy
+  - typography rhythm
+use-cases:
+  - blog post
+  - documentation
+  - marketing copy
+  - long-form content
+  - article
+---
+
+Web Awesome's [native styles](/docs/utilities/native/) give every block-level element the same vertical breathing room. That works well for app UIs and dashboards where hierarchy comes from layout structure, but it can make long-form copy feel structurally flat — a major section break reads the same as the next sentence.
+
+Wrap a block of content in `wa-prose` to switch on a richer rhythm: more space above headings (separating from the prior section), less below (so the heading hugs the content it introduces), generous breathing room around major non-text blocks, and a true section divider for `<hr>`. Spacing is em-based, so the whole prose body scales when composed with `wa-font-size-*` utilities.
+
+## Using prose
+
+Wrap your long-form content in any block element with the `wa-prose` class.
+
+```html
+<article class="wa-prose">
+  <h2>Section heading</h2>
+  <p>Body content…</p>
+</article>
+```
+
+By default, content is constrained to a comfortable reading column of `65ch`. Override `--wa-prose-line-length` on the container — or set `max-inline-size` directly — to widen, narrow, or remove the constraint.
+
+## Examples
+
+### Headings and paragraphs
+
+Each heading level has a different relationship with the content above and below — generous space above, tight space below — so the eye reads headings as part of the section they introduce, not the one they follow.
+
+```html {.example}
+<article class="wa-prose">
+  <h2>Customizing components</h2>
+  <p>
+    Web Awesome components expose CSS parts, custom properties, and custom states so you can adjust their look without
+    touching their internals.
+  </p>
+
+  <h3>CSS parts</h3>
+  <p>
+    Use <code>::part()</code> to style any element a component exposes by name. Parts are stable hooks that survive
+    changes to a component's internal markup.
+  </p>
+
+  <h4>When to use them</h4>
+  <p>
+    Reach for parts when a custom property doesn't expose what you need, or when the change is specific to one element
+    inside the shadow DOM.
+  </p>
+</article>
+```
+
+### Section breaks and major blocks
+
+Code samples, tables, callouts, and horizontal rules get more breathing room than running prose, so they read as distinct chunks of content rather than another sentence.
+
+```html {.example}
+<article class="wa-prose">
+  <h2>Component sizes</h2>
+  <p>Most form controls and content components support a <code>size</code> attribute with three values.</p>
+
+  <pre><code>&lt;wa-button size="small"&gt;Small&lt;/wa-button&gt;
+&lt;wa-button size="medium"&gt;Medium&lt;/wa-button&gt;
+&lt;wa-button size="large"&gt;Large&lt;/wa-button&gt;</code></pre>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Value</th>
+        <th>Use for</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>small</code></td>
+        <td>Compact UI, sidebars, dense forms</td>
+      </tr>
+      <tr>
+        <td><code>medium</code></td>
+        <td>Default for most contexts</td>
+      </tr>
+      <tr>
+        <td><code>large</code></td>
+        <td>Hero areas, emphasized actions</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <hr />
+
+  <wa-callout variant="brand">
+    <wa-icon slot="icon" name="lightbulb" variant="regular"></wa-icon>
+    Pair sizes with the <a href="/docs/utilities/text/">text utilities</a> to keep type and component scale in lockstep.
+  </wa-callout>
+</article>
+```
+
+### Inline elements and definitions
+
+`wa-prose` styles the inline and structural elements you'd reach for in long-form writing — including `<kbd>`, `<mark>`, `<sub>`/`<sup>`, `<abbr>`, and definition lists.
+
+```html {.example}
+<article class="wa-prose">
+  <p>
+    Press <kbd>/</kbd> to <mark>jump to search</mark> the docs. Inline notation like H<sub>2</sub>O or E=mc<sup>2</sup>
+    renders correctly, and the <abbr title="Application Programming Interface">API</abbr> reference sits at the end of
+    every component page.
+  </p>
+
+  <dl>
+    <dt>Em</dt>
+    <dd>A length relative to the current element's font-size.</dd>
+    <dt>Rem</dt>
+    <dd>A length relative to the root element's font-size.</dd>
+    <dt>Ch</dt>
+    <dd>The advance measure of the "0" character — useful for capping reading column width.</dd>
+  </dl>
+</article>
+```
+
+## Composing with font-size utilities
+
+`wa-prose` uses em-based spacing internally. Apply any [`wa-font-size-*`](/docs/utilities/text/#font-size) utility to the same container and the whole prose body — text, headings, and rhythm — scales proportionally. No size variants required.
+
+```html {.example}
+<div class="wa-cluster wa-align-items-flex-start" style="gap: var(--wa-space-l);">
+  <article class="wa-prose" style="--wa-prose-line-length: 28ch;">
+    <h3>Default size</h3>
+    <p>Headings, body text, and rhythm all use the theme's default scale.</p>
+    <ul>
+      <li>One item</li>
+      <li>Another item</li>
+    </ul>
+  </article>
+
+  <article class="wa-prose wa-font-size-s" style="--wa-prose-line-length: 28ch;">
+    <h3>With wa-font-size-s</h3>
+    <p>Same content, scaled down. Heading-to-paragraph rhythm stays proportional.</p>
+    <ul>
+      <li>One item</li>
+      <li>Another item</li>
+    </ul>
+  </article>
+</div>
+```
+
+## Adjusting rhythm
+
+Override `--wa-prose-rhythm-scale` (default `1`) on the prose container to multiply every margin in the system. Values below `1` tighten the rhythm; values above loosen it. Type sizes are unaffected.
+
+```html {.example}
+<div class="wa-cluster wa-align-items-flex-start" style="gap: var(--wa-space-l);">
+  <article class="wa-prose" style="--wa-prose-line-length: 28ch;">
+    <h3>Default rhythm</h3>
+    <p>Standard breathing room between blocks.</p>
+    <p>This second paragraph follows the default scale.</p>
+  </article>
+
+  <article class="wa-prose" style="--wa-prose-line-length: 28ch; --wa-prose-rhythm-scale: 0.6;">
+    <h3>Tighter rhythm</h3>
+    <p>Every gap is 40% smaller — useful for sidebars or dense content.</p>
+    <p>Type stays the same size; only the spacing tightens.</p>
+  </article>
+</div>
+```
+
+## Theming
+
+Color in `wa-prose` flows from your theme's [color tokens](/docs/tokens/color/) — toggle dark mode or switch themes and the prose follows automatically. To recolor a specific element for prose contexts, use a descendant selector on your container.
+
+```css
+.changelog.wa-prose a {
+  color: var(--wa-color-brand-on-quiet);
+}
+```
+
+## Opting out of prose
+
+Apply `wa-not-prose` to any element inside a `wa-prose` container to disable the prose rhythm for that element and its descendants. Other utility classes — like `wa-cluster`, `wa-stack`, or `wa-font-size-*` — keep working inside the opt-out subtree.
+
+```html {.example}
+<article class="wa-prose">
+  <h3>Inside prose</h3>
+  <p>This paragraph follows wa-prose rhythm.</p>
+
+  <div class="wa-not-prose">
+    <div class="wa-cluster" style="gap: var(--wa-space-s);">
+      <wa-button variant="brand">Get started</wa-button>
+      <wa-button appearance="outlined">Learn more</wa-button>
+    </div>
+  </div>
+
+  <p>This paragraph picks up the prose rhythm again.</p>
+</article>
+```

--- a/packages/webawesome/docs/docs/utilities/prose.md
+++ b/packages/webawesome/docs/docs/utilities/prose.md
@@ -19,7 +19,7 @@ use-cases:
 
 Web Awesome's [native styles](/docs/utilities/native/) give every block-level element the same vertical breathing room. That works well for app UIs and dashboards where hierarchy comes from layout structure, but it can make long-form copy feel structurally flat — a major section break reads the same as the next sentence.
 
-Wrap a block of content in `wa-prose` to switch on a richer rhythm: more space above headings (separating from the prior section), less below (so the heading hugs the content it introduces), generous breathing room around major non-text blocks, and a true section divider for `<hr>`. Spacing is em-based, so the whole prose body scales when composed with `wa-font-size-*` utilities.
+Wrap a block of content in `wa-prose` to switch on a richer rhythm: generous space above headings, tighter space below, more breathing room around major non-text blocks, and a true section divider for `<hr>`. Spacing is em-based and scales with `wa-font-size-*` utilities.
 
 ## Using prose
 
@@ -38,33 +38,81 @@ By default, content is constrained to a comfortable reading column of `65ch`. Ov
 
 ### Headings and paragraphs
 
-Each heading level has a different relationship with the content above and below — generous space above, tight space below — so the eye reads headings as part of the section they introduce, not the one they follow.
+Each heading level gets generous space above and tight space below, so the eye reads it as part of the section it introduces — not the one it follows. When two headings sit back-to-back, the second tightens up so it reads as subordinate to the first.
 
 ```html {.example}
 <article class="wa-prose">
-  <h2>Customizing components</h2>
+  <h1>Customizing components</h1>
+  <h2>Three hooks to know</h2>
   <p>
-    Web Awesome components expose CSS parts, custom properties, and custom states so you can adjust their look without
-    touching their internals.
+    Web Awesome components are built to bend to your design system without your having to crack them open. Three
+    customization hooks do most of the work — CSS parts, custom properties, and custom states — each suited to a
+    different kind of override.
   </p>
 
   <h3>CSS parts</h3>
   <p>
-    Use <code>::part()</code> to style any element a component exposes by name. Parts are stable hooks that survive
-    changes to a component's internal markup.
+    Reach for <code>::part()</code> when you need to style an element a component exposes by name. Parts are stable
+    hooks that survive changes to a component's internal markup.
   </p>
 
-  <h4>When to use them</h4>
+  <h4>When to reach for them</h4>
   <p>
-    Reach for parts when a custom property doesn't expose what you need, or when the change is specific to one element
-    inside the shadow DOM.
+    Use parts when a custom property doesn't expose what you need, or when the change is specific to one element inside
+    the shadow DOM and you'd like it to survive a future version bump.
   </p>
 </article>
 ```
 
-### Section breaks and major blocks
+### Lists
 
-Code samples, tables, callouts, and horizontal rules get more breathing room than running prose, so they read as distinct chunks of content rather than another sentence.
+Lists get a small breath between multi-line items and quiet `::marker` colors so bullets and numbers don't compete with the prose. Definition lists bold the term so each pair reads as a unit.
+
+```html {.example}
+<article class="wa-prose">
+  <ul>
+    <li>CSS parts let you style elements a component exposes by name.</li>
+    <li>
+      Custom properties expose specific values that components compose into their own styles — the preferred surface for
+      theme-level overrides.
+    </li>
+    <li>Custom states reflect a component's internal state for transitions and modes.</li>
+  </ul>
+
+  <ol>
+    <li>Try a custom property first.</li>
+    <li>If nothing fits, reach for a CSS part.</li>
+    <li>For state-driven changes, use the matching custom state.</li>
+  </ol>
+
+  <dl>
+    <dt>Em</dt>
+    <dd>A length relative to the current element's font-size.</dd>
+    <dt>Rem</dt>
+    <dd>A length relative to the root element's font-size.</dd>
+    <dt>Ch</dt>
+    <dd>The advance measure of the "0" character — useful for capping reading column width.</dd>
+  </dl>
+</article>
+```
+
+### Inline elements
+
+Inline elements you'd reach for in long-form writing — `<kbd>`, `<mark>`, `<sub>`/`<sup>`, `<abbr>` — work as expected inside a prose container, styled by [native styles](/docs/utilities/native/).
+
+```html {.example}
+<article class="wa-prose">
+  <p>
+    Press <kbd>/</kbd> to <mark>jump to search</mark> the docs. Inline notation like H<sub>2</sub>O or E=mc<sup>2</sup>
+    renders correctly, and the <abbr title="Application Programming Interface">API</abbr> reference sits at the end of
+    every component page.
+  </p>
+</article>
+```
+
+### Major blocks
+
+Code samples, tables, callouts, and collapsible `<details>` get more breathing room than running prose, so they read as distinct chunks of content rather than another sentence.
 
 ```html {.example}
 <article class="wa-prose">
@@ -98,7 +146,13 @@ Code samples, tables, callouts, and horizontal rules get more breathing room tha
     </tbody>
   </table>
 
-  <hr />
+  <details>
+    <summary>Why three sizes and not more?</summary>
+    <p>
+      Three covers the practical span — compact, default, prominent — without forcing authors to pick from a long list.
+      For finer control, reach for the <a href="/docs/utilities/text/">text utilities</a>.
+    </p>
+  </details>
 
   <wa-callout variant="brand">
     <wa-icon slot="icon" name="lightbulb" variant="regular"></wa-icon>
@@ -107,32 +161,39 @@ Code samples, tables, callouts, and horizontal rules get more breathing room tha
 </article>
 ```
 
-### Inline elements and definitions
+### Section breaks
 
-`wa-prose` styles the inline and structural elements you'd reach for in long-form writing — including `<kbd>`, `<mark>`, `<sub>`/`<sup>`, `<abbr>`, and definition lists.
+`<hr>` marks a topic shift. Its own margin defines the gap; the heading or paragraph that follows hugs up to it so the divider stays visually anchored to what comes next.
 
 ```html {.example}
 <article class="wa-prose">
   <p>
-    Press <kbd>/</kbd> to <mark>jump to search</mark> the docs. Inline notation like H<sub>2</sub>O or E=mc<sup>2</sup>
-    renders correctly, and the <abbr title="Application Programming Interface">API</abbr> reference sits at the end of
-    every component page.
+    Web Awesome components expose stable surfaces for customization, but every project eventually needs something the
+    component author didn't anticipate.
   </p>
 
-  <dl>
-    <dt>Em</dt>
-    <dd>A length relative to the current element's font-size.</dd>
-    <dt>Rem</dt>
-    <dd>A length relative to the root element's font-size.</dd>
-    <dt>Ch</dt>
-    <dd>The advance measure of the "0" character — useful for capping reading column width.</dd>
-  </dl>
+  <hr />
+
+  <h3>Reaching past the API</h3>
+  <p>
+    When that happens, you have two clean options — fork the component, or wrap it in your own. Both keep your styles
+    decoupled from the component's internals.
+  </p>
 </article>
 ```
 
+## Typographic details
+
+A few quieter refinements come along with the rhythm:
+
+- **Oldstyle proportional figures** in running text; tables stay `tabular-nums` so numeric columns still align.
+- **Hanging punctuation** pulls opening quotes, em-dashes, and trailing stops into the margin (Safari today; progressive enhancement elsewhere).
+- **Quiet list markers** so bullets and numbers don't compete with the prose they label.
+- **Long-word breaks** on `<code>` and `<pre>` so URLs and identifiers can't overflow the column.
+
 ## Composing with font-size utilities
 
-`wa-prose` uses em-based spacing internally. Apply any [`wa-font-size-*`](/docs/utilities/text/#font-size) utility to the same container and the whole prose body — text, headings, and rhythm — scales proportionally. No size variants required.
+Apply any [`wa-font-size-*`](/docs/utilities/text/#font-size) utility to a `wa-prose` container and text, headings, and rhythm scale together. No size variants required.
 
 ```html {.example}
 <div class="wa-cluster wa-align-items-flex-start" style="gap: var(--wa-space-l);">
@@ -140,8 +201,8 @@ Code samples, tables, callouts, and horizontal rules get more breathing room tha
     <h3>Default size</h3>
     <p>Headings, body text, and rhythm all use the theme's default scale.</p>
     <ul>
-      <li>One item</li>
-      <li>Another item</li>
+      <li>Set by the theme's font-size tokens.</li>
+      <li>Scales smoothly with composition.</li>
     </ul>
   </article>
 
@@ -149,8 +210,8 @@ Code samples, tables, callouts, and horizontal rules get more breathing room tha
     <h3>With wa-font-size-s</h3>
     <p>Same content, scaled down. Heading-to-paragraph rhythm stays proportional.</p>
     <ul>
-      <li>One item</li>
-      <li>Another item</li>
+      <li>Set by the theme's font-size tokens.</li>
+      <li>Scales smoothly with composition.</li>
     </ul>
   </article>
 </div>
@@ -158,7 +219,7 @@ Code samples, tables, callouts, and horizontal rules get more breathing room tha
 
 ## Adjusting rhythm
 
-Override `--wa-prose-rhythm-scale` (default `1`) on the prose container to multiply every margin in the system. Values below `1` tighten the rhythm; values above loosen it. Type sizes are unaffected.
+Set `--wa-prose-rhythm-scale` on the prose container to multiply every margin in the system. Values below `1` tighten the rhythm; values above loosen it. Type sizes are unaffected.
 
 ```html {.example}
 <div class="wa-cluster wa-align-items-flex-start" style="gap: var(--wa-space-l);">
@@ -176,9 +237,20 @@ Override `--wa-prose-rhythm-scale` (default `1`) on the prose container to multi
 </div>
 ```
 
+## Composing with other utilities
+
+The `wa-prose` class and its element rules sit at `0,0,0` specificity, so any utility class you apply alongside — `wa-heading-m`, `wa-cluster`, `wa-text-align-center`, and so on — wins automatically. The same goes for plain element rules in your own stylesheet, no `!important` or specificity tricks required.
+
+```css
+/* Wins against wa-prose's `h2 { font-size: 2em }` */
+h2.release-header {
+  font-size: var(--wa-font-size-m);
+}
+```
+
 ## Theming
 
-Color in `wa-prose` flows from your theme's [color tokens](/docs/tokens/color/) — toggle dark mode or switch themes and the prose follows automatically. To recolor a specific element for prose contexts, use a descendant selector on your container.
+Color flows from your theme's [color tokens](/docs/tokens/color/), so prose follows dark mode and theme changes automatically. To recolor an element inside prose, use a descendant selector on your container.
 
 ```css
 .changelog.wa-prose a {
@@ -188,12 +260,15 @@ Color in `wa-prose` flows from your theme's [color tokens](/docs/tokens/color/) 
 
 ## Opting out of prose
 
-Apply `wa-not-prose` to any element inside a `wa-prose` container to disable the prose rhythm for that element and its descendants. Other utility classes — like `wa-cluster`, `wa-stack`, or `wa-font-size-*` — keep working inside the opt-out subtree.
+Apply `wa-not-prose` to any element inside a `wa-prose` container to disable prose rhythm for that element and its descendants. Other utilities — `wa-cluster`, `wa-stack`, `wa-font-size-*` — keep working in the opt-out subtree.
 
 ```html {.example}
 <article class="wa-prose">
-  <h3>Inside prose</h3>
-  <p>This paragraph follows wa-prose rhythm.</p>
+  <h3>Ready to build something?</h3>
+  <p>
+    The rhythm above follows wa-prose. The button row below opts out — it sits in a <code>wa-not-prose</code> wrapper so
+    margins and font sizes revert.
+  </p>
 
   <div class="wa-not-prose">
     <div class="wa-cluster" style="gap: var(--wa-space-s);">
@@ -202,6 +277,6 @@ Apply `wa-not-prose` to any element inside a `wa-prose` container to disable the
     </div>
   </div>
 
-  <p>This paragraph picks up the prose rhythm again.</p>
+  <p>And the paragraph after picks the rhythm back up where it left off.</p>
 </article>
 ```

--- a/packages/webawesome/docs/docs/utilities/prose.md
+++ b/packages/webawesome/docs/docs/utilities/prose.md
@@ -42,24 +42,23 @@ Each heading level gets generous space above and tight space below, so the eye r
 
 ```html {.example}
 <article class="wa-prose">
-  <h1>Customizing components</h1>
-  <h2>Three hooks to know</h2>
+  <h1>A short history of paper</h1>
+  <h2>From bark to broadsheet</h2>
   <p>
-    Web Awesome components are built to bend to your design system without your having to crack them open. Three
-    customization hooks do most of the work — CSS parts, custom properties, and custom states — each suited to a
-    different kind of override.
+    Long before pulp mills and printing presses, people wrote on whatever surface would hold a mark. Clay, papyrus, palm
+    leaves, bark, animal skins — each one pinned a culture's words to a place and a moment.
   </p>
 
-  <h3>CSS parts</h3>
+  <h3>The rag era</h3>
   <p>
-    Reach for <code>::part()</code> when you need to style an element a component exposes by name. Parts are stable
-    hooks that survive changes to a component's internal markup.
+    Early European paper was beaten from cotton and linen rags. Quality was measured in fiber: the longer the strand,
+    the stronger the sheet, the longer it survived in a binding.
   </p>
 
-  <h4>When to reach for them</h4>
+  <h4>Watermarks and laid lines</h4>
   <p>
-    Use parts when a custom property doesn't expose what you need, or when the change is specific to one element inside
-    the shadow DOM and you'd like it to survive a future version bump.
+    Hold a rag sheet up to the light and you can still see the maker's mark and the fine lines pressed in by the mould —
+    small signatures of the hand that pulled it.
   </p>
 </article>
 ```
@@ -71,27 +70,26 @@ Lists get a small breath between multi-line items and quiet `::marker` colors so
 ```html {.example}
 <article class="wa-prose">
   <ul>
-    <li>CSS parts let you style elements a component exposes by name.</li>
+    <li>Loose-leaf greens, kept cool and dry.</li>
     <li>
-      Custom properties expose specific values that components compose into their own styles — the preferred surface for
-      theme-level overrides.
+      Black tea pressed into wheels and aged for decades, sometimes longer than the people drinking it have been alive.
     </li>
-    <li>Custom states reflect a component's internal state for transitions and modes.</li>
+    <li>Fresh herbs, picked the morning of and steeped just past warm.</li>
   </ul>
 
   <ol>
-    <li>Try a custom property first.</li>
-    <li>If nothing fits, reach for a CSS part.</li>
-    <li>For state-driven changes, use the matching custom state.</li>
+    <li>Warm the pot with a splash of hot water; pour it out.</li>
+    <li>Measure one teaspoon of leaves per cup, plus one for the pot.</li>
+    <li>Pour, cover, and wait — three minutes for black, two for green.</li>
   </ol>
 
   <dl>
-    <dt>Em</dt>
-    <dd>A length relative to the current element's font-size.</dd>
-    <dt>Rem</dt>
-    <dd>A length relative to the root element's font-size.</dd>
-    <dt>Ch</dt>
-    <dd>The advance measure of the "0" character — useful for capping reading column width.</dd>
+    <dt>Steep</dt>
+    <dd>To soak leaves in hot water until the flavor is fully released.</dd>
+    <dt>Decant</dt>
+    <dd>To pour brewed tea off its leaves to halt further extraction.</dd>
+    <dt>Cupping</dt>
+    <dd>A side-by-side tasting used to evaluate tea or coffee.</dd>
   </dl>
 </article>
 ```
@@ -103,9 +101,9 @@ Inline elements you'd reach for in long-form writing — `<kbd>`, `<mark>`, `<su
 ```html {.example}
 <article class="wa-prose">
   <p>
-    Press <kbd>/</kbd> to <mark>jump to search</mark> the docs. Inline notation like H<sub>2</sub>O or E=mc<sup>2</sup>
-    renders correctly, and the <abbr title="Application Programming Interface">API</abbr> reference sits at the end of
-    every component page.
+    Press <kbd>⌘</kbd> + <kbd>K</kbd> to open the command palette and <mark>jump anywhere</mark> from the keyboard.
+    Inline notation reads cleanly too — H<sub>2</sub>O, E=mc<sup>2</sup> — and abbreviations like
+    <abbr title="As Soon As Possible">ASAP</abbr> hint their full meaning on hover.
   </p>
 </article>
 ```
@@ -116,47 +114,47 @@ Code samples, tables, callouts, and collapsible `<details>` get more breathing r
 
 ```html {.example}
 <article class="wa-prose">
-  <h2>Component sizes</h2>
-  <p>Most form controls and content components support a <code>size</code> attribute with three values.</p>
+  <h2>Reading a film canister</h2>
+  <p>Most rolls of film list the same three pieces of information on the side.</p>
 
-  <pre><code>&lt;wa-button size="small"&gt;Small&lt;/wa-button&gt;
-&lt;wa-button size="medium"&gt;Medium&lt;/wa-button&gt;
-&lt;wa-button size="large"&gt;Large&lt;/wa-button&gt;</code></pre>
+  <pre><code>ISO 400
+36 exposures
+develop in HC-110, dilution B</code></pre>
 
   <table>
     <thead>
       <tr>
-        <th>Value</th>
-        <th>Use for</th>
+        <th>ISO</th>
+        <th>Best for</th>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <td><code>small</code></td>
-        <td>Compact UI, sidebars, dense forms</td>
+        <td>100</td>
+        <td>Bright daylight, fine grain</td>
       </tr>
       <tr>
-        <td><code>medium</code></td>
-        <td>Default for most contexts</td>
+        <td>400</td>
+        <td>Mixed conditions, everyday use</td>
       </tr>
       <tr>
-        <td><code>large</code></td>
-        <td>Hero areas, emphasized actions</td>
+        <td>3200</td>
+        <td>Low light, available light</td>
       </tr>
     </tbody>
   </table>
 
   <details>
-    <summary>Why three sizes and not more?</summary>
+    <summary>What does "push processing" mean?</summary>
     <p>
-      Three covers the practical span — compact, default, prominent — without forcing authors to pick from a long list.
-      For finer control, reach for the <a href="/docs/utilities/text/">text utilities</a>.
+      Exposing film at a higher ISO than its rated speed, then developing it longer to compensate. You gain a stop or
+      two in low light, at the cost of more grain and deeper contrast.
     </p>
   </details>
 
   <wa-callout variant="brand">
     <wa-icon slot="icon" name="lightbulb" variant="regular"></wa-icon>
-    Pair sizes with the <a href="/docs/utilities/text/">text utilities</a> to keep type and component scale in lockstep.
+    Note the development time on the canister with a permanent marker — it saves a trip back to the binder later.
   </wa-callout>
 </article>
 ```
@@ -168,16 +166,16 @@ Code samples, tables, callouts, and collapsible `<details>` get more breathing r
 ```html {.example}
 <article class="wa-prose">
   <p>
-    Web Awesome components expose stable surfaces for customization, but every project eventually needs something the
-    component author didn't anticipate.
+    A morning routine, repeated long enough, stops needing motivation. The coffee gets made, the bed gets pulled flat,
+    the kettle clicks on while the blinds go up.
   </p>
 
   <hr />
 
-  <h3>Reaching past the API</h3>
+  <h3>When the routine breaks</h3>
   <p>
-    When that happens, you have two clean options — fork the component, or wrap it in your own. Both keep your styles
-    decoupled from the component's internals.
+    Travel, illness, a new schedule — the small steps drift apart. The trick is to rebuild around one anchor first, then
+    let the rest follow.
   </p>
 </article>
 ```
@@ -199,19 +197,19 @@ Apply any [`wa-font-size-*`](/docs/utilities/text/#font-size) utility to a `wa-p
 <div class="wa-cluster wa-align-items-flex-start" style="gap: var(--wa-space-l);">
   <article class="wa-prose" style="--wa-prose-line-length: 28ch;">
     <h3>Default size</h3>
-    <p>Headings, body text, and rhythm all use the theme's default scale.</p>
+    <p>A quiet morning is the rarest hour of the day — claim it before the world wakes up.</p>
     <ul>
-      <li>Set by the theme's font-size tokens.</li>
-      <li>Scales smoothly with composition.</li>
+      <li>One cup, one book, one window.</li>
+      <li>No notifications until the second pour.</li>
     </ul>
   </article>
 
   <article class="wa-prose wa-font-size-s" style="--wa-prose-line-length: 28ch;">
     <h3>With wa-font-size-s</h3>
-    <p>Same content, scaled down. Heading-to-paragraph rhythm stays proportional.</p>
+    <p>A quiet morning is the rarest hour of the day — claim it before the world wakes up.</p>
     <ul>
-      <li>Set by the theme's font-size tokens.</li>
-      <li>Scales smoothly with composition.</li>
+      <li>One cup, one book, one window.</li>
+      <li>No notifications until the second pour.</li>
     </ul>
   </article>
 </div>
@@ -225,14 +223,14 @@ Set `--wa-prose-rhythm-scale` on the prose container to multiply every margin in
 <div class="wa-cluster wa-align-items-flex-start" style="gap: var(--wa-space-l);">
   <article class="wa-prose" style="--wa-prose-line-length: 28ch;">
     <h3>Default rhythm</h3>
-    <p>Standard breathing room between blocks.</p>
-    <p>This second paragraph follows the default scale.</p>
+    <p>Two paragraphs of the same length, at the same size.</p>
+    <p>The space between them is what changes from one card to the next.</p>
   </article>
 
   <article class="wa-prose" style="--wa-prose-line-length: 28ch; --wa-prose-rhythm-scale: 0.6;">
     <h3>Tighter rhythm</h3>
-    <p>Every gap is 40% smaller — useful for sidebars or dense content.</p>
-    <p>Type stays the same size; only the spacing tightens.</p>
+    <p>Two paragraphs of the same length, at the same size.</p>
+    <p>The space between them is what changes from one card to the next.</p>
   </article>
 </div>
 ```
@@ -264,16 +262,16 @@ Apply `wa-not-prose` to any element inside a `wa-prose` container to disable pro
 
 ```html {.example}
 <article class="wa-prose">
-  <h3>Ready to build something?</h3>
+  <h3>Ready when you are</h3>
   <p>
-    The rhythm above follows wa-prose. The button row below opts out — it sits in a <code>wa-not-prose</code> wrapper so
-    margins and font sizes revert.
+    The paragraphs around this section follow prose rhythm. The button row below sits inside a
+    <code>wa-not-prose</code> wrapper, so its spacing reverts to the component defaults.
   </p>
 
   <div class="wa-not-prose">
     <div class="wa-cluster" style="gap: var(--wa-space-s);">
-      <wa-button variant="brand">Get started</wa-button>
-      <wa-button appearance="outlined">Learn more</wa-button>
+      <wa-button variant="brand">Primary action</wa-button>
+      <wa-button appearance="outlined">Secondary action</wa-button>
     </div>
   </div>
 

--- a/packages/webawesome/docs/docs/utilities/prose.md
+++ b/packages/webawesome/docs/docs/utilities/prose.md
@@ -184,9 +184,8 @@ develop in HC-110, dilution B</code></pre>
 
 A few quieter refinements come along with the rhythm:
 
-- **Oldstyle proportional figures** in running text; `tabular-nums` in tables so numeric columns line up.
+- **Oldstyle proportional figures** in running text so numerals sit alongside letters more naturally.
 - **Hanging punctuation** pulls opening quotes, em-dashes, and trailing stops into the margin (Safari today; progressive enhancement elsewhere).
-- **Quiet list markers** so bullets and numbers don't compete with the prose they label.
 - **Long-word breaks** on `<code>` and `<pre>` so URLs and identifiers can't overflow the column.
 
 ## Composing with font-size utilities

--- a/packages/webawesome/docs/docs/utilities/prose.md
+++ b/packages/webawesome/docs/docs/utilities/prose.md
@@ -21,7 +21,7 @@ Web Awesome's [native styles](/docs/utilities/native/) give every block-level el
 
 Wrap a block of content in `wa-prose` to switch on a richer rhythm: generous space above headings, tighter space below, more breathing room around major non-text blocks, and a true section divider for `<hr>`. Spacing is em-based and scales with `wa-font-size-*` utilities.
 
-`wa-prose` layers on top of [native styles](/docs/utilities/native/) — native sets how each element looks (color, font, borders, marker treatment); prose adjusts rhythm, type scale, and the reading column.
+Element styling — color, font, borders — still comes from [native styles](/docs/utilities/native/). `wa-prose` only adjusts rhythm, type scale, and the reading column.
 
 ## Using prose
 
@@ -67,7 +67,7 @@ Each heading level gets generous space above and tight space below, so the eye r
 
 ### Lists
 
-Lists get a small breath between multi-line items so neighboring lines stay distinct. Quiet markers and bold `<dt>` terms come from [native styles](/docs/utilities/native/) — prose just adds the rhythm.
+Lists get a small breath between multi-line items. Quiet markers and bold `<dt>` terms come from [native styles](/docs/utilities/native/).
 
 ```html {.example}
 <article class="wa-prose">
@@ -186,9 +186,9 @@ develop in HC-110, dilution B</code></pre>
 
 A few quieter refinements come along with the rhythm:
 
-- **Oldstyle proportional figures** in running text; tables keep their native `tabular-nums` so numeric columns still align.
+- **Oldstyle proportional figures** in running text; `tabular-nums` in tables so numeric columns line up.
 - **Hanging punctuation** pulls opening quotes, em-dashes, and trailing stops into the margin (Safari today; progressive enhancement elsewhere).
-- **Quiet list markers** (inherited from native) keep bullets and numbers from competing with the prose they label.
+- **Quiet list markers** so bullets and numbers don't compete with the prose they label.
 - **Long-word breaks** on `<code>` and `<pre>` so URLs and identifiers can't overflow the column.
 
 ## Composing with font-size utilities

--- a/packages/webawesome/docs/docs/utilities/prose.md
+++ b/packages/webawesome/docs/docs/utilities/prose.md
@@ -17,11 +17,9 @@ use-cases:
   - article
 ---
 
-Web Awesome's [native styles](/docs/utilities/native/) give every block-level element the same vertical breathing room. That works well for app UIs and dashboards where hierarchy comes from layout structure, but it can make long-form copy feel structurally flat — a major section break reads the same as the next sentence.
+Wrap a block of content in `wa-prose` to apply a hierarchical, asymmetric typographic rhythm: generous space above headings, tighter space below, more breathing room around major non-text blocks, and a true section divider for `<hr>`. Spacing is em-based and scales with `wa-font-size-*` utilities.
 
-Wrap a block of content in `wa-prose` to switch on a richer rhythm: generous space above headings, tighter space below, more breathing room around major non-text blocks, and a true section divider for `<hr>`. Spacing is em-based and scales with `wa-font-size-*` utilities.
-
-Element styling — color, font, borders — still comes from [native styles](/docs/utilities/native/). `wa-prose` only adjusts rhythm, type scale, and the reading column.
+Reach for it on documentation, blog posts, articles, or marketing copy. Element styling (color, font, borders) still comes from [native styles](/docs/utilities/native/); `wa-prose` only adjusts rhythm, type scale, and the reading column.
 
 ## Using prose
 

--- a/packages/webawesome/docs/docs/utilities/prose.md
+++ b/packages/webawesome/docs/docs/utilities/prose.md
@@ -21,6 +21,8 @@ Web Awesome's [native styles](/docs/utilities/native/) give every block-level el
 
 Wrap a block of content in `wa-prose` to switch on a richer rhythm: generous space above headings, tighter space below, more breathing room around major non-text blocks, and a true section divider for `<hr>`. Spacing is em-based and scales with `wa-font-size-*` utilities.
 
+`wa-prose` layers on top of [native styles](/docs/utilities/native/) — native sets how each element looks (color, font, borders, marker treatment); prose adjusts rhythm, type scale, and the reading column.
+
 ## Using prose
 
 Wrap your long-form content in any block element with the `wa-prose` class.
@@ -65,7 +67,7 @@ Each heading level gets generous space above and tight space below, so the eye r
 
 ### Lists
 
-Lists get a small breath between multi-line items and quiet `::marker` colors so bullets and numbers don't compete with the prose. Definition lists bold the term so each pair reads as a unit.
+Lists get a small breath between multi-line items so neighboring lines stay distinct. Quiet markers and bold `<dt>` terms come from [native styles](/docs/utilities/native/) — prose just adds the rhythm.
 
 ```html {.example}
 <article class="wa-prose">
@@ -184,9 +186,9 @@ develop in HC-110, dilution B</code></pre>
 
 A few quieter refinements come along with the rhythm:
 
-- **Oldstyle proportional figures** in running text; tables stay `tabular-nums` so numeric columns still align.
+- **Oldstyle proportional figures** in running text; tables keep their native `tabular-nums` so numeric columns still align.
 - **Hanging punctuation** pulls opening quotes, em-dashes, and trailing stops into the margin (Safari today; progressive enhancement elsewhere).
-- **Quiet list markers** so bullets and numbers don't compete with the prose they label.
+- **Quiet list markers** (inherited from native) keep bullets and numbers from competing with the prose they label.
 - **Long-word breaks** on `<code>` and `<pre>` so URLs and identifiers can't overflow the column.
 
 ## Composing with font-size utilities

--- a/packages/webawesome/src/styles/utilities.css
+++ b/packages/webawesome/src/styles/utilities.css
@@ -11,6 +11,7 @@
 @import url('utilities/gap.css');
 @import url('utilities/text.css');
 @import url('utilities/layout.css');
+@import url('utilities/prose.css');
 
 @import url('utilities/size.css');
 @import url('utilities/variants.css');

--- a/packages/webawesome/src/styles/utilities/prose.css
+++ b/packages/webawesome/src/styles/utilities/prose.css
@@ -106,46 +106,17 @@
       margin-block-end: var(--wa-prose-rhythm-2xs);
     }
 
-    /* `::marker` ignores opacity — bake de-emphasis into the color. */
-    & :where(li)::marker {
-      color: color-mix(in oklch, var(--wa-color-text-quiet) 75%, transparent);
-    }
-
-    & :where(dt) {
-      font-weight: var(--wa-font-weight-bold);
-    }
     & :where(dd):has(+ *) {
       margin-block-end: var(--wa-prose-rhythm-s);
     }
     /* #endregion */
 
-    /* #region Captions & block quotes ~~~~~~~~~~~~ */
+    /* #region Captions ~~~~~~~~~~~~ */
 
+    /* Em-based override keeps caption spacing in step with the prose
+       container; wa-native sets the visual style. */
     & :where(figcaption) {
-      color: var(--wa-color-text-quiet);
-      font-size: var(--wa-font-size-smaller);
-      line-height: var(--wa-line-height-condensed);
       margin-block-start: var(--wa-prose-rhythm-xs);
-    }
-
-    /* Em-based size keeps blockquote scaling with `wa-font-size-*`
-       (wa-native's rem-based --wa-font-size-l doesn't). */
-    & :where(blockquote) {
-      color: var(--wa-color-text-quiet);
-      font-size: 1.25em;
-    }
-    /* #endregion */
-
-    /* #region Tables ~~~~~~~~~~~~ */
-
-    /* Lining tabular figures so numeric columns align. Overrides the
-       container's oldstyle proportional figures. */
-    & :where(table) {
-      font-variant-numeric: tabular-nums;
-    }
-
-    & :where(th) {
-      border-block-end: var(--wa-border-style) var(--wa-border-width-s) var(--wa-color-border-normal);
     }
     /* #endregion */
 
@@ -196,7 +167,5 @@
     letter-spacing: revert-layer;
     font-variant-numeric: revert-layer;
     hanging-punctuation: revert-layer;
-    color: revert-layer;
-    border-block-end: revert-layer;
   }
 }

--- a/packages/webawesome/src/styles/utilities/prose.css
+++ b/packages/webawesome/src/styles/utilities/prose.css
@@ -1,0 +1,177 @@
+@layer wa-utilities {
+  /* `wa-prose` applies hierarchical, asymmetric typographic rhythm to a block
+     of long-form content. It builds on `wa-native`'s base block styles rather
+     than duplicating them, and uses em-based spacing internally so it scales
+     when composed with `wa-font-size-*` utilities. Colors flow from theme
+     tokens — no prose-specific color variants required. */
+  .wa-prose {
+    /* #region Tokens ~~~~~~~~~~~~ */
+
+    /* Em-based spacing scale that mirrors `--wa-space-*` numerically. Each
+       token resolves at the use site, so heading and block margins scale with
+       the container's font-size. `--wa-prose-rhythm-scale` lets advanced users
+       tighten or loosen all rhythm at once. */
+    --wa-prose-rhythm-scale: 1;
+    --wa-prose-rhythm-2xs: calc(0.25em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
+    --wa-prose-rhythm-xs: calc(0.5em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
+    --wa-prose-rhythm-s: calc(0.75em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
+    --wa-prose-rhythm-m: calc(1em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
+    --wa-prose-rhythm-l: calc(1.5em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
+    --wa-prose-rhythm-xl: calc(2em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
+    --wa-prose-rhythm-2xl: calc(2.5em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
+    --wa-prose-rhythm-3xl: calc(3em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
+
+    /* Comfortable reading column. Override or set max-inline-size directly. */
+    --wa-prose-line-length: 65ch;
+
+    max-inline-size: var(--wa-prose-line-length);
+    /* #endregion */
+
+    /* #region Headings ~~~~~~~~~~~~ */
+
+    /* Em-based heading sizes match WA's modular scale at the default root, so
+       `wa-font-size-*` utilities can rescale the whole prose body. Authors
+       overriding these should also use em values to preserve composition. */
+    & h1 {
+      font-size: calc(2.5625em * var(--wa-font-size-scale));
+    }
+    & h2 {
+      font-size: calc(2em * var(--wa-font-size-scale));
+    }
+    & h3 {
+      font-size: calc(1.5625em * var(--wa-font-size-scale));
+    }
+    & h4 {
+      font-size: calc(1.25em * var(--wa-font-size-scale));
+    }
+    & h5 {
+      font-size: 1em;
+    }
+    & h6 {
+      font-size: calc(0.75em * var(--wa-font-size-scale));
+    }
+
+    /* Slight optical tracking; only the larger sizes need it. */
+    & :is(h1, h2) {
+      letter-spacing: -0.01em;
+    }
+
+    /* Headings hug what they introduce: generous above, tight below. */
+    & * + h2 {
+      margin-block-start: var(--wa-prose-rhythm-2xl);
+    }
+    & h2:has(+ *) {
+      margin-block-end: var(--wa-prose-rhythm-s);
+    }
+
+    & * + h3 {
+      margin-block-start: var(--wa-prose-rhythm-xl);
+    }
+    & h3:has(+ *) {
+      margin-block-end: var(--wa-prose-rhythm-s);
+    }
+
+    & :is(h4, h5, h6):has(+ *) {
+      margin-block-end: var(--wa-prose-rhythm-xs);
+    }
+
+    /* Prevents stacked top + bottom margins on back-to-back headings. */
+    & h2 + :is(h3, h4),
+    & h3 + h4 {
+      margin-block-start: var(--wa-prose-rhythm-m);
+    }
+    /* #endregion */
+
+    /* #region Body text & lists ~~~~~~~~~~~~ */
+
+    /* Override `wa-native`'s rem-based content spacing with the em-based prose
+       scale. Same visual size at default root, but scales with composition. */
+    & p:has(+ *),
+    & :is(ul, ol, dl):has(+ *) {
+      margin-block-end: var(--wa-prose-rhythm-l);
+    }
+
+    /* Multi-line list items get a small breath between them. */
+    & :is(ul, ol) > li:has(+ li) {
+      margin-block-end: var(--wa-prose-rhythm-2xs);
+    }
+
+    & dt {
+      font-weight: var(--wa-font-weight-bold);
+    }
+    & dd:has(+ *) {
+      margin-block-end: var(--wa-prose-rhythm-s);
+    }
+    /* #endregion */
+
+    /* #region Captions & block quotes ~~~~~~~~~~~~ */
+
+    & figcaption {
+      color: var(--wa-color-text-quiet);
+      font-size: var(--wa-font-size-smaller);
+      line-height: var(--wa-line-height-condensed);
+      margin-block-start: var(--wa-prose-rhythm-xs);
+    }
+
+    /* Quoted text reads as quieter than running prose. Hanging punctuation
+       pulls opening quote marks into the margin where supported (Safari today). */
+    & blockquote {
+      color: var(--wa-color-text-quiet);
+      hanging-punctuation: first last;
+    }
+    /* #endregion */
+
+    /* #region Tables ~~~~~~~~~~~~ */
+
+    /* Tabular numerals so numeric columns align cleanly. */
+    & table {
+      font-variant-numeric: tabular-nums;
+    }
+
+    & th {
+      border-block-end: var(--wa-border-style) var(--wa-border-width-s) var(--wa-color-border-normal);
+    }
+    /* #endregion */
+
+    /* #region Section breaks & major non-text blocks ~~~~~~~~~~~~ */
+
+    /* `<hr>` marks a topic shift. Its own margin defines the gap; the heading
+       or paragraph that follows shouldn't double-stack on top. */
+    & hr {
+      margin-block: var(--wa-prose-rhythm-3xl);
+    }
+    & hr + :is(h1, h2, h3, h4, h5, h6) {
+      margin-block-start: 0;
+    }
+
+    /* Major non-text blocks (code, figures, tables, quotes, callouts) get
+       more breathing room than running prose, but headings still hug — so the
+       top-margin rule only applies after non-heading siblings. */
+    & :is(pre, figure, table, blockquote, wa-callout):has(+ *) {
+      margin-block-end: var(--wa-prose-rhythm-xl);
+    }
+
+    & :not(h1, h2, h3, h4, h5, h6) + :is(pre, figure, table, blockquote, wa-callout) {
+      margin-block-start: var(--wa-prose-rhythm-xl);
+    }
+
+    /* Visually heavy blocks still deserve a minimum breath after a heading. */
+    & :is(h1, h2, h3, h4, h5, h6) + :is(pre, figure, table, blockquote, wa-callout) {
+      margin-block-start: var(--wa-prose-rhythm-m);
+    }
+    /* #endregion */
+  }
+
+  /* Reverts only the properties wa-prose touches, so layout and typography
+     utilities applied alongside (e.g., `wa-cluster`, `wa-font-size-l`) keep
+     working inside the opt-out subtree. */
+  .wa-not-prose,
+  .wa-not-prose * {
+    margin-block-start: revert-layer;
+    margin-block-end: revert-layer;
+    font-size: revert-layer;
+    letter-spacing: revert-layer;
+    font-variant-numeric: revert-layer;
+    hanging-punctuation: revert-layer;
+  }
+}

--- a/packages/webawesome/src/styles/utilities/prose.css
+++ b/packages/webawesome/src/styles/utilities/prose.css
@@ -1,16 +1,16 @@
 @layer wa-utilities {
   /* `wa-prose` applies hierarchical, asymmetric typographic rhythm to a block
-     of long-form content. It builds on `wa-native`'s base block styles rather
-     than duplicating them, and uses em-based spacing internally so it scales
-     when composed with `wa-font-size-*` utilities. Colors flow from theme
-     tokens — no prose-specific color variants required. */
-  .wa-prose {
+     of long-form content. Builds on `wa-native`'s base block styles instead of
+     duplicating them. Em-based spacing scales when composed with `wa-font-size-*`.
+     The class and its element selectors are wrapped in `:where()` so every rule
+     sits at 0,0,0 specificity — any utility class or element rule the author
+     applies inside the container takes precedence without weight tricks. */
+  :where(.wa-prose) {
     /* #region Tokens ~~~~~~~~~~~~ */
 
-    /* Em-based spacing scale that mirrors `--wa-space-*` numerically. Each
-       token resolves at the use site, so heading and block margins scale with
-       the container's font-size. `--wa-prose-rhythm-scale` lets advanced users
-       tighten or loosen all rhythm at once. */
+    /* Em-based rhythm scale: each token resolves at the use site, so margins
+       scale with the element's own font-size. `--wa-prose-rhythm-scale` is a
+       single knob to tighten or loosen everything at once. */
     --wa-prose-rhythm-scale: 1;
     --wa-prose-rhythm-2xs: calc(0.25em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
     --wa-prose-rhythm-xs: calc(0.5em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
@@ -21,150 +21,173 @@
     --wa-prose-rhythm-2xl: calc(2.5em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
     --wa-prose-rhythm-3xl: calc(3em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
 
-    /* Comfortable reading column. Override or set max-inline-size directly. */
     --wa-prose-line-length: 65ch;
 
     max-inline-size: var(--wa-prose-line-length);
+
+    /* Oldstyle proportional figures for running text; tables reassert
+       `tabular-nums` below. Fonts without the OpenType feature fall back. */
+    font-variant-numeric: oldstyle-nums proportional-nums;
+
+    /* Inherits to descendants. Safari today; progressive enhancement elsewhere. */
+    hanging-punctuation: first last allow-end;
     /* #endregion */
 
     /* #region Headings ~~~~~~~~~~~~ */
 
-    /* Em-based heading sizes match WA's modular scale at the default root, so
-       `wa-font-size-*` utilities can rescale the whole prose body. Authors
-       overriding these should also use em values to preserve composition. */
-    & h1 {
-      font-size: calc(2.5625em * var(--wa-font-size-scale));
+    /* Em sizes inherit through the cascade — re-applying `--wa-font-size-scale`
+       here would double-scale. Authors overriding should stay em-based. */
+    & :where(h1) {
+      font-size: 2.5625em;
     }
-    & h2 {
-      font-size: calc(2em * var(--wa-font-size-scale));
+    & :where(h2) {
+      font-size: 2em;
     }
-    & h3 {
-      font-size: calc(1.5625em * var(--wa-font-size-scale));
+    & :where(h3) {
+      font-size: 1.5625em;
     }
-    & h4 {
-      font-size: calc(1.25em * var(--wa-font-size-scale));
+    & :where(h4) {
+      font-size: 1.25em;
     }
-    & h5 {
+    & :where(h5) {
       font-size: 1em;
     }
-    & h6 {
-      font-size: calc(0.75em * var(--wa-font-size-scale));
+    & :where(h6) {
+      font-size: 0.75em;
     }
 
     /* Slight optical tracking; only the larger sizes need it. */
-    & :is(h1, h2) {
+    & :where(h1, h2) {
       letter-spacing: -0.01em;
     }
 
     /* Headings hug what they introduce: generous above, tight below. */
-    & * + h2 {
+    & * + :where(h1) {
+      margin-block-start: var(--wa-prose-rhythm-3xl);
+    }
+    & :where(h1):has(+ *) {
+      margin-block-end: var(--wa-prose-rhythm-s);
+    }
+
+    & * + :where(h2) {
       margin-block-start: var(--wa-prose-rhythm-2xl);
     }
-    & h2:has(+ *) {
+    & :where(h2):has(+ *) {
       margin-block-end: var(--wa-prose-rhythm-s);
     }
 
-    & * + h3 {
+    & * + :where(h3) {
       margin-block-start: var(--wa-prose-rhythm-xl);
     }
-    & h3:has(+ *) {
+    & :where(h3):has(+ *) {
       margin-block-end: var(--wa-prose-rhythm-s);
     }
 
-    & :is(h4, h5, h6):has(+ *) {
+    & :where(h4, h5, h6):has(+ *) {
       margin-block-end: var(--wa-prose-rhythm-xs);
     }
 
-    /* Prevents stacked top + bottom margins on back-to-back headings. */
-    & h2 + :is(h3, h4),
-    & h3 + h4 {
+    /* Back-to-back headings tighten so the second reads as subordinate.
+       Enumerated explicitly — skipping more than two levels is rare enough
+       that the default rhythm reads better. */
+    & :where(h1 + h2, h1 + h3, h2 + h3, h2 + h4, h3 + h4, h4 + h5, h5 + h6) {
       margin-block-start: var(--wa-prose-rhythm-m);
     }
     /* #endregion */
 
     /* #region Body text & lists ~~~~~~~~~~~~ */
 
-    /* Override `wa-native`'s rem-based content spacing with the em-based prose
-       scale. Same visual size at default root, but scales with composition. */
-    & p:has(+ *),
-    & :is(ul, ol, dl):has(+ *) {
+    /* Replaces wa-native's rem-based `--wa-content-spacing` with em rhythm. */
+    & :where(p, ul, ol, dl):has(+ *) {
       margin-block-end: var(--wa-prose-rhythm-l);
     }
 
-    /* Multi-line list items get a small breath between them. */
-    & :is(ul, ol) > li:has(+ li) {
+    & :where(ul, ol) > :where(li):has(+ li) {
       margin-block-end: var(--wa-prose-rhythm-2xs);
     }
 
-    & dt {
+    /* `::marker` ignores opacity — bake de-emphasis into the color. */
+    & :where(li)::marker {
+      color: var(--wa-color-text-quiet);
+    }
+
+    & :where(dt) {
       font-weight: var(--wa-font-weight-bold);
     }
-    & dd:has(+ *) {
+    & :where(dd):has(+ *) {
       margin-block-end: var(--wa-prose-rhythm-s);
     }
     /* #endregion */
 
     /* #region Captions & block quotes ~~~~~~~~~~~~ */
 
-    & figcaption {
+    & :where(figcaption) {
       color: var(--wa-color-text-quiet);
       font-size: var(--wa-font-size-smaller);
       line-height: var(--wa-line-height-condensed);
       margin-block-start: var(--wa-prose-rhythm-xs);
     }
 
-    /* Quoted text reads as quieter than running prose. Hanging punctuation
-       pulls opening quote marks into the margin where supported (Safari today). */
-    & blockquote {
+    /* Em-based size keeps blockquote scaling with `wa-font-size-*`
+       (wa-native's rem-based --wa-font-size-l doesn't). */
+    & :where(blockquote) {
       color: var(--wa-color-text-quiet);
-      hanging-punctuation: first last;
+      font-size: 1.25em;
     }
     /* #endregion */
 
     /* #region Tables ~~~~~~~~~~~~ */
 
-    /* Tabular numerals so numeric columns align cleanly. */
-    & table {
+    /* Lining tabular figures so numeric columns align. Overrides the
+       container's oldstyle proportional figures. */
+    & :where(table) {
       font-variant-numeric: tabular-nums;
     }
 
-    & th {
+    & :where(th) {
       border-block-end: var(--wa-border-style) var(--wa-border-width-s) var(--wa-color-border-normal);
+    }
+    /* #endregion */
+
+    /* #region Inline code & long-word breaks ~~~~~~~~~~~~ */
+
+    /* `anywhere` is the right trade-off in prose: long URLs and identifiers
+       break instead of overflowing the column. */
+    & :where(code, pre) {
+      overflow-wrap: anywhere;
     }
     /* #endregion */
 
     /* #region Section breaks & major non-text blocks ~~~~~~~~~~~~ */
 
-    /* `<hr>` marks a topic shift. Its own margin defines the gap; the heading
-       or paragraph that follows shouldn't double-stack on top. */
-    & hr {
+    /* `<hr>`'s own margin defines the gap; the next heading shouldn't double-stack. */
+    & :where(hr) {
       margin-block: var(--wa-prose-rhythm-3xl);
     }
-    & hr + :is(h1, h2, h3, h4, h5, h6) {
+    & :where(hr + :is(h1, h2, h3, h4, h5, h6)) {
       margin-block-start: 0;
     }
 
-    /* Major non-text blocks (code, figures, tables, quotes, callouts) get
-       more breathing room than running prose, but headings still hug — so the
-       top-margin rule only applies after non-heading siblings. */
-    & :is(pre, figure, table, blockquote, wa-callout):has(+ *) {
+    /* Major non-text blocks get more air than running prose, but headings
+       still hug — so the top-margin rule excludes the heading-to-block case
+       (handled separately below with a smaller gap). */
+    & :where(pre, figure, table, blockquote, wa-callout, details):has(+ *) {
       margin-block-end: var(--wa-prose-rhythm-xl);
     }
 
-    & :not(h1, h2, h3, h4, h5, h6) + :is(pre, figure, table, blockquote, wa-callout) {
+    & :where(:not(h1, h2, h3, h4, h5, h6) + :is(pre, figure, table, blockquote, wa-callout, details)) {
       margin-block-start: var(--wa-prose-rhythm-xl);
     }
 
-    /* Visually heavy blocks still deserve a minimum breath after a heading. */
-    & :is(h1, h2, h3, h4, h5, h6) + :is(pre, figure, table, blockquote, wa-callout) {
+    & :where(:is(h1, h2, h3, h4, h5, h6) + :is(pre, figure, table, blockquote, wa-callout, details)) {
       margin-block-start: var(--wa-prose-rhythm-m);
     }
     /* #endregion */
   }
 
-  /* Reverts only the properties wa-prose touches, so layout and typography
-     utilities applied alongside (e.g., `wa-cluster`, `wa-font-size-l`) keep
-     working inside the opt-out subtree. */
+  /* Reverts the properties wa-prose touches so utilities like `wa-cluster`
+     or `wa-font-size-*` still work inside the opt-out subtree. `.wa-not-prose *`
+     at 0,1,0 wins over wa-prose's 0,0,0 element rules. */
   .wa-not-prose,
   .wa-not-prose * {
     margin-block-start: revert-layer;

--- a/packages/webawesome/src/styles/utilities/prose.css
+++ b/packages/webawesome/src/styles/utilities/prose.css
@@ -196,5 +196,7 @@
     letter-spacing: revert-layer;
     font-variant-numeric: revert-layer;
     hanging-punctuation: revert-layer;
+    color: revert-layer;
+    border-block-end: revert-layer;
   }
 }

--- a/packages/webawesome/src/styles/utilities/prose.css
+++ b/packages/webawesome/src/styles/utilities/prose.css
@@ -108,7 +108,7 @@
 
     /* `::marker` ignores opacity — bake de-emphasis into the color. */
     & :where(li)::marker {
-      color: var(--wa-color-text-quiet);
+      color: color-mix(in oklch, var(--wa-color-text-quiet) 75%, transparent);
     }
 
     & :where(dt) {


### PR DESCRIPTION
🧪 This work is an experiment that spun off from #2368. 

It adds a new `wa-prose` utility class that applies hierarchical, asymmetric typographic rhythm to long-form content — docs pages, blog posts, marketing copy, changelogs.

It builds on `wa-native`'s base block styles rather than duplicating them, so headings, lists, code blocks, callouts, tables, and `<details>` all pick up consistent rhythm without each page reinventing it.

## Why

#2368 added prose rhythm to `docs.css` scoped to `#content`. That solved the docs problem, but the same rhythm is useful anywhere we render long-form content — blog posts, the changelog, future marketing pages, third-party sites embedding our themes.

Promoting it to an official utility means folks using Web Awesome get the rhythm by adding a class instead of nesting their content under a specific ID.

## Under the Hood

Spacing is **em-based**, not rem-based. That's the key design choice: apply any `wa-font-size-*` utility to the same container and the whole prose body — text, headings, *and* the spacing between them — scales proportionally. There's no need for a `wa-prose-small` variant; sizing is a separate axis.

The rhythm itself is tunable through custom properties on the container. `--wa-prose-line-length` (default `65ch`) caps the reading column. `--wa-prose-rhythm-scale` (default `1`) multiplies every margin in the system, so a sidebar can use `0.6` for a tighter rhythm without touching type sizes. Both compose cleanly with theme tokens — colors flow from the existing `--wa-color-*` palette, so dark mode and themes work without additional class variants.

The rhythm covers every heading level (h1 through h6), with back-to-back tightening so a subhead reads as subordinate to the heading above it instead of a peer with its own air. Major non-text blocks — `<pre>`, `<table>`, `<blockquote>`, `<wa-callout>`, and `<details>` — get more breathing room than running prose so they read as distinct chunks. Selectors are wrapped in `:where()` so every
  rule sits at specificity `0,1,0`, and authors can override with simple element or class rules without specificity tricks. Quieter typographic touches come along too: hanging punctuation on the prose container, oldstyle proportional figures for body text (tables reassert `tabular-nums` for column alignment), a `::marker` color override so list bullets and numbers don't compete with prose, and
`overflow-wrap: anywhere` on `<code>` and `<pre>` so long URLs and identifiers don't blow out the column.

For islands of UI inside a prose container (a button cluster, a custom layout), `wa-not-prose` reverts only the properties `wa-prose` touches via `revert-layer`. Other utilities like `wa-cluster` and `wa-stack` keep working inside the opt-out subtree.

## Additional Work Done

As part of this work, the Docs have been updated to use this utility. Here's how...

`base.njk` now adds `wa-prose` to `#content` whenever a page sets `proseContent: true`. A new `docs/docs.json` data file flips that flag for the entire docs section, so every component, utility, token, and resource page picks up prose rhythm without per-page changes. Marketing pages, index pages, and other layouts that opted out of prose rhythm before stay opted out.

* `docs.css` keeps the existing column-width tokens by anchoring `--wa-prose-line-length` to `--content-width-s` on `#content`.
* The docs remap `wa-prose`'s em-based rhythm tokens to the rem-based `--wa-space-*` scale on `#content` so the established docs cadence stays intact.
* `.code-example` live demos still get the major-block treatment via a small docs-level extension. The changelog's release-header tightening and prerelease-`h2` subordination patterns are preserved.
* Existing layouts (default, modern-card-list, page-wide) render at their established widths.
* The previous `#content`-scoped prose rules from #2368 are removed since the utility now owns them.