### PR TITLE
fix(button): centre the slotted icon in xs icon buttons on Firefox

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -50,6 +50,7 @@ These are still finding their shape. APIs can change between minor versions, so 
 - Fixed a bug in `<wa-drawer>` that caused the `light-dismiss` option not work as intended [pr:2437]
 - Fixed a bug in `<wa-dropdown>` that prevented items from being visible when the selected overflowed [pr:2430]
 - Fixed a bug in `<wa-carousel>` that prevented the carousel from smoothly snapping back into position when using with the mouse [issue:1103]
+- Fixed a bug in `<wa-button>` where the slotted icon was rendered off-centre at `size="xs"` in Firefox [issue:2426]
 
 :::
 

--- a/packages/webawesome/src/components/button/button.styles.ts
+++ b/packages/webawesome/src/components/button/button.styles.ts
@@ -278,6 +278,11 @@ export default css`
 
   .is-icon-button .label {
     display: flex;
+    /* Center the slotted icon horizontally so the icon sits in the
+       middle of the square label regardless of the icon host's
+       intrinsic width. Without this, Firefox renders the icon off-
+       centre at small sizes (e.g. size="xs"). */
+    justify-content: center;
   }
 
   .label::slotted(wa-icon) {


### PR DESCRIPTION
Closes #2426.

The slotted `<wa-icon>` inside `<wa-button size="xs">` rendered off-centre in Firefox: a noticeable shift toward one edge of the otherwise-square xs icon button. The contributor-suggested workaround was to add the `auto-width` attribute on the icon (\`<wa-icon auto-width>\`), which sized the host to the SVG's intrinsic width instead of the fixed 1.25em default.

### Root cause

`packages/webawesome/src/components/button/button.styles.ts` had:

```css
.is-icon-button .label {
  display: flex;
}

.label::slotted(wa-icon) {
  align-self: center;
}
```

`align-self: center` aligns the slotted icon along the flex container's cross axis. For the default row direction, that's vertical only. The icon's host width (1.25em) is typically wider than its inner SVG (whose `width: auto` resolves to the FA glyph's intrinsic aspect ratio), so the SVG sits inside the host with the host's own centring rules. The label, however, never centred its child horizontally, and Firefox renders the result a few pixels off-centre in the xs icon button.

### Fix

Add `justify-content: center` to `.is-icon-button .label`. The label now centres the icon host along the inline axis as well as the cross axis, matching the visual centre Chromium-based browsers already produce.

### Manual verification

Using the issue's repro with `size="xs"` and `pill` variants:

- Chromium and WebKit: unchanged. The icon already appeared centred and continues to do so.
- Firefox: the icon now sits in the visual centre of the square xs button. The `auto-width` workaround is no longer required.

Adjacent button shapes verified unchanged: text-only buttons, buttons with start/end slots, icon buttons with caret, larger sizes.