### PR TITLE
Add `text-transform`-Based Text Utilities

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -19,10 +19,9 @@ These are still finding their shape. APIs can change between minor versions, so 
 :::added
 
 - Added the `capture` attribute to `<wa-file-input>` for capturing media directly from a device's camera or microphone [discuss:2380]
-- Added the `wa-text-transform-uppercase` text utility class for transforming text to uppercase
-- Added the `wa-text-transform-lowercase` text utility class for transforming text to lowercase
-- Added the `wa-text-transform-capitalize` text utility class for capitalizing the first letter of each word
-- Added the `wa-text-transform-none` text utility class for resetting inherited text transformations
+- Added the `wa-text-uppercase` text utility class for transforming text to uppercase
+- Added the `wa-text-lowercase` text utility class for transforming text to lowercase
+- Added the `wa-text-capitalize` text utility class for capitalizing the first letter of each word
 
 :::
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -19,6 +19,10 @@ These are still finding their shape. APIs can change between minor versions, so 
 :::added
 
 - Added the `capture` attribute to `<wa-file-input>` for capturing media directly from a device's camera or microphone [discuss:2380]
+- Added the `wa-text-transform-uppercase` text utility class for transforming text to uppercase
+- Added the `wa-text-transform-lowercase` text utility class for transforming text to lowercase
+- Added the `wa-text-transform-capitalize` text utility class for capitalizing the first letter of each word
+- Added the `wa-text-transform-none` text utility class for resetting inherited text transformations
 
 :::
 

--- a/packages/webawesome/docs/docs/utilities/text.md
+++ b/packages/webawesome/docs/docs/utilities/text.md
@@ -191,14 +191,13 @@ Use `wa-text-wrap-*` classes to control how text wraps across lines. These utili
 
 ## Transform
 
