### PR TITLE
Fix popover on narrow screens

### DIFF
--- a/packages/webawesome/docs/docs/components/popover.md
+++ b/packages/webawesome/docs/docs/components/popover.md
@@ -68,7 +68,7 @@ Use `data-popover="close"` on any button inside a popover to close it automatica
 Use the `placement` attribute to set where the popover appears relative to its anchor. The popover will automatically reposition if there isn't enough space in the preferred location. The default placement is `top`.
 
 ```html {.example}
-<div style="display: flex; gap: 1rem; align-items: center;">
+<div style="display: flex; gap: 1rem; flex-wrap: wrap; align-items: center;">
   <wa-button appearance="filled" id="popover__top">Top</wa-button>
   <wa-popover for="popover__top" placement="top">I'm on the top</wa-popover>
 
@@ -129,7 +129,7 @@ Use the [`autofocus`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_a
 ```html {.example}
 <wa-popover for="popover__autofocus">
   <div style="display: flex; flex-direction: column; gap: 1rem;">
-    <wa-textarea autofocus placeholder="What's on your mind?" size="s" resize="none" rows="3"></wa-textarea>
+    <wa-textarea autofocus placeholder="What's on your mind?" size="s" resize="none" rows="2"></wa-textarea>
     <wa-button appearance="filled" variant="primary" size="s" data-popover="close"> Submit </wa-button>
   </div>
 </wa-popover>

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -18,6 +18,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug in `<wa-textarea>` with `resize="auto"` where the height stayed collapsed when the textarea was initially hidden [issue:2347]
 - Fixed a bug in `<wa-button-group>` that caused single buttons to not have the correct border radius [issue:2367]
 - Fixed a bug in `<wa-switch>` that showed the switch direction backwards in RTL [pr:2330]
+- Fixed a bug in `<wa-popover>` where the popover would overflow the viewport on narrow screens [issue:2333]
 
 ## 3.6.0
 

--- a/packages/webawesome/src/components/popover/popover.styles.ts
+++ b/packages/webawesome/src/components/popover/popover.styles.ts
@@ -79,7 +79,7 @@ export default css`
     display: flex;
     flex-direction: column;
     width: max-content;
-    max-width: min(var(--max-width), 100vw - var(--wa-space-l) * 2);
+    max-width: min(var(--max-width), 100vw);
     padding: var(--wa-space-l);
     background-color: var(--wa-color-surface-default);
     border: var(--wa-panel-border-width) solid var(--wa-color-surface-border);

--- a/packages/webawesome/src/components/popover/popover.styles.ts
+++ b/packages/webawesome/src/components/popover/popover.styles.ts
@@ -79,7 +79,7 @@ export default css`
     display: flex;
     flex-direction: column;
     width: max-content;
-    max-width: var(--max-width);
+    max-width: min(var(--max-width), 100vw - var(--wa-space-l) * 2);
     padding: var(--wa-space-l);
     background-color: var(--wa-color-surface-default);
     border: var(--wa-panel-border-width) solid var(--wa-color-surface-border);

--- a/packages/webawesome/src/components/popover/popover.styles.ts
+++ b/packages/webawesome/src/components/popover/popover.styles.ts
@@ -78,7 +78,7 @@ export default css`
   .body {
     display: flex;
     flex-direction: column;
-    width: max-content;
+    width: auto;
     max-width: min(var(--max-width), 100vw);
     padding: var(--wa-space-l);
     background-color: var(--wa-color-surface-default);


### PR DESCRIPTION
Fixes #2333 by adjusting the max width to match 100% of the viewport minus the popover's margin, while still allowing the `--max-width` when the screen size allows.

Also fixes an example that had a flex row that didn't wrap, causing mobile screens to scroll horizontally.