### PR TITLE
Docs: Unifying Component Category Labels

### DIFF
--- a/packages/webawesome/docs/docs/components/animated-image.md
+++ b/packages/webawesome/docs/docs/components/animated-image.md
@@ -1,7 +1,7 @@
 ---
 title: Animated Image
 layout: component
-category: Imagery
+category: Media
 synonyms:
   - gif
   - webp

--- a/packages/webawesome/docs/docs/components/avatar.md
+++ b/packages/webawesome/docs/docs/components/avatar.md
@@ -1,7 +1,7 @@
 ---
 title: Avatar
 layout: component
-category: Imagery
+category: Media
 synonyms:
   - profile picture
   - user image

--- a/packages/webawesome/docs/docs/components/badge.md
+++ b/packages/webawesome/docs/docs/components/badge.md
@@ -1,7 +1,7 @@
 ---
 title: Badge
 layout: component
-category: Feedback & Status
+category: Feedback
 synonyms:
   - chip
   - label

--- a/packages/webawesome/docs/docs/components/callout.md
+++ b/packages/webawesome/docs/docs/components/callout.md
@@ -1,7 +1,7 @@
 ---
 title: Callout
 layout: component
-category: Feedback & Status
+category: Feedback
 synonyms:
   - alert
   - admonition

--- a/packages/webawesome/docs/docs/components/card.md
+++ b/packages/webawesome/docs/docs/components/card.md
@@ -1,7 +1,7 @@
 ---
 title: Card
 layout: component
-category: Organization
+category: Layout
 synonyms:
   - tile
   - panel
@@ -115,7 +115,7 @@ If using SSR, you need to also use the `with-media` attribute to add a media sec
         alt="A kitten walks towards camera on top of pallet."
       />
     </div>
-    This card has an image of a kitten walking along a pallet. 
+    This card has an image of a kitten walking along a pallet.
   </wa-card>
   <wa-card class="card-media">
     <video slot="media" controls>

--- a/packages/webawesome/docs/docs/components/carousel-item.md
+++ b/packages/webawesome/docs/docs/components/carousel-item.md
@@ -1,7 +1,7 @@
 ---
 title: Carousel Item
 layout: component
-category: Imagery
+category: Media
 synonyms:
   - slide
   - carousel slide

--- a/packages/webawesome/docs/docs/components/carousel.md
+++ b/packages/webawesome/docs/docs/components/carousel.md
@@ -1,7 +1,7 @@
 ---
 title: Carousel
 layout: component
-category: Imagery
+category: Media
 synonyms:
   - slider
   - slideshow

--- a/packages/webawesome/docs/docs/components/checkbox.md
+++ b/packages/webawesome/docs/docs/components/checkbox.md
@@ -1,7 +1,7 @@
 ---
 title: Checkbox
 layout: component
-category: Form Controls
+category: Forms
 synonyms:
   - check
   - tick

--- a/packages/webawesome/docs/docs/components/color-picker.md
+++ b/packages/webawesome/docs/docs/components/color-picker.md
@@ -1,7 +1,7 @@
 ---
 title: Color Picker
 layout: component
-category: Form Controls
+category: Forms
 synonyms:
   - color chooser
   - color selector
@@ -84,7 +84,7 @@ You can also pass an array of objects with `color` and `label` properties using 
     { color: '#4a90e2', label: 'Blue' },
     { color: '#bd10e0', label: 'Purple' },
     { color: '#000', label: 'Black' },
-    { color: '#fff', label: 'White' }
+    { color: '#fff', label: 'White' },
   ];
 </script>
 ```

--- a/packages/webawesome/docs/docs/components/comparison.md
+++ b/packages/webawesome/docs/docs/components/comparison.md
@@ -1,7 +1,7 @@
 ---
 title: Comparison
 layout: component
-category: Imagery
+category: Media
 synonyms:
   - before after
   - image compare

--- a/packages/webawesome/docs/docs/components/details.md
+++ b/packages/webawesome/docs/docs/components/details.md
@@ -1,7 +1,7 @@
 ---
 title: Details
 layout: component
-category: Organization
+category: Layout
 synonyms:
   - accordion
   - collapsible
@@ -55,8 +55,8 @@ Use the `expand-icon` and `collapse-icon` slots to change the expand and collaps
   <wa-icon name="square-plus" slot="expand-icon" variant="regular"></wa-icon>
   <wa-icon name="square-minus" slot="collapse-icon" variant="regular"></wa-icon>
 
-  This example uses custom plus and minus icons for expanding and collapsing. You can use any icon you want to match
-  the look and feel of your app.
+  This example uses custom plus and minus icons for expanding and collapsing. You can use any icon you want to match the
+  look and feel of your app.
 </wa-details>
 
 <style>
@@ -78,8 +78,8 @@ The default position for the expand and collapse icons is at the end of the summ
     are used to tree views and file explorers.
   </wa-details>
   <wa-details summary="End" icon-placement="end">
-    The expand/collapse icon is at the end of the summary. This is the default placement and works great for most
-    use cases.
+    The expand/collapse icon is at the end of the summary. This is the default placement and works great for most use
+    cases.
   </wa-details>
 </div>
 ```

