### PR TITLE
Make drawer lightDismiss default false

### DIFF
--- a/packages/webawesome/src/components/drawer/drawer.test.ts
+++ b/packages/webawesome/src/components/drawer/drawer.test.ts
@@ -87,9 +87,9 @@ describe('<wa-drawer>', () => {
           expect(el.placement).to.equal('end');
         });
 
-        it('should default lightDismiss to true', async () => {
+        it('should default lightDismiss to false', async () => {
           const el = await fixture<WaDrawer>(html`<wa-drawer>Content</wa-drawer>`);
-          expect(el.lightDismiss).to.be.true;
+          expect(el.lightDismiss).to.be.false;
         });
       });
 

--- a/packages/webawesome/src/components/drawer/drawer.ts
+++ b/packages/webawesome/src/components/drawer/drawer.ts
@@ -86,7 +86,7 @@ export default class WaDrawer extends WebAwesomeElement {
   @property({ attribute: 'without-header', type: Boolean, reflect: true }) withoutHeader = false;
 
   /** When enabled, the drawer will be closed when the user clicks outside of it. */
-  @property({ attribute: 'light-dismiss', type: Boolean }) lightDismiss = true;
+  @property({ attribute: 'light-dismiss', type: Boolean }) lightDismiss = false;
 
   /**
    * Only required for SSR. Set to `true` if you're slotting in a `footer` element so the server-rendered markup


### PR DESCRIPTION
## Summary
This PR reverts the incorrect default value of `lightDismiss` in the Drawer component from `true` to `false`.

Boolean attributes must NEVER default to true, [per Web Awesome's own contribution guidelines](https://webawesome.com/docs/resources/contributing#boolean-props), as there's no way to unset them declaratively.

## Motivation
This PR restores the originally intended behavior of the `lightDismiss` boolean attribute in `<wa-drawer>`.

Boolean attributes in Web Awesome follow standard HTML conventions where the presence of the attribute represents `true`, and the absence represents `false`. Because of this, boolean properties should not default to `true`, as there is no declarative way to disable them in markup.

The previous default of `true` was introduced unintentionally and is inconsistent with `<wa-dialog>`, which served as the original reference implementation for `<wa-drawer>`.

This change corrects that inconsistency and aligns the component with established Web Awesome boolean attribute conventions.

## Changes
- Update default value of `lightDismiss` from `true` to `false`

## Impact
This changes the default click-outside-to-close behavior for `<wa-drawer>`.
Existing users relying on the previous default may be affected.

Fixes #2433