### PR TITLE
Docs: Standardizing Hover Utilities for Card Links

### DIFF
--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -267,11 +267,6 @@ wa-page > main:has(> .search-list) {
         min-block-size: calc(6rem + var(--spacing));
         padding: var(--spacing);
       }
-
-      &:hover {
-        border-color: var(--wa-color-brand-border-loud);
-        box-shadow: 0 0 0 0.0625rem var(--wa-color-brand-border-loud);
-      }
     }
   }
 }
@@ -316,22 +311,10 @@ wa-card .page-name {
       block-size: 100%;
     }
 
-    wa-card:defined {
-      transition:
-        border-color var(--wa-transition-normal),
-        box-shadow var(--wa-transition-normal);
-    }
-
     wa-card::part(body) {
       display: flex;
       flex-direction: column;
       block-size: 100%;
-    }
-
-    a:hover wa-card,
-    a:focus-visible wa-card {
-      border-color: var(--wa-color-brand-border-loud);
-      box-shadow: 0 0 0 0.0625rem var(--wa-color-brand-border-loud);
     }
 
     .page-name {

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -1000,6 +1000,25 @@
     }
   }
 
+  /* Hover border + outline ring; pair with .hover-grow for card grids */
+  .hover-emphasize-border wa-card {
+    outline: var(--wa-border-width-s) solid transparent;
+    transition:
+      border-color var(--wa-transition-normal),
+      outline-color var(--wa-transition-normal);
+  }
+
+  .hover-emphasize-border:is(:hover, :focus-visible) wa-card {
+    border-color: var(--wa-color-brand-border-loud);
+    outline-color: var(--wa-color-brand-border-loud);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .hover-emphasize-border wa-card {
+      transition: none;
+    }
+  }
+
   /* #endregion */
   /* #endregion */
 

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -963,6 +963,44 @@
   .de-emphasize {
     opacity: 0.6;
   }
+
+  /* #region hover utilities */
+
+  /* Hover scale; override --hover-grow-scale per instance */
+  .hover-grow,
+  .hover-grow-from-direct-child {
+    --hover-grow-scale: 1.025;
+    transform-origin: center;
+    transition: transform var(--wa-transition-slow) ease-in-out;
+  }
+
+  .hover-grow:is(:hover, :focus-visible) {
+    transform: scale(var(--hover-grow-scale));
+  }
+
+  /* Scale when a direct child link or button is hovered */
+  .hover-grow-from-direct-child:has(> :is(a, button):hover),
+  .hover-grow-from-direct-child:has(> :is(a, button):focus-visible) {
+    transform: scale(var(--hover-grow-scale));
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .hover-grow,
+    .hover-grow-from-direct-child {
+      transition: none;
+    }
+
+    .hover-grow:is(:hover, :focus-visible) {
+      transform: none;
+    }
+
+    .hover-grow-from-direct-child:has(> :is(a, button):hover),
+    .hover-grow-from-direct-child:has(> :is(a, button):focus-visible) {
+      transform: none;
+    }
+  }
+
+  /* #endregion */
   /* #endregion */
 
   /* #region resets */

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -971,7 +971,7 @@
   .hover-grow-from-direct-child {
     --hover-grow-scale: 1.025;
     transform-origin: center;
-    transition: transform var(--wa-transition-slow) ease-in-out;
+    transition: transform var(--wa-transition-slow) var(--wa-transition-easing);
   }
 
   .hover-grow:is(:hover, :focus-visible) {
@@ -1001,20 +1001,20 @@
   }
 
   /* Hover border + outline ring; pair with .hover-grow for card grids */
