### PR TITLE
Syncing Component Durations + WA Transition Tokens

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -32,6 +32,13 @@ These are still finding their shape. APIs can change between minor versions, so 
 
 :::
 
+:::changed
+
+- Standardized default `--show-duration` and `--hide-duration` values across `<wa-dropdown>`, `<wa-popup>`, `<wa-popover>`, `<wa-select>`, `<wa-details>`, `<wa-dialog>`, `<wa-drawer>`, and `<wa-tree-item>` to use `--wa-transition-fast` or `--wa-transition-normal` tokens. Popups now open/close at 75ms (previously 50–100ms) and panels at 150ms (previously 200ms). Override the custom properties per component to restore prior timing.
+- Standardized hardcoded transition values in `<wa-copy-button>` and `<wa-select>` to use `--wa-transition-*` tokens.
+
+:::
+
 ## 3.7.0
 
 <small><time datetime="2026-05-12">May 12, 2026</time></small>

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -29,13 +29,14 @@ These are still finding their shape. APIs can change between minor versions, so 
 - Fixed a regression in `<wa-breadcrumb-item>` that caused items without an `href` to render as a link instead of a button
 - Fixed a regression in `<wa-popover>` where the body's viewport-edge margin caused the popover and arrow to be misaligned for `top/bottom-start` and `top/bottom-end` placements
 - Fixed a bug in `<wa-textarea>` where the disabled state had no visual styling, unlike other form controls [issue:2416]
+- Fixed default show/hide animations in `<wa-dropdown>`, `<wa-popup>`, `<wa-popover>`, `<wa-select>`, `<wa-details>`, `<wa-dialog>`, `<wa-drawer>`, and `<wa-tree-item>` to honor `prefers-reduced-motion: reduce`
 
 :::
 
 :::changed
 
-- Standardized default `--show-duration` and `--hide-duration` values across `<wa-dropdown>`, `<wa-popup>`, `<wa-popover>`, `<wa-select>`, `<wa-details>`, `<wa-dialog>`, `<wa-drawer>`, and `<wa-tree-item>` to use `--wa-transition-fast` or `--wa-transition-normal` tokens. Popups now open/close at 75ms (previously 50–100ms) and panels at 150ms (previously 200ms). Override the custom properties per component to restore prior timing.
-- Standardized hardcoded transition values in `<wa-copy-button>` and `<wa-select>` to use `--wa-transition-*` tokens.
+- Synced default `--show-duration` and `--hide-duration` values in `<wa-dropdown>`, `<wa-popup>`, `<wa-popover>`, `<wa-select>`, `<wa-details>`, `<wa-dialog>`, `<wa-drawer>`, and `<wa-tree-item>` with `--wa-transition-fast` and `--wa-transition-normal` tokens
+- Synced hardcoded transitions in `<wa-copy-button>` and `<wa-select>` with `--wa-transition-*` tokens
 
 :::
 

--- a/packages/webawesome/src/components/copy-button/copy-button.styles.ts
+++ b/packages/webawesome/src/components/copy-button/copy-button.styles.ts
@@ -59,11 +59,11 @@ export default css`
 
   /* Icon swap animation */
   .show {
-    animation: copy-button-icon-show 100ms ease;
+    animation: copy-button-icon-show var(--wa-transition-fast) var(--wa-transition-easing);
   }
 
   .hide {
-    animation: copy-button-icon-show 100ms ease reverse;
+    animation: copy-button-icon-show var(--wa-transition-fast) var(--wa-transition-easing) reverse;
   }
 
   @keyframes copy-button-icon-show {

--- a/packages/webawesome/src/components/details/details.styles.ts
+++ b/packages/webawesome/src/components/details/details.styles.ts
@@ -3,8 +3,8 @@ import { css } from 'lit';
 export default css`
   :host {
     --spacing: var(--wa-space-m);
-    --show-duration: 200ms;
-    --hide-duration: 200ms;
+    --show-duration: var(--wa-transition-normal);
+    --hide-duration: var(--wa-transition-normal);
 
     display: block;
   }

