### PR TITLE
Fixes radio group's label alignment

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -18,6 +18,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug in `<wa-textarea>` with `resize="auto"` where the height stayed collapsed when the textarea was initially hidden [issue:2347]
 - Fixed a bug in `<wa-button-group>` that caused single buttons to not have the correct border radius [issue:2367]
 - Fixed a bug in `<wa-switch>` that showed the switch direction backwards in RTL [pr:2330]
+- Fixed a bug in `<wa-radio-group>` where the label was vertically offset by a few pixels compared to other form control labels
 
 ## 3.6.0
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -18,7 +18,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug in `<wa-textarea>` with `resize="auto"` where the height stayed collapsed when the textarea was initially hidden [issue:2347]
 - Fixed a bug in `<wa-button-group>` that caused single buttons to not have the correct border radius [issue:2367]
 - Fixed a bug in `<wa-switch>` that showed the switch direction backwards in RTL [pr:2330]
-- Fixed a bug in `<wa-radio-group>` where the label was vertically offset by a few pixels compared to other form control labels
+- Fixed a bug in `<wa-radio-group>` where the label was vertically offset by a few pixels compared to other form control labels [issue:2334]
 
 ## 3.6.0
 

--- a/packages/webawesome/src/components/radio-group/radio-group.styles.ts
+++ b/packages/webawesome/src/components/radio-group/radio-group.styles.ts
@@ -1,10 +1,6 @@
 import { css } from 'lit';
 
 export default css`
-  :host {
-    display: block;
-  }
-
   .form-control {
     position: relative;
     border: none;


### PR DESCRIPTION
Fixes #2334. The problem was we were overriding the form controls default display styling.

Before
<img width="1238" height="238" alt="CleanShot 2026-05-07 at 13 08 13 2@2x" src="https://github.com/user-attachments/assets/cb560201-f5bf-416a-807a-5a1813019b16" />

After
<img width="1236" height="230" alt="CleanShot 2026-05-07 at 13 08 25 2@2x" src="https://github.com/user-attachments/assets/5f46d4b7-0941-4eb4-95fb-7a79091cd951" />
