### PR TITLE
Improve placement of content in textarea when exceeding rows

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -37,6 +37,7 @@ These are still finding their shape. APIs can change between minor versions, so 
 
 - Synced default `--show-duration` and `--hide-duration` values in `<wa-dropdown>`, `<wa-popup>`, `<wa-popover>`, `<wa-select>`, `<wa-combobox>`, `<wa-details>`, `<wa-dialog>`, `<wa-drawer>`, `<wa-tree-item>`, and `<wa-toast-item>` with `--wa-transition-fast` and `--wa-transition-normal` tokens
 - Synced hardcoded transitions in `<wa-copy-button>`, `<wa-select>`, `<wa-combobox>`, and `<wa-toast-item>` with `--wa-transition-*` tokens
+- Improved the vertical placement of content within `<wa-textarea>` and `textarea` when the content overflows the control [pr:2424]
 
 :::
 

--- a/packages/webawesome/src/components/textarea/textarea.styles.ts
+++ b/packages/webawesome/src/components/textarea/textarea.styles.ts
@@ -57,6 +57,7 @@ export default css`
     font: inherit;
     color: inherit;
     cursor: inherit;
+    scroll-padding-block: var(--wa-form-control-padding-block);
     padding: calc(var(--wa-form-control-padding-block) - ((1lh - 1em) / 2)) var(--wa-form-control-padding-inline); /* accounts for the larger line height of textarea content */
     min-height: calc(var(--wa-form-control-height) - var(--border-width) * 2);
     box-shadow: none;

--- a/packages/webawesome/src/styles/native.css
+++ b/packages/webawesome/src/styles/native.css
@@ -1080,6 +1080,7 @@
   textarea {
     height: auto;
     min-height: var(--wa-form-control-height);
+    scroll-padding-block: var(--wa-form-control-padding-block);
     padding: calc(var(--wa-form-control-padding-block) - ((1lh - 1em) / 2)) var(--wa-form-control-padding-inline); /* accounts for the larger line height of textarea content */
 
     line-height: var(--wa-line-height-normal);


### PR DESCRIPTION
Demo: https://codepen.io/roydukkey/pen/ByQRdMB?editors=1100

https://github.com/user-attachments/assets/778ddea4-9fc2-4502-8532-93bd85599320

This improves the vertical placement of content in the textarea when the input exceeds the amount of visible rows. Instead of having the new line smushed right against the bottom border, it will be offset from the border.