-Use `wa-text-transform-*` classes to change the case of text. These utilities apply standard CSS [`text-transform`](https://developer.mozilla.org/docs/Web/CSS/text-transform) values.
+Use these classes to change the case of text. They apply standard CSS [`text-transform`](https://developer.mozilla.org/docs/Web/CSS/text-transform) values.
 
-| Class Name                     | Preview                                                             |
-| ------------------------------ | ------------------------------------------------------------------- |
-| `wa-text-transform-uppercase`  | <div class="wa-text-transform-uppercase">Five boxing wizards</div>  |
-| `wa-text-transform-lowercase`  | <div class="wa-text-transform-lowercase">Five boxing wizards</div>  |
-| `wa-text-transform-capitalize` | <div class="wa-text-transform-capitalize">Five boxing wizards</div> |
-| `wa-text-transform-none`       | <div class="wa-text-transform-none">Five boxing wizards</div>       |
+| Class Name           | Preview                                                   |
+| -------------------- | --------------------------------------------------------- |
+| `wa-text-uppercase`  | <div class="wa-text-uppercase">Five boxing wizards</div>  |
+| `wa-text-lowercase`  | <div class="wa-text-lowercase">Five boxing wizards</div>  |
+| `wa-text-capitalize` | <div class="wa-text-capitalize">Five boxing wizards</div> |
 
 :::info
 Large blocks of uppercase text are [harder for everyone to read](https://www.w3.org/WAI/WCAG21/Understanding/visual-presentation.html) and especially difficult for folks with dyslexia. Reserve it for buttons, badges, or short headings.

--- a/packages/webawesome/docs/docs/utilities/text.md
+++ b/packages/webawesome/docs/docs/utilities/text.md
@@ -179,14 +179,29 @@ Use single-purpose `wa-color-text-*` classes to apply a given [text color](/docs
 
 Use `wa-text-wrap-*` classes to control how text wraps across lines. These utilities apply standard CSS [`text-wrap`](https://developer.mozilla.org/docs/Web/CSS/text-wrap) values.
 
-| Class Name             | Preview                                                                                                                                                                               |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Class Name             | Preview                                                                                                                                                      |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `wa-text-wrap-nowrap`  | <div class="wa-text-wrap-nowrap" style="max-width: 40ch; overflow: hidden;">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div> |
-| `wa-text-wrap-balance` | <div class="wa-text-wrap-balance" style="max-width: 40ch;">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div>                                           |
-| `wa-text-wrap-pretty`  | <div class="wa-text-wrap-pretty" style="max-width: 40ch;">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div>                                            |
+| `wa-text-wrap-balance` | <div class="wa-text-wrap-balance" style="max-width: 40ch;">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div>                  |
+| `wa-text-wrap-pretty`  | <div class="wa-text-wrap-pretty" style="max-width: 40ch;">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div>                   |
 
 :::info
 `wa-text-wrap-pretty` is wrapped in an `@supports` rule because Firefox does not yet support `text-wrap: pretty`. In unsupported browsers, the class has no effect and text wraps normally.
+:::
+
+## Transform
+
+Use `wa-text-transform-*` classes to change the case of text. These utilities apply standard CSS [`text-transform`](https://developer.mozilla.org/docs/Web/CSS/text-transform) values.
+
+| Class Name                     | Preview                                                             |
+| ------------------------------ | ------------------------------------------------------------------- |
+| `wa-text-transform-uppercase`  | <div class="wa-text-transform-uppercase">Five boxing wizards</div>  |
+| `wa-text-transform-lowercase`  | <div class="wa-text-transform-lowercase">Five boxing wizards</div>  |
+| `wa-text-transform-capitalize` | <div class="wa-text-transform-capitalize">Five boxing wizards</div> |
+| `wa-text-transform-none`       | <div class="wa-text-transform-none">Five boxing wizards</div>       |
+
+:::info
+Large blocks of uppercase text are [harder for everyone to read](https://www.w3.org/WAI/WCAG21/Understanding/visual-presentation.html) and especially difficult for folks with dyslexia. Reserve it for buttons, badges, or short headings.
 :::
 
 ## Truncation

--- a/packages/webawesome/src/styles/utilities/text.css
+++ b/packages/webawesome/src/styles/utilities/text.css
@@ -161,6 +161,22 @@
       text-wrap: pretty;
     }
   }
+
+  .wa-text-transform-uppercase {
+    text-transform: uppercase;
+  }
+
+  .wa-text-transform-lowercase {
+    text-transform: lowercase;
+  }
+
+  .wa-text-transform-capitalize {
+    text-transform: capitalize;
+  }
+
+  .wa-text-transform-none {
+    text-transform: none;
+  }
   /* #endregion */
 
   /* #region Links ~~~~~~~ */

--- a/packages/webawesome/src/styles/utilities/text.css
+++ b/packages/webawesome/src/styles/utilities/text.css
@@ -162,20 +162,16 @@
     }
   }
 
-  .wa-text-transform-uppercase {
+  .wa-text-uppercase {
     text-transform: uppercase;
   }
 
-  .wa-text-transform-lowercase {
+  .wa-text-lowercase {
     text-transform: lowercase;
   }
 
-  .wa-text-transform-capitalize {
+  .wa-text-capitalize {
     text-transform: capitalize;
-  }
-
-  .wa-text-transform-none {
-    text-transform: none;
   }
   /* #endregion */
 


### PR DESCRIPTION
This work adds three new text transform utility classes for changing the case of text.

### What's New

- `wa-text-uppercase` → `text-transform: uppercase`
- `wa-text-lowercase` → `text-transform: lowercase`
- `wa-text-capitalize` → `text-transform: capitalize`

`full-width` (East Asian typography), `full-size-kana` (ruby annotation), and `math-auto` (MathML) are intentionally omitted — they're niche enough that custom CSS covers the rare projects that need them.

### What Changed Since the Initial Draft

The initial draft used `wa-text-transform-*` and also shipped a `none` value. Both have been revised based on review feedback:

- **Flat naming.** Class names are now `wa-text-uppercase` etc., not `wa-text-transform-uppercase`. The full convention rationale can be found in #2403, which establishes the pattern for all text utilities.
- **Dropping `none`.** `wa-text-none` is too semantically vague to ship — it doesn't read as anything specific, Bootstrap doesn't ship an equivalent, and resetting an inherited transform is rarely
needed as a utility. Easy to add back later if real cases surface.

### Docs

A new **Transform** section in `docs/docs/utilities/text.md`, near **Wrapping** and **Truncation**, with the standard accessibility callout about large blocks of uppercase text.