### PR TITLE
Fix: Set `wa-breadcrumb-item` Render `href=""` as a Link

### DIFF
--- a/packages/webawesome/docs/docs/components/breadcrumb.md
+++ b/packages/webawesome/docs/docs/components/breadcrumb.md
@@ -31,6 +31,8 @@ By default, breadcrumb items are rendered as buttons so you can use them to navi
 
 For websites, you'll probably want to use links instead. You can make any breadcrumb item a link by applying an `href` attribute to it. Now, when the user activates it, they'll be taken to the corresponding page — no event listeners required.
 
+The last item represents the current page. Use `href=""` so it points at itself — `<wa-breadcrumb>` will mark it with `aria-current="page"` and style it as non-interactive for you.
+
 ```html {.example}
 <wa-breadcrumb>
   <wa-breadcrumb-item href="https://example.com/home">Homepage</wa-breadcrumb-item>
@@ -39,7 +41,7 @@ For websites, you'll probably want to use links instead. You can make any breadc
 
   <wa-breadcrumb-item href="https://example.com/home/services/digital">Digital Media</wa-breadcrumb-item>
 
-  <wa-breadcrumb-item href="https://example.com/home/services/digital/web-design">Web Design</wa-breadcrumb-item>
+  <wa-breadcrumb-item href="">Web Design</wa-breadcrumb-item>
 </wa-breadcrumb>
 ```
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -14,6 +14,14 @@ These have a settled API. Breaking changes land only in major versions, and depr
 <h2 class="wa-heading-m wa-cluster wa-gap-s" data-no-anchor data-no-outline>Experimental Components {{ statusBadge('experimental') }}</h2>
 These are still finding their shape. APIs can change between minor versions, so use them in prototypes — not production code you can't easily update.
 
+## Unreleased
+
+:::fixed
+
+- Fixed a bug in `<wa-breadcrumb-item>` where `href=""` rendered as a button instead of a link, making it harder to follow the [WAI-ARIA breadcrumb pattern](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/) for the current-page item [issue:2387]
+
+:::
+
 ## 3.7.0
 
 <small><time datetime="2026-05-12">May 12, 2026</time></small>

--- a/packages/webawesome/src/components/breadcrumb-item/breadcrumb-item.test.ts
+++ b/packages/webawesome/src/components/breadcrumb-item/breadcrumb-item.test.ts
@@ -59,6 +59,16 @@ describe('<wa-breadcrumb-item>', () => {
           expect(link).to.have.attribute('href', 'https://example.com/');
         });
 
+        it('should render a link when href is an empty string', async () => {
+          const el = await fixture<WaBreadcrumbItem>(
+            html`<wa-breadcrumb-item href="">Current page</wa-breadcrumb-item>`,
+          );
+          const link = el.shadowRoot!.querySelector<HTMLAnchorElement>('[part~="label"]');
+          expect(link).to.exist;
+          expect(link!.tagName.toLowerCase()).to.equal('a');
+          expect(link).to.have.attribute('href', '');
+        });
+
         it('should set the target attribute on the link', async () => {
           const el = await fixture<WaBreadcrumbItem>(html`
             <wa-breadcrumb-item href="https://example.com/" target="_blank">Home</wa-breadcrumb-item>

--- a/packages/webawesome/src/components/breadcrumb-item/breadcrumb-item.test.ts
+++ b/packages/webawesome/src/components/breadcrumb-item/breadcrumb-item.test.ts
@@ -26,6 +26,13 @@ describe('<wa-breadcrumb-item>', () => {
           await expect(el).to.be.accessible();
         });
 
+        it('should pass accessibility tests with an empty href', async () => {
+          const el = await fixture<WaBreadcrumbItem>(
+            html`<wa-breadcrumb-item href="">Current page</wa-breadcrumb-item>`,
+          );
+          await expect(el).to.be.accessible();
+        });
+
         it('should hide the separator from screen readers', async () => {
           const el = await fixture<WaBreadcrumbItem>(html`<wa-breadcrumb-item>Home</wa-breadcrumb-item>`);
           const separator = el.shadowRoot!.querySelector('[part~="separator"]');

--- a/packages/webawesome/src/components/breadcrumb-item/breadcrumb-item.ts
+++ b/packages/webawesome/src/components/breadcrumb-item/breadcrumb-item.ts
@@ -48,7 +48,7 @@ export default class WaBreadcrumbItem extends WebAwesomeElement {
       this.defaultSlot.assignedElements({ flatten: true }).filter(i => i.tagName.toLowerCase() === 'wa-dropdown')
         .length > 0;
 
-    if (this.href) {
+    if (this.href != null) {
       this.renderType = 'link';
       return;
     }

--- a/packages/webawesome/src/components/breadcrumb-item/breadcrumb-item.ts
+++ b/packages/webawesome/src/components/breadcrumb-item/breadcrumb-item.ts
@@ -48,7 +48,7 @@ export default class WaBreadcrumbItem extends WebAwesomeElement {
       this.defaultSlot.assignedElements({ flatten: true }).filter(i => i.tagName.toLowerCase() === 'wa-dropdown')
         .length > 0;
 
-    if (this.href != null) {
+    if (this.href !== null) {
       this.renderType = 'link';
       return;
     }


### PR DESCRIPTION
### What Changed
`<wa-breadcrumb-item>` now renders as a link when `href` is set to an empty string, not just when it's a non-empty URL. 

This makes `href=""` a working shorthand for the current-page item — browsers resolve an empty `href` to the current URL, and `<wa-breadcrumb>` already adds `aria-current="page"` to the last item.

### Why
Follow-up to #2387. The [WAI-ARIA breadcrumb pattern](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/) calls for every item — including the current page — to be a link, with the current one marked `aria-current="page"`. The component's previous truthy check (`if (this.href)`) treated `""` the same as no attribute, so the current-page item couldn't be a link without specifying a real URL.

### The Fix
One-line change in `breadcrumb-item.ts`: `if (this.href)` → `if (this.href != null)`. Adds a test for the empty-string case, documents the convention in the Links example, and adds a changelog entry under the new Unreleased section.