### PR TITLE
fix(zoomable-frame): Import wa-icon to prevent missing icon rendering

### DIFF
--- a/packages/webawesome/src/components/zoomable-frame/zoomable-frame.ts
+++ b/packages/webawesome/src/components/zoomable-frame/zoomable-frame.ts
@@ -6,6 +6,7 @@ import { ColorSchemeController } from '../../internal/color-scheme-controller.js
 import { parseSpaceDelimitedTokens } from '../../internal/parse.js';
 import WebAwesomeElement from '../../internal/webawesome-element.js';
 import { LocalizeController } from '../../utilities/localize.js';
+import '../icon/icon.js';
 import styles from './zoomable-frame.styles.js';
 
 /**


### PR DESCRIPTION
## Summary

This PR fixes a regression in `wa-zoomable-frame` where the zoom control icons (`plus`/`minus`) were not rendered because the `wa-icon` dependency was not guaranteed to be registered.

## Root cause
`wa-zoomable-frame` uses `<wa-icon>` in its zoom controls, but it did not explicitly import the icon module (`../icon/icon.js`). In environments where `wa-icon` was not already loaded globally, the icons failed to render.

## Fix
This change restores the missing dependency by explicitly importing `wa-icon`:
```
import '../icon/icon.js';
```

This ensures the custom element is registered when `wa-zoomable-frame` is used in isolation or in modular builds where tree-shaking may otherwise omit side-effect imports.

## Impact
Zoom in/out icons (`plus` / `minus`) are now consistently rendered

Fixes #2455