### PR TITLE
Docs: Code Example Polish

### DIFF
--- a/packages/webawesome/docs/_transformers/code-examples.js
+++ b/packages/webawesome/docs/_transformers/code-examples.js
@@ -162,7 +162,7 @@ export function codeExamplesTransformer(options = {}) {
               `
                 : ''
             }
-            <div class="code-example-source" id="${id}"${isOpen ? '' : ' aria-hidden="true"'}>
+            <div class="code-example-source" id="${id}" role="region" aria-label="Example source code"${isOpen ? '' : ' aria-hidden="true"'}>
               ${elementPre?.outerHTML ?? pre.outerHTML}
             </div>
             ${

--- a/packages/webawesome/docs/_transformers/code-examples.js
+++ b/packages/webawesome/docs/_transformers/code-examples.js
@@ -162,7 +162,7 @@ export function codeExamplesTransformer(options = {}) {
               `
                 : ''
             }
-            <div class="code-example-source" id="${id}">
+            <div class="code-example-source" id="${id}"${isOpen ? '' : ' aria-hidden="true"'}>
               ${elementPre?.outerHTML ?? pre.outerHTML}
             </div>
             ${

--- a/packages/webawesome/docs/assets/scripts/code-examples.js
+++ b/packages/webawesome/docs/assets/scripts/code-examples.js
@@ -148,6 +148,9 @@ async function setCodeExampleOpen(codeExample, toggle, open) {
 
   toggle.setAttribute('aria-expanded', 'false');
   source.classList.add('is-animating');
+  // Remove .open before the animation so the chevron rotation and panel collapse run together,
+  // mirroring the open path where .open is added before the panel animates.
+  codeExample.classList.remove('open');
   // Setting an explicit pixel height flushes layout, so no rAF is needed here
   // (unlike the open path, which animates from height: 0 and must measure scrollHeight first).
   const startHeight = source.scrollHeight;
@@ -168,7 +171,6 @@ async function setCodeExampleOpen(codeExample, toggle, open) {
 
   setCodeExampleSourceCollapsed(source, true);
   source.classList.remove('is-animating');
-  codeExample.classList.remove('open');
   setCodeExampleSourceAccessibility(source, false);
 }
 

--- a/packages/webawesome/docs/assets/scripts/code-examples.js
+++ b/packages/webawesome/docs/assets/scripts/code-examples.js
@@ -42,8 +42,8 @@ function cancelSourceAnimations(source) {
 
 function getCodeExampleDurations(source) {
   const style = getComputedStyle(source);
-  const showDuration = parseDuration(style.getPropertyValue('--show-duration').trim() || '200ms');
-  const hideDuration = parseDuration(style.getPropertyValue('--hide-duration').trim() || '200ms');
+  const showDuration = parseDuration(style.getPropertyValue('--code-example-show-duration').trim() || '200ms');
+  const hideDuration = parseDuration(style.getPropertyValue('--code-example-hide-duration').trim() || '200ms');
 
   return { showDuration, hideDuration };
 }
@@ -67,12 +67,29 @@ function setCodeExampleSourceCollapsed(source, collapsed) {
   source.style.opacity = '';
 }
 
+function resetCodeExampleElement(codeExample) {
+  const source = codeExample.querySelector('.code-example-source');
+  const preview = codeExample.querySelector('.code-example-preview');
+
+  if (source) {
+    cancelSourceAnimations(source);
+    source.classList.remove('code-example-source--animating');
+  }
+
+  if (preview) {
+    preview.classList.remove('code-example-preview--dragging');
+    preview.style.removeProperty('width');
+  }
+}
+
 function initCodeExamples() {
   document.querySelectorAll('.code-example').forEach(codeExample => {
     const source = codeExample.querySelector('.code-example-source');
     if (!source) {
       return;
     }
+
+    resetCodeExampleElement(codeExample);
 
     const open = codeExample.classList.contains('open');
     setCodeExampleSourceCollapsed(source, !open);
@@ -107,6 +124,8 @@ async function setCodeExampleOpen(codeExample, toggle, open) {
     source.classList.add('code-example-source--animating');
     source.style.height = '0';
     source.style.opacity = '0';
+
+    await new Promise(resolve => requestAnimationFrame(resolve));
 
     await animate(
       source,
@@ -150,6 +169,7 @@ async function setCodeExampleOpen(codeExample, toggle, open) {
   setCodeExampleSourceAccessibility(source, false);
 }
 
+// Initial pass for first paint; turbo:load re-syncs after client-side navigation.
 initCodeExamples();
 document.addEventListener('turbo:load', initCodeExamples);
 
@@ -199,14 +219,21 @@ document.addEventListener('click', event => {
   // Toggle source
   if (toggle) {
     const codeExample = toggle.closest('.code-example');
-    const open = !codeExample.classList.contains('open');
+    if (!codeExample) {
+      return;
+    }
 
+    const open = !codeExample.classList.contains('open');
     void setCodeExampleOpen(codeExample, toggle, open);
   }
 
   // Edit in CodePen
   if (pen) {
     const codeExample = pen.closest('.code-example');
+    if (!codeExample) {
+      return;
+    }
+
     const code = codeExample.querySelector('code');
     const html =
       `<link rel="stylesheet" href="https://ka-p.webawesome.com/kit/b9bfcf2dca544e85/webawesome@${version}/styles/webawesome.css">\n` +

--- a/packages/webawesome/docs/assets/scripts/code-examples.js
+++ b/packages/webawesome/docs/assets/scripts/code-examples.js
@@ -36,8 +36,12 @@ function bumpAnimationGeneration(codeExample) {
   return generation;
 }
 
-function getCodeExampleDurations(codeExample) {
-  const style = getComputedStyle(codeExample);
+function cancelSourceAnimations(source) {
+  source.getAnimations().forEach(animation => animation.cancel());
+}
+
+function getCodeExampleDurations(source) {
+  const style = getComputedStyle(source);
   const showDuration = parseDuration(style.getPropertyValue('--show-duration').trim() || '200ms');
   const hideDuration = parseDuration(style.getPropertyValue('--hide-duration').trim() || '200ms');
 
@@ -45,7 +49,11 @@ function getCodeExampleDurations(codeExample) {
 }
 
 function setCodeExampleSourceAccessibility(source, open) {
-  source.setAttribute('aria-hidden', open ? 'false' : 'true');
+  if (open) {
+    source.removeAttribute('aria-hidden');
+  } else {
+    source.setAttribute('aria-hidden', 'true');
+  }
 }
 
 function setCodeExampleSourceCollapsed(source, collapsed) {
@@ -79,6 +87,8 @@ async function setCodeExampleOpen(codeExample, toggle, open) {
   }
 
   const generation = bumpAnimationGeneration(codeExample);
+  cancelSourceAnimations(source);
+  source.classList.remove('code-example-source--animating');
 
   if (prefersReducedMotion()) {
     toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
@@ -88,7 +98,7 @@ async function setCodeExampleOpen(codeExample, toggle, open) {
     return;
   }
 
-  const { showDuration, hideDuration } = getCodeExampleDurations(codeExample);
+  const { showDuration, hideDuration } = getCodeExampleDurations(source);
 
   if (open) {
     toggle.setAttribute('aria-expanded', 'true');
@@ -141,6 +151,7 @@ async function setCodeExampleOpen(codeExample, toggle, open) {
 }
 
 initCodeExamples();
+document.addEventListener('turbo:load', initCodeExamples);
 
 //
 // Resizing previews

--- a/packages/webawesome/docs/assets/scripts/code-examples.js
+++ b/packages/webawesome/docs/assets/scripts/code-examples.js
@@ -146,7 +146,10 @@ async function setCodeExampleOpen(codeExample, toggle, open) {
     return;
   }
 
+  toggle.setAttribute('aria-expanded', 'false');
   source.classList.add('code-example-source--animating');
+  // Setting an explicit pixel height flushes layout, so no rAF is needed here
+  // (unlike the open path, which animates from height: 0 and must measure scrollHeight first).
   source.style.height = `${source.scrollHeight}px`;
 
   await animate(
@@ -164,7 +167,6 @@ async function setCodeExampleOpen(codeExample, toggle, open) {
 
   setCodeExampleSourceCollapsed(source, true);
   source.classList.remove('code-example-source--animating');
-  toggle.setAttribute('aria-expanded', 'false');
   codeExample.classList.remove('open');
   setCodeExampleSourceAccessibility(source, false);
 }

--- a/packages/webawesome/docs/assets/scripts/code-examples.js
+++ b/packages/webawesome/docs/assets/scripts/code-examples.js
@@ -73,11 +73,11 @@ function resetCodeExampleElement(codeExample) {
 
   if (source) {
     cancelSourceAnimations(source);
-    source.classList.remove('code-example-source--animating');
+    source.classList.remove('is-animating');
   }
 
   if (preview) {
-    preview.classList.remove('code-example-preview--dragging');
+    preview.classList.remove('is-dragging');
     preview.style.removeProperty('width');
   }
 }
@@ -105,7 +105,7 @@ async function setCodeExampleOpen(codeExample, toggle, open) {
 
   const generation = bumpAnimationGeneration(codeExample);
   cancelSourceAnimations(source);
-  source.classList.remove('code-example-source--animating');
+  source.classList.remove('is-animating');
 
   if (prefersReducedMotion()) {
     toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
@@ -121,7 +121,7 @@ async function setCodeExampleOpen(codeExample, toggle, open) {
     toggle.setAttribute('aria-expanded', 'true');
     codeExample.classList.add('open');
     setCodeExampleSourceAccessibility(source, true);
-    source.classList.add('code-example-source--animating');
+    source.classList.add('is-animating');
     source.style.height = '0';
     source.style.opacity = '0';
 
@@ -142,20 +142,21 @@ async function setCodeExampleOpen(codeExample, toggle, open) {
 
     source.style.height = 'auto';
     source.style.opacity = '';
-    source.classList.remove('code-example-source--animating');
+    source.classList.remove('is-animating');
     return;
   }
 
   toggle.setAttribute('aria-expanded', 'false');
-  source.classList.add('code-example-source--animating');
+  source.classList.add('is-animating');
   // Setting an explicit pixel height flushes layout, so no rAF is needed here
   // (unlike the open path, which animates from height: 0 and must measure scrollHeight first).
-  source.style.height = `${source.scrollHeight}px`;
+  const startHeight = source.scrollHeight;
+  source.style.height = `${startHeight}px`;
 
   await animate(
     source,
     [
-      { height: `${source.scrollHeight}px`, opacity: '1' },
+      { height: `${startHeight}px`, opacity: '1' },
       { height: '0', opacity: '0' },
     ],
     { duration: hideDuration, easing: 'linear' },
@@ -166,7 +167,7 @@ async function setCodeExampleOpen(codeExample, toggle, open) {
   }
 
   setCodeExampleSourceCollapsed(source, true);
-  source.classList.remove('code-example-source--animating');
+  source.classList.remove('is-animating');
   codeExample.classList.remove('open');
   setCodeExampleSourceAccessibility(source, false);
 }
@@ -191,7 +192,7 @@ function handleResizerDrag(event) {
   let startWidth = parseInt(document.defaultView.getComputedStyle(preview).width, 10);
 
   event.preventDefault();
-  preview.classList.add('code-example-preview--dragging');
+  preview.classList.add('is-dragging');
   document.documentElement.addEventListener('mousemove', dragMove);
   document.documentElement.addEventListener('touchmove', dragMove);
   document.documentElement.addEventListener('mouseup', dragStop);
@@ -203,7 +204,7 @@ function handleResizerDrag(event) {
   }
 
   function dragStop() {
-    preview.classList.remove('code-example-preview--dragging');
+    preview.classList.remove('is-dragging');
     document.documentElement.removeEventListener('mousemove', dragMove);
     document.documentElement.removeEventListener('touchmove', dragMove);
     document.documentElement.removeEventListener('mouseup', dragStop);

--- a/packages/webawesome/docs/assets/scripts/code-examples.js
+++ b/packages/webawesome/docs/assets/scripts/code-examples.js
@@ -1,5 +1,147 @@
 const version = document.documentElement.getAttribute('data-version') || '';
 
+const codeExampleAnimations = new WeakMap();
+
+function parseDuration(duration) {
+  duration = String(duration).toLowerCase();
+
+  if (duration.includes('ms')) {
+    return parseFloat(duration) || 0;
+  }
+
+  if (duration.includes('s')) {
+    return (parseFloat(duration) || 0) * 1000;
+  }
+
+  return parseFloat(duration) || 0;
+}
+
+async function animate(el, keyframes, options) {
+  return el.animate(keyframes, options).finished.catch(() => {
+    /* suppress errors in Safari */
+  });
+}
+
+function prefersReducedMotion() {
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+function getAnimationGeneration(codeExample) {
+  return codeExampleAnimations.get(codeExample) || 0;
+}
+
+function bumpAnimationGeneration(codeExample) {
+  const generation = getAnimationGeneration(codeExample) + 1;
+  codeExampleAnimations.set(codeExample, generation);
+  return generation;
+}
+
+function getCodeExampleDurations(codeExample) {
+  const style = getComputedStyle(codeExample);
+  const showDuration = parseDuration(style.getPropertyValue('--show-duration').trim() || '200ms');
+  const hideDuration = parseDuration(style.getPropertyValue('--hide-duration').trim() || '200ms');
+
+  return { showDuration, hideDuration };
+}
+
+function setCodeExampleSourceAccessibility(source, open) {
+  source.setAttribute('aria-hidden', open ? 'false' : 'true');
+}
+
+function setCodeExampleSourceCollapsed(source, collapsed) {
+  if (collapsed) {
+    source.style.height = '0';
+    source.style.opacity = '0';
+    return;
+  }
+
+  source.style.height = 'auto';
+  source.style.opacity = '';
+}
+
+function initCodeExamples() {
+  document.querySelectorAll('.code-example').forEach(codeExample => {
+    const source = codeExample.querySelector('.code-example-source');
+    if (!source) {
+      return;
+    }
+
+    const open = codeExample.classList.contains('open');
+    setCodeExampleSourceCollapsed(source, !open);
+    setCodeExampleSourceAccessibility(source, open);
+  });
+}
+
+async function setCodeExampleOpen(codeExample, toggle, open) {
+  const source = codeExample.querySelector('.code-example-source');
+  if (!source) {
+    return;
+  }
+
+  const generation = bumpAnimationGeneration(codeExample);
+
+  if (prefersReducedMotion()) {
+    toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+    codeExample.classList.toggle('open', open);
+    setCodeExampleSourceCollapsed(source, !open);
+    setCodeExampleSourceAccessibility(source, open);
+    return;
+  }
+
+  const { showDuration, hideDuration } = getCodeExampleDurations(codeExample);
+
+  if (open) {
+    toggle.setAttribute('aria-expanded', 'true');
+    codeExample.classList.add('open');
+    setCodeExampleSourceAccessibility(source, true);
+    source.classList.add('code-example-source--animating');
+    source.style.height = '0';
+    source.style.opacity = '0';
+
+    await animate(
+      source,
+      [
+        { height: '0', opacity: '0' },
+        { height: `${source.scrollHeight}px`, opacity: '1' },
+      ],
+      { duration: showDuration, easing: 'linear' },
+    );
+
+    if (getAnimationGeneration(codeExample) !== generation) {
+      return;
+    }
+
+    source.style.height = 'auto';
+    source.style.opacity = '';
+    source.classList.remove('code-example-source--animating');
+    return;
+  }
+
+  source.classList.add('code-example-source--animating');
+  source.style.height = `${source.scrollHeight}px`;
+
+  await animate(
+    source,
+    [
+      { height: `${source.scrollHeight}px`, opacity: '1' },
+      { height: '0', opacity: '0' },
+    ],
+    { duration: hideDuration, easing: 'linear' },
+  );
+
+  if (getAnimationGeneration(codeExample) !== generation) {
+    return;
+  }
+
+  setCodeExampleSourceCollapsed(source, true);
+  source.classList.remove('code-example-source--animating');
+  toggle.setAttribute('aria-expanded', 'false');
+  codeExample.classList.remove('open');
+  setCodeExampleSourceAccessibility(source, false);
+}
+
+initCodeExamples();
+
 //
 // Resizing previews
 //
@@ -46,10 +188,9 @@ document.addEventListener('click', event => {
   // Toggle source
   if (toggle) {
     const codeExample = toggle.closest('.code-example');
-    const isOpen = !codeExample.classList.contains('open');
+    const open = !codeExample.classList.contains('open');
 
-    toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
-    codeExample.classList.toggle('open', isOpen);
+    void setCodeExampleOpen(codeExample, toggle, open);
   }
 
   // Edit in CodePen

--- a/packages/webawesome/docs/assets/styles/code-examples.css
+++ b/packages/webawesome/docs/assets/styles/code-examples.css
@@ -3,8 +3,8 @@
   --code-example-resizer-inline-size: calc(var(--wa-space-l) + var(--wa-space-2xs));
   --code-example-preview-min-inline-size: calc(4 * var(--wa-space-5xl));
   --code-example-pen-inline-size: calc(6.25 * var(--wa-space-m));
-  --code-example-show-duration: var(--wa-transition-normal);
-  --code-example-hide-duration: var(--wa-transition-normal);
+  --code-example-show-duration: 200ms; /* matches wa-details' 200ms timing; */
+  --code-example-hide-duration: 200ms;
   --code-example-border: var(--wa-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
   --code-example-preview-padding-block: var(--wa-space-xl);
   --code-example-preview-padding-inline-start: var(--wa-space-xl);

--- a/packages/webawesome/docs/assets/styles/code-examples.css
+++ b/packages/webawesome/docs/assets/styles/code-examples.css
@@ -1,6 +1,8 @@
 .code-example {
   --code-example-panel-radius: calc(var(--wa-panel-border-radius) - var(--wa-panel-border-width));
-  --code-example-resizer-width: 1.75rem;
+  --code-example-compact-max-width: 37.5rem;
+  --code-example-resizer-width: calc(var(--wa-space-l) + var(--wa-space-2xs));
+  --code-example-preview-min-width: calc(4 * var(--wa-space-5xl));
   --code-example-border: var(--wa-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
   --code-example-preview-padding-block: var(--wa-space-xl);
   --code-example-preview-padding-inline-start: var(--wa-space-xl);
@@ -18,7 +20,7 @@
     margin-block-end: var(--wa-content-spacing);
   }
 
-  @container code-example (max-width: 600px) {
+  @container code-example (max-width: var(--code-example-compact-max-width)) {
     .code-example-preview {
       padding-block: var(--wa-space-m);
       padding-inline: var(--wa-space-m);
@@ -38,7 +40,7 @@
   border-block-end: var(--code-example-border);
   padding-block: var(--code-example-preview-padding-block);
   padding-inline: var(--code-example-preview-padding-inline-start) var(--code-example-preview-padding-inline-end);
-  min-width: min(100%, 20rem);
+  min-width: min(100%, var(--code-example-preview-min-width));
   max-width: 100%;
 
   > :first-child:not(dialog) {
@@ -86,7 +88,7 @@
 }
 
 .code-example-toggle wa-icon {
-  transition: rotate 150ms ease;
+  transition: rotate var(--wa-transition-normal) var(--wa-transition-easing);
 
   @media (prefers-reduced-motion: reduce) {
     transition: none;
@@ -150,8 +152,8 @@
     padding: var(--wa-space-xs);
     cursor: pointer;
 
-    @container code-example (max-width: 600px) {
-      min-block-size: 2.75rem;
+    @container code-example (max-width: var(--code-example-compact-max-width)) {
+      min-block-size: var(--wa-form-control-height);
     }
 
     &:first-of-type {

--- a/packages/webawesome/docs/assets/styles/code-examples.css
+++ b/packages/webawesome/docs/assets/styles/code-examples.css
@@ -3,8 +3,8 @@
   --code-example-resizer-inline-size: calc(var(--wa-space-l) + var(--wa-space-2xs));
   --code-example-preview-min-inline-size: calc(4 * var(--wa-space-5xl));
   --code-example-pen-inline-size: calc(6.25 * var(--wa-space-m));
-  --code-example-show-duration: 200ms; /* matches wa-details' 200ms timing; */
-  --code-example-hide-duration: 200ms;
+  --code-example-show-duration: var(--wa-transition-normal);
+  --code-example-hide-duration: var(--wa-transition-normal);
   --code-example-border: var(--wa-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
   --code-example-preview-padding-block: var(--wa-space-xl);
   --code-example-preview-padding-inline-start: var(--wa-space-xl);

--- a/packages/webawesome/docs/assets/styles/code-examples.css
+++ b/packages/webawesome/docs/assets/styles/code-examples.css
@@ -120,7 +120,6 @@
 }
 
 .code-example-source {
-  overflow: hidden;
   border-block-end: var(--code-example-border);
   border-radius: 0;
 
@@ -132,9 +131,15 @@
   }
 }
 
+/* Only clip while the panel is animating or fully collapsed; otherwise let inner content control its own overflow. */
+.code-example-source--animating {
+  overflow: hidden;
+}
+
 .code-example:not(.open) .code-example-source:not(.code-example-source--animating) {
   height: 0;
   opacity: 0;
+  overflow: hidden;
   border-block-end: none;
   pointer-events: none;
 }

--- a/packages/webawesome/docs/assets/styles/code-examples.css
+++ b/packages/webawesome/docs/assets/styles/code-examples.css
@@ -1,12 +1,13 @@
 .code-example {
   --code-example-panel-radius: calc(var(--wa-panel-border-radius) - var(--wa-panel-border-width));
   --code-example-resizer-width: 1.75rem;
+  --code-example-border: var(--wa-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
   --code-example-preview-padding-block: var(--wa-space-xl);
   --code-example-preview-padding-inline-start: var(--wa-space-xl);
   --code-example-preview-padding-inline-end: calc(var(--wa-space-xl) + var(--code-example-resizer-width));
 
   background: var(--wa-color-surface-lowered);
-  border: var(--wa-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
+  border: var(--code-example-border);
   border-radius: var(--wa-panel-border-radius);
   color: var(--wa-color-text-normal);
   container-type: inline-size;
@@ -34,7 +35,7 @@
   background: var(--wa-color-surface-default);
   border-start-start-radius: var(--wa-panel-border-radius);
   border-start-end-radius: var(--wa-panel-border-radius);
-  border-block-end: var(--wa-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
+  border-block-end: var(--code-example-border);
   padding-block: var(--code-example-preview-padding-block);
   padding-inline: var(--code-example-preview-padding-inline-start) var(--code-example-preview-padding-inline-end);
   min-width: min(100%, 20rem);
@@ -65,18 +66,17 @@
   align-items: center;
   justify-content: center;
   position: absolute;
-  inset-block-start: 0;
+  inset-block: 0;
   inset-inline-end: 0;
-  inset-block-end: 0;
   width: var(--code-example-resizer-width);
   color: var(--wa-color-text-quiet);
   background-color: var(--wa-color-surface-default);
-  border-inline-start: var(--wa-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
+  border-inline-start: var(--code-example-border);
   border-start-end-radius: var(--code-example-panel-radius);
   cursor: ew-resize;
 
   wa-icon {
-    font-size: 1rem;
+    font-size: var(--wa-font-size-m);
   }
 }
 
@@ -90,7 +90,7 @@
 }
 
 .code-example-source {
-  border-block-end: var(--wa-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
+  border-block-end: var(--code-example-border);
   border-radius: 0;
 
   & pre {
@@ -135,11 +135,11 @@
     position: relative;
     all: unset;
     flex: 1 0 auto;
-    font-size: 0.875rem;
+    font-size: var(--wa-font-size-s);
     color: var(--wa-color-text-quiet);
-    border-inline-start: var(--wa-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
+    border-inline-start: var(--code-example-border);
     text-align: center;
-    padding: 0.5rem;
+    padding: var(--wa-space-xs);
     cursor: pointer;
 
     @container code-example (max-width: 600px) {

--- a/packages/webawesome/docs/assets/styles/code-examples.css
+++ b/packages/webawesome/docs/assets/styles/code-examples.css
@@ -83,7 +83,6 @@
   }
 }
 
-
 .code-example:not(.open) .code-example-source {
   display: none;
 }
@@ -169,6 +168,18 @@
     &:focus-visible {
       z-index: 3;
       outline: var(--wa-focus-ring);
+    }
+  }
+
+  .code-example-toggle,
+  .code-example-pen {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--wa-space-2xs);
+
+    wa-icon {
+      font-size: var(--wa-font-size-s);
     }
   }
 

--- a/packages/webawesome/docs/assets/styles/code-examples.css
+++ b/packages/webawesome/docs/assets/styles/code-examples.css
@@ -4,6 +4,8 @@
   --code-example-resizer-width: calc(var(--wa-space-l) + var(--wa-space-2xs));
   --code-example-preview-min-width: calc(4 * var(--wa-space-5xl));
   --code-example-pen-inline-size: calc(6.25 * var(--wa-space-m));
+  --show-duration: var(--wa-transition-normal);
+  --hide-duration: var(--wa-transition-normal);
   --code-example-border: var(--wa-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
   --code-example-preview-padding-block: var(--wa-space-xl);
   --code-example-preview-padding-inline-start: var(--wa-space-xl);
@@ -101,8 +103,15 @@
   color: var(--wa-color-text-normal);
 }
 
-.code-example:not(.open) .code-example-source {
-  display: none;
+.code-example:not(.open) .code-example-source:not(.code-example-source--animating) {
+  height: 0;
+  opacity: 0;
+  border-block-end: none;
+  pointer-events: none;
+}
+
+.code-example-source--animating {
+  overflow: hidden;
 }
 
 .code-example-toggle wa-icon {
@@ -118,6 +127,7 @@
 }
 
 .code-example-source {
+  overflow: hidden;
   border-block-end: var(--code-example-border);
   border-radius: 0;
 

--- a/packages/webawesome/docs/assets/styles/code-examples.css
+++ b/packages/webawesome/docs/assets/styles/code-examples.css
@@ -9,10 +9,23 @@
   border: var(--wa-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
   border-radius: var(--wa-panel-border-radius);
   color: var(--wa-color-text-normal);
+  container-type: inline-size;
+  container-name: code-example;
   isolation: isolate;
 
   &:has(+ *) {
     margin-block-end: var(--wa-content-spacing);
+  }
+
+  @container code-example (max-width: 600px) {
+    .code-example-preview {
+      padding-block: var(--wa-space-m);
+      padding-inline: var(--wa-space-m);
+    }
+
+    .code-example-resizer {
+      display: none;
+    }
   }
 }
 
@@ -67,18 +80,6 @@
   }
 }
 
-/* Resizer hidden and compact preview padding below this width */
-@media screen and (max-width: 600px) {
-  .code-example {
-    --code-example-preview-padding-block: var(--wa-space-m);
-    --code-example-preview-padding-inline-start: var(--wa-space-m);
-    --code-example-preview-padding-inline-end: var(--wa-space-m);
-  }
-
-  .code-example-resizer {
-    display: none;
-  }
-}
 
 .code-example:not(.open) .code-example-source {
   display: none;
@@ -141,7 +142,7 @@
     padding: 0.5rem;
     cursor: pointer;
 
-    @media screen and (max-width: 600px) {
+    @container code-example (max-width: 600px) {
       min-block-size: 2.75rem;
     }
 

--- a/packages/webawesome/docs/assets/styles/code-examples.css
+++ b/packages/webawesome/docs/assets/styles/code-examples.css
@@ -4,8 +4,8 @@
   --code-example-resizer-width: calc(var(--wa-space-l) + var(--wa-space-2xs));
   --code-example-preview-min-width: calc(4 * var(--wa-space-5xl));
   --code-example-pen-inline-size: calc(6.25 * var(--wa-space-m));
-  --show-duration: var(--wa-transition-normal);
-  --hide-duration: var(--wa-transition-normal);
+  --code-example-show-duration: var(--wa-transition-normal);
+  --code-example-hide-duration: var(--wa-transition-normal);
   --code-example-border: var(--wa-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
   --code-example-preview-padding-block: var(--wa-space-xl);
   --code-example-preview-padding-inline-start: var(--wa-space-xl);
@@ -96,22 +96,15 @@
   wa-icon {
     font-size: var(--wa-font-size-m);
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
 }
 
 .code-example-preview--dragging .code-example-resizer {
   background-color: var(--wa-color-neutral-fill-quiet);
   color: var(--wa-color-text-normal);
-}
-
-.code-example:not(.open) .code-example-source:not(.code-example-source--animating) {
-  height: 0;
-  opacity: 0;
-  border-block-end: none;
-  pointer-events: none;
-}
-
-.code-example-source--animating {
-  overflow: hidden;
 }
 
 .code-example-toggle wa-icon {
@@ -137,6 +130,13 @@
     margin: 0;
     white-space: normal;
   }
+}
+
+.code-example:not(.open) .code-example-source:not(.code-example-source--animating) {
+  height: 0;
+  opacity: 0;
+  border-block-end: none;
+  pointer-events: none;
 }
 
 /* Adapt borders and rounding to which code example features are disabled */
@@ -209,6 +209,10 @@
     &:focus-visible {
       z-index: 3;
       outline: var(--wa-focus-ring);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
     }
   }
 

--- a/packages/webawesome/docs/assets/styles/code-examples.css
+++ b/packages/webawesome/docs/assets/styles/code-examples.css
@@ -22,7 +22,7 @@
     margin-block-end: var(--wa-content-spacing);
   }
 
-  @container code-example (max-width: var(--code-example-compact-max-width)) {
+  @container code-example (max-inline-size: 30rem) {
     .code-example-preview {
       padding-block: var(--wa-space-m);
       padding-inline: var(--wa-space-m);
@@ -197,7 +197,7 @@
       color: var(--wa-color-text-normal);
     }
 
-    @container code-example (max-width: var(--code-example-compact-max-width)) {
+    @container code-example (max-inline-size: 25rem) {
       min-block-size: var(--wa-form-control-height);
     }
 

--- a/packages/webawesome/docs/assets/styles/code-examples.css
+++ b/packages/webawesome/docs/assets/styles/code-examples.css
@@ -1,15 +1,14 @@
 .code-example {
   --code-example-panel-radius: calc(var(--wa-panel-border-radius) - var(--wa-panel-border-width));
-  --code-example-compact-max-width: 37.5rem;
-  --code-example-resizer-width: calc(var(--wa-space-l) + var(--wa-space-2xs));
-  --code-example-preview-min-width: calc(4 * var(--wa-space-5xl));
+  --code-example-resizer-inline-size: calc(var(--wa-space-l) + var(--wa-space-2xs));
+  --code-example-preview-min-inline-size: calc(4 * var(--wa-space-5xl));
   --code-example-pen-inline-size: calc(6.25 * var(--wa-space-m));
   --code-example-show-duration: var(--wa-transition-normal);
   --code-example-hide-duration: var(--wa-transition-normal);
   --code-example-border: var(--wa-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
   --code-example-preview-padding-block: var(--wa-space-xl);
   --code-example-preview-padding-inline-start: var(--wa-space-xl);
-  --code-example-preview-padding-inline-end: calc(var(--wa-space-xl) + var(--code-example-resizer-width));
+  --code-example-preview-padding-inline-end: calc(var(--wa-space-xl) + var(--code-example-resizer-inline-size));
 
   background: var(--wa-color-surface-lowered);
   border: var(--code-example-border);
@@ -43,12 +42,12 @@
   border-block-end: var(--code-example-border);
   padding-block: var(--code-example-preview-padding-block);
   padding-inline: var(--code-example-preview-padding-inline-start) var(--code-example-preview-padding-inline-end);
-  min-width: min(100%, var(--code-example-preview-min-width));
-  max-width: 100%;
+  min-inline-size: min(100%, var(--code-example-preview-min-inline-size));
+  max-inline-size: 100%;
 
   > :first-child:not(dialog) {
-    max-width: 100%;
-    overflow-x: auto;
+    max-inline-size: 100%;
+    overflow-inline: auto;
     margin-block-start: 0;
   }
 
@@ -73,7 +72,7 @@
   position: absolute;
   inset-block: 0;
   inset-inline-end: 0;
-  width: var(--code-example-resizer-width);
+  inline-size: var(--code-example-resizer-inline-size);
   color: var(--wa-color-text-quiet);
   background-color: var(--wa-color-surface-default);
   border-inline-start: var(--code-example-border);
@@ -137,7 +136,7 @@
 }
 
 .code-example:not(.open) .code-example-source:not(.is-animating) {
-  height: 0;
+  block-size: 0;
   opacity: 0;
   overflow: hidden;
   border-block-end: none;

--- a/packages/webawesome/docs/assets/styles/code-examples.css
+++ b/packages/webawesome/docs/assets/styles/code-examples.css
@@ -1,4 +1,9 @@
 .code-example {
+  --code-example-panel-radius: calc(var(--wa-panel-border-radius) - var(--wa-panel-border-width));
+  --code-example-preview-padding-block: var(--wa-space-xl);
+  --code-example-preview-padding-inline-start: var(--wa-space-xl);
+  --code-example-preview-padding-inline-end: calc(var(--wa-space-xl) + 1.75rem);
+
   background: var(--wa-color-surface-lowered);
   border: var(--wa-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
   border-radius: var(--wa-panel-border-radius);
@@ -16,7 +21,8 @@
   border-start-start-radius: var(--wa-panel-border-radius);
   border-start-end-radius: var(--wa-panel-border-radius);
   border-block-end: var(--wa-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
-  padding: 2rem 3.25rem 2rem 2rem;
+  padding-block: var(--code-example-preview-padding-block);
+  padding-inline: var(--code-example-preview-padding-inline-start) var(--code-example-preview-padding-inline-end);
   min-width: 20rem;
   max-width: 100%;
 
@@ -33,10 +39,7 @@
 .code-example-preview--dragging:after {
   content: '';
   position: absolute;
-  inset-block-start: 0;
-  inset-inline-start: 0;
-  width: 100%;
-  height: 100%;
+  inset: 0;
   opacity: 0;
   cursor: ew-resize;
 }
@@ -53,7 +56,7 @@
   color: var(--wa-color-text-quiet);
   background-color: var(--wa-color-surface-default);
   border-inline-start: var(--wa-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
-  border-start-end-radius: calc(var(--wa-panel-border-radius) - var(--wa-panel-border-width));
+  border-start-end-radius: var(--code-example-panel-radius);
   cursor: ew-resize;
 
   wa-icon {
@@ -61,9 +64,16 @@
   }
 }
 
+/* Resizer hidden and compact preview padding below this width */
 @media screen and (max-width: 600px) {
+  .code-example {
+    --code-example-preview-padding-block: var(--wa-space-m);
+    --code-example-preview-padding-inline-start: var(--wa-space-m);
+    --code-example-preview-padding-inline-end: var(--wa-space-m);
+  }
+
   .code-example-preview {
-    padding-inline-end: 2rem;
+    min-width: 0;
   }
 
   .code-example-resizer {
@@ -94,13 +104,13 @@
 /* Adapt borders and rounding to which code example features are disabled */
 .code-example-source:has(.no-buttons) {
   border-block-end: none;
-  border-end-end-radius: calc(var(--wa-panel-border-radius) - var(--wa-panel-border-width));
-  border-end-start-radius: calc(var(--wa-panel-border-radius) - var(--wa-panel-border-width));
+  border-end-end-radius: var(--code-example-panel-radius);
+  border-end-start-radius: var(--code-example-panel-radius);
 }
 
 .code-example-source:has(.no-preview) {
-  border-start-end-radius: calc(var(--wa-panel-border-radius) - var(--wa-panel-border-width));
-  border-start-start-radius: calc(var(--wa-panel-border-radius) - var(--wa-panel-border-width));
+  border-start-end-radius: var(--code-example-panel-radius);
+  border-start-start-radius: var(--code-example-panel-radius);
 }
 
 .code-example-source:has(.no-preview) + .code-example-buttons {

--- a/packages/webawesome/docs/assets/styles/code-examples.css
+++ b/packages/webawesome/docs/assets/styles/code-examples.css
@@ -141,6 +141,10 @@
     padding: 0.5rem;
     cursor: pointer;
 
+    @media screen and (max-width: 600px) {
+      min-block-size: 2.75rem;
+    }
+
     &:first-of-type {
       border-inline-start: none;
       border-end-start-radius: var(--wa-panel-border-radius);

--- a/packages/webawesome/docs/assets/styles/code-examples.css
+++ b/packages/webawesome/docs/assets/styles/code-examples.css
@@ -3,6 +3,7 @@
   --code-example-compact-max-width: 37.5rem;
   --code-example-resizer-width: calc(var(--wa-space-l) + var(--wa-space-2xs));
   --code-example-preview-min-width: calc(4 * var(--wa-space-5xl));
+  --code-example-pen-inline-size: calc(6.25 * var(--wa-space-m));
   --code-example-border: var(--wa-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
   --code-example-preview-padding-block: var(--wa-space-xl);
   --code-example-preview-padding-inline-start: var(--wa-space-xl);
@@ -172,7 +173,7 @@
   }
 
   .code-example-pen {
-    flex: 0 0 100px;
+    flex: 0 0 var(--code-example-pen-inline-size);
     white-space: nowrap;
   }
 }

--- a/packages/webawesome/docs/assets/styles/code-examples.css
+++ b/packages/webawesome/docs/assets/styles/code-examples.css
@@ -28,6 +28,8 @@
   max-width: 100%;
 
   > :first-child:not(dialog) {
+    max-width: 100%;
+    overflow-x: auto;
     margin-block-start: 0;
   }
 

--- a/packages/webawesome/docs/assets/styles/code-examples.css
+++ b/packages/webawesome/docs/assets/styles/code-examples.css
@@ -85,6 +85,14 @@
   display: none;
 }
 
+.code-example-toggle wa-icon {
+  transition: rotate 150ms ease;
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+}
+
 .code-example.open .code-example-toggle wa-icon {
   rotate: 180deg;
 }

--- a/packages/webawesome/docs/assets/styles/code-examples.css
+++ b/packages/webawesome/docs/assets/styles/code-examples.css
@@ -1,8 +1,9 @@
 .code-example {
   --code-example-panel-radius: calc(var(--wa-panel-border-radius) - var(--wa-panel-border-width));
+  --code-example-resizer-width: 1.75rem;
   --code-example-preview-padding-block: var(--wa-space-xl);
   --code-example-preview-padding-inline-start: var(--wa-space-xl);
-  --code-example-preview-padding-inline-end: calc(var(--wa-space-xl) + 1.75rem);
+  --code-example-preview-padding-inline-end: calc(var(--wa-space-xl) + var(--code-example-resizer-width));
 
   background: var(--wa-color-surface-lowered);
   border: var(--wa-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
@@ -23,7 +24,7 @@
   border-block-end: var(--wa-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
   padding-block: var(--code-example-preview-padding-block);
   padding-inline: var(--code-example-preview-padding-inline-start) var(--code-example-preview-padding-inline-end);
-  min-width: 20rem;
+  min-width: min(100%, 20rem);
   max-width: 100%;
 
   > :first-child:not(dialog) {
@@ -52,7 +53,7 @@
   inset-block-start: 0;
   inset-inline-end: 0;
   inset-block-end: 0;
-  width: 1.75rem;
+  width: var(--code-example-resizer-width);
   color: var(--wa-color-text-quiet);
   background-color: var(--wa-color-surface-default);
   border-inline-start: var(--wa-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
@@ -70,10 +71,6 @@
     --code-example-preview-padding-block: var(--wa-space-m);
     --code-example-preview-padding-inline-start: var(--wa-space-m);
     --code-example-preview-padding-inline-end: var(--wa-space-m);
-  }
-
-  .code-example-preview {
-    min-width: 0;
   }
 
   .code-example-resizer {

--- a/packages/webawesome/docs/assets/styles/code-examples.css
+++ b/packages/webawesome/docs/assets/styles/code-examples.css
@@ -77,10 +77,28 @@
   border-inline-start: var(--code-example-border);
   border-start-end-radius: var(--code-example-panel-radius);
   cursor: ew-resize;
+  transition:
+    background-color var(--wa-transition-fast) var(--wa-transition-easing),
+    color var(--wa-transition-fast) var(--wa-transition-easing);
+
+  &:hover {
+    background-color: var(--wa-color-surface-lowered);
+    color: var(--wa-color-text-normal);
+  }
+
+  &:active {
+    background-color: var(--wa-color-neutral-fill-quiet);
+    color: var(--wa-color-text-normal);
+  }
 
   wa-icon {
     font-size: var(--wa-font-size-m);
   }
+}
+
+.code-example-preview--dragging .code-example-resizer {
+  background-color: var(--wa-color-neutral-fill-quiet);
+  color: var(--wa-color-text-normal);
 }
 
 .code-example:not(.open) .code-example-source {
@@ -151,6 +169,19 @@
     text-align: center;
     padding: var(--wa-space-xs);
     cursor: pointer;
+    transition:
+      background-color var(--wa-transition-fast) var(--wa-transition-easing),
+      color var(--wa-transition-fast) var(--wa-transition-easing);
+
+    &:hover {
+      background-color: var(--wa-color-surface-lowered);
+      color: var(--wa-color-text-normal);
+    }
+
+    &:active {
+      background-color: var(--wa-color-neutral-fill-quiet);
+      color: var(--wa-color-text-normal);
+    }
 
     @container code-example (max-width: var(--code-example-compact-max-width)) {
       min-block-size: var(--wa-form-control-height);

--- a/packages/webawesome/docs/assets/styles/code-examples.css
+++ b/packages/webawesome/docs/assets/styles/code-examples.css
@@ -58,7 +58,7 @@
 }
 
 /* Block the preview while dragging to prevent iframes from intercepting drag events */
-.code-example-preview--dragging:after {
+.code-example-preview.is-dragging:after {
   content: '';
   position: absolute;
   inset: 0;
@@ -102,7 +102,7 @@
   }
 }
 
-.code-example-preview--dragging .code-example-resizer {
+.code-example-preview.is-dragging .code-example-resizer {
   background-color: var(--wa-color-neutral-fill-quiet);
   color: var(--wa-color-text-normal);
 }
@@ -132,11 +132,11 @@
 }
 
 /* Only clip while the panel is animating or fully collapsed; otherwise let inner content control its own overflow. */
-.code-example-source--animating {
+.code-example-source.is-animating {
   overflow: hidden;
 }
 
-.code-example:not(.open) .code-example-source:not(.code-example-source--animating) {
+.code-example:not(.open) .code-example-source:not(.is-animating) {
   height: 0;
   opacity: 0;
   overflow: hidden;


### PR DESCRIPTION
This work modernizes docs code examples for narrow viewports, design tokens, and interaction polish. Here's more on what it changes...

### Layout & Responsiveness
- Tighter preview padding when the example block is narrow (container queries, not just viewport width)
- Resizer width and preview min-width use WA spacing tokens
- Wide preview content scrolls horizontally instead of overflowing
- Larger toolbar touch targets in compact layouts

### Design Tokens & UI Polish
- Borders, spacing, transitions, and pen width use `--wa-*` and scoped `--code-example-*` custom properties
- Hover/active feedback on Code/Edit buttons and the resize grip
- Toggle/Edit buttons use flex + gap for icon alignment
- Chevron rotation respects `prefers-reduced-motion`

### Expand/Collapse Animation
- Source panel animates height + opacity via Web Animations API (aligned with `wa-details`)
- Scoped `--code-example-show-duration` / `--code-example-hide-duration` so nested `wa-details` don’t steal timing
- Turbo navigation re-inits state; rapid toggles cancel in-flight animations
- Source panel gets `role="region"`, `aria-label`, and `aria-hidden` when collapsed

### Files Changed
- `docs/assets/styles/code-examples.css`
- `docs/assets/scripts/code-examples.js`
- `docs/_transformers/code-examples.js`