### PR TITLE
Design Nits + Bits

### DIFF
--- a/packages/webawesome/docs/.eleventy.js
+++ b/packages/webawesome/docs/.eleventy.js
@@ -2,7 +2,7 @@ import { nanoid } from 'nanoid';
 import { parse as HTMLParse } from 'node-html-parser';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { anchorHeadingsTransformer } from './_transformers/anchor-headings.js';
+import { anchorHeadingsTransformer, createId } from './_transformers/anchor-headings.js';
 import { changelogListIconsTransformer } from './_transformers/changelog-list-icons.js';
 import { codeExamplesTransformer } from './_transformers/code-examples.js';
 import { copyCodeTransformer } from './_transformers/copy-code.js';
@@ -135,6 +135,8 @@ export default async function (eleventyConfig) {
   eleventyConfig.addFilter('stripExtension', string => path.parse(string + '').name);
   eleventyConfig.addFilter('stripPrefix', content => content.replace(/^wa-/, ''));
   eleventyConfig.addFilter('uniqueId', (_value, length = 8) => nanoid(length));
+  // Generates the same heading anchor id used by anchorHeadingsTransformer, so links can target headings reliably
+  eleventyConfig.addFilter('headingId', content => createId(String(content ?? '')));
 
   eleventyConfig.addGlobalData('eleventyComputed', {
     // Page title with smart + default site name formatting

--- a/packages/webawesome/docs/503.md
+++ b/packages/webawesome/docs/503.md
@@ -223,7 +223,7 @@ unlisted: true
   </header>
   <main id="content">
     <div class="content-container wa-stack wa-gap-xl wa-align-items-center">
-      <h1 class="font-brand wa-stack wa-gap-s heading heading-stacked"  style="text-align: center;">
+      <h1 class="font-brand wa-stack wa-gap-s heading heading-stacked wa-text-center">
         <span class="wa-heading-l heading-stacked-subtitle">
           under 
           <span class="wa-visually-hidden">maintenance</span>
@@ -237,7 +237,7 @@ unlisted: true
         </span>
         <span class="wa-heading-4xl heading-stacked-title">Hey! We're Workin&apos; Here</span>
       </h1>
-      <p class="copy wa-body-l line-length line-length-m" style="text-align: center;">Mind the <code>wa-gap</code>! webawesome.com is undergoing maintenance and will be back shortly.</p>
+      <p class="copy wa-body-l line-length line-length-m wa-text-center">Mind the <code>wa-gap</code>! webawesome.com is undergoing maintenance and will be back shortly.</p>
       <div class="wa-grid wa-gap-xl status">
         <wa-callout appearance="plain" variant="neutral">
           <wa-icon slot="icon" family="duotone" variant="regular" name="diamond-exclamation" class="icon-embiggen" style="--secondary-opacity: 1; --secondary-color: var(--wa-color-warning-fill-normal);"></wa-icon>

--- a/packages/webawesome/docs/_includes/base.njk
+++ b/packages/webawesome/docs/_includes/base.njk
@@ -69,7 +69,7 @@
   </script>
 </head>
 <body
-  class="layout-{{ layout | stripExtension }} page-{{ pageType }}{{ ' page-wide' if wide }}">
+  class="layout-{{ layout | stripExtension }} page-{{ pageType }}">
 
   {% set defaultWaPageAttributes = defaultWaPageAttributes or { view: 'desktop', 'disable-navigation-toggle': true,
   'mobile-breakpoint': 1180, 'disable-sticky': 'banner' } %}

--- a/packages/webawesome/docs/_includes/macros/component-badges.njk
+++ b/packages/webawesome/docs/_includes/macros/component-badges.njk
@@ -25,11 +25,11 @@ and `categories` are optional — card callers omit them and skip the link. #}
 {% if component.since %}
 {% if categories %}
 {# Pad 2-part versions (e.g. `3.6`) to match 3-part changelog headings (`## 3.6.0` → `#wa_360`).
-The anchor transform slugifies headings as `wa_<digits>`; if no match exists the link still lands on the changelog.
+The `headingId` filter mirrors the anchor transform's slug exactly; if no heading matches the link still lands on the changelog.
   Card callers omit `categories` and skip the link to avoid nesting anchors inside the card's outer link. #}
   {%- set sinceVersion = component.since -%}
   {%- if sinceVersion.split('.').length == 2 -%}{%- set sinceVersion = sinceVersion + '.0' -%}{%- endif -%}
-  <a class="component-since-link" href="/docs/resources/changelog#wa_{{ sinceVersion | replace('.', '') }}">
+  <a class="component-since-link" href="/docs/resources/changelog#{{ sinceVersion | headingId }}">
     <wa-badge variant="neutral" appearance="filled" pill>Since {{ component.since }}</wa-badge>
   </a>
   {% else %}

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -19,7 +19,7 @@
   Getting Started
 </h2>
 <ul>
-  <li><a href="/docs/">Installation</a></li>
+  <li><a href="/docs">Installation</a></li>
   <li><a href="/docs/usage">Usage</a></li>
   <li><a href="/docs/form-controls">Form Controls</a></li>
   <li><a href="/docs/localization">Localization</a></li>

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -32,14 +32,10 @@
     </span>
   </li>
   <li>
-    <span class="wa-split">
-      <a href="/docs/ssr">Server Rendering</a>
-      <wa-badge
-        variant="warning"
-        appearance="filled"
-        pill
-      ><wa-icon label="Experimental" name="flask"></wa-icon></wa-badge>
-    </span>
+    <a class="wa-cluster wa-gap-xs" href="/docs/ssr">
+      Server Rendering
+      <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
+    </a>
   </li>
 </ul>
 
@@ -85,12 +81,12 @@
 </h2>
 <ul>
     <li>
-      <a href="/docs/components/accordion/">
+      <a class="wa-cluster wa-gap-xs" href="/docs/components/accordion/">
         Accordion
         <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
       </a>
       <ul>
-        <li><a href="/docs/components/accordion-item">
+        <li><a class="wa-cluster wa-gap-xs" href="/docs/components/accordion-item">
           Accordion Item
           <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
         </a></li>
@@ -129,7 +125,7 @@
     </li>
     <li>
       <span class="wa-split">
-        <a href="/docs/components/date-picker/">
+        <a class="wa-cluster wa-gap-xs" href="/docs/components/date-picker/">
           Date Picker
           <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
         </a>
@@ -186,7 +182,7 @@
     </li>
     <li>
       <span class="wa-split">
-        <a href="/docs/components/video/">
+        <a class="wa-cluster wa-gap-xs" href="/docs/components/video/">
           Video
           <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
         </a>
@@ -195,7 +191,7 @@
     </li>
     <li>
       <span class="wa-split">
-        <a href="/docs/components/video-playlist/">
+        <a class="wa-cluster wa-gap-xs" href="/docs/components/video-playlist/">
           Video Playlist
           <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
         </a>
@@ -244,7 +240,7 @@
     <li><span class="is-planned wa-split">Data Grid <span>{{ plannedBadge("A Web Awesome Kickstarter stretch goal!") }}</span></span></li>
     <li>
       <span class="wa-split">
-        <a href="/docs/components/date-input">
+        <a class="wa-cluster wa-gap-xs" href="/docs/components/date-input">
           Date Input
           <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
         </a>
@@ -258,7 +254,7 @@
       </span>
     </li>
     <li><a href="/docs/components/input/">Input</a></li>
-    <li><a href="/docs/components/known-date/">
+    <li><a class="wa-cluster wa-gap-xs" href="/docs/components/known-date/">
       Known Date
       <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
     </a></li>
@@ -279,7 +275,7 @@
     <li><a href="/docs/components/slider/">Slider</a></li>
     <li><a href="/docs/components/switch/">Switch</a></li>
     <li><a href="/docs/components/textarea/">Textarea</a></li>
-    <li><a href="/docs/components/time-input/">
+    <li><a class="wa-cluster wa-gap-xs" href="/docs/components/time-input/">
       Time Input
       <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>
     </a></li>

--- a/packages/webawesome/docs/_transformers/anchor-headings.js
+++ b/packages/webawesome/docs/_transformers/anchor-headings.js
@@ -2,7 +2,7 @@ import { parse } from 'node-html-parser';
 import slugify from 'slugify';
 import { v4 as uuid } from 'uuid';
 
-function createId(text) {
+export function createId(text) {
   let slug = slugify(String(text), {
     remove: /[^\w|\s]/g,
     lower: true,

--- a/packages/webawesome/docs/_transformers/current-link.js
+++ b/packages/webawesome/docs/_transformers/current-link.js
@@ -24,7 +24,12 @@ function markCurrent(el, pageUrl, className) {
   if (href == null || href === '' || href.startsWith('#')) {
     return;
   }
-  if (normalize(href) === normalize(pageUrl)) {
+  const normalizedHref = normalize(href);
+  const normalizedPageUrl = normalize(pageUrl);
+  const isSectionLink = href.endsWith('/') && href !== '/';
+  const isExactMatch = normalizedHref === normalizedPageUrl;
+  const isChildOfSection = isSectionLink && normalizedPageUrl.startsWith(normalizedHref + '/');
+  if (isExactMatch || isChildOfSection) {
     el.classList.add(className);
   }
 }

--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -82,14 +82,8 @@ wa-page > main {
   margin-inline: auto;
 }
 
-/* increase max-inline-size for index pages */
-wa-page > main:has(.modern-card-list) {
-  max-inline-size: var(--content-width-m);
-}
-
 /* The docs main column is wider than `wa-prose`'s default 65ch. Anchor the
-   reading-column custom property to the docs token so existing layouts —
-   default, modern-card-list, and page-wide — keep their established widths. */
+   reading-column custom property to the docs token to keep the established width. */
 #content {
   --wa-prose-line-length: var(--content-width-s);
 
@@ -519,16 +513,6 @@ wa-scroller:has(.component-table) {
 @media screen and (min-width: 73.75rem) {
   wa-page > main {
     padding: var(--wa-space-3xl);
-  }
-}
-
-.page-wide {
-  wa-page > main {
-    max-inline-size: var(--content-width-l);
-
-    .max-line-length {
-      max-inline-size: var(--line-length-l);
-    }
   }
 }
 

--- a/packages/webawesome/docs/docs/components/divider.md
+++ b/packages/webawesome/docs/docs/components/divider.md
@@ -41,7 +41,7 @@ Use the `--color` custom property to change the color of the divider.
 Use the `--spacing` custom property to change the amount of space between the divider and it's neighboring elements.
 
 ```html {.example}
-<div style="text-align: center;">
+<div class="wa-text-center">
   Above
   <wa-divider style="--spacing: 2rem;"></wa-divider>
   Below

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -6,13 +6,26 @@ layout: page-outline
 
 {% from "macros/component-badges.njk" import statusBadge %}
 
-Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Semantic Versioning</a>, and each release on this page follows the <a href="https://keepachangelog.com/" class="appearance-plain">Keep a Changelog</a> convention. Each [component](/docs/components) carries a status badge that tells you what to expect from its API.
+Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Semantic Versioning</a>, and each release on this page follows the <a href="https://keepachangelog.com/" class="appearance-plain">Keep a Changelog</a> convention. Additionally, both [components](/docs/components) and features carry a status badge that tells you what to expect from their API.
 
-<h2 class="wa-heading-m wa-cluster wa-gap-s" data-no-anchor data-no-outline>Stable Components {{ statusBadge('stable') }}</h2>
-These have a settled API. Breaking changes land only in major versions, and deprecated features stay through the next major release.
-
-<h2 class="wa-heading-m wa-cluster wa-gap-s" data-no-anchor data-no-outline>Experimental Components {{ statusBadge('experimental') }}</h2>
-These are still finding their shape. APIs can change between minor versions, so use them in prototypes — not production code you can't easily update.
+<table>
+  <thead>
+    <tr>
+      <th>Status</th>
+      <th>What to Expect</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{ statusBadge('stable') }}</td>
+      <td>A settled API you can build on. Breaking changes land only in major releases, and anything deprecated stays available through the next major version. Safe for production.</td>
+    </tr>
+    <tr>
+      <td>{{ statusBadge('experimental') }}</td>
+      <td>Still taking shape. The API can change in any minor release, so it's ideal for prototyping — but risky for production code you can't easily update.</td>
+    </tr>
+  </tbody>
+</table>
 
 {% include "changelog-email-signup.njk" %}
 

--- a/packages/webawesome/docs/docs/resources/visual-tests.md
+++ b/packages/webawesome/docs/docs/resources/visual-tests.md
@@ -2,7 +2,6 @@
 title: Visual Tests
 description: A page to visually test component styles against native styles.
 layout: page
-wide: true
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/ssr.md
+++ b/packages/webawesome/docs/docs/ssr.md
@@ -13,18 +13,14 @@ layout: page-outline
 <p>Server Side Rendering ("SSR") means your webpage is rendered on the server before being sent to the user's browser. This provides a fully formed HTML page right from the start, which is great for SEO and initial load times. Once the page is rendered, JavaScript kicks in to "hydrate" the components which makes them interactive. The Web platform supports this through a feature called <a href="https://web.dev/articles/declarative-shadow-dom">Declarative Shadow DOM</a></p>
 
 :::warning
-**SSR is experimental.**
-Be mindful of [known bugs and timing issues](#known-issues). This status is also partially due to Lit's SSR package being experimental.
-
-**Notice a bug that we didn't?**
-[Report the issue on GitHub](https://github.com/shoelace-style/webawesome/issues).
+**SSR is experimental**, in part because Lit's SSR package is too. Watch for [known bugs and timing issues](#known-issues), and please [report anything new on GitHub](https://github.com/shoelace-style/webawesome/issues).
 :::
 
 ## Goals of SSR
 
-The goal of SSR in Web Awesome currently is reduce layout shifting and provide a rough approximation of the final component once the JavaScript for the component is ready, they are **NOT** meant to be components that fully work without JavaScript.
+The goal of SSR in Web Awesome currently is to reduce layout shifting and provide a rough approximation of the final component until its JavaScript is ready. SSR components are **NOT** meant to fully work without JavaScript.
 
-Progressive enhancement is _not_ a goal of Web Awesome (currently). This is partially because for form controls in particular, there is no browser API to "hoist" form controls from the shadow root. Other reasons is there are certain components like `<wa-chart>`, `<wa-qr-code>`, etc that depend on browser APIs like `<canvas>` being available.
+Progressive enhancement is _not_ a goal of Web Awesome (currently). This is partially because, for form controls in particular, there is no browser API to "hoist" form controls from the shadow root. Another reason is that certain components like `<wa-chart>` and `<wa-qr-code>` depend on browser APIs like `<canvas>` being available.
 
 ## Enable Hydration
 
@@ -79,10 +75,12 @@ All Web Awesome components that get rendered for SSR will receive the `did-ssr` 
 <wa-button appearance="filled" did-ssr></wa-button>
 ```
 
-This can help if you need some styling prior to the element connecting. Such as:
+This can help you style elements before they connect. For example, you can hide custom elements that _weren't_ server-rendered until they're defined, so SSR'd elements still show their pre-hydration markup:
 
 ```css
-[did-ssr]:not(:defined) {
+/* Avoid a flash of unstyled content for elements that weren't server-rendered. */
+:not([did-ssr]):not(:defined) {
+  visibility: hidden;
 }
 ```
 
@@ -132,11 +130,13 @@ function fixDeclarativeShadowDOM(e) {
 });
 ```
 
-### The `with-*` Attributes
+## The `with-*` Attributes
 
 Some components use slot detection to conditionally render parts of their template. For example, `<wa-dialog>` only renders its footer when a `footer` slot is present. During SSR, slot detection doesn't work because the DOM isn't available, so these parts would be missing from the initial server-rendered markup.
 
 To solve this, components that rely on slot detection provide `with-*` attributes. These tell the component to render the relevant section during SSR, before hydration kicks in and slot detection takes over.
+
+Not every component has `with-*` attributes—only those that conditionally render parts based on slot content. Check a component's documentation to see which `with-*` attributes it supports.
 
 ```html
 <!-- Without with-footer, the footer won't appear in the server-rendered HTML -->
@@ -150,19 +150,7 @@ To solve this, components that rely on slot detection provide `with-*` attribute
 
 These attributes are only needed for SSR. After the component hydrates on the client, slot detection works normally and the attributes have no effect.
 
-#### For Contributors
-
-When adding slot detection to a component's render method using `HasSlotController`, always include an SSR fallback using the `hasUpdated` ternary pattern:
-
-```ts
-// Add a with-* property
-@property({ attribute: 'with-label', type: Boolean }) withLabel = false;
-
-// In render(), fall back to the with-* property before the component has hydrated
-const hasLabelSlot = this.hasUpdated
-  ? this.hasSlotController.test('label')
-  : this.withLabel;
-```
+Contributing a component that needs a `with-*` fallback? See [Server-Side Rendering in the contributing guide](/docs/resources/contributing#server-side-rendering-ssr) for the implementation pattern.
 
 ## Known Issues
 

--- a/packages/webawesome/docs/docs/ssr.md
+++ b/packages/webawesome/docs/docs/ssr.md
@@ -4,10 +4,8 @@ description: A document on how to get started with SSR in Web Awesome.
 layout: page-outline
 ---
 
-
 <wa-badge variant="warning" appearance="filled" pill>
-  Experimental
-  <wa-icon name="flask"></wa-icon>
+  <wa-icon name="flask" slot="start"></wa-icon>Experimental
 </wa-badge>
 <br><br>
 <p>Server Side Rendering ("SSR") means your webpage is rendered on the server before being sent to the user's browser. This provides a fully formed HTML page right from the start, which is great for SEO and initial load times. Once the page is rendered, JavaScript kicks in to "hydrate" the components which makes them interactive. The Web platform supports this through a feature called <a href="https://web.dev/articles/declarative-shadow-dom">Declarative Shadow DOM</a></p>

--- a/packages/webawesome/docs/docs/tokens/index.njk
+++ b/packages/webawesome/docs/docs/tokens/index.njk
@@ -2,7 +2,6 @@
 title: Design Tokens
 description: CSS custom properties that control the look and feel of every Web Awesome component, giving your theme a consistent, customizable appearance.
 layout: page-outline
-wide: true
 hasBreadcrumbs: false
 hasOutline: false
 override:tags: []

--- a/packages/webawesome/docs/docs/utilities/prose.md
+++ b/packages/webawesome/docs/docs/utilities/prose.md
@@ -236,7 +236,7 @@ Set `--wa-prose-rhythm-scale` on the prose container to multiply every margin in
 
 ## Composing with other utilities
 
-The `wa-prose` class and its element rules sit at `0,0,0` specificity, so any utility class you apply alongside — `wa-heading-m`, `wa-cluster`, `wa-text-align-center`, and so on — wins automatically. The same goes for plain element rules in your own stylesheet, no `!important` or specificity tricks required.
+The `wa-prose` class and its element rules sit at `0,0,0` specificity, so any utility class you apply alongside — `wa-heading-m`, `wa-cluster`, `wa-text-center`, and so on — wins automatically. The same goes for plain element rules in your own stylesheet, no `!important` or specificity tricks required.
 
 ```css
 /* Wins against wa-prose's `h2 { font-size: 2em }` */


### PR DESCRIPTION
This is another series of design-minded NITs...

### Sidebar polish

The current-link transformer now matches "section root" hrefs (those ending in `/`) against any pageUrl beneath them, so a section root stays highlighted while you're reading any child page; exact-match behavior is preserved for non-section hrefs. The "experimental" indicator across `sidebar.njk` is standardized so each treatment matches.

### Changelog deep-links

A shared `createId` helper is lifted out of the anchor-headings transformer and exposed as a Nunjucks `headingId` filter, so templates can generate the exact same anchor slug as the generated heading ids. The component "Since" badge links use the new filter instead of hand-rolling the `wa_` prefix + dot-stripping, keeping the deep-link in lockstep with the heading it points at. The changelog page's status formatting and inline explanation are also tightened.

### SSR docs cleanup

The SSR page picks up a single-sentence experimental warning, tighter Goals copy, a corrected `did-ssr` CSS example that no longer hides server-rendered content, and a top-level "with-* attributes" section noting that coverage varies by component. Contributor implementation guidance that duplicated the contributing guide is replaced with a link to it.

### Width + utility cleanup

`wide: true` frontmatter is dropped from the tokens index and visual-tests page, the `.page-wide` rule is removed, and the `:has(.modern-card-list)` auto-widening on index pages goes with it. Standalone `text-align: center` rules in the divider example wrapper and 503 page swap to `wa-text-center`, and a stale `wa-text-align-center` reference in the prose docs is corrected.

## Companion PRs
- https://github.com/shoelace-style/webawesome-pro/pull/232
- https://github.com/shoelace-style/webawesome-app/pull/383