--- a/packages/webawesome/docs/docs/components/dialog.md
+++ b/packages/webawesome/docs/docs/components/dialog.md
@@ -1,7 +1,7 @@
 ---
 title: Dialog
 layout: component
-category: Organization
+category: Layout
 synonyms:
   - modal
   - popup

--- a/packages/webawesome/docs/docs/components/divider.md
+++ b/packages/webawesome/docs/docs/components/divider.md
@@ -1,7 +1,7 @@
 ---
 title: Divider
 layout: component
-category: Organization
+category: Layout
 synonyms:
   - separator
   - rule

--- a/packages/webawesome/docs/docs/components/drawer.md
+++ b/packages/webawesome/docs/docs/components/drawer.md
@@ -1,7 +1,7 @@
 ---
 title: Drawer
 layout: component
-category: Organization
+category: Layout
 synonyms:
   - sidebar
   - side panel

--- a/packages/webawesome/docs/docs/components/icon.md
+++ b/packages/webawesome/docs/docs/components/icon.md
@@ -1,7 +1,7 @@
 ---
 title: Icon
 layout: component
-category: Imagery
+category: Media
 synonyms:
   - symbol
   - glyph

--- a/packages/webawesome/docs/docs/components/input.md
+++ b/packages/webawesome/docs/docs/components/input.md
@@ -1,7 +1,7 @@
 ---
 title: Input
 layout: component
-category: Form Controls
+category: Forms
 synonyms:
   - text field
   - text box

--- a/packages/webawesome/docs/docs/components/number-input.md
+++ b/packages/webawesome/docs/docs/components/number-input.md
@@ -1,7 +1,7 @@
 ---
 title: Number Input
 layout: component
-category: Form Controls
+category: Forms
 synonyms:
   - numeric input
   - stepper
@@ -36,7 +36,11 @@ Use the `label` attribute to give the input an accessible label. For labels that
 Add descriptive hint to an input with the `hint` attribute. For hints that contain HTML, use the `hint` slot instead.
 
 ```html {.example}
-<wa-number-input label="Order quantity" hint="Enter the number of items you'd like to order" style="max-width: 260px;"></wa-number-input>
+<wa-number-input
+  label="Order quantity"
+  hint="Enter the number of items you'd like to order"
+  style="max-width: 260px;"
+></wa-number-input>
 ```
 
 ### Placeholders
@@ -72,7 +76,12 @@ Use the `appearance` attribute to change the input's visual appearance.
 <br />
 <wa-number-input label="Filled" appearance="filled" value="42" style="max-width: 260px;"></wa-number-input>
 <br />
