### PR TITLE
Add `text-align`-Based Text Utilities + Adopt Flat `wa-text-` Naming

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -22,6 +22,10 @@ These are still finding their shape. APIs can change between minor versions, so 
 - Added the `wa-text-uppercase` text utility class for transforming text to uppercase
 - Added the `wa-text-lowercase` text utility class for transforming text to lowercase
 - Added the `wa-text-capitalize` text utility class for capitalizing the first letter of each word
+- Added the `wa-text-align-start` text utility class for logical (direction-aware) text alignment
+- Added the `wa-text-align-center` text utility class for centered text alignment
+- Added the `wa-text-align-end` text utility class for logical (direction-aware) text alignment
+- Added the `wa-text-align-justify` text utility class for justified text alignment
 
 :::
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -22,10 +22,10 @@ These are still finding their shape. APIs can change between minor versions, so 
 - Added the `wa-text-uppercase` text utility class for transforming text to uppercase
 - Added the `wa-text-lowercase` text utility class for transforming text to lowercase
 - Added the `wa-text-capitalize` text utility class for capitalizing the first letter of each word
-- Added the `wa-text-align-start` text utility class for logical (direction-aware) text alignment
-- Added the `wa-text-align-center` text utility class for centered text alignment
-- Added the `wa-text-align-end` text utility class for logical (direction-aware) text alignment
-- Added the `wa-text-align-justify` text utility class for justified text alignment
+- Added the `wa-text-start` text utility class for logical (direction-aware) text alignment
+- Added the `wa-text-center` text utility class for centered text alignment
+- Added the `wa-text-end` text utility class for logical (direction-aware) text alignment
+- Added the `wa-text-justify` text utility class for justified text alignment
 
 :::
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -49,7 +49,13 @@ These are still finding their shape. APIs can change between minor versions, so 
 - Synced hardcoded transitions in `<wa-copy-button>`, `<wa-select>`, `<wa-combobox>`, and `<wa-toast-item>` with `--wa-transition-*` tokens
 - Improved the vertical placement of content within `<wa-textarea>` and `textarea` when the content overflows the control [pr:2424]
 - Updated Native Styles to reset the `list-style`, `margin`, and `padding` of `menu` elements [discuss:2436]
+- Renamed `wa-text-wrap-nowrap`, `wa-text-wrap-balance`, and `wa-text-wrap-pretty` to `wa-text-nowrap`, `wa-text-balance`, and `wa-text-pretty` to align with the flat `wa-text-*` utility namespace. The original class names continue to work as aliases.
 
+:::
+
+:::deprecated
+
+- Deprecated `wa-text-wrap-nowrap`, `wa-text-wrap-balance`, and `wa-text-wrap-pretty` in favor of their shorter `wa-text-*` equivalents. The original names still work but will be removed in a future major version.
 :::
 
 ## 3.7.0

