### PR TITLE
Docs: Link to a Component's Category

### DIFF
--- a/packages/webawesome/docs/_data/componentCategories.json
+++ b/packages/webawesome/docs/_data/componentCategories.json
@@ -1,0 +1,10 @@
+[
+  { "label": "Actions", "slug": "actions", "icon": "hand-pointer" },
+  { "label": "Feedback", "slug": "feedback", "icon": "comments" },
+  { "label": "Forms", "slug": "forms", "icon": "pen-field" },
+  { "label": "Media", "slug": "media", "icon": "image" },
+  { "label": "Navigation", "slug": "navigation", "icon": "compass" },
+  { "label": "Layout", "slug": "layout", "icon": "layer" },
+  { "label": "Utilities", "slug": "utilities", "icon": "wrench" },
+  { "label": "Data Viz", "slug": "data-viz", "icon": "chart-line" }
+]

--- a/packages/webawesome/docs/_includes/macros/component-badges.njk
+++ b/packages/webawesome/docs/_includes/macros/component-badges.njk
@@ -4,24 +4,36 @@
 {# `.preview` opts the brand-variant badge out of site theming (orange). #}
 <wa-badge class="preview" variant="brand" pill><wa-icon name="check" slot="start"></wa-icon>Stable</wa-badge>
 {%- elif status == 'experimental' -%}
-<wa-badge variant="warning" appearance="filled" pill><wa-icon name="flask" slot="start"></wa-icon>Experimental</wa-badge>
+<wa-badge variant="warning" appearance="filled" pill><wa-icon name="flask"
+    slot="start"></wa-icon>Experimental</wa-badge>
 {%- endif -%}
 {%- endmacro -%}
 
 {# Status, optional category link, and Since badges for a component. `category`
-   and `categories` are optional — card callers omit them and skip the link. #}
+and `categories` are optional — card callers omit them and skip the link. #}
 {% macro componentMetaBadges(component, category, categories) %}
 {{ statusBadge(component.status) }}
 {% if category and categories %}
 {% for cat in categories %}{% if cat.label == category %}
 <a class="component-category-link" href="/docs/components/?category={{ cat.slug }}">
   <wa-badge variant="neutral" appearance="filled" pill>
-    <wa-icon name="{{ cat.icon }}" slot="start"></wa-icon>{{ cat.label }}
+    <wa-icon variant="regular" name="{{ cat.icon }}" slot="start"></wa-icon>{{ cat.label }}
   </wa-badge>
 </a>
 {% endif %}{% endfor %}
 {% endif %}
 {% if component.since %}
-<wa-badge variant="neutral" appearance="filled" pill>Since {{ component.since }}</wa-badge>
-{% endif %}
-{% endmacro %}
+{% if categories %}
+{# Pad 2-part versions (e.g. `3.6`) to match 3-part changelog headings (`## 3.6.0` → `#wa_360`).
+The anchor transform slugifies headings as `wa_<digits>`; if no match exists the link still lands on the changelog.
+  Card callers omit `categories` and skip the link to avoid nesting anchors inside the card's outer link. #}
+  {%- set sinceVersion = component.since -%}
+  {%- if sinceVersion.split('.').length == 2 -%}{%- set sinceVersion = sinceVersion + '.0' -%}{%- endif -%}
+  <a class="component-since-link" href="/docs/resources/changelog#wa_{{ sinceVersion | replace('.', '') }}">
+    <wa-badge variant="neutral" appearance="filled" pill>Since {{ component.since }}</wa-badge>
+  </a>
+  {% else %}
+  <wa-badge variant="neutral" appearance="filled" pill>Since {{ component.since }}</wa-badge>
+  {% endif %}
+  {% endif %}
+  {% endmacro %}

--- a/packages/webawesome/docs/_includes/macros/component-badges.njk
+++ b/packages/webawesome/docs/_includes/macros/component-badges.njk
@@ -8,10 +8,20 @@
 {%- endif -%}
 {%- endmacro -%}
 
-{# Status + Since badges for a component. #}
-{% macro componentStatusBadges(component) %}
+{# Status, optional category link, and Since badges for a component. `category`
+   and `categories` are optional — card callers omit them and skip the link. #}
+{% macro componentMetaBadges(component, category, categories) %}
 {{ statusBadge(component.status) }}
+{% if category and categories %}
+{% for cat in categories %}{% if cat.label == category %}
+<a class="component-category-link" href="/docs/components/?category={{ cat.slug }}">
+  <wa-badge variant="neutral" appearance="filled" pill>
+    <wa-icon name="{{ cat.icon }}" slot="start"></wa-icon>{{ cat.label }}
+  </wa-badge>
+</a>
+{% endif %}{% endfor %}
+{% endif %}
 {% if component.since %}
-<wa-badge class="since" variant="neutral" appearance="filled" pill>Since {{ component.since }}</wa-badge>
+<wa-badge variant="neutral" appearance="filled" pill>Since {{ component.since }}</wa-badge>
 {% endif %}
 {% endmacro %}

--- a/packages/webawesome/docs/_layouts/component.njk
+++ b/packages/webawesome/docs/_layouts/component.njk
@@ -1,326 +1,333 @@
 {% extends '../_layouts/docs.njk' %}
 {% from "pro-badge.njk" import proBadge %}
-{% from "macros/component-badges.njk" import componentStatusBadges %}
+{% from "macros/component-badges.njk" import componentMetaBadges %}
 {% set component = getComponent('wa-' + page.fileSlug) %}
 {% set description = component.summary %}
 
 {# Component header #}
 {% block beforeContent %}
-  <div class="component-info">
-    <code class="component-tag">&lt;{{ component.tagName }}&gt;</code>
-    {{ componentStatusBadges(component) }}
+<div class="component-info wa-cluster">
+  <code class="component-tag">&lt;{{ component.tagName }}&gt;</code>
+  <div class="wa-cluster wa-gap-xs">
     {% if isProComponent %}
-      {{ proBadge({ description: "Included with " ~ site.namePro }) }}
+    {{ proBadge({ description: "Included with " ~ site.namePro }) }}
     {% endif %}
+    {{ componentMetaBadges(component, category, componentCategories) }}
   </div>
+</div>
 
-  <p class="component-summary">
-    {{ component.summary | inlineMarkdown | safe }}
-  </p>
+<p class="component-summary">
+  {{ component.summary | inlineMarkdown | safe }}
+</p>
 
-  {% if isProComponent %}
-    {% include "pro-component-notice.njk" ignore missing %}
-  {% endif %}
+{% if isProComponent %}
+{% include "pro-component-notice.njk" ignore missing %}
+{% endif %}
 {% endblock %}
 
 {# Component API #}
 {% block afterContent %}
-  {# Importing #}
-  <h2>Importing</h2>
-  <p>
-    If you're using the autoloader or a hosted project, components load on demand &mdash; no manual import needed. To cherry-pick a component manually, use one of the following snippets.
-  </p>
+{# Importing #}
+<h2>Importing</h2>
+<p>
+  If you're using the autoloader or a hosted project, components load on demand &mdash; no manual import needed. To
+  cherry-pick a component manually, use one of the following snippets.
+</p>
 
-  {% set componentName = component.tagName | stripPrefix %}
-  {% set componentPath = ["components/", componentName, "/", componentName, ".js"] | join("") %}
-  <wa-tab-group label="How would you like to import this component?" data-install-tabs>
-    <wa-tab panel="cdn"><wa-icon name="globe" variant="regular"></wa-icon> CDN</wa-tab>
-    <wa-tab panel="npm"><wa-icon name="box-open" variant="regular"></wa-icon> npm</wa-tab>
-    <wa-tab panel="self-hosted"><wa-icon name="arrow-down-to-line" variant="regular"></wa-icon> Self-Hosted</wa-tab>
-    <wa-tab panel="react"><wa-icon name="react" family="brands"></wa-icon> React</wa-tab>
+{% set componentName = component.tagName | stripPrefix %}
+{% set componentPath = ["components/", componentName, "/", componentName, ".js"] | join("") %}
+<wa-tab-group label="How would you like to import this component?" data-install-tabs>
+  <wa-tab panel="cdn"><wa-icon name="globe" variant="regular"></wa-icon> CDN</wa-tab>
+  <wa-tab panel="npm"><wa-icon name="box-open" variant="regular"></wa-icon> npm</wa-tab>
+  <wa-tab panel="self-hosted"><wa-icon name="arrow-down-to-line" variant="regular"></wa-icon> Self-Hosted</wa-tab>
+  <wa-tab panel="react"><wa-icon name="react" family="brands"></wa-icon> React</wa-tab>
 
-    <wa-tab-panel name="cdn">
-      <p>Import this component directly from the CDN:</p>
-      <pre><code class="language-js">import '{% cdnUrl componentPath %}';</code></pre>
-    </wa-tab-panel>
+  <wa-tab-panel name="cdn">
+    <p>Import this component directly from the CDN:</p>
+    <pre><code class="language-js">import '{% cdnUrl componentPath %}';</code></pre>
+  </wa-tab-panel>
 
-    <wa-tab-panel name="npm">
-      <p>After installing Web Awesome via npm, import this component:</p>
-      <pre><code class="language-js">import '@awesome.me/webawesome/dist/{{ componentPath }}';</code></pre>
-    </wa-tab-panel>
+  <wa-tab-panel name="npm">
+    <p>After installing Web Awesome via npm, import this component:</p>
+    <pre><code class="language-js">import '@awesome.me/webawesome/dist/{{ componentPath }}';</code></pre>
+  </wa-tab-panel>
 
-    <wa-tab-panel name="self-hosted">
-      <p>If you're self-hosting Web Awesome, import this component from your server:</p>
-      <pre><code class="language-js">import './webawesome/dist/{{ componentPath }}';</code></pre>
-    </wa-tab-panel>
+  <wa-tab-panel name="self-hosted">
+    <p>If you're self-hosting Web Awesome, import this component from your server:</p>
+    <pre><code class="language-js">import './webawesome/dist/{{ componentPath }}';</code></pre>
+  </wa-tab-panel>
 
-    <wa-tab-panel name="react">
-      <p>To import this component for React 18 or below, use the following code:</p>
-      <pre><code class="language-js">import {{ component.name }} from '@awesome.me/webawesome/dist/react/{{ componentName }}/index.js';</code></pre>
-    </wa-tab-panel>
-  </wa-tab-group>
+  <wa-tab-panel name="react">
+    <p>To import this component for React 18 or below, use the following code:</p>
+    <pre><code class="language-js">import {{ component.name }} from '@awesome.me/webawesome/dist/react/{{ componentName }}/index.js';</code></pre>
+  </wa-tab-panel>
+</wa-tab-group>
 
-  {# Slots #}
-  {% if component.slots.length %}
-    <h2>Slots</h2>
-    <p>Learn more about <a href="/docs/usage/#slots">using slots</a>.</p>
+{# Slots #}
+{% if component.slots.length %}
+<h2>Slots</h2>
+<p>Learn more about <a href="/docs/usage/#slots">using slots</a>.</p>
 
-    <wa-scroller>
-      <table class="component-table wa-hover-rows">
-        <thead>
-          <tr>
-            <th class="table-name">Name</th>
-            <th class="table-description">Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for slot in component.slots %}
-            <tr>
-              <td class="table-name">
-                {% if slot.name %}
-                  <code>{{ slot.name }}</code>
-                {% else %}
-                  (default)
-                {% endif %}
-              </td>
-              <td class="table-description">{{ slot.description | inlineMarkdown | safe }}</td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </wa-scroller>
-  {% endif %}
+<wa-scroller>
+  <table class="component-table wa-hover-rows">
+    <thead>
+      <tr>
+        <th class="table-name">Name</th>
+        <th class="table-description">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for slot in component.slots %}
+      <tr>
+        <td class="table-name">
+          {% if slot.name %}
+          <code>{{ slot.name }}</code>
+          {% else %}
+          (default)
+          {% endif %}
+        </td>
+        <td class="table-description">{{ slot.description | inlineMarkdown | safe }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</wa-scroller>
+{% endif %}
 
-  {# Properties #}
-  {% if component.properties.length %}
-    <h2>Attributes & Properties</h2>
-    <p>Learn more about <a href="/docs/usage/#attributes-and-properties">attributes and properties</a>.</p>
+{# Properties #}
+{% if component.properties.length %}
+<h2>Attributes & Properties</h2>
+<p>Learn more about <a href="/docs/usage/#attributes-and-properties">attributes and properties</a>.</p>
 
-    <wa-scroller>
-      <table class="component-table wa-hover-rows">
-        <thead>
-          <tr>
-            <th class="table-name">Name</th>
-            <th class="table-description">Description</th>
-            <th class="table-reflect">Reflects</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for prop in component.properties %}
-            <tr>
-              <td class="table-name">
-                <code title="JS property">{{ prop.name }}</code><br>
-                {% if prop.attribute %}
-                  <div><small><code title="HTML attribute">{{ prop.attribute }}</code></small></div>
-                {% endif %}
-              </td>
-              <td class="table-description">
-                <div>{{ prop.description | inlineMarkdown | safe }}</div>
-                {% if prop.type.text %}
-                  <div><small><strong>Type</strong>&nbsp;<code>{{ prop.type.text | trimPipes | inlineMarkdown | safe }}</code></small></div>
-                {% endif %}
-                {% if prop.default %}
-                  <div><small><strong>Default</strong>&nbsp;<code>{{ prop.default | inlineMarkdown | safe }}</code></small></div>
-                {% endif %}
-              </td>
-              <td class="table-reflect">
-                {% if prop.reflects %}
-                  <wa-icon name="check"></wa-icon>
-                {% endif %}
-              </td>
-              <td class="table-default">
+<wa-scroller>
+  <table class="component-table wa-hover-rows">
+    <thead>
+      <tr>
+        <th class="table-name">Name</th>
+        <th class="table-description">Description</th>
+        <th class="table-reflect">Reflects</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for prop in component.properties %}
+      <tr>
+        <td class="table-name">
+          <code title="JS property">{{ prop.name }}</code><br>
+          {% if prop.attribute %}
+          <div><small><code title="HTML attribute">{{ prop.attribute }}</code></small></div>
+          {% endif %}
+        </td>
+        <td class="table-description">
+          <div>{{ prop.description | inlineMarkdown | safe }}</div>
+          {% if prop.type.text %}
+          <div>
+            <small><strong>Type</strong>&nbsp;<code>{{ prop.type.text | trimPipes | inlineMarkdown | safe }}</code></small>
+          </div>
+          {% endif %}
+          {% if prop.default %}
+          <div><small><strong>Default</strong>&nbsp;<code>{{ prop.default | inlineMarkdown | safe }}</code></small>
+          </div>
+          {% endif %}
+        </td>
+        <td class="table-reflect">
+          {% if prop.reflects %}
+          <wa-icon name="check"></wa-icon>
+          {% endif %}
+        </td>
+        <td class="table-default">
 
-              </td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </wa-scroller>
-  {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</wa-scroller>
+{% endif %}
 
-  {# Methods #}
-  {% if component.methods.length %}
-    <h2>Methods</h2>
-    <p>Learn more about <a href="/docs/usage/#methods">methods</a>.</p>
+{# Methods #}
+{% if component.methods.length %}
+<h2>Methods</h2>
+<p>Learn more about <a href="/docs/usage/#methods">methods</a>.</p>
 
-    <wa-scroller>
-      <table class="component-table wa-hover-rows">
-        <thead>
-          <tr>
-            <th class="table-name">Name</th>
-            <th class="table-description">Description</th>
-            <th class="table-arguments">Arguments</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for method in component.methods %}
-            <tr>
-              <td class="table-name"><code>{{ method.name }}()</code></td>
-              <td class="table-description">{{ method.description | inlineMarkdown | safe }}</td>
-              <td class="table-arguments">
-                {% if method.parameters.length %}
-                  <code>
+<wa-scroller>
+  <table class="component-table wa-hover-rows">
+    <thead>
+      <tr>
+        <th class="table-name">Name</th>
+        <th class="table-description">Description</th>
+        <th class="table-arguments">Arguments</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for method in component.methods %}
+      <tr>
+        <td class="table-name"><code>{{ method.name }}()</code></td>
+        <td class="table-description">{{ method.description | inlineMarkdown | safe }}</td>
+        <td class="table-arguments">
+          {% if method.parameters.length %}
+          <code>
                     {% for param in method.parameters %}
                       {{ param.name }}: {{ param.type.text | trimPipes }}{% if not loop.last %},{% endif %}
                     {% endfor %}
                   </code>
-                {% endif %}
-              </td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </wa-scroller>
-  {% endif %}
-
-  {# Events #}
-  {% if component.events.length %}
-    <h2>Events</h2>
-    <p>Learn more about <a href="/docs/usage/#events">events</a>.</p>
-
-    <wa-scroller>
-      <table class="component-table wa-hover-rows">
-        <thead>
-          <tr>
-            <th class="table-name">Name</th>
-            <th class="table-description">Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for event in component.events %}
-            {% if event.name %}
-              <tr>
-                <td class="table-name"><code>{{ event.name }}</code></td>
-                <td class="table-description">{{ event.description | inlineMarkdown | safe }}</td>
-              </tr>
-            {% endif %}
-          {% endfor %}
-        </tbody>
-      </table>
-    </wa-scroller>
-  {% endif %}
-
-  {# Custom Properties #}
-  {% if component.cssProperties.length %}
-    <h2>CSS custom properties</h2>
-    <p>Learn more about <a href="/docs/usage/#custom-properties">CSS custom properties</a>.</p>
-
-    <wa-scroller>
-      <table class="component-table wa-hover-rows">
-        <thead>
-          <tr>
-            <th class="table-name">Name</th>
-            <th class="table-description">Description</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for cssProperty in component.cssProperties %}
-            <tr>
-              <td class="table-name"><code>{{ cssProperty.name }}</code></td>
-              <td class="table-description">
-                <div>{{ cssProperty.description | inlineMarkdown | safe }}</div>
-                {% if cssProperty.default %}
-                  <div>
-                    <small><strong>Default</strong>&nbsp;<code>{{ cssProperty.default }}</code></small>
-                    </div>
-                {% endif %}
-              </td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </wa-scroller>
-  {% endif %}
-
-  {# Custom States #}
-  {% if component.cssStates.length %}
-    <h2>Custom States</h2>
-    <p>Learn more about <a href="/docs/usage/#custom-states">custom states</a>.</p>
-
-    <wa-scroller>
-      <table class="component-table wa-hover-rows">
-        <thead>
-          <tr>
-            <th class="table-name">Name</th>
-            <th class="table-description">Description</th>
-            <th class="table-selector">CSS selector</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for state in component.cssStates %}
-            <tr>
-              <td class="table-name"><code>{{ state.name }}</code></td>
-              <td class="table-description">{{ state.description | inlineMarkdown | safe }}</td>
-              <td class="table-selector">
-                <span class="wa-cluster wa-gap-3xs">
-                  <code>:state({{ state.name }})</code>
-                  <wa-copy-button value=":state({{ state.name }})"></wa-copy-button>
-                </span>
-              </td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </wa-scroller>
-  {% endif %}
-
-  {# CSS Parts #}
-  {% if component.cssParts.length %}
-    <h2>CSS parts</h2>
-    <p>Learn more about <a href="/docs/usage/#css-parts">CSS parts</a>.</p>
-
-    <wa-scroller>
-      <table class="component-table wa-hover-rows">
-        <thead>
-          <tr>
-            <th class="table-name">Name</th>
-            <th class="table-description">Description</th>
-            <th class="table-selector">CSS selector</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for cssPart in component.cssParts %}
-            <tr>
-              <td class="table-name"><code>{{ cssPart.name }}</code></td>
-              <td class="table-description">{{ cssPart.description | inlineMarkdown | safe }}</td>
-              <td class="table-selector">
-                <span class="wa-cluster wa-gap-3xs">
-                  <code>::part({{ cssPart.name }})</code>
-                  <wa-copy-button value="::part({{ cssPart.name }})"></wa-copy-button>
-                </span>
-              </td>
-            </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </wa-scroller>
-  {% endif %}
-
-  {# Dependencies #}
-  {% if component.dependencies.length %}
-    <h2>Dependencies</h2>
-    <p>
-      This component automatically imports the following elements. Sub-dependencies, if any exist, will also be included in this list.
-    </p>
-
-    <ul class="dependency-list">
-      {% for dependency in component.dependencies %}
-        <li><a href="/docs/components/{{ dependency | stripPrefix }}"><code>&lt;{{ dependency }}&gt;</code></a></li>
+          {% endif %}
+        </td>
+      </tr>
       {% endfor %}
-    </ul>
-  {% endif %}
+    </tbody>
+  </table>
+</wa-scroller>
+{% endif %}
 
-  <wa-divider></wa-divider>
+{# Events #}
+{% if component.events.length %}
+<h2>Events</h2>
+<p>Learn more about <a href="/docs/usage/#events">events</a>.</p>
 
-  <div class="component-help">
-    <strong>Need a hand?</strong>
-    <wa-button size="s" appearance="filled" variant="neutral" href="{{ site.github.issues }}" target="_blank">
-      <wa-icon slot="start" variant="regular" name="bug"></wa-icon>
-      Report a bug
-    </wa-button>
-    <wa-button size="s" appearance="filled" variant="neutral" href="{{ site.github.discussions }}" target="_blank">
-      <wa-icon slot="start" variant="regular" name="message-question"></wa-icon>
-      Ask for help
-    </wa-button>
-  </div>
+<wa-scroller>
+  <table class="component-table wa-hover-rows">
+    <thead>
+      <tr>
+        <th class="table-name">Name</th>
+        <th class="table-description">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for event in component.events %}
+      {% if event.name %}
+      <tr>
+        <td class="table-name"><code>{{ event.name }}</code></td>
+        <td class="table-description">{{ event.description | inlineMarkdown | safe }}</td>
+      </tr>
+      {% endif %}
+      {% endfor %}
+    </tbody>
+  </table>
+</wa-scroller>
+{% endif %}
+
+{# Custom Properties #}
+{% if component.cssProperties.length %}
+<h2>CSS custom properties</h2>
+<p>Learn more about <a href="/docs/usage/#custom-properties">CSS custom properties</a>.</p>
+
+<wa-scroller>
+  <table class="component-table wa-hover-rows">
+    <thead>
+      <tr>
+        <th class="table-name">Name</th>
+        <th class="table-description">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for cssProperty in component.cssProperties %}
+      <tr>
+        <td class="table-name"><code>{{ cssProperty.name }}</code></td>
+        <td class="table-description">
+          <div>{{ cssProperty.description | inlineMarkdown | safe }}</div>
+          {% if cssProperty.default %}
+          <div>
+            <small><strong>Default</strong>&nbsp;<code>{{ cssProperty.default }}</code></small>
+          </div>
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</wa-scroller>
+{% endif %}
+
+{# Custom States #}
+{% if component.cssStates.length %}
+<h2>Custom States</h2>
+<p>Learn more about <a href="/docs/usage/#custom-states">custom states</a>.</p>
+
+<wa-scroller>
+  <table class="component-table wa-hover-rows">
+    <thead>
+      <tr>
+        <th class="table-name">Name</th>
+        <th class="table-description">Description</th>
+        <th class="table-selector">CSS selector</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for state in component.cssStates %}
+      <tr>
+        <td class="table-name"><code>{{ state.name }}</code></td>
+        <td class="table-description">{{ state.description | inlineMarkdown | safe }}</td>
+        <td class="table-selector">
+          <span class="wa-cluster wa-gap-3xs">
+            <code>:state({{ state.name }})</code>
+            <wa-copy-button value=":state({{ state.name }})"></wa-copy-button>
+          </span>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</wa-scroller>
+{% endif %}
+
+{# CSS Parts #}
+{% if component.cssParts.length %}
+<h2>CSS parts</h2>
+<p>Learn more about <a href="/docs/usage/#css-parts">CSS parts</a>.</p>
+
+<wa-scroller>
+  <table class="component-table wa-hover-rows">
+    <thead>
+      <tr>
+        <th class="table-name">Name</th>
+        <th class="table-description">Description</th>
+        <th class="table-selector">CSS selector</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for cssPart in component.cssParts %}
+      <tr>
+        <td class="table-name"><code>{{ cssPart.name }}</code></td>
+        <td class="table-description">{{ cssPart.description | inlineMarkdown | safe }}</td>
+        <td class="table-selector">
+          <span class="wa-cluster wa-gap-3xs">
+            <code>::part({{ cssPart.name }})</code>
+            <wa-copy-button value="::part({{ cssPart.name }})"></wa-copy-button>
+          </span>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</wa-scroller>
+{% endif %}
+
+{# Dependencies #}
+{% if component.dependencies.length %}
+<h2>Dependencies</h2>
+<p>
+  This component automatically imports the following elements. Sub-dependencies, if any exist, will also be included in
+  this list.
+</p>
+
+<ul class="dependency-list">
+  {% for dependency in component.dependencies %}
+  <li><a href="/docs/components/{{ dependency | stripPrefix }}"><code>&lt;{{ dependency }}&gt;</code></a></li>
+  {% endfor %}
+</ul>
+{% endif %}
+
+<wa-divider></wa-divider>
+
+<div class="component-help">
+  <strong>Need a hand?</strong>
+  <wa-button size="s" appearance="filled" variant="neutral" href="{{ site.github.issues }}" target="_blank">
+    <wa-icon slot="start" variant="regular" name="bug"></wa-icon>
+    Report a bug
+  </wa-button>
+  <wa-button size="s" appearance="filled" variant="neutral" href="{{ site.github.discussions }}" target="_blank">
+    <wa-icon slot="start" variant="regular" name="message-question"></wa-icon>
+    Ask for help
+  </wa-button>
+</div>
 {% endblock %}

--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -246,10 +246,6 @@ h1.title {
 }
 
 .component-info {
-  display: flex;
-  gap: var(--wa-space-xs);
-  flex-wrap: wrap;
-  align-items: center;
   margin-block-end: var(--wa-content-spacing);
 
   code {
@@ -260,6 +256,15 @@ h1.title {
     background-color: transparent;
     color: var(--wa-color-text-quiet);
     font-size: var(--wa-font-size-l);
+  }
+
+  /* The category badge is wrapped in an <a> for the link, but the wrapper was
+     introducing a baseline offset against the bare wa-badge siblings. Using
+     display: contents removes the anchor's box from layout so the badge
+     becomes a direct flex child of the cluster (same as the others). */
+  .component-category-link {
+    display: contents;
+    text-decoration: none;
   }
 }
 

--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -258,11 +258,12 @@ h1.title {
     font-size: var(--wa-font-size-l);
   }
 
-  /* The category badge is wrapped in an <a> for the link, but the wrapper was
-     introducing a baseline offset against the bare wa-badge siblings. Using
-     display: contents removes the anchor's box from layout so the badge
-     becomes a direct flex child of the cluster (same as the others). */
-  .component-category-link {
+  /* The category and since badges are wrapped in an <a> for the link, but the
+     wrapper was introducing a baseline offset against the bare wa-badge
+     siblings. Using display: contents removes the anchor's box from layout so
+     the badge becomes a direct flex child of the cluster (same as the others). */
+  .component-category-link,
+  .component-since-link {
     display: contents;
     text-decoration: none;
   }

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -498,8 +498,8 @@
     }
   }
 
-  /* "Since X.X" badge: subtler than the default filled neutral */
-  wa-badge.since {
+  /* Subtler treatment for filled neutral badges (since, category, etc.) */
+  wa-badge[variant='neutral'][appearance='filled'] {
     background-color: var(--wa-color-surface-lowered);
   }
 

--- a/packages/webawesome/docs/docs/components/index.njk
+++ b/packages/webawesome/docs/docs/components/index.njk
@@ -5,7 +5,7 @@ layout: docs
 ---
 
 {% from "pro-badge.njk" import proBadge %}
-{% from "macros/component-badges.njk" import componentStatusBadges %}
+{% from "macros/component-badges.njk" import componentMetaBadges %}
 
 <div class="search-list component-list">
   <wa-input class="search-list-input" type="search" placeholder="Search Components" pill autofocus with-clear>
@@ -25,7 +25,7 @@ layout: docs
             <p class="component-list-summary">{{ component.summary | inlineMarkdown | striptags | safe }}</p>
           {% endif %}
           <div class="wa-cluster wa-gap-2xs component-list-badges">
-            {{ componentStatusBadges(component) }}
+            {{ componentMetaBadges(component) }}
             {% if page.data.isProComponent %}
               {{ proBadge({ description: "Included with " ~ site.namePro }) }}
             {% endif %}


### PR DESCRIPTION
This work updates component detail pages (e.g. `/docs/components/avatar/`) so that they carry a clickable category badge in the meta row next to the tag, status, and "Since" badges. This badge links to `/docs/components/?category={slug}` with the index filtered to that category — closing the loop between the Components Listing and the Component Detail view.

### New Shared Data File

`docs/_data/componentCategories.json` holds the label, slug, and icon for each category. It's the single source of truth for category metadata — the pro repo's components index filter loops over the same file, so the icon/slug set can't drift between the two consumers.

### `componentStatusBadges` → `componentMetaBadges`

The badges macro was renamed to reflect what it now renders: status, optional category link, and "Since" pill, in that order. Card callers (the index grid) omit the category args and skip the link; the detail-page layout passes the category in.

### Subtler-Fill Badge Styling Generalized

The "Since X.X" badge's `surface-lowered` background was previously keyed to a `.since` class. That override now lives on `wa-badge[variant='neutral'][appearance='filled']`, so the category badge picks up the same treatment automatically. `.pro`, `.free`, and `.planned` all carry their own class-based backgrounds and are unaffected.

### Heads Up

The pro repo's components index card needs to use the renamed macro at the same time this lands — see shoelace-style/webawesome-pro#224.