### PR TITLE
fix(dropdown-item): correct cursor for disabled items in submenus

### DIFF
--- a/packages/webawesome/src/components/dropdown-item/dropdown-item.styles.ts
+++ b/packages/webawesome/src/components/dropdown-item/dropdown-item.styles.ts
@@ -32,7 +32,6 @@ export default css`
   :host([disabled]) {
     opacity: 0.5;
     cursor: not-allowed;
-    pointer-events: none;
   }
 
   /* Danger variant */

--- a/packages/webawesome/src/components/dropdown-item/dropdown-item.ts
+++ b/packages/webawesome/src/components/dropdown-item/dropdown-item.ts
@@ -123,7 +123,6 @@ export default class WaDropdownItem extends WebAwesomeElement {
     if (changedProperties.has('disabled')) {
       this.setAttribute('aria-disabled', this.disabled ? 'true' : 'false');
       this.customStates.set('disabled', this.disabled);
-      this.style.pointerEvents = this.disabled ? 'none' : '';
     }
 
     if (changedProperties.has('type')) {


### PR DESCRIPTION
## Summary

Removes `pointer-events: none` from disabled `<wa-dropdown-item>` elements so that the `cursor: not-allowed` style is actually visible when hovering over a disabled item inside a submenu.

## Problem

Disabled dropdown items were styled with both `cursor: not-allowed` and `pointer-events: none`. Because `pointer-events: none` suppresses all mouse interaction — including the visual cursor — the `not-allowed` cursor never appeared. Users hovering over a disabled submenu item saw the default arrow cursor instead, giving no visual indication that the item was non-interactive.

## Fix

Remove `pointer-events: none` from:
- `dropdown-item.styles.ts` — the CSS `:host([disabled])` rule
- `dropdown-item.ts` — the `updated()` inline style assignment

Click and keyboard events are already guarded by the `disabled` attribute check in the component's event handlers, so removing `pointer-events: none` does not allow disabled items to be activated.

## Before / After

| State | Before | After |
|---|---|---|
| Hover over disabled item | Default cursor | `not-allowed` cursor |
| Click disabled item | Blocked (pointer-events) | Blocked (event handler guard) |
