### PR TITLE
Make `linkify-components` Transformer Site-Wide

### DIFF
--- a/packages/webawesome/docs/.eleventyignore
+++ b/packages/webawesome/docs/.eleventyignore
@@ -1,0 +1,1 @@
+_transformers

--- a/packages/webawesome/docs/_includes/base.njk
+++ b/packages/webawesome/docs/_includes/base.njk
@@ -4,8 +4,10 @@
 {% if hasThemeSelector == undefined %}{% set hasThemeSelector = true %}{% endif %}
 {% if hasSiteDialog == undefined %}{% set hasSiteDialog = true %}{% endif %}
 {% if hasGeneratedTitle == undefined %}{% set hasGeneratedTitle = true %}{% endif %}
-<html lang="en" data-fa-kit-code="38c11e3f20" data-version="{{ package.version }}" class="wa-cloak" {% if
-  hasAnchors == false %} data-no-anchor{% endif %}>
+{% if hasLinkify == undefined %}{% set hasLinkify = true %}{% endif %}
+<html lang="en" data-fa-kit-code="38c11e3f20" data-version="{{ package.version }}" class="wa-cloak"
+  {% if hasAnchors == false %} data-no-anchor{% endif %}
+  {% if hasLinkify == false %} data-no-linkify{% endif %}>
 <head>
   {% include 'head.njk' %}
   <meta name="theme-color" content="#f36944">

--- a/packages/webawesome/docs/_transformers/README.md
+++ b/packages/webawesome/docs/_transformers/README.md
@@ -1,0 +1,61 @@
+# Doc transformers
+
+Build-time HTML transforms that run on every rendered Eleventy page. Each module exports a factory that returns a function `(doc) => void`, which mutates the parsed HTML document in place. They're registered as a single `doc-transforms` Eleventy transform in [`../.eleventy.js`](../.eleventy.js).
+
+## Pipeline
+
+Order matters — each transformer sees the output of the previous one.
+
+| Transformer               | Purpose                                                                              |
+| ------------------------- | ------------------------------------------------------------------------------------ |
+| `anchor-headings.js`      | Adds a permalink anchor (hashtag icon + tooltip) to every heading inside `#content`. |
+| `outline.js`              | Builds the per-page outline (table of contents) from `h2`/`h3` headings.             |
+| `current-link.js`         | Marks links in navs that match the current page.                                     |
+| `code-examples.js`        | Wraps fenced `{.example}` code blocks for live demos.                                |
+| `highlight-code.js`       | Applies syntax highlighting to code blocks.                                          |
+| `copy-code.js`            | Adds copy buttons to `<pre>` blocks.                                                 |
+| `changelog-list-icons.js` | Replaces bullets in `.changelog-group-*` containers with category icons.             |
+| `linkify-components.js`   | Wraps inline `<code>` mentions of `<wa-*>` tags in anchors to their docs pages.      |
+
+`format-code.js` lives in this folder but is a Prettier helper, not a transformer. It's used by other tools, not registered in the pipeline.
+
+## Opt-out attributes
+
+Most transformers that scan content support a `data-no-*` attribute so authors can skip processing for a specific page, region, or element. Each works at three scopes:
+
+- **Page** — set on `<html>` (typically via a layout or front matter).
+- **Region** — set on any ancestor element. The transformer skips any descendants.
+- **Element** — set on the target element directly.
+
+| Attribute         | Skips                                       |
+| ----------------- | ------------------------------------------- |
+| `data-no-anchor`  | Permalink injection on headings.            |
+| `data-no-outline` | Inclusion of a heading in the page outline. |
+| `data-no-linkify` | Automatic component-tag linkification.      |
+
+### Examples
+
+Skip linkification on an entire page (set in the layout):
+
+```njk
+<html lang="en" data-no-linkify>
+```
+
+Skip a single inline mention:
+
+```html
+The bare token <code data-no-linkify>&lt;wa-input&gt;</code> won't be auto-linked.
+```
+
+Skip a whole region:
+
+```html
+<section data-no-linkify>Anything here mentioning <code>&lt;wa-input&gt;</code> stays as plain code.</section>
+```
+
+## Adding a transformer
+
+1. Create the file in this folder. Export a factory: `export function myTransformer(options) { return function (doc) { /* ... */ }; }`.
+2. Import and add to the `transformers` array in [`../.eleventy.js`](../.eleventy.js).
+3. If the transformer scans content for replacement, support a `data-no-*` opt-out via `closest()` and document it in the table above.
+4. Use the existing transformers as a reference for `node-html-parser` patterns (`querySelectorAll`, `closest`, `insertAdjacentHTML`, `replaceWith`).

--- a/packages/webawesome/docs/_transformers/README.md
+++ b/packages/webawesome/docs/_transformers/README.md
@@ -23,22 +23,24 @@ Order matters — each transformer sees the output of the previous one.
 
 Most transformers that scan content support a `data-no-*` attribute so authors can skip processing for a specific page, region, or element. Each works at three scopes:
 
-- **Page** — set on `<html>` (typically via a layout or front matter).
+- **Page** — set on `<html>` via the base layout. `base.njk` opts in by default and reads page-level toggles from front matter (`hasAnchors`, `hasLinkify`) — set one to `false` to apply the matching `data-no-*` attribute for that page.
 - **Region** — set on any ancestor element. The transformer skips any descendants.
 - **Element** — set on the target element directly.
 
