### PR TITLE
Don't clip outlines everywhere

### DIFF
--- a/packages/webawesome/docs/assets/styles/code-examples.css
+++ b/packages/webawesome/docs/assets/styles/code-examples.css
@@ -47,7 +47,6 @@
 
   > :first-child:not(dialog) {
     max-inline-size: 100%;
-    overflow-inline: auto;
     margin-block-start: 0;
   }
 


### PR DESCRIPTION
<img width="1476" height="368" alt="CleanShot 2026-05-28 at 14 40 19@2x" src="https://github.com/user-attachments/assets/58f9c4f3-2241-4608-89c3-745f0fa1cf2d" />

A recent change to code examples in the docs started clipping all of the outlines in our form controls. This reverts that.