-<wa-number-input label="Filled Outlined" appearance="filled-outlined" value="42" style="max-width: 260px;"></wa-number-input>
+<wa-number-input
+  label="Filled Outlined"
+  appearance="filled-outlined"
+  value="42"
+  style="max-width: 260px;"
+></wa-number-input>
 ```
 
 ### Disabled

--- a/packages/webawesome/docs/docs/components/option.md
+++ b/packages/webawesome/docs/docs/components/option.md
@@ -1,7 +1,7 @@
 ---
 title: Option
 layout: component
-category: Form Controls
+category: Forms
 synonyms:
   - select option
   - list option

--- a/packages/webawesome/docs/docs/components/page.md
+++ b/packages/webawesome/docs/docs/components/page.md
@@ -1,7 +1,7 @@
 ---
 title: Page
 layout: component
-category: Organization
+category: Layout
 synonyms:
   - layout
   - page layout

--- a/packages/webawesome/docs/docs/components/progress-bar.md
+++ b/packages/webawesome/docs/docs/components/progress-bar.md
@@ -1,7 +1,7 @@
 ---
 title: Progress Bar
 layout: component
-category: Feedback & Status
+category: Feedback
 synonyms:
   - loading bar
   - progress indicator

--- a/packages/webawesome/docs/docs/components/progress-ring.md
+++ b/packages/webawesome/docs/docs/components/progress-ring.md
@@ -1,7 +1,7 @@
 ---
 title: Progress Ring
 layout: component
-category: Feedback & Status
+category: Feedback
 synonyms:
   - circular progress
   - donut chart

--- a/packages/webawesome/docs/docs/components/radio-group.md
+++ b/packages/webawesome/docs/docs/components/radio-group.md
@@ -1,7 +1,7 @@
 ---
 title: Radio Group
 layout: component
-category: Form Controls
+category: Forms
 synonyms:
   - radio buttons
   - option group
@@ -132,25 +132,25 @@ The size of radios will be determined by the Radio Group's `size` attribute.
   <wa-radio value="2">Option 2</wa-radio>
   <wa-radio value="3">Option 3</wa-radio>
 </wa-radio-group>
-<br>
+<br />
 <wa-radio-group label="Small options" size="s" value="1">
   <wa-radio value="1">Option 1</wa-radio>
   <wa-radio value="2">Option 2</wa-radio>
   <wa-radio value="3">Option 3</wa-radio>
 </wa-radio-group>
-<br>
+<br />
 <wa-radio-group label="Medium options" size="m" value="2">
   <wa-radio value="1">Option 1</wa-radio>
   <wa-radio value="2">Option 2</wa-radio>
   <wa-radio value="3">Option 3</wa-radio>
 </wa-radio-group>
-<br>
+<br />
 <wa-radio-group label="Large options" size="l" value="3">
   <wa-radio value="1">Option 1</wa-radio>
   <wa-radio value="2">Option 2</wa-radio>
   <wa-radio value="3">Option 3</wa-radio>
 </wa-radio-group>
-<br>
+<br />
 <wa-radio-group label="Extra large options" size="xl" value="3">
   <wa-radio value="1">Option 1</wa-radio>
   <wa-radio value="2">Option 2</wa-radio>

--- a/packages/webawesome/docs/docs/components/radio.md
+++ b/packages/webawesome/docs/docs/components/radio.md
@@ -1,7 +1,7 @@
 ---
 title: Radio
 layout: component
-category: Form Controls
+category: Forms
 synonyms:
   - radio button
   - option button

--- a/packages/webawesome/docs/docs/components/rating.md
+++ b/packages/webawesome/docs/docs/components/rating.md
@@ -1,7 +1,7 @@
 ---
 title: Rating
 layout: component
-category: Form Controls
+category: Forms
 synonyms:
   - stars
   - star rating
@@ -177,10 +177,7 @@ Use the `required` attribute to make the rating mandatory. The form will not sub
 <script type="module">
   const form = document.querySelector('.rating-required');
 
-  await Promise.all([
-    customElements.whenDefined('wa-button'),
-    customElements.whenDefined('wa-rating'),
-  ]).then(() => {
+  await Promise.all([customElements.whenDefined('wa-button'), customElements.whenDefined('wa-rating')]).then(() => {
     form.addEventListener('submit', event => {
       event.preventDefault();
       alert('All fields are valid!');
@@ -214,10 +211,7 @@ Use the `setCustomValidity()` method to set a custom validation message. This wi
     rating.setCustomValidity(rating.value >= 3 ? '' : errorMessage);
   });
 
-  await Promise.all([
-    customElements.whenDefined('wa-button'),
-    customElements.whenDefined('wa-rating'),
-  ]).then(() => {
+  await Promise.all([customElements.whenDefined('wa-button'), customElements.whenDefined('wa-rating')]).then(() => {
     form.addEventListener('submit', event => {
       event.preventDefault();
       alert('All fields are valid!');

--- a/packages/webawesome/docs/docs/components/scroller.md
+++ b/packages/webawesome/docs/docs/components/scroller.md
@@ -1,7 +1,7 @@
 ---
 title: Scroller
 layout: component
-category: Organization
+category: Layout
 synonyms:
   - scrollable
   - scroll container

--- a/packages/webawesome/docs/docs/components/select.md
+++ b/packages/webawesome/docs/docs/components/select.md
@@ -1,7 +1,7 @@
 ---
 title: Select
 layout: component
-category: Form Controls
+category: Forms
 synonyms:
   - dropdown select
   - combobox

--- a/packages/webawesome/docs/docs/components/skeleton.md
+++ b/packages/webawesome/docs/docs/components/skeleton.md
@@ -1,7 +1,7 @@
 ---
 title: Skeleton
 layout: component
-category: Feedback & Status
+category: Feedback
 synonyms:
   - placeholder
   - shimmer

--- a/packages/webawesome/docs/docs/components/slider.md
+++ b/packages/webawesome/docs/docs/components/slider.md
@@ -1,7 +1,7 @@
 ---
 title: Slider
 layout: component
-category: Form Controls
+category: Forms
 synonyms:
   - range
   - range slider
@@ -291,4 +291,3 @@ Use the `disabled` attribute to disable a slider.
 ```html {.example}
 <wa-slider label="Disabled" value="50" disabled></wa-slider>
 ```
-

--- a/packages/webawesome/docs/docs/components/spinner.md
+++ b/packages/webawesome/docs/docs/components/spinner.md
@@ -1,7 +1,7 @@
 ---
 title: Spinner
 layout: component
-category: Feedback & Status
+category: Feedback
 synonyms:
   - loading
   - loader

--- a/packages/webawesome/docs/docs/components/split-panel.md
+++ b/packages/webawesome/docs/docs/components/split-panel.md
@@ -1,7 +1,7 @@
 ---
 title: Split Panel
 layout: component
-category: Organization
+category: Layout
 synonyms:
   - resizable panels
   - pane splitter

--- a/packages/webawesome/docs/docs/components/switch.md
+++ b/packages/webawesome/docs/docs/components/switch.md
@@ -1,7 +1,7 @@
 ---
 title: Switch
 layout: component
-category: Form Controls
+category: Forms
 synonyms:
   - toggle
   - toggle switch

--- a/packages/webawesome/docs/docs/components/tag.md
+++ b/packages/webawesome/docs/docs/components/tag.md
@@ -1,7 +1,7 @@
 ---
 title: Tag
 layout: component
-category: Feedback & Status
+category: Feedback
 synonyms:
   - chip
   - label

--- a/packages/webawesome/docs/docs/components/textarea.md
+++ b/packages/webawesome/docs/docs/components/textarea.md
@@ -1,7 +1,7 @@
 ---
 title: Textarea
 layout: component
-category: Form Controls
+category: Forms
 synonyms:
   - text area
   - multiline input

--- a/packages/webawesome/docs/docs/components/tooltip.md
+++ b/packages/webawesome/docs/docs/components/tooltip.md
@@ -1,7 +1,7 @@
 ---
 title: Tooltip
 layout: component
-category: Feedback & Status
+category: Feedback
 synonyms:
   - hint
   - hover text
@@ -16,7 +16,8 @@ use-cases:
 A tooltip's target is based on the `for` attribute which points to an element id.
 
 ```html {.example}
