### PR TITLE
Docs: Sync Component-Based Badges Across Views

### DIFF
--- a/packages/webawesome/docs/_includes/macros/component-badges.njk
+++ b/packages/webawesome/docs/_includes/macros/component-badges.njk
@@ -1,0 +1,20 @@
+{# Renders the status (Stable/Experimental) and "Since X.X" badges for a component.
+   Used by the individual component view, the components index, and component cards. #}
+{% macro componentStatusBadges(component) %}
+{% if component.status == 'stable' %}
+{# `.preview` opts the brand-variant badge out of site theming (orange) so it
+   renders in the default brand (blue) wherever it appears. #}
+<wa-badge class="preview" variant="brand" pill>
+  <wa-icon name="check" slot="start"></wa-icon>
+  Stable
+</wa-badge>
+{% elif component.status == 'experimental' %}
+<wa-badge variant="warning" appearance="filled" pill>
+  <wa-icon name="flask" slot="start"></wa-icon>
+  Experimental
+</wa-badge>
+{% endif %}
+{% if component.since %}
+<wa-badge class="since" variant="neutral" appearance="filled" pill>Since {{ component.since }}</wa-badge>
+{% endif %}
+{% endmacro %}

--- a/packages/webawesome/docs/_layouts/component.njk
+++ b/packages/webawesome/docs/_layouts/component.njk
@@ -1,5 +1,6 @@
 {% extends '../_layouts/docs.njk' %}
 {% from "pro-badge.njk" import proBadge %}
+{% from "macros/component-badges.njk" import componentStatusBadges %}
 {% set component = getComponent('wa-' + page.fileSlug) %}
 {% set description = component.summary %}
 
@@ -7,22 +8,7 @@
 {% block beforeContent %}
   <div class="component-info">
     <code class="component-tag">&lt;{{ component.tagName }}&gt;</code>
-    {% if component.status %}
-      <wa-badge
-        {% if component.status == 'stable' %}variant="brand"{% endif %}
-        {% if component.status == 'experimental' %}variant="warning" appearance="filled"{% endif %}
-        pill
-      >
-        {% if component.status == 'stable' %}
-          <wa-icon name="check" slot="start"></wa-icon>
-        {% endif %}
-        {% if component.status == 'experimental' %}
-          <wa-icon name="flask" slot="start"></wa-icon>
-        {% endif %}
-        {{ component.status | capitalize }}
-      </wa-badge>
-    {% endif %}
-    <wa-badge variant="neutral" appearance="filled" pill>Since {{ component.since }}</wa-badge>
+    {{ componentStatusBadges(component) }}
     {% if isProComponent %}
       {{ proBadge({ description: "Included with " ~ site.namePro }) }}
     {% endif %}

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -483,6 +483,11 @@
     }
   }
 
+  /* "Since X.X" badge: subtler than the default filled neutral */
+  wa-badge.since {
+    background-color: var(--wa-color-surface-lowered);
+  }
+
   /* colophon + sidebar: social link row */
   #colophon {
     margin-block-start: var(--wa-space-2xl);

--- a/packages/webawesome/docs/docs/components/index.njk
+++ b/packages/webawesome/docs/docs/components/index.njk
@@ -5,6 +5,7 @@ layout: docs
 ---
 
 {% from "pro-badge.njk" import proBadge %}
+{% from "macros/component-badges.njk" import componentStatusBadges %}
 
 <div class="search-list component-list">
   <wa-input class="search-list-input" type="search" placeholder="Search Components" pill autofocus with-clear>
@@ -24,20 +25,7 @@ layout: docs
             <p class="component-list-summary">{{ component.summary | inlineMarkdown | striptags | safe }}</p>
           {% endif %}
           <div class="wa-cluster wa-gap-2xs component-list-badges">
-            {% if component.status == 'stable' %}
-              <wa-badge variant="brand" pill>
-                <wa-icon name="check" slot="start"></wa-icon>
-                Stable
-              </wa-badge>
-            {% elif component.status == 'experimental' %}
-              <wa-badge variant="warning" appearance="filled" pill>
-                <wa-icon name="flask" slot="start"></wa-icon>
-                Experimental
-              </wa-badge>
-            {% endif %}
-            {% if component.since %}
-              <wa-badge variant="neutral" appearance="filled" pill>Since {{ component.since }}</wa-badge>
-            {% endif %}
+            {{ componentStatusBadges(component) }}
             {% if page.data.isProComponent %}
               {{ proBadge({ description: "Included with " ~ site.namePro }) }}
             {% endif %}


### PR DESCRIPTION
This work introduces a shared `componentStatusBadges(component)` macro at `docs/_includes/macros/component-badges.njk` that renders the Stable/Experimental status badge and the "Since X.X" badge for a component. Both the individual component view (`docs/_layouts/component.njk`) and the free components index (`docs/docs/components/index.njk`) now call the macro instead of inlining their own badge markup.                                                                                                                         

### Stable Badge
Standardized on the individual-view treatment: `variant="brand"` with a check icon. The macro adds `class="preview"` to the Stable badge, so it opts out of `wa-theme-site` brand coloring and renders in the default brand (blue) wherever it appears — including on pages themed orange by the site palette.

### "Since X.X" badge
Standardized on the listing's subtler treatment. A new `wa-badge.since` rule in `docs/assets/styles/utils.css` (alongside `.pro`, `.free`, `.planned`) gives the badge a `--wa-color-surface-lowered` background so it recedes from the more prominent status badge. The macro applies the `since` class. 