--- a/packages/webawesome/docs/docs/utilities/text.md
+++ b/packages/webawesome/docs/docs/utilities/text.md
@@ -201,6 +201,28 @@ Use these classes to change the case of text. They apply standard CSS [`text-tra
 
 :::info
 Large blocks of uppercase text are [harder for everyone to read](https://www.w3.org/WAI/WCAG21/Understanding/visual-presentation.html) and especially difficult for folks with dyslexia. Reserve it for buttons, badges, or short headings.
+
+## Alignment
+
+<style>
+  .preview-wrapper {
+    border: var(--layout-example-border);
+    border-radius: var(--wa-border-radius-m);
+    padding: var(--wa-space-xs);
+  }
+</style>
+
+Use `wa-text-align-*` classes to align text within its container. These utilities apply standard CSS [`text-align`](https://developer.mozilla.org/docs/Web/CSS/text-align) values using logical properties, so they adapt automatically to the document's writing direction.
+
+| Class Name              | Preview                                                                                                                              |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `wa-text-align-start`   | <div class="wa-text-align-start preview-wrapper">Five boxing wizards</div>                                                           |
+| `wa-text-align-center`  | <div class="wa-text-align-center preview-wrapper">Five boxing wizards</div>                                                          |
+| `wa-text-align-end`     | <div class="wa-text-align-end preview-wrapper">Five boxing wizards</div>                                                             |
+| `wa-text-align-justify` | <div class="wa-text-align-justify preview-wrapper">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div>  |
+
+::: info
+Justified text can create uneven word spacing that's [harder for everyone to read](https://www.w3.org/WAI/WCAG21/Understanding/visual-presentation.html) and especially difficult for folks with dyslexia. Reserve it for short, narrow text columns.
 :::
 
 ## Truncation

--- a/packages/webawesome/docs/docs/utilities/text.md
+++ b/packages/webawesome/docs/docs/utilities/text.md
@@ -177,16 +177,20 @@ Use single-purpose `wa-color-text-*` classes to apply a given [text color](/docs
 
 ## Wrapping
 
-Use `wa-text-wrap-*` classes to control how text wraps across lines. These utilities apply standard CSS [`text-wrap`](https://developer.mozilla.org/docs/Web/CSS/text-wrap) values.
+Use these classes to control how text wraps across lines. They apply standard CSS [`text-wrap`](https://developer.mozilla.org/docs/Web/CSS/text-wrap) values.
 
-| Class Name             | Preview                                                                                                                                                      |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `wa-text-wrap-nowrap`  | <div class="wa-text-wrap-nowrap" style="max-width: 40ch; overflow: hidden;">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div> |
-| `wa-text-wrap-balance` | <div class="wa-text-wrap-balance" style="max-width: 40ch;">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div>                  |
-| `wa-text-wrap-pretty`  | <div class="wa-text-wrap-pretty" style="max-width: 40ch;">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div>                   |
+| Class Name        | Preview                                                                                                                                                 |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `wa-text-nowrap`  | <div class="wa-text-nowrap" style="max-width: 40ch; overflow: hidden;">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div> |
+| `wa-text-balance` | <div class="wa-text-balance" style="max-width: 40ch;">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div>                  |
+| `wa-text-pretty`  | <div class="wa-text-pretty" style="max-width: 40ch;">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div>                   |
 
 :::info
-`wa-text-wrap-pretty` is wrapped in an `@supports` rule because Firefox does not yet support `text-wrap: pretty`. In unsupported browsers, the class has no effect and text wraps normally.
+`wa-text-pretty` is wrapped in an `@supports` rule because Firefox does not yet support `text-wrap: pretty`. In unsupported browsers, the class has no effect and text wraps normally.
+:::
+
+:::info
+The original `wa-text-wrap-nowrap`, `wa-text-wrap-balance`, and `wa-text-wrap-pretty` class names continue to work as aliases for backwards compatibility. These older names are deprecated and will be removed in a future major version — we recommend updating to the shorter `wa-text-*` names above.
 :::
 
 ## Transform
@@ -201,6 +205,7 @@ Use these classes to change the case of text. They apply standard CSS [`text-tra
 
 :::info
 Large blocks of uppercase text are [harder for everyone to read](https://www.w3.org/WAI/WCAG21/Understanding/visual-presentation.html) and especially difficult for folks with dyslexia. Reserve it for buttons, badges, or short headings.
+:::
 
 ## Alignment
 

--- a/packages/webawesome/docs/docs/utilities/text.md
+++ b/packages/webawesome/docs/docs/utilities/text.md
@@ -212,14 +212,14 @@ Large blocks of uppercase text are [harder for everyone to read](https://www.w3.
   }
 </style>
 
-Use `wa-text-align-*` classes to align text within its container. These utilities apply standard CSS [`text-align`](https://developer.mozilla.org/docs/Web/CSS/text-align) values using logical properties, so they adapt automatically to the document's writing direction.
+Use these classes to align text within its container. They apply standard CSS [`text-align`](https://developer.mozilla.org/docs/Web/CSS/text-align) values using logical properties, so they adapt automatically to the document's writing direction.
 
-| Class Name              | Preview                                                                                                                              |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `wa-text-align-start`   | <div class="wa-text-align-start preview-wrapper">Five boxing wizards</div>                                                           |
-| `wa-text-align-center`  | <div class="wa-text-align-center preview-wrapper">Five boxing wizards</div>                                                          |
-| `wa-text-align-end`     | <div class="wa-text-align-end preview-wrapper">Five boxing wizards</div>                                                             |
-| `wa-text-align-justify` | <div class="wa-text-align-justify preview-wrapper">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div>  |
+| Class Name        | Preview                                                                                                                       |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `wa-text-start`   | <div class="wa-text-start preview-wrapper">Five boxing wizards</div>                                                          |
+| `wa-text-center`  | <div class="wa-text-center preview-wrapper">Five boxing wizards</div>                                                         |
+| `wa-text-end`     | <div class="wa-text-end preview-wrapper">Five boxing wizards</div>                                                            |
+| `wa-text-justify` | <div class="wa-text-justify preview-wrapper">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div> |
 
 ::: info
 Justified text can create uneven word spacing that's [harder for everyone to read](https://www.w3.org/WAI/WCAG21/Understanding/visual-presentation.html) and especially difficult for folks with dyslexia. Reserve it for short, narrow text columns.

--- a/packages/webawesome/src/styles/utilities/text.css
+++ b/packages/webawesome/src/styles/utilities/text.css
@@ -172,19 +172,21 @@
 
   .wa-text-capitalize {
     text-transform: capitalize;
-  .wa-text-align-start {
+  }
+
+  .wa-text-start {
     text-align: start;
   }
 
-  .wa-text-align-center {
+  .wa-text-center {
     text-align: center;
   }
 
-  .wa-text-align-end {
+  .wa-text-end {
     text-align: end;
   }
 
-  .wa-text-align-justify {
+  .wa-text-justify {
     text-align: justify;
   }
   /* #endregion */

--- a/packages/webawesome/src/styles/utilities/text.css
+++ b/packages/webawesome/src/styles/utilities/text.css
@@ -172,6 +172,20 @@
 
   .wa-text-capitalize {
     text-transform: capitalize;
+  .wa-text-align-start {
+    text-align: start;
+  }
+
+  .wa-text-align-center {
+    text-align: center;
+  }
+
+  .wa-text-align-end {
+    text-align: end;
+  }
+
+  .wa-text-align-justify {
+    text-align: justify;
   }
   /* #endregion */
 

--- a/packages/webawesome/src/styles/utilities/text.css
+++ b/packages/webawesome/src/styles/utilities/text.css
@@ -148,15 +148,18 @@
     white-space: nowrap;
   }
 
+  .wa-text-nowrap,
   .wa-text-wrap-nowrap {
     text-wrap: nowrap;
   }
 
+  .wa-text-balance,
   .wa-text-wrap-balance {
     text-wrap: balance;
   }
 
   @supports (text-wrap: pretty) {
+    .wa-text-pretty,
     .wa-text-wrap-pretty {
       text-wrap: pretty;
     }


### PR DESCRIPTION
This work introduces four new text alignment utility classes and refactors the existing wrapping utilities to adopt a flatter, more concise class naming convention.

### What's New

Four alignment utilities, all using logical values (`start`/`end` instead of `left`/`right`), so they adapt to the document's writing direction:

- `wa-text-start` → `text-align: start`
- `wa-text-center` → `text-align: center`
- `wa-text-end` → `text-align: end`
- `wa-text-justify` → `text-align: justify`

Physical values, `match-parent`, and `justify-all` are intentionally omitted — custom CSS covers the rare cases where they're needed.

### Naming Convention

PR feedback on #2404 raised that `wa-text-{property}-{value}` reads as overly verbose when the property name doesn't add disambiguation (`wa-text-transform-uppercase` is heavy for what it does). 

I surveyed how Bootstrap, Tailwind, Bulma, Primer, PatternFly, and other major design systems handle this and settled on a flat `wa-text-*` namespace where the class name encodes the value, not the property. 

Bootstrap has shipped this convention for 10+ years and has only had to qualify it for `text-decoration` (where values like `line-through` and `none` don't read well flat) — a known constraint that we can plan around if/when we support that property. 

But this would still be a departure from other CSS utility class names, so we'd have to be okay with that.

### Migration: `wa-text-wrap-*` → `wa-text-*`

The three wrap utilities from `3.7.0` get shorter names, with the original names kept as backwards-compatible aliases:

- `wa-text-wrap-nowrap` → `wa-text-nowrap`
- `wa-text-wrap-balance` → `wa-text-balance`
- `wa-text-wrap-pretty` → `wa-text-pretty`

Old names are flagged as deprecated in the docs and changelog. They'll be removed in a future major version.

### Docs

A new **Alignment** section between **Wrapping** and **Truncation** in `docs/docs/utilities/text.md`. The **Wrapping** section is updated to use the new names with a deprecation callout for the
originals.