-<wa-tooltip for="my-button">This is a tooltip</wa-tooltip> <wa-button appearance="filled" id="my-button">Hover Me</wa-button>
+<wa-tooltip for="my-button">This is a tooltip</wa-tooltip>
+<wa-button appearance="filled" id="my-button">Hover Me</wa-button>
 ```
 
 ## Examples

--- a/packages/webawesome/docs/docs/components/zoomable-frame.md
+++ b/packages/webawesome/docs/docs/components/zoomable-frame.md
@@ -1,7 +1,7 @@
 ---
 title: Zoomable Frame
 layout: component
-category: Imagery
+category: Media
 synonyms:
   - iframe zoom
   - preview frame


### PR DESCRIPTION
This work collapses the canonical front-matter `category:` labels to match what the components index filter on `/docs/components` displays, so the same names work in both places without per-page translation. 

- Form Controls becomes Forms
- Feedback & Status becomes Feedback
- Organization becomes Layout
- Imagery becomes Media. 
- Actions, Navigation, and Utilities keep their existing labels.

### Why

The filter UI used short, conversational labels (Forms, Layout) while the front matter still used the longer canonical ones (Form Controls, Organization). 

That forced the components index code to maintain a translation table. Bringing the two into alignment kills that translation step and makes adding a new category a single-line change.