### PR TITLE
Fix <wa-button-group> border radius when only one item is present

### DIFF
--- a/packages/webawesome/src/components/button-group/button-group.styles.ts
+++ b/packages/webawesome/src/components/button-group/button-group.styles.ts
@@ -58,24 +58,24 @@ export default css`
 
   /* Remove leading and trailing buttons border radius individually */
   :host([orientation='horizontal']) {
-    ::slotted(:first-child) {
+    ::slotted(:first-child:not(:last-child)) {
       --_button-start-end-radius: 0;
       --_button-end-end-radius: 0;
     }
 
-    ::slotted(:last-child) {
+    ::slotted(:last-child:not(:first-child)) {
       --_button-start-start-radius: 0;
       --_button-end-start-radius: 0;
     }
   }
 
   :host([orientation='vertical']) {
-    ::slotted(:first-child) {
+    ::slotted(:first-child:not(:last-child)) {
       --_button-end-start-radius: 0;
       --_button-end-end-radius: 0;
     }
 
-    ::slotted(:last-child) {
+    ::slotted(:last-child:not(:first-child)) {
       --_button-start-start-radius: 0;
       --_button-start-end-radius: 0;
     }


### PR DESCRIPTION
Fix for https://github.com/shoelace-style/webawesome/issues/2367

before
<img width="295" height="159" alt="before" src="https://github.com/user-attachments/assets/c2f36885-35c3-437e-a727-6f25aa034b5a" />

after
<img width="295" height="157" alt="after" src="https://github.com/user-attachments/assets/ef9c6498-3942-45fd-b210-1d25991d8dd1" />