### PR TITLE
fix: scroll select typeahead matches into view

### DIFF
--- a/packages/webawesome/src/components/select/select.test.ts
+++ b/packages/webawesome/src/components/select/select.test.ts
@@ -622,6 +622,32 @@ describe('<wa-select>', () => {
           await el.updateComplete;
           expect(displayInput.getAttribute('aria-expanded')).to.equal('false');
         });
+
+        it('should scroll the matched option into view when typing', async () => {
+          const el = await fixture<WaSelect>(html`
+            <wa-select>
+              ${Array.from(
+                { length: 30 },
+                (_, index) => html`<wa-option value=${`option-${index}`}>Option ${index}</wa-option>`,
+              )}
+              <wa-option value="ghana">Ghana</wa-option>
+            </wa-select>
+          `);
+          const ghanaOption = el.querySelector<WaOption>('wa-option[value="ghana"]')!;
+
+          el.listbox.style.height = '120px';
+          await el.show();
+          await el.updateComplete;
+          el.listbox.scrollTop = 0;
+
+          el.focus();
+          await sendKeys({ press: 'g' });
+          await el.updateComplete;
+          await aTimeout(50);
+
+          expect(el.currentOption).to.equal(ghanaOption);
+          expect(el.listbox.scrollTop).to.be.greaterThan(0);
+        });
       });
 
       describe('form integration', () => {

--- a/packages/webawesome/src/components/select/select.ts
+++ b/packages/webawesome/src/components/select/select.ts
@@ -715,6 +715,10 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
       option.current = true;
       option.tabIndex = 0;
       option.focus({ preventScroll: true });
+
+      if (this.open && this.listbox && !this.listbox.hidden) {
+        scrollIntoView(option, this.listbox, 'vertical', 'auto');
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #2472.

When typeahead finds an option while the select popup is open, the matched option is now scrolled into the visible listbox area. This makes long option lists feel responsive because typing a hidden match no longer leaves the visible menu unchanged.

Also adds a regression test with a long option list to verify the matched option becomes current and the listbox scrolls.

Validation:
- SKIP_SLOW_STEPS=true npm run build
- CSR_ONLY=true npx web-test-runner --group select