### PR TITLE
fix(carousel): Smooth mouse drag on carousel (#1103)

### DIFF
--- a/packages/webawesome/src/components/carousel/carousel.styles.ts
+++ b/packages/webawesome/src/components/carousel/carousel.styles.ts
@@ -76,11 +76,6 @@ export default css`
     overflow-x: hidden;
   }
 
-  .slides-dragging,
-  .slides-dropping {
-    scroll-snap-type: unset;
-  }
-
   :host([vertical]) ::slotted(wa-carousel-item) {
     height: 100%;
   }


### PR DESCRIPTION
Fixes issue: #1103 

---

Tested on:

"macOS Sequoia 15.7.5"
- with mouse input
  - "Firefox 150.0.2"
  - "Edge Version 148.0.3967.54  (Official build)  (x86_64)"
  - "Safari Version 26.4 (20624.1.16.18.2)"
- with magic mouse scroll
  - "Chrome 148.0.7778.97"
- with trackpad scroll
  - "Chrome 148.0.7778.97"

"iPadOS 26.4.2"
- with touch input
  - "Safari 26"

"Android 16"
- with touch input
  - "Firefox 150.0.3"
  - "Chrome 148.0.7778.120"

"Windows 11 25H2"
- with mouse input
  - "Firefox 150.0.3"
  - "Edge Version 148.0.3967.54 (Official build) (64-bit)"
- with trackpad input
  - "Firefox 150.0.3"
  - "Edge Version 148.0.3967.54 (Official build) (64-bit)"