-| Attribute         | Skips                                       |
-| ----------------- | ------------------------------------------- |
-| `data-no-anchor`  | Permalink injection on headings.            |
-| `data-no-outline` | Inclusion of a heading in the page outline. |
-| `data-no-linkify` | Automatic component-tag linkification.      |
+| Attribute         | Front-matter toggle | Skips                                       |
+| ----------------- | ------------------- | ------------------------------------------- |
+| `data-no-anchor`  | `hasAnchors: false` | Permalink injection on headings.            |
+| `data-no-outline` | —                   | Inclusion of a heading in the page outline. |
+| `data-no-linkify` | `hasLinkify: false` | Automatic component-tag linkification.      |
 
 ### Examples
 
-Skip linkification on an entire page (set in the layout):
+Skip linkification on an entire page (front matter):
 
-```njk
-<html lang="en" data-no-linkify>
+```yaml
+---
+hasLinkify: false
+---
 ```
 
 Skip a single inline mention:

--- a/packages/webawesome/docs/_transformers/linkify-components.js
+++ b/packages/webawesome/docs/_transformers/linkify-components.js
@@ -10,7 +10,7 @@ export function linkifyComponentsTransformer(componentTagNames) {
     // View-level opt-out: skip the entire page when `<html data-no-linkify>` is set.
     if (doc.querySelector('html[data-no-linkify]')) return;
 
-    const currentPath = normalize(this?.page?.url ?? '');
+    const currentPath = normalize(this.page.url);
 
     doc.querySelectorAll('#content code').forEach(code => {
       // Skip code blocks, code inside interactive ancestors, and code inside an opt-out region.

--- a/packages/webawesome/docs/_transformers/linkify-components.js
+++ b/packages/webawesome/docs/_transformers/linkify-components.js
@@ -7,11 +7,14 @@ export function linkifyComponentsTransformer(componentTagNames) {
   const normalize = path => path.replace(/\/$/, '');
 
   return function (doc) {
+    // View-level opt-out: skip the entire page when `<html data-no-linkify>` is set.
+    if (doc.querySelector('html[data-no-linkify]')) return;
+
     const currentPath = normalize(this?.page?.url ?? '');
 
     doc.querySelectorAll('#content code').forEach(code => {
-      // Skip code blocks (`<pre>`) and code already inside an interactive ancestor.
-      if (code.closest('pre, a, button')) return;
+      // Skip code blocks, code inside interactive ancestors, and code inside an opt-out region.
+      if (code.closest('pre, a, button, [data-no-linkify]')) return;
 
       const match = code.innerHTML.match(tagPattern);
       if (!match) return;

--- a/packages/webawesome/docs/_transformers/linkify-components.js
+++ b/packages/webawesome/docs/_transformers/linkify-components.js
@@ -1,21 +1,28 @@
 import { parse } from 'node-html-parser';
 
-/** Wraps `<code>&lt;wa-*&gt;</code>` in anchors pointing to the component's doc page.
- *  Scoped to `.changelog-group` for now; expand site-wide in a follow-up. */
+/** Wraps `<code>&lt;wa-*&gt;</code>` in anchors pointing to the component's doc page. */
 export function linkifyComponentsTransformer(componentTagNames) {
   const tagSet = new Set(componentTagNames);
   const tagPattern = /^&lt;(wa-[a-z0-9-]+)(?:\s|&gt;)/;
+  const normalize = path => path.replace(/\/$/, '');
 
   return function (doc) {
-    doc.querySelectorAll('.changelog-group code').forEach(code => {
+    const currentPath = normalize(this?.page?.url ?? '');
+
+    doc.querySelectorAll('#content code').forEach(code => {
+      // Skip code blocks (`<pre>`) and code already inside an interactive ancestor.
+      if (code.closest('pre, a, button')) return;
+
       const match = code.innerHTML.match(tagPattern);
       if (!match) return;
 
       const tag = match[1];
       if (!tagSet.has(tag)) return;
 
-      const slug = tag.slice(3); // strip "wa-"
-      code.replaceWith(parse(`<a class="component-ref" href="/docs/components/${slug}">${code.outerHTML}</a>`));
+      const targetPath = `/docs/components/${tag.slice(3)}`;
+      if (currentPath === targetPath) return;
+
+      code.replaceWith(parse(`<a class="component-ref" href="${targetPath}">${code.outerHTML}</a>`));
     });
   };
 }


### PR DESCRIPTION
This work expands the `linkify-components` doc transformer (started in https://github.com/shoelace-style/webawesome/pull/2395) from a changelog-only scope to the whole `#content` region, so any inline `<code>&lt;wa-*&gt;</code>` mention across the docs becomes a link to that component's page.

### Opt-outs

Adds a `data-no-linkify` attribute that works at three scopes: page (set on `<html>` via layout/front matter), region (any ancestor element), or single element. The transformer also skips code inside `<pre>`, `<a>`, `<button>`, and self-references where the target matches the current page, so component pages don't auto-link to themselves.

### Docs

New `docs/_transformers/README.md` documents the full transformer pipeline (order matters, each sees the previous one's output), the shared `data-no-*` opt-out convention (`data-no-anchor`, `data-no-outline`, `data-no-linkify`), and a short guide for adding new transformers.