--- a/packages/webawesome/src/components/details/details.ts
+++ b/packages/webawesome/src/components/details/details.ts
@@ -42,8 +42,8 @@ import styles from './details.styles.js';
  * @csspart content - The details content.
  *
  * @cssproperty --spacing - The amount of space around and between the details' content. Expects a single value.
- * @cssproperty [--show-duration=200ms] - The show duration to use when applying built-in animation classes.
- * @cssproperty [--hide-duration=200ms] - The hide duration to use when applying built-in animation classes.
+ * @cssproperty [--show-duration=var(--wa-transition-normal)] - The show duration to use when applying built-in animation classes.
+ * @cssproperty [--hide-duration=var(--wa-transition-normal)] - The hide duration to use when applying built-in animation classes.
  *
  * @cssstate animating - Applied when the details is animating expand/collapse.
  */

--- a/packages/webawesome/src/components/dialog/dialog.styles.ts
+++ b/packages/webawesome/src/components/dialog/dialog.styles.ts
@@ -5,8 +5,8 @@ export default css`
     --width: 31rem;
     --spacing: var(--wa-space-l);
     --backdrop-filter: none;
-    --show-duration: 200ms;
-    --hide-duration: 200ms;
+    --show-duration: var(--wa-transition-normal);
+    --hide-duration: var(--wa-transition-normal);
 
     display: none;
   }

--- a/packages/webawesome/src/components/dialog/dialog.ts
+++ b/packages/webawesome/src/components/dialog/dialog.ts
@@ -51,8 +51,8 @@ import styles from './dialog.styles.js';
  * @cssproperty --spacing - The amount of space around and between the dialog's content.
  * @cssproperty --width - The preferred width of the dialog. Note that the dialog will shrink to accommodate smaller screens.
  * @cssproperty [--backdrop-filter=none] - A filter to apply to the backdrop behind the dialog.
- * @cssproperty [--show-duration=200ms] - The animation duration when showing the dialog.
- * @cssproperty [--hide-duration=200ms] - The animation duration when hiding the dialog.
+ * @cssproperty [--show-duration=var(--wa-transition-normal)] - The animation duration when showing the dialog.
+ * @cssproperty [--hide-duration=var(--wa-transition-normal)] - The animation duration when hiding the dialog.
  */
 @customElement('wa-dialog')
 export default class WaDialog extends WebAwesomeElement {

--- a/packages/webawesome/src/components/drawer/drawer.styles.ts
+++ b/packages/webawesome/src/components/drawer/drawer.styles.ts
@@ -5,8 +5,8 @@ export default css`
     --size: 25rem;
     --spacing: var(--wa-space-l);
     --backdrop-filter: none;
-    --show-duration: 200ms;
-    --hide-duration: 200ms;
+    --show-duration: var(--wa-transition-normal);
+    --hide-duration: var(--wa-transition-normal);
 
     display: none;
   }

--- a/packages/webawesome/src/components/drawer/drawer.ts
+++ b/packages/webawesome/src/components/drawer/drawer.ts
@@ -53,8 +53,8 @@ import styles from './drawer.styles.js';
  * @cssproperty --size - The preferred size of the drawer. This will be applied to the drawer's width or height
  *   depending on its `placement`. Note that the drawer will shrink to accommodate smaller screens.
  * @cssproperty [--backdrop-filter=none] - A filter to apply to the backdrop behind the drawer.
- * @cssproperty [--show-duration=200ms] - The animation duration when showing the drawer.
- * @cssproperty [--hide-duration=200ms] - The animation duration when hiding the drawer.
+ * @cssproperty [--show-duration=var(--wa-transition-normal)] - The animation duration when showing the drawer.
+ * @cssproperty [--hide-duration=var(--wa-transition-normal)] - The animation duration when hiding the drawer.
  *
  * @property modal - Exposes the internal modal utility that controls focus trapping. To temporarily disable focus
  *   trapping and allow third-party modals spawned from an active Shoelace modal, call `modal.activateExternal()` when