-  .hover-emphasize-border wa-card {
+  .hover-emphasize-border > wa-card {
     outline: var(--wa-border-width-s) solid transparent;
     transition:
       border-color var(--wa-transition-normal),
       outline-color var(--wa-transition-normal);
   }
 
-  .hover-emphasize-border:is(:hover, :focus-visible) wa-card {
+  .hover-emphasize-border:is(:hover, :focus-visible) > wa-card {
     border-color: var(--wa-color-brand-border-loud);
     outline-color: var(--wa-color-brand-border-loud);
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .hover-emphasize-border wa-card {
+    .hover-emphasize-border > wa-card {
       transition: none;
     }
   }

--- a/packages/webawesome/docs/docs/components/index.njk
+++ b/packages/webawesome/docs/docs/components/index.njk
@@ -18,7 +18,7 @@ layout: docs
   <section class="search-list-grid">
     {% for page in collections.componentPages | sort(false, false, 'data.title') %}
       {% set component = page.data.component %}
-      <a href="{{ page.url }}">
+      <a class="hover-grow hover-emphasize-border" href="{{ page.url }}">
         <wa-card>
           <span class="page-name">{{ page.data.title }}</span>
           {% if component.summary %}

--- a/packages/webawesome/docs/docs/frameworks.md
+++ b/packages/webawesome/docs/docs/frameworks.md
@@ -19,7 +19,7 @@ Web Awesome is designed to work in harmony with various frameworks. We have docu
 Select your framework below to get started.
 
 <div class="wa-grid" style="--min-column-size: 20ch;">
-  <a href="/docs/frameworks/angular" class="wa-link-plain">
+  <a href="/docs/frameworks/angular" class="wa-link-plain hover-grow hover-emphasize-border">
     <wa-card appearance="outlined" style="height: 100%;">
       <div class="wa-stack wa-align-items-center">
         <wa-icon name="angular" family="brands" style="font-size: var(--wa-font-size-4xl); color: #dd0031;"></wa-icon>
@@ -27,7 +27,7 @@ Select your framework below to get started.
       </div>
     </wa-card>
   </a>
-  <a href="/docs/frameworks/react" class="wa-link-plain">
+  <a href="/docs/frameworks/react" class="wa-link-plain hover-grow hover-emphasize-border">
     <wa-card appearance="outlined" style="height: 100%;">
       <div class="wa-stack wa-align-items-center">
         <wa-icon name="react" family="brands" style="font-size: var(--wa-font-size-4xl); color: #61dafb;"></wa-icon>
@@ -35,7 +35,7 @@ Select your framework below to get started.
       </div>
     </wa-card>
   </a>
-  <a href="/docs/frameworks/svelte" class="wa-link-plain">
+  <a href="/docs/frameworks/svelte" class="wa-link-plain hover-grow hover-emphasize-border">
     <wa-card appearance="outlined" style="height: 100%;">
       <div class="wa-stack wa-align-items-center">
         <wa-icon src="/assets/images/svelte.svg" style="font-size: var(--wa-font-size-4xl); color: #ff3e00;"></wa-icon>
@@ -43,7 +43,7 @@ Select your framework below to get started.
       </div>
     </wa-card>
   </a>
-  <a href="/docs/frameworks/vue" class="wa-link-plain">
+  <a href="/docs/frameworks/vue" class="wa-link-plain hover-grow hover-emphasize-border">
     <wa-card appearance="outlined" style="height: 100%;">
       <div class="wa-stack wa-align-items-center">
         <wa-icon name="vuejs" family="brands" style="font-size: var(--wa-font-size-4xl); color: #41b883;"></wa-icon>
@@ -51,7 +51,7 @@ Select your framework below to get started.
       </div>
     </wa-card>
   </a>
-  <a href="/docs/frameworks/vue-2" class="wa-link-plain">
+  <a href="/docs/frameworks/vue-2" class="wa-link-plain hover-grow hover-emphasize-border">
     <wa-card appearance="outlined" style="height: 100%;">
       <div class="wa-stack wa-align-items-center">
         <wa-icon name="vuejs" family="brands" style="font-size: var(--wa-font-size-4xl); color: #41b883;"></wa-icon>

--- a/packages/webawesome/docs/docs/tokens/index.njk
+++ b/packages/webawesome/docs/docs/tokens/index.njk
@@ -15,7 +15,7 @@ Design tokens are the building blocks of your [theme](/docs/themes) and thread t
 <div class="modern-card-list">
   <section class="search-list-grid">
     {% for page in collections.tokens | sort(false, false, 'data.title') %}
-      <a href="{{ page.url }}">
+      <a class="hover-grow hover-emphasize-border" href="{{ page.url }}">
         <wa-card>
           <span class="page-name">{{ page.data.title }}</span>
           {% if page.data.description %}

--- a/packages/webawesome/docs/docs/utilities/index.njk
+++ b/packages/webawesome/docs/docs/utilities/index.njk
@@ -77,7 +77,7 @@ Preset rules for customizing colors, typography, rounding, and more &mdash; fram
 <div class="modern-card-list">
   <section class="search-list-grid">
     {% for page in collections.styleUtilities | sort(false, false, 'data.title') %}
-      <a href="{{ page.url }}">
+      <a class="hover-grow hover-emphasize-border" href="{{ page.url }}">
         <wa-card>
           <span class="page-name">{{ page.data.title }}</span>
           {% if page.data.description %}
@@ -97,7 +97,7 @@ Named layouts like [`wa-stack`](/docs/utilities/stack), [`wa-cluster`](/docs/uti
 <div class="modern-card-list">
   <section class="search-list-grid">
     {% for page in collections.layoutUtilities | sort(false, false, 'data.title') %}
-      <a href="{{ page.url }}">
+      <a class="hover-grow hover-emphasize-border" href="{{ page.url }}">
         <wa-card>
           <span class="page-name">{{ page.data.title }}</span>
           {% if page.data.description %}


### PR DESCRIPTION
This work introduces and applies two shared hover-card utilities — `hover-grow` (scale-on-hover) and `hover-emphasize-border` (brand border + outline ring on hover). 

**These utilities are meant to standardize some existing hover treatments we were using in different cases with cards**.                                                                                                   
   
### Promoting `hover-grow` to `utils.css`                                                                 
`hover-grow` and its `hover-grow-from-direct-child` sibling were previously defined in `webawesome-pro's `site.css`. They now live in`utils.css`, available here as well as the site/app CSS.

### Adding `hover-emphasize-border`
Based on our components, design utilities, and pattern grid listings, this is a new utility that pairs with `hover-grow` for card-grid links. On hover/focus-visible, the wrapped `wa-card` swaps its `border-color` to `var(--wa-color-brand-border-loud)` and gains a brand-color `outline` ring whose width scales with the theme via `--wa-border-width-s`. 

Using `outline` rather than `box-shadow` leaves `wa-card`'s resting elevation shadow intact across all appearances.                             
                                                                                                                                               
### Adopting across the docs card grids
Replaces the inline border-hover rules previously in `docs.css` (originally introduced in #1085) with the new utility classes on each anchor. The now-superseded inline rules are stripped; layout and typography rules stay put. This affects: `/docs/components`, `/docs/tokens`, `/docs/utilities`, and `/docs/frameworks`. 