### PR TITLE
fix badge with icon height; closes #2280

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -18,6 +18,7 @@ Components with the <wa-badge variant="warning">Experimental</wa-badge> badge sh
 - Fixed a bug in `<wa-textarea>` with `resize="auto"` where the height stayed collapsed when the textarea was initially hidden [issue:2347]
 - Fixed a bug in `<wa-button-group>` that caused single buttons to not have the correct border radius [issue:2367]
 - Fixed a bug in `<wa-switch>` that showed the switch direction backwards in RTL [pr:2330]
+- Fixed a bug in `<wa-badge>` that caused the height to differ slightly when icons were present in the `start` or `end` slot [issue:2280]
 
 ## 3.6.0
 

--- a/packages/webawesome/src/components/badge/badge.styles.ts
+++ b/packages/webawesome/src/components/badge/badge.styles.ts
@@ -100,7 +100,12 @@ export default css`
     }
   }
 
-  /* Slots */
+  /* Prevents vertical space when icons with vertical-align are slotted in - https://github.com/shoelace-style/webawesome/issues/2280 */
+  [part='start'],
+  [part='end'] {
+    line-height: 0;
+  }
+
   slot[name='start']::slotted(*) {
     margin-inline-end: 0.375em;
   }


### PR DESCRIPTION
Applies to the fix suggested by @ABWEBIT in #2280 for consistent badge heights when using icons.