--- a/packages/webawesome/src/components/dropdown-item/dropdown-item.styles.ts
+++ b/packages/webawesome/src/components/dropdown-item/dropdown-item.styles.ts
@@ -149,11 +149,11 @@ export default css`
     }
 
     &.show {
-      animation: submenu-show var(--show-duration, 50ms) ease;
+      animation: submenu-show var(--show-duration, var(--wa-transition-fast)) ease;
     }
 
     &.hide {
-      animation: submenu-show var(--show-duration, 50ms) ease reverse;
+      animation: submenu-show var(--show-duration, var(--wa-transition-fast)) ease reverse;
     }
 
     /* Submenu placement transform origins */

--- a/packages/webawesome/src/components/dropdown/dropdown.styles.ts
+++ b/packages/webawesome/src/components/dropdown/dropdown.styles.ts
@@ -2,8 +2,8 @@ import { css } from 'lit';
 
 export default css`
   :host {
-    --show-duration: 50ms;
-    --hide-duration: 50ms;
+    --show-duration: var(--wa-transition-fast);
+    --hide-duration: var(--wa-transition-fast);
     display: contents;
   }
 

--- a/packages/webawesome/src/components/popover/popover.styles.ts
+++ b/packages/webawesome/src/components/popover/popover.styles.ts
@@ -4,8 +4,8 @@ export default css`
   :host {
     --arrow-size: 0.375rem;
     --max-width: 25rem;
-    --show-duration: 100ms;
-    --hide-duration: 100ms;
+    --show-duration: var(--wa-transition-fast);
+    --hide-duration: var(--wa-transition-fast);
 
     display: contents;
 

--- a/packages/webawesome/src/components/popover/popover.ts
+++ b/packages/webawesome/src/components/popover/popover.ts
@@ -41,8 +41,8 @@ const openPopovers = new Set<WaPopover>();
  *
  * @cssproperty [--arrow-size=0.375rem] - The size of the tiny arrow that points to the popover (set to zero to remove).
  * @cssproperty [--max-width=25rem] - The maximum width of the popover's body content.
- * @cssproperty [--show-duration=100ms] - The speed of the show animation.
- * @cssproperty [--hide-duration=100ms] - The speed of the hide animation.
+ * @cssproperty [--show-duration=var(--wa-transition-fast)] - The speed of the show animation.
+ * @cssproperty [--hide-duration=var(--wa-transition-fast)] - The speed of the hide animation.
  *
  * @cssstate open - Applied when the popover is open.
  */

--- a/packages/webawesome/src/components/popup/popup.styles.ts
+++ b/packages/webawesome/src/components/popup/popup.styles.ts
@@ -5,8 +5,8 @@ export default css`
     --arrow-color: black;
     --arrow-size: var(--wa-tooltip-arrow-size);
     --popup-border-width: 0px;
