### PR TITLE
Docs: Use New Size-Based Attribute Values

### DIFF
--- a/packages/webawesome/docs/docs/usage.md
+++ b/packages/webawesome/docs/docs/usage.md
@@ -31,7 +31,7 @@ If you're new to custom elements, often referred to as "web components," this se
 Many components have properties that can be set using attributes. For example, buttons accept a `size` attribute that maps to the `size` property which dictates the button's size.
 
 ```html
-<wa-button size="small">Click me</wa-button>
+<wa-button size="s">Click me</wa-button>
 ```
 
 Some properties are boolean, so they only have true/false values. To activate a boolean property, add the corresponding attribute without a value.


### PR DESCRIPTION
In `3.6.0` we deprecated `small`, `medium`, and `large` size values in favor of `s`, `m`, and `l`. 

Our own docs examples should model the new convention, so this work pdates the single `<wa-button size="small">` example in `docs/docs/usage.md` (the Attributes & Properties section) to `size="s"`.           