### PR TITLE
Consolidate Pro Callout Styles + Extend the `:::pro` Directive

### DIFF
--- a/packages/webawesome/docs/_utils/markdown.js
+++ b/packages/webawesome/docs/_utils/markdown.js
@@ -38,11 +38,17 @@ markdown.use(markdownItMark);
 });
 
 markdown.use(markdownItContainer, 'pro', {
+  validate: params => /^pro(\s+.+)?$/.test(params.trim()),
   render: function (tokens, idx) {
     if (tokens[idx].nesting === 1) {
+      const info = tokens[idx].info.trim().replace(/^pro\s*/, '');
+      const iconMatch = info.match(/^\{([\w-]+)\}\s*(.*)$/);
+      const iconName = iconMatch ? iconMatch[1] : 'hand-wave';
+      const title = iconMatch ? iconMatch[2].trim() : info.trim();
       return `
         <wa-callout class="pro">
-          <wa-icon slot="icon" name="star-circle"></wa-icon>
+          <wa-icon slot="icon" name="${markdown.utils.escapeHtml(iconName)}"></wa-icon>
+          ${title ? `<strong>${markdown.utils.escapeHtml(title)}</strong>` : ''}
       `;
     }
     return '</wa-callout>\n';

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -420,12 +420,28 @@
 
   /* pro callout */
   wa-callout.pro {
+    margin-block: calc(var(--wa-content-spacing) * 2);
+    padding: var(--wa-space-l);
     background-color: color-mix(in oklab, var(--wa-brand-orange) 12%, var(--wa-color-surface-default));
     border-color: color-mix(in oklab, var(--wa-brand-orange) 30%, var(--wa-color-surface-default));
     color: var(--wa-color-text-normal);
 
     &::part(icon) {
+      align-items: flex-start;
       color: var(--wa-brand-orange);
+    }
+
+    wa-icon[slot='icon'] {
+      font-size: var(--wa-font-size-xl);
+    }
+
+    strong {
+      display: block;
+      margin-block-end: var(--wa-space-2xs);
+    }
+
+    strong a {
+      color: inherit;
     }
   }
 

--- a/packages/webawesome/docs/docs/frameworks/react.md
+++ b/packages/webawesome/docs/docs/frameworks/react.md
@@ -17,6 +17,7 @@ To add Web Awesome to your React app, install the package from npm.
 ```bash
 npm install @awesome.me/webawesome
 ```
+
 Next, include the Web Awesome theme in your app, import the components you need, and start using them!
 
 ```jsx
@@ -32,11 +33,9 @@ React 19+ [supports custom elements](https://react.dev/blog/2024/04/25/react-19#
 
 If you're using React 18 or below, skip to the [legacy React wrappers](#legacy-react-wrappers-react-18-and-below) section.
 
-<wa-callout class="pro">
-  <wa-icon slot="icon" name="hand-wave" animation="shake" style="--animation-delay: 2s; --animation-duration: 4s;"></wa-icon>
-  <strong>Using Web Awesome Pro?</strong>
-  Get personalized installation instructions from <a href="/workspaces">your&nbsp;workspaces</a> instead.
-</wa-callout>
+:::pro Using Web Awesome Pro?
+Get personalized installation instructions from <a href="/workspaces">your&nbsp;workspaces</a> instead.
+:::
 
 ## TypeScript
 
@@ -145,8 +144,8 @@ Object.defineProperty(window, 'matchMedia', {
     removeListener: jest.fn(), // deprecated
     addEventListener: jest.fn(),
     removeEventListener: jest.fn(),
-    dispatchEvent: jest.fn()
-  }))
+    dispatchEvent: jest.fn(),
+  })),
 });
 ```
 
@@ -220,10 +219,12 @@ import WaInput from '@awesome.me/webawesome/dist/react/input/index.js';
 function MyComponent() {
   const [value, setValue] = useState('');
 
-  return <>
-    <WaInput value={value} onInput={event => setValue(event.target.value)} />;
-    <WaInput defaultValue={"Foo"} /> {/* This is an "uncontrolled input" */}
-  </>
+  return (
+    <>
+      <WaInput value={value} onInput={event => setValue(event.target.value)} />;
+      <WaInput defaultValue={'Foo'} /> {/* This is an "uncontrolled input" */}
+    </>
+  );
 }
 
 export default MyComponent;

--- a/packages/webawesome/docs/docs/frameworks/react.md
+++ b/packages/webawesome/docs/docs/frameworks/react.md
@@ -32,9 +32,11 @@ React 19+ [supports custom elements](https://react.dev/blog/2024/04/25/react-19#
 
 If you're using React 18 or below, skip to the [legacy React wrappers](#legacy-react-wrappers-react-18-and-below) section.
 
-:::pro
-Pro users: get installation instructions from <a href="/workspaces">your&nbsp;workspaces</a> instead.
-:::
+<wa-callout class="pro">
+  <wa-icon slot="icon" name="hand-wave" animation="shake" style="--animation-delay: 2s; --animation-duration: 4s;"></wa-icon>
+  <strong>Using Web Awesome Pro?</strong>
+  Get personalized installation instructions from <a href="/workspaces">your&nbsp;workspaces</a> instead.
+</wa-callout>
 
 ## TypeScript
 

--- a/packages/webawesome/docs/docs/index.md
+++ b/packages/webawesome/docs/docs/index.md
@@ -15,7 +15,7 @@ You can load Web Awesome via CDN or by installing it locally. If you’re using 
 The CDN is the fastest way to get started with Web Awesome. Just copy and paste the following into the `<head>` of your HTML to get started!
 
 ```html
-<link rel="stylesheet" href="{% cdnUrl 'styles/webawesome.css' %}">
+<link rel="stylesheet" href="{% cdnUrl 'styles/webawesome.css' %}" />
 <script type="module" src="{% cdnUrl 'webawesome.loader.js' %}"></script>
 ```
 
@@ -25,11 +25,9 @@ Now you can [use any Web Awesome component](/docs/components)! Try putting a but
 <wa-button variant="brand">Click me!</wa-button>
 ```
 
-<wa-callout class="pro">
-  <wa-icon slot="icon" name="hand-wave" animation="shake" style="--animation-delay: 2s; --animation-duration: 4s;"></wa-icon>
-  <strong>Using Web Awesome Pro?</strong>
-  Get personalized installation instructions from <a href="/workspaces">your&nbsp;workspaces</a> instead.
-</wa-callout>
+:::pro Using Web Awesome Pro?
+Get personalized installation instructions from <a href="/workspaces">your&nbsp;workspaces</a> instead.
+:::
 
 ## Installing with npm
 
@@ -52,11 +50,9 @@ import '@awesome.me/webawesome/dist/components/input/input.js';
 
 Once a component has been imported, you can use it in your HTML normally. Components are cherry picked to ensure you're getting the smallest possible bundle. You can find each component import in the "Importing" section of its documentation.
 
-<wa-callout class="pro">
-  <wa-icon slot="icon" name="hand-wave" animation="shake" style="--animation-delay: 2s; --animation-duration: 4s;"></wa-icon>
-  <strong>Using Web Awesome Pro?</strong>
-  Get personalized installation instructions from <a href="/workspaces">your&nbsp;workspaces</a> instead.
-</wa-callout>
+:::pro Using Web Awesome Pro?
+Get personalized installation instructions from <a href="/workspaces">your&nbsp;workspaces</a> instead.
+:::
 
 ## Get the Download (Advanced)
 
@@ -92,7 +88,6 @@ If you're self-hosting Web Awesome, you'll need to set up your pages to referenc
 ```html
 <!-- Option 1: use all Web Awesome styles -->
 <link rel="stylesheet" href="/dist/styles/webawesome.css" />
-
 
 <!-- Option 2: pick and choose styles -->
 

--- a/packages/webawesome/docs/docs/index.md
+++ b/packages/webawesome/docs/docs/index.md
@@ -25,9 +25,11 @@ Now you can [use any Web Awesome component](/docs/components)! Try putting a but
 <wa-button variant="brand">Click me!</wa-button>
 ```
 
-:::pro
-Pro users: get installation instructions from <a href="/workspaces">your&nbsp;workspaces</a> instead.
-:::
+<wa-callout class="pro">
+  <wa-icon slot="icon" name="hand-wave" animation="shake" style="--animation-delay: 2s; --animation-duration: 4s;"></wa-icon>
+  <strong>Using Web Awesome Pro?</strong>
+  Get personalized installation instructions from <a href="/workspaces">your&nbsp;workspaces</a> instead.
+</wa-callout>
 
 ## Installing with npm
 
@@ -50,9 +52,11 @@ import '@awesome.me/webawesome/dist/components/input/input.js';
 
 Once a component has been imported, you can use it in your HTML normally. Components are cherry picked to ensure you're getting the smallest possible bundle. You can find each component import in the "Importing" section of its documentation.
 
-:::pro
-Pro users: get installation instructions from <a href="/workspaces">your&nbsp;workspaces</a> instead.
-:::
+<wa-callout class="pro">
+  <wa-icon slot="icon" name="hand-wave" animation="shake" style="--animation-delay: 2s; --animation-duration: 4s;"></wa-icon>
+  <strong>Using Web Awesome Pro?</strong>
+  Get personalized installation instructions from <a href="/workspaces">your&nbsp;workspaces</a> instead.
+</wa-callout>
 
 ## Get the Download (Advanced)
 

--- a/packages/webawesome/docs/docs/resources/migrating-from-shoelace.md
+++ b/packages/webawesome/docs/docs/resources/migrating-from-shoelace.md
@@ -4,28 +4,10 @@ description: A complete, component-by-component guide for moving from Shoelace 2
 layout: page-outline
 ---
 
-<link rel="stylesheet" href="/assets/styles/theme-site-embed.css" data-turbo-track="reload" />
-
 <style type="text/css">
   .migration-soft-landing-callout,
-  .migration-warning-callout,
-  .pro-component-notice {
+  .migration-warning-callout {
     margin-block: var(--wa-space-xl);
-  }
-
-  .pro-component-notice {
-    padding: var(--wa-space-l);
-  }
-
-  .pro-component-notice::part(icon) {
-    align-items: flex-start;
-    color: var(--wa-color-brand);
-  }
-
-  .pro-component-notice wa-icon[slot='icon'] {
-    --animation-delay: 2s;
-    --animation-duration: 4s;
-    font-size: var(--wa-font-size-xl);
   }
 
   .migration-checklist-actions {
@@ -40,9 +22,9 @@ This guide is for developers with a working Shoelace 2.x project who want to upg
 
 If you're brand new to Web Awesome, the [Getting Started](/docs/) guide is a better starting point.
 
-<wa-callout appearance="outlined-filled" variant="brand" class="pro-component-notice wa-brand-site wa-theme-site wa-align-items-start">
-  <wa-icon slot="icon" name="hand-wave" animation="shake"></wa-icon>
-  <strong>A Few Components Now Live In Web Awesome Pro</strong><br>
+<wa-callout class="pro">
+  <wa-icon slot="icon" name="hand-wave" animation="shake" style="--animation-delay: 2s; --animation-duration: 4s;"></wa-icon>
+  <strong>A Few Components Now Live In Web Awesome Pro</strong>
   Toast notifications, Comboboxes, File Inputs, and Charts moved to <a href="#whats-in-web-awesome-pro">Web&nbsp;Awesome&nbsp;Pro</a>. We mark them clearly with a
   <wa-badge appearance="accent" pill class="pro" data-pro-badge>Pro</wa-badge>
   badge so you'll see them coming.


### PR DESCRIPTION
## What changed

1. The styled "Get X with Web Awesome Pro!" callouts (combobox and other Pro component pages).
2. And the migrating-from-shoelace "A Few Components Now Live..." callout shared duplicated CSS across two locations. 
3. The `:::pro` markdown directive used a separate, smaller visual style. 

☝️ This work unifies them: a single `wa-callout.pro` rule in `utils.css` is now the source of truth, and the `:::pro` directive picks up the same styling automatically.                                                                                                                             

 ## What's new
The `:::pro` directive now accepts an optional title (`:::pro Some Title`) and an optional icon override (`:::pro {star-circle} Title`). The default icon is `hand-wave`.
                                                                                                                                               
 ## Page updates                                                                                                                          
The migration page drops its inline `<style>` block and the marketing-palette stylesheet `<link>` — both no longer needed since the shared  `.pro` rule uses `--wa-brand-orange` directly. The `/docs` and `/docs/frameworks/react` callouts now use the new `:::pro Using Web Awesome  Pro?` syntax for a styled title and body.