### PR TITLE
Abstract + Refine Docs-Style Breadcrumbs

### DIFF
--- a/packages/webawesome/docs/_includes/base.njk
+++ b/packages/webawesome/docs/_includes/base.njk
@@ -113,7 +113,7 @@
       {% for item in collections.all %}
         {% if item.url == breadcrumbParentUrl %}{% set breadcrumbParentTitle = item.data.title %}{% endif %}
       {% endfor %}
-      <wa-breadcrumb class="docs-subpage-crumbs">
+      <wa-breadcrumb class="page-breadcrumbs">
         <wa-icon slot="separator" name="angle-right" variant="regular"></wa-icon>
         <wa-breadcrumb-item href="{{ breadcrumbParentUrl }}">{{ breadcrumbParentTitle }}</wa-breadcrumb-item>
         <wa-breadcrumb-item>{{ title }}</wa-breadcrumb-item>

--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -17,18 +17,6 @@
   --layout-example-element-border-radius: var(--wa-border-radius-m);
 }
 
-/* Full-width pill-shaped breadcrumb used at the top of subpages */
-.docs-subpage-crumbs {
-  display: flex;
-  inline-size: 100%;
-  background-color: var(--wa-color-surface-lowered);
-  border: var(--wa-panel-border-width) var(--wa-panel-border-style) var(--wa-color-surface-border);
-  border-radius: var(--wa-border-radius-pill);
-  font-size: var(--wa-font-size-s);
-  padding: var(--wa-space-xs) var(--wa-space-m);
-  margin-block-end: var(--wa-content-spacing);
-}
-
 /* "Browse\ ___" / "Back to ___" link with an arrow that nudges on hover */
 .browse-all-link wa-icon,
 .back-link wa-icon {

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -276,16 +276,23 @@
     }
   }
 
-  /* Full-width pill-shaped breadcrumb used at the top of subpages */
+  /* breadcrumbs */
   .page-breadcrumbs {
     display: flex;
+    align-items: center;
     inline-size: 100%;
-    background-color: var(--wa-color-surface-lowered);
-    border: var(--wa-panel-border-width) var(--wa-panel-border-style) var(--wa-color-surface-border);
+    /* translucent tint so the pill recedes on any surface */
+    background-color: color-mix(in oklab, var(--wa-color-text-normal) 4.5%, transparent);
     border-radius: var(--wa-border-radius-pill);
     font-size: var(--wa-font-size-s);
     padding: var(--wa-space-xs) var(--wa-space-m);
     margin-block-end: var(--wa-content-spacing);
+
+    /* fade past the component's text-quiet + optical-align nudge */
+    wa-icon[slot='separator'] {
+      color: color-mix(in oklab, var(--wa-color-text-quiet), transparent 50%);
+      translate: 0 0.075em;
+    }
   }
 
   /* header */

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -276,6 +276,18 @@
     }
   }
 
