### PR TITLE
Fix: Render `wa-breadcrumb-item` as a Button When `href` is Absent

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -19,6 +19,7 @@ These are still finding their shape. APIs can change between minor versions, so 
 :::fixed
 
 - Fixed a bug in `<wa-breadcrumb-item>` where `href=""` rendered as a button instead of a link, making it harder to follow the [WAI-ARIA breadcrumb pattern](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/) for the current-page item [issue:2387]
+- Fixed a regression in `<wa-breadcrumb-item>` that caused items without an `href` to render as a link instead of a button
 
 :::
 

--- a/packages/webawesome/src/components/breadcrumb-item/breadcrumb-item.ts
+++ b/packages/webawesome/src/components/breadcrumb-item/breadcrumb-item.ts
@@ -48,7 +48,7 @@ export default class WaBreadcrumbItem extends WebAwesomeElement {
       this.defaultSlot.assignedElements({ flatten: true }).filter(i => i.tagName.toLowerCase() === 'wa-dropdown')
         .length > 0;
 
-    if (this.href !== null) {
+    if (typeof this.href === 'string') {
       this.renderType = 'link';
       return;
     }


### PR DESCRIPTION
#2398 changed the render-type check in `setRenderType()` from `if (this.href)` to `if (this.href !== null)`. The intent was to render an `<a>` for `href=""` (the current-page item in a breadcrumb), which the old falsy check missed. But because `@property() href?: string` is `undefined` when the attribute is absent — not `null` — the new check evaluated `undefined !== null` as `true` and rendered every breadcrumb item as a link, even ones without an `href`.

This swaps the check to `typeof this.href === 'string'`, which correctly distinguishes the three cases: `undefined` renders a `<button>`, `""` renders an `<a href="">`, and any other string renders an `<a href="…">`. 

Existing tests for both behaviors now pass.