### PR TITLE
Docs: Fix `ProBadge`'s Default Description

### DIFF
--- a/packages/webawesome/docs/_includes/pro-badge.njk
+++ b/packages/webawesome/docs/_includes/pro-badge.njk
@@ -1,5 +1,5 @@
 {% macro proBadge(params) %}
-  {% set description = params.description or ("This requires access to " ~ site.namePro) %}
+  {% set description = params.description or "This requires access to Web Awesome Pro" %}
   {% set badgeId = params.id or ("pro-badge-" + ("" | uniqueId(8))) %}
   <wa-badge appearance="accent" pill class="pro" id="{{ badgeId }}" data-pro-badge>Pro</wa-badge>
   <wa-tooltip for="{{ badgeId }}">{{ description }}</wa-tooltip>


### PR DESCRIPTION
I got a bit overzealous in https://github.com/shoelace-style/webawesome/pull/2359 when it came to our `proBadge` macro. 

Nunjucks macros imported via `{% from "pro-badge.njk" import proBadge %` run in an isolated scope — they don't see the caller's site data. So `site` is undefined inside the macro.

This work moves the macro's default description back to a literal to fix that.