+  /* Full-width pill-shaped breadcrumb used at the top of subpages */
+  .page-breadcrumbs {
+    display: flex;
+    inline-size: 100%;
+    background-color: var(--wa-color-surface-lowered);
+    border: var(--wa-panel-border-width) var(--wa-panel-border-style) var(--wa-color-surface-border);
+    border-radius: var(--wa-border-radius-pill);
+    font-size: var(--wa-font-size-s);
+    padding: var(--wa-space-xs) var(--wa-space-m);
+    margin-block-end: var(--wa-content-spacing);
+  }
+
   /* header */
   wa-page > [slot='header'] {
     /* reset default page component-based header styles */

--- a/packages/webawesome/docs/docs/frameworks/angular.md
+++ b/packages/webawesome/docs/docs/frameworks/angular.md
@@ -4,7 +4,7 @@ description: Tips for using Web Awesome in your Angular app.
 layout: page-outline
 ---
 
-<wa-breadcrumb class="docs-subpage-crumbs">
+<wa-breadcrumb class="page-breadcrumbs">
   <wa-icon slot="separator" name="angle-right" variant="regular"></wa-icon>
   <wa-breadcrumb-item href="/docs/frameworks">Frameworks</wa-breadcrumb-item>
   <wa-breadcrumb-item>{{ title }}</wa-breadcrumb-item>

--- a/packages/webawesome/docs/docs/frameworks/react.md
+++ b/packages/webawesome/docs/docs/frameworks/react.md
@@ -4,7 +4,7 @@ description: Tips for using Web Awesome in your React app.
 layout: page-outline
 ---
 
-<wa-breadcrumb class="docs-subpage-crumbs">
+<wa-breadcrumb class="page-breadcrumbs">
   <wa-icon slot="separator" name="angle-right" variant="regular"></wa-icon>
   <wa-breadcrumb-item href="/docs/frameworks">Frameworks</wa-breadcrumb-item>
   <wa-breadcrumb-item>{{ title }}</wa-breadcrumb-item>

--- a/packages/webawesome/docs/docs/frameworks/svelte.md
+++ b/packages/webawesome/docs/docs/frameworks/svelte.md
@@ -4,7 +4,7 @@ description: Tips for using Web Awesome in your Svelte app.
 layout: page-outline
 ---
 
-<wa-breadcrumb class="docs-subpage-crumbs">
+<wa-breadcrumb class="page-breadcrumbs">
   <wa-icon slot="separator" name="angle-right" variant="regular"></wa-icon>
   <wa-breadcrumb-item href="/docs/frameworks">Frameworks</wa-breadcrumb-item>
   <wa-breadcrumb-item>{{ title }}</wa-breadcrumb-item>

--- a/packages/webawesome/docs/docs/frameworks/vue-2.md
+++ b/packages/webawesome/docs/docs/frameworks/vue-2.md
@@ -4,7 +4,7 @@ description: Tips for using Web Awesome in your Vue 2 app.
 layout: page-outline
 ---
 
-<wa-breadcrumb class="docs-subpage-crumbs">
+<wa-breadcrumb class="page-breadcrumbs">
   <wa-icon slot="separator" name="angle-right" variant="regular"></wa-icon>
   <wa-breadcrumb-item href="/docs/frameworks">Frameworks</wa-breadcrumb-item>
   <wa-breadcrumb-item>{{ title }}</wa-breadcrumb-item>

--- a/packages/webawesome/docs/docs/frameworks/vue.md
+++ b/packages/webawesome/docs/docs/frameworks/vue.md
@@ -4,7 +4,7 @@ description: Tips for using Web Awesome in your Vue 3 app.
 layout: page-outline
 ---
 
-<wa-breadcrumb class="docs-subpage-crumbs">
+<wa-breadcrumb class="page-breadcrumbs">
   <wa-icon slot="separator" name="angle-right" variant="regular"></wa-icon>
   <wa-breadcrumb-item href="/docs/frameworks">Frameworks</wa-breadcrumb-item>
   <wa-breadcrumb-item>{{ title }}</wa-breadcrumb-item>

--- a/packages/webawesome/docs/docs/resources/migration-checklist.njk
+++ b/packages/webawesome/docs/docs/resources/migration-checklist.njk
@@ -4,7 +4,7 @@ description: Interactive checklist for migrating a project from Shoelace 2.x to 
 layout: page
 ---
 
-<wa-breadcrumb class="docs-subpage-crumbs">
+<wa-breadcrumb class="page-breadcrumbs">
   <wa-icon slot="separator" name="angle-right" variant="regular"></wa-icon>
   <wa-breadcrumb-item href="/docs/resources/migrating-from-shoelace">Migrating from Shoelace</wa-breadcrumb-item>
   <wa-breadcrumb-item>{{ title }}</wa-breadcrumb-item>


### PR DESCRIPTION
This work modifies a few aspects of the recently added/styled `.docs-subpage-crumbs` pattern...

1. It abstracts the styles to render this pattern to `utils.css` for use across the app's UI/UX
2. It renames the pattern to `.page-breadcrumbs` to more accurately describe the purpose
3. It revises the background to work on any any surface level (not just the default one)
4. It visually refines the breadcrumbs - removing the border, aligning the separators with text better, and making the separators more subtle.

| Before | After |
|--------|--------|
| <img width="1352" height="404" alt="CleanShot 2026-05-11 at 22 23 15@2x" src="https://github.com/user-attachments/assets/0559d49f-6ddf-4425-aa59-0b8471bb4636" /> | <img width="1350" height="390" alt="CleanShot 2026-05-11 at 22 23 37@2x" src="https://github.com/user-attachments/assets/0c4e3791-0124-4f45-b91c-0c9f5aa4aad8" /> |