### PR TITLE
Fix: `<wa-textarea>`'s Disabled State Styling

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -24,9 +24,10 @@ These are still finding their shape. APIs can change between minor versions, so 
 
 :::fixed
 
-- Fixed a bug in `<wa-video>` where  the `timeupdate` method was not emitting when seeking or scrubbing the timeline [issue:2393]
+- Fixed a bug in `<wa-video>` where the `timeupdate` method was not emitting when seeking or scrubbing the timeline [issue:2393]
 - Fixed a bug in `<wa-breadcrumb-item>` where `href=""` rendered as a button instead of a link, making it harder to follow the [WAI-ARIA breadcrumb pattern](https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/) for the current-page item [issue:2387]
 - Fixed a regression in `<wa-breadcrumb-item>` that caused items without an `href` to render as a link instead of a button
+- Fixed a bug in `<wa-textarea>` where the disabled state had no visual styling, unlike other form controls [issue:2416]
 
 :::
 

--- a/packages/webawesome/src/components/textarea/textarea.styles.ts
+++ b/packages/webawesome/src/components/textarea/textarea.styles.ts
@@ -25,6 +25,12 @@ export default css`
     &:focus-within {
       outline-color: var(--wa-color-focus);
     }
+
+    /* Style disabled textareas */
+    &:has(:disabled) {
+      cursor: not-allowed;
+      opacity: 0.5;
+    }
   }
 
   /* Appearance modifiers */
@@ -50,6 +56,7 @@ export default css`
     background: transparent;
     font: inherit;
     color: inherit;
+    cursor: inherit;
     padding: calc(var(--wa-form-control-padding-block) - ((1lh - 1em) / 2)) var(--wa-form-control-padding-inline); /* accounts for the larger line height of textarea content */
     min-height: calc(var(--wa-form-control-height) - var(--border-width) * 2);
     box-shadow: none;


### PR DESCRIPTION
This work resolves https://github.com/shoelace-style/webawesome/issues/2416 by adding styling to `<wa-textarea>` to mirror how Web Awesome styles disabled text input components.

### Preview
You can view the newly styled state at https://webawesome-git-talbs-enable-the-disable-sty-dfc7d8-font-awesome.vercel.app/docs/components/textarea#disabled.