-    --show-duration: 100ms;
-    --hide-duration: 100ms;
+    --show-duration: var(--wa-transition-fast);
+    --hide-duration: var(--wa-transition-fast);
 
     /*
      * These properties are computed to account for the arrow's dimensions after being rotated 45º. The constant

--- a/packages/webawesome/src/components/popup/popup.ts
+++ b/packages/webawesome/src/components/popup/popup.ts
@@ -66,8 +66,8 @@ const SUPPORTS_POPOVER = globalThis?.HTMLElement?.prototype.hasOwnProperty('popo
  * @cssproperty [--auto-size-available-height] - A read-only custom property that determines the amount of height the
  *  popup can be before overflowing. Useful for positioning child elements that need to overflow. This property is only
  *  available when using `auto-size`.
- * @cssproperty [--show-duration=100ms] - The show duration to use when applying built-in animation classes.
- * @cssproperty [--hide-duration=100ms] - The hide duration to use when applying built-in animation classes.
+ * @cssproperty [--show-duration=var(--wa-transition-fast)] - The show duration to use when applying built-in animation classes.
+ * @cssproperty [--hide-duration=var(--wa-transition-fast)] - The hide duration to use when applying built-in animation classes.
  */
 @customElement('wa-popup')
 export default class WaPopup extends WebAwesomeElement {

--- a/packages/webawesome/src/components/select/select.styles.ts
+++ b/packages/webawesome/src/components/select/select.styles.ts
@@ -3,8 +3,8 @@ import { css } from 'lit';
 export default css`
   :host {
     --tag-max-size: 10ch;
-    --show-duration: 100ms;
-    --hide-duration: 100ms;
+    --show-duration: var(--wa-transition-fast);
+    --hide-duration: var(--wa-transition-fast);
   }
 
   /* Add ellipses to multi select options */

--- a/packages/webawesome/src/components/select/select.styles.ts
+++ b/packages/webawesome/src/components/select/select.styles.ts
@@ -236,7 +236,7 @@ export default css`
     display: flex;
     align-items: center;
     color: var(--wa-color-neutral-on-quiet);
-    transition: rotate var(--wa-transition-slow) ease;
+    transition: rotate var(--wa-transition-slow) var(--wa-transition-easing);
     rotate: 0deg;
     margin-inline-start: var(--wa-form-control-padding-inline);
 

--- a/packages/webawesome/src/components/select/select.ts
+++ b/packages/webawesome/src/components/select/select.ts
@@ -77,8 +77,8 @@ import styles from './select.styles.js';
  * @csspart clear-button - The clear button.
  * @csspart expand-icon - The container that wraps the expand icon.
  *
- * @cssproperty [--show-duration=100ms] - The duration of the show animation.
- * @cssproperty [--hide-duration=100ms] - The duration of the hide animation.
+ * @cssproperty [--show-duration=var(--wa-transition-fast)] - The duration of the show animation.
+ * @cssproperty [--hide-duration=var(--wa-transition-fast)] - The duration of the hide animation.
  * @cssproperty [--tag-max-size=10ch] - When using `multiple`, the max size of tags before their content is truncated.
  *
  * @cssstate blank - The select is empty.

--- a/packages/webawesome/src/components/tree-item/tree-item.styles.ts
+++ b/packages/webawesome/src/components/tree-item/tree-item.styles.ts
@@ -4,8 +4,8 @@ export default css`
   :host {
     /* Private - set by the component to control indentation depth */
     --indent: 0px;
-    --show-duration: 200ms;
-    --hide-duration: 200ms;
+    --show-duration: var(--wa-transition-normal);
+    --hide-duration: var(--wa-transition-normal);
 
     display: block;
     color: var(--wa-color-text-normal);

--- a/packages/webawesome/src/components/tree-item/tree-item.ts
+++ b/packages/webawesome/src/components/tree-item/tree-item.ts
@@ -58,8 +58,8 @@ import styles from './tree-item.styles.js';
  * @csspart checkbox__indeterminate-icon - The checkbox's exported `indeterminate-icon` part.
  * @csspart checkbox__label - The checkbox's exported `label` part.
  *
- * @cssproperty [--show-duration=200ms] - The animation duration when expanding tree items.
- * @cssproperty [--hide-duration=200ms] - The animation duration when collapsing tree items.
+ * @cssproperty [--show-duration=var(--wa-transition-normal)] - The animation duration when expanding tree items.
+ * @cssproperty [--hide-duration=var(--wa-transition-normal)] - The animation duration when collapsing tree items.
  *
  * @cssstate disabled - Applied when the tree item is disabled.
  * @cssstate expanded - Applied when the tree item is expanded.


### PR DESCRIPTION
### Motivation

While polishing the docs code-example toggle in https://github.com/shoelace-style/webawesome/pull/2414, I found `<wa-details>` defaulting `--show-duration` / `--hide-duration` to literal `200ms` instead of `--wa-transition-*` tokens. A library audit showed the same pattern everywhere: popup components use ad hoc 50/100/200ms values that don’t match tokens, so motion drifts from the design system.

### What changed

Show/hide defaults snap to the nearest existing `--wa-transition-*` token, plus two small fixes where tokens were already available but unused.

#### Easy wins

`<wa-copy-button>` icon swap and `<wa-select>` chevron easing now use transition tokens instead of hardcoded `100ms ease` / `ease`.

#### Show/hide duration snaps

Popups (`wa-dropdown`, `wa-popup`, `wa-popover`, `wa-select`): 50–100ms → `--wa-transition-fast` (75ms). Panels (`wa-details`, `wa-dialog`, `wa-drawer`, `wa-tree-item`): 200ms → `--wa-transition-normal` (150ms). One commit per component for easy bisect/revert.

### User-visible motion changes

Popups are slightly faster; panels finish ~50ms sooner. Overrides via `--show-duration` / `--hide-duration` are unchanged — only defaults moved.