### PR TITLE
Docs: Update Metadata

### DIFF
--- a/packages/webawesome/docs/_data/componentCategories.json
+++ b/packages/webawesome/docs/_data/componentCategories.json
@@ -1,10 +1,10 @@
 [
   { "label": "Actions", "slug": "actions", "icon": "hand-pointer" },
-  { "label": "Feedback", "slug": "feedback", "icon": "comments" },
+  { "label": "Feedback", "slug": "feedback", "icon": "bell" },
   { "label": "Forms", "slug": "forms", "icon": "pen-field" },
-  { "label": "Media", "slug": "media", "icon": "image" },
+  { "label": "Media", "slug": "media", "icon": "photo-film" },
   { "label": "Navigation", "slug": "navigation", "icon": "compass" },
   { "label": "Layout", "slug": "layout", "icon": "layer" },
-  { "label": "Utilities", "slug": "utilities", "icon": "wrench" },
+  { "label": "Helpers", "slug": "helpers", "icon": "wrench" },
   { "label": "Data Viz", "slug": "data-viz", "icon": "chart-line" }
 ]

--- a/packages/webawesome/docs/_data/componentCategories.json
+++ b/packages/webawesome/docs/_data/componentCategories.json
@@ -1,10 +1,10 @@
 [
   { "label": "Actions", "slug": "actions", "icon": "hand-pointer" },
-  { "label": "Feedback", "slug": "feedback", "icon": "bell" },
   { "label": "Forms", "slug": "forms", "icon": "pen-field" },
-  { "label": "Media", "slug": "media", "icon": "photo-film" },
-  { "label": "Navigation", "slug": "navigation", "icon": "compass" },
   { "label": "Layout", "slug": "layout", "icon": "layer" },
-  { "label": "Helpers", "slug": "helpers", "icon": "wrench" },
-  { "label": "Data Viz", "slug": "data-viz", "icon": "chart-line" }
+  { "label": "Navigation", "slug": "navigation", "icon": "compass" },
+  { "label": "Feedback", "slug": "feedback", "icon": "bell" },
+  { "label": "Media", "slug": "media", "icon": "photo-film" },
+  { "label": "Data Viz", "slug": "data-viz", "icon": "chart-line" },
+  { "label": "Helpers", "slug": "helpers", "icon": "wrench" }
 ]

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -21,7 +21,7 @@
 <ul>
   <li><a href="/docs/">Installation</a></li>
   <li><a href="/docs/usage">Usage</a></li>
-  <li><a href="/docs/form-controls">Form Controls</a></li>
+  <li><a href="/docs/form-controls">Forms</a></li>
   <li><a href="/docs/localization">Localization</a></li>
   <li><a href="/docs/frameworks/">Frameworks</a></li>
   <li><a href="/docs/ai">Using with AI</a></li>

--- a/packages/webawesome/docs/docs/components/accordion-item.md
+++ b/packages/webawesome/docs/docs/components/accordion-item.md
@@ -1,7 +1,7 @@
 ---
 title: Accordion Item
 layout: component
-category: Organization
+category: Layout
 synonyms:
   - collapsible section
   - expandable section

--- a/packages/webawesome/docs/docs/components/accordion-item.md
+++ b/packages/webawesome/docs/docs/components/accordion-item.md
@@ -6,7 +6,10 @@ synonyms:
   - collapsible section
   - expandable section
   - disclosure item
+  - panel
+  - expandable panel
 use-cases:
+  - FAQ entry
   - FAQ item
   - settings section
   - collapsible content

--- a/packages/webawesome/docs/docs/components/accordion.md
+++ b/packages/webawesome/docs/docs/components/accordion.md
@@ -7,6 +7,8 @@ synonyms:
   - expandable
   - disclosure
   - FAQ
+  - panel group
+  - details list
 use-cases:
   - FAQ sections
   - settings panel

--- a/packages/webawesome/docs/docs/components/accordion.md
+++ b/packages/webawesome/docs/docs/components/accordion.md
@@ -1,7 +1,7 @@
 ---
 title: Accordion
 layout: component
-category: Organization
+category: Layout
 synonyms:
   - collapsible
   - expandable
@@ -59,9 +59,7 @@ Use the `disabled` attribute on an accordion item to prevent it from being toggl
   <wa-accordion-item label="Active item" expanded>
     This item can be expanded and collapsed normally.
   </wa-accordion-item>
-  <wa-accordion-item label="Disabled item" disabled>
-    This item is disabled and cannot be toggled.
-  </wa-accordion-item>
+  <wa-accordion-item label="Disabled item" disabled> This item is disabled and cannot be toggled. </wa-accordion-item>
 </wa-accordion>
 ```
 
@@ -73,12 +71,8 @@ But if an accordion lives outside the document outline, for example, inside a na
 
 ```html {.example}
 <wa-accordion heading-level="none">
-  <wa-accordion-item label="Settings">
-    Adjust your preferences here.
-  </wa-accordion-item>
-  <wa-accordion-item label="Notifications">
-    Manage how and when you receive notifications.
-  </wa-accordion-item>
+  <wa-accordion-item label="Settings"> Adjust your preferences here. </wa-accordion-item>
+  <wa-accordion-item label="Notifications"> Manage how and when you receive notifications. </wa-accordion-item>
 </wa-accordion>
 ```
 
@@ -88,9 +82,7 @@ The default heading level is `3`. Use `heading-level` on the accordion to match 
 
 ```html {.example}
 <wa-accordion heading-level="2">
-  <wa-accordion-item label="Section one">
-    This trigger is wrapped in an <code>&lt;h2&gt;</code>.
-  </wa-accordion-item>
+  <wa-accordion-item label="Section one"> This trigger is wrapped in an <code>&lt;h2&gt;</code>. </wa-accordion-item>
   <wa-accordion-item label="Section two">
     Match the level to where this accordion sits in your document outline.
   </wa-accordion-item>
@@ -103,27 +95,21 @@ The accordion's text and expand/collapse icon scale with `font-size`. Setting `f
 
 ```html {.example}
 <wa-accordion style="font-size: 0.875rem;">
-  <wa-accordion-item label="Small accordion">
-    Text and icon scale down together.
-  </wa-accordion-item>
+  <wa-accordion-item label="Small accordion"> Text and icon scale down together. </wa-accordion-item>
   <wa-accordion-item label="Another item">Content here.</wa-accordion-item>
 </wa-accordion>
 
 <br />
 
 <wa-accordion>
-  <wa-accordion-item label="Default accordion">
-    The default size.
-  </wa-accordion-item>
+  <wa-accordion-item label="Default accordion"> The default size. </wa-accordion-item>
   <wa-accordion-item label="Another item">Content here.</wa-accordion-item>
 </wa-accordion>
 
 <br />
 
 <wa-accordion style="font-size: 1.25rem;">
-  <wa-accordion-item label="Large accordion">
-    Everything scales up together.
-  </wa-accordion-item>
+  <wa-accordion-item label="Large accordion"> Everything scales up together. </wa-accordion-item>
   <wa-accordion-item label="Another item">Content here.</wa-accordion-item>
 </wa-accordion>
 ```
@@ -143,14 +129,16 @@ Use the `appearance` attribute to change the accordion's visual appearance.
 
   <wa-accordion appearance="filled-outlined">
     <wa-accordion-item label="Filled-outlined">
-      The filled-outlined appearance combines a filled header with an outlined body. It gives the summary a bit more visual weight while keeping the content area clean.
+      The filled-outlined appearance combines a filled header with an outlined body. It gives the summary a bit more
+      visual weight while keeping the content area clean.
     </wa-accordion-item>
     <wa-accordion-item label="Another item">More content here.</wa-accordion-item>
   </wa-accordion>
 
   <wa-accordion appearance="filled">
     <wa-accordion-item label="Filled">
-      The filled appearance adds a background color to the entire component. Use this when you want the details to really pop on the page.
+      The filled appearance adds a background color to the entire component. Use this when you want the details to
+      really pop on the page.
     </wa-accordion-item>
     <wa-accordion-item label="Another item">More content here.</wa-accordion-item>
   </wa-accordion>
@@ -193,12 +181,8 @@ Use `single-collapsible` when you want the same one-at-a-time constraint but sti
   <wa-accordion-item label="Filters">
     Opening another section will collapse this one, and clicking the open section closes it.
   </wa-accordion-item>
-  <wa-accordion-item label="Sort">
-    Try opening and closing each section in turn.
-  </wa-accordion-item>
-  <wa-accordion-item label="Display">
-    Zero open sections is a valid state in this mode.
-  </wa-accordion-item>
+  <wa-accordion-item label="Sort"> Try opening and closing each section in turn. </wa-accordion-item>
+  <wa-accordion-item label="Display"> Zero open sections is a valid state in this mode. </wa-accordion-item>
 </wa-accordion>
 ```
 
@@ -336,9 +320,7 @@ Listen for the `wa-expand` or `wa-collapse` events and call `event.preventDefaul
   <wa-accordion-item label="Locked open" expanded>
     This item is locked open — the <code>wa-collapse</code> event is being intercepted and prevented.
   </wa-accordion-item>
-  <wa-accordion-item label="Works normally">
-    This item can be toggled normally.
-  </wa-accordion-item>
+  <wa-accordion-item label="Works normally"> This item can be toggled normally. </wa-accordion-item>
 </wa-accordion>
 
 <script>

--- a/packages/webawesome/docs/docs/components/animation.md
+++ b/packages/webawesome/docs/docs/components/animation.md
@@ -1,7 +1,7 @@
 ---
 title: Animation
 layout: component
-category: Utilities
+category: Helpers
 synonyms:
   - motion
   - transition

--- a/packages/webawesome/docs/docs/components/format-bytes.md
+++ b/packages/webawesome/docs/docs/components/format-bytes.md
@@ -1,7 +1,7 @@
 ---
 title: Format Bytes
 layout: component
-category: Utilities
+category: Helpers
 synonyms:
   - file size
   - byte formatter

--- a/packages/webawesome/docs/docs/components/format-date.md
+++ b/packages/webawesome/docs/docs/components/format-date.md
@@ -1,7 +1,7 @@
 ---
 title: Format Date
 layout: component
-category: Utilities
+category: Helpers
 synonyms:
   - date formatter
   - time formatter

--- a/packages/webawesome/docs/docs/components/format-number.md
+++ b/packages/webawesome/docs/docs/components/format-number.md
@@ -1,7 +1,7 @@
 ---
 title: Format Number
 layout: component
-category: Utilities
+category: Helpers
 synonyms:
   - number formatter
   - currency

--- a/packages/webawesome/docs/docs/components/include.md
+++ b/packages/webawesome/docs/docs/components/include.md
@@ -1,7 +1,7 @@
 ---
 title: Include
 layout: component
-category: Utilities
+category: Helpers
 synonyms:
   - html include
   - embed

--- a/packages/webawesome/docs/docs/components/intersection-observer.md
+++ b/packages/webawesome/docs/docs/components/intersection-observer.md
@@ -1,7 +1,7 @@
 ---
 title: Intersection Observer
 layout: component
-category: Utilities
+category: Helpers
 synonyms:
   - scroll spy
   - lazy load trigger

--- a/packages/webawesome/docs/docs/components/known-date.md
+++ b/packages/webawesome/docs/docs/components/known-date.md
@@ -1,7 +1,7 @@
 ---
 title: Known Date
 layout: component
-category: Form Controls
+category: Forms
 synonyms:
   - dmy input
   - birthday input

--- a/packages/webawesome/docs/docs/components/known-date.md
+++ b/packages/webawesome/docs/docs/components/known-date.md
@@ -6,10 +6,15 @@ synonyms:
   - dmy input
   - birthday input
   - date fields
+  - split date input
+  - gov.uk date input
+  - manual date entry
 use-cases:
   - capture birthdays
   - capture passport and document dates
   - capture any date the user already knows
+  - issue date entry
+  - expiration date entry
 ---
 
 Known Date collects a date the user already knows — a birthday, a passport issue date, an expiration — through three separate fields for day, month, and year. It follows the [UK Government Design System date input pattern](https://design-system.service.gov.uk/components/date-input/): a labeled `<fieldset>` wraps three plain `<input>` elements, the user types each part themselves, and the host submits a single canonical ISO date.

--- a/packages/webawesome/docs/docs/components/markdown.md
+++ b/packages/webawesome/docs/docs/components/markdown.md
@@ -6,10 +6,16 @@ synonyms:
   - md
   - markdown renderer
   - rich text
+  - gfm
+  - marked.js
+  - rendered markdown
 use-cases:
   - markdown display
   - markdown preview
   - content rendering
+  - documentation pages
+  - blog post rendering
+  - readme display
 ---
 
 The markdown component turns raw markdown into rendered HTML using the [Marked](https://marked.js.org/) library. Indentation is handled automatically. You can nest your markdown at any depth to match the surrounding HTML structure and the common leading whitespace will be stripped before parsing.

--- a/packages/webawesome/docs/docs/components/markdown.md
+++ b/packages/webawesome/docs/docs/components/markdown.md
@@ -1,7 +1,7 @@
 ---
 title: Markdown
 layout: component
-category: Utilities
+category: Media
 synonyms:
   - md
   - markdown renderer
@@ -19,7 +19,7 @@ The markdown component turns raw markdown into rendered HTML using the [Marked](
   <script type="text/markdown">
     ## Getting Started
 
-    Here's a quick overview with **bold**, *italic*, and `inline code`.
+    Here's a quick overview with **bold**, _italic_, and `inline code`.
 
     - Install the package
     - Import the component
@@ -27,7 +27,6 @@ The markdown component turns raw markdown into rendered HTML using the [Marked](
   </script>
 </wa-markdown>
 ```
-
 
 :::info
 Since content is rendered client-side, it won't be visible to search engine crawlers or available before JavaScript loads. This makes it a poor fit for SEO-critical content like landing pages and blog posts. It's best suited for prototyping, dashboards, admin panels, and other contexts where search indexing isn't a concern.
@@ -67,13 +66,13 @@ This means you can write markdown at any indentation level and it will render co
 ```html {.example .no-edit}
 <wa-markdown>
   <script type="text/markdown">
-            ## Deeply Indented
+    ## Deeply Indented
 
-            Even though this content is heavily indented in the source,
-            the shared whitespace is stripped before parsing.
+    Even though this content is heavily indented in the source,
+    the shared whitespace is stripped before parsing.
 
-                Lines with extra indentation beyond the common
-                prefix are preserved, like this code block.
+        Lines with extra indentation beyond the common
+        prefix are preserved, like this code block.
   </script>
 </wa-markdown>
 ```
@@ -134,7 +133,7 @@ All `<wa-markdown>` instances share a single [Marked](https://marked.js.org/usin
     link(href, title, text) {
       const titleAttr = title ? ` title="${title}"` : '';
       return `<a href="${href}"${titleAttr} target="_blank" rel="noopener">${text}</a>`;
-    }
+    },
   };
 
   md.marked.use({ renderer });
@@ -162,24 +161,28 @@ Custom [Marked extensions](https://marked.js.org/using_advanced#extensions) can 
   const md = document.getElementById('markdown__plugin');
 
   const highlight = {
-    extensions: [{
-      name: 'highlight',
-      level: 'inline',
-      start(src) { return src.indexOf('=='); },
-      tokenizer(src) {
-        const match = src.match(/^==([^=]+)==/);
-        if (match) {
-          return {
-            type: 'highlight',
-            raw: match[0],
-            text: match[1]
-          };
-        }
+    extensions: [
+      {
+        name: 'highlight',
+        level: 'inline',
+        start(src) {
+          return src.indexOf('==');
+        },
+        tokenizer(src) {
+          const match = src.match(/^==([^=]+)==/);
+          if (match) {
+            return {
+              type: 'highlight',
+              raw: match[0],
+              text: match[1],
+            };
+          }
+        },
+        renderer(token) {
+          return `<mark>${token.text}</mark>`;
+        },
       },
-      renderer(token) {
-        return `<mark>${token.text}</mark>`;
-      }
-    }]
+    ],
   };
 
   md.marked.use(highlight);
@@ -198,7 +201,7 @@ The component parses and renders automatically when the script element is first 
       Click the button to swap this content out.
     </script>
   </wa-markdown>
-  <br>
+  <br />
   <wa-button>Update content</wa-button>
 </div>
 

--- a/packages/webawesome/docs/docs/components/mutation-observer.md
+++ b/packages/webawesome/docs/docs/components/mutation-observer.md
@@ -1,7 +1,7 @@
 ---
 title: Mutation Observer
 layout: component
-category: Utilities
+category: Helpers
 synonyms:
   - dom watcher
   - dom observer

--- a/packages/webawesome/docs/docs/components/popover.md
+++ b/packages/webawesome/docs/docs/components/popover.md
@@ -1,7 +1,7 @@
 ---
 title: Popover
 layout: component
-category: Utilities
+category: Helpers
 synonyms:
   - popup content
   - info popup

--- a/packages/webawesome/docs/docs/components/popup.md
+++ b/packages/webawesome/docs/docs/components/popup.md
@@ -1,7 +1,7 @@
 ---
 title: Popup
 layout: component
-category: Utilities
+category: Helpers
 synonyms:
   - floating element
   - anchor
@@ -28,7 +28,12 @@ Popup is a low-level utility built specifically for positioning elements. Do not
   </wa-popup>
 
   <div class="popup-overview-options">
-    <wa-combobox label="Placement" name="placement" placeholder="Select placement..." class="popup-overview-select"></wa-combobox>
+    <wa-combobox
+      label="Placement"
+      name="placement"
+      placeholder="Select placement..."
+      class="popup-overview-select"
+    ></wa-combobox>
     <wa-input type="number" name="distance" label="distance" value="0"></wa-input>
     <wa-input type="number" name="skidding" label="Skidding" value="0"></wa-input>
   </div>
@@ -51,7 +56,20 @@ Popup is a low-level utility built specifically for positioning elements. Do not
   const active = container.querySelector('wa-switch[name="active"]');
   const arrow = container.querySelector('wa-switch[name="arrow"]');
 
-  const placements = ['top', 'top-start', 'top-end', 'bottom', 'bottom-start', 'bottom-end', 'right', 'right-start', 'right-end', 'left', 'left-start', 'left-end'];
+  const placements = [
+    'top',
+    'top-start',
+    'top-end',
+    'bottom',
+    'bottom-start',
+    'bottom-end',
+    'right',
+    'right-start',
+    'right-end',
+    'left',
+    'left-start',
+    'left-end',
+  ];
 
   placements.forEach(value => {
     const option = document.createElement('wa-option');
@@ -233,7 +251,20 @@ Since placement is preferred when using `flip`, you can observe the popup's curr
   const popup = container.querySelector('wa-popup');
   const placement = container.querySelector('wa-combobox');
 
-  const placements = ['top', 'top-start', 'top-end', 'bottom', 'bottom-start', 'bottom-end', 'right', 'right-start', 'right-end', 'left', 'left-start', 'left-end'];
+  const placements = [
+    'top',
+    'top-start',
+    'top-end',
+    'bottom',
+    'bottom-start',
+    'bottom-end',
+    'right',
+    'right-start',
+    'right-end',
+    'left',
+    'left-start',
+    'left-end',
+  ];
 
   placements.forEach(value => {
     const option = document.createElement('wa-option');
@@ -352,7 +383,12 @@ By default, the arrow will be aligned as close to the center of the _anchor_ as 
   </wa-popup>
 
   <div class="popup-arrow-options">
-    <wa-combobox label="Placement" name="placement" placeholder="Select placement..." class="popup-overview-select"></wa-combobox>
+    <wa-combobox
+      label="Placement"
+      name="placement"
+      placeholder="Select placement..."
+      class="popup-overview-select"
+    ></wa-combobox>
 
     <wa-select label="Arrow Placement" name="arrow-placement" value="anchor">
       <wa-option value="anchor">anchor</wa-option>
@@ -413,7 +449,20 @@ By default, the arrow will be aligned as close to the center of the _anchor_ as 
     const arrowPlacement = container.querySelector('wa-select[name="arrow-placement"]');
     const arrow = container.querySelector('[name="arrow"]');
 
-    const placements = ['top', 'top-start', 'top-end', 'bottom', 'bottom-start', 'bottom-end', 'right', 'right-start', 'right-end', 'left', 'left-start', 'left-end'];
+    const placements = [
+      'top',
+      'top-start',
+      'top-end',
+      'bottom',
+      'bottom-start',
+      'bottom-end',
+      'right',
+      'right-start',
+      'right-end',
+      'left',
+      'left-start',
+      'left-end',
+    ];
 
     placements.forEach(value => {
       const option = document.createElement('wa-option');
@@ -447,11 +496,15 @@ When adding borders to the popup element which has an arrow, make sure to set th
   </wa-popup>
 
   <div class="popup-border-options">
-    <wa-combobox label="Placement" name="placement" placeholder="Select placement..." class="popup-overview-select"></wa-combobox>
+    <wa-combobox
+      label="Placement"
+      name="placement"
+      placeholder="Select placement..."
+      class="popup-overview-select"
+    ></wa-combobox>
   </div>
 
   <style>
-
     .popup-border span[slot='anchor'] {
       display: inline-block;
       width: 150px;
@@ -499,7 +552,20 @@ When adding borders to the popup element which has an arrow, make sure to set th
     const popup = container.querySelector('wa-popup');
     const placement = container.querySelector('wa-combobox[name="placement"]');
 
-    const placements = ['top', 'top-start', 'top-end', 'bottom', 'bottom-start', 'bottom-end', 'right', 'right-start', 'right-end', 'left', 'left-start', 'left-end'];
+    const placements = [
+      'top',
+      'top-start',
+      'top-end',
+      'bottom',
+      'bottom-start',
+      'bottom-end',
+      'right',
+      'right-start',
+      'right-end',
+      'left',
+      'left-start',
+      'left-end',
+    ];
 
     placements.forEach(value => {
       const option = document.createElement('wa-option');
@@ -570,6 +636,7 @@ Use the `sync` attribute to make the popup the same width or height as the ancho
   sync.addEventListener('change', () => (popup.sync = sync.value));
 </script>
 ```
+
 #}
 
 ### Flip

--- a/packages/webawesome/docs/docs/components/qr-code.md
+++ b/packages/webawesome/docs/docs/components/qr-code.md
@@ -1,7 +1,7 @@
 ---
 title: QR Code
 layout: component
-category: Actions
+category: Media
 synonyms:
   - barcode
   - quick response code
@@ -32,7 +32,7 @@ QR codes are useful for providing small pieces of information to users who can q
     qrCode.updateComplete.then(() => {
       input.value = qrCode.value;
       input.addEventListener('input', () => (qrCode.value = input.value));
-    })
+    });
   });
 </script>
 
@@ -82,10 +82,7 @@ A _quiet zone_ is the blank space around a QR code that helps scanners detect it
 You can change the color of the corners to be different from the main element with the `--corner-color` custom property.
 
 ```html {.example}
-<wa-qr-code
-  value="https://webawesome.com/"
-  style="--corner-color: var(--wa-color-brand)"
-></wa-qr-code>
+<wa-qr-code value="https://webawesome.com/" style="--corner-color: var(--wa-color-brand)"></wa-qr-code>
 ```
 
 ### Radius
@@ -122,10 +119,7 @@ QR codes can be rendered with various levels of [error correction](https://www.q
 Use the `image` attribute to add a logo or image to the center of the QR code. When using an image, the error correction level will automatically be set to `H` to ensure the code remains scannable.
 
 ```html {.example}
-<wa-qr-code
-  value="https://webawesome.com/"
-  image="/assets/images/logos/wa-avatar4x.png"
-></wa-qr-code>
+<wa-qr-code value="https://webawesome.com/" image="/assets/images/logos/wa-avatar4x.png"></wa-qr-code>
 ```
 
 ### Image Coverage
@@ -136,9 +130,21 @@ The higher the `image-coverage` value, the harder it will be for QR readers to s
 
 ```html {.example}
 <div class="qr-ec-cover">
-  <wa-qr-code value="https://fontawesome.com/" image="/assets/images/logos/fa-avatar4x.png" image-coverage="0.3"></wa-qr-code>
-  <wa-qr-code value="https://webawesome.com/" image="/assets/images/logos/wa-avatar4x.png" image-coverage="0.6"></wa-qr-code>
-  <wa-qr-code value="https://build.awesome.me/" image="/assets/images/logos/ba-avatar4x.png" image-coverage="0.9"></wa-qr-code>
+  <wa-qr-code
+    value="https://fontawesome.com/"
+    image="/assets/images/logos/fa-avatar4x.png"
+    image-coverage="0.3"
+  ></wa-qr-code>
+  <wa-qr-code
+    value="https://webawesome.com/"
+    image="/assets/images/logos/wa-avatar4x.png"
+    image-coverage="0.6"
+  ></wa-qr-code>
+  <wa-qr-code
+    value="https://build.awesome.me/"
+    image="/assets/images/logos/ba-avatar4x.png"
+    image-coverage="0.9"
+  ></wa-qr-code>
 </div>
 
 <style>

--- a/packages/webawesome/docs/docs/components/relative-time.md
+++ b/packages/webawesome/docs/docs/components/relative-time.md
@@ -1,7 +1,7 @@
 ---
 title: Relative Time
 layout: component
-category: Utilities
+category: Helpers
 synonyms:
   - time ago
   - timeago

--- a/packages/webawesome/docs/docs/components/resize-observer.md
+++ b/packages/webawesome/docs/docs/components/resize-observer.md
@@ -1,7 +1,7 @@
 ---
 title: Resize Observer
 layout: component
-category: Utilities
+category: Helpers
 synonyms:
   - size watcher
   - resize listener

--- a/packages/webawesome/docs/docs/components/time-input.md
+++ b/packages/webawesome/docs/docs/components/time-input.md
@@ -6,9 +6,15 @@ synonyms:
   - time input
   - clock input
   - timepicker
+  - time field
+  - time of day input
+  - clock picker
 use-cases:
   - enter a time of day in a form
   - pick a time from a column-roulette popup
+  - meeting time selection
+  - appointment time entry
+  - scheduled event time
 ---
 
 Time Input is the time-of-day counterpart to [Date Input](/docs/components/date-input). It renders a segmented input with hour, minute, optional seconds, and optional AM/PM spinbutton segments in the user's locale order, alongside a popup column picker modeled on Chrome's native time UI.

--- a/packages/webawesome/docs/docs/components/time-input.md
+++ b/packages/webawesome/docs/docs/components/time-input.md
@@ -1,7 +1,7 @@
 ---
 title: Time Input
 layout: component
-category: Form Controls
+category: Forms
 synonyms:
   - time input
   - clock input

--- a/packages/webawesome/scripts/plop/templates/component/docs.hbs
+++ b/packages/webawesome/scripts/plop/templates/component/docs.hbs
@@ -2,6 +2,7 @@
 title: {{ tagToTitle tag }}
 description: Description of component.
 layout: component
+category: TODO # one of: Actions, Forms, Layout, Navigation, Feedback, Media, Data Viz, Helpers
 ---
 
 ```html {.example}


### PR DESCRIPTION
This work touches up several things related to our site/component metadata...

### Category Labels and Icons
Renames the **Utilities** component category to **Helpers** so it stops colliding with the existing "Theming & Utilities" docs section that lives above it in the sidebar. 

Swaps the **Feedback** icon from `comments` (chat bubbles) to `bell` since the category is about status and notification, not conversation. 

Swaps the **Media** icon from `image` to `photo-film` to reflect that it covers motion content alongside stills. Renames the Getting Started link from "Form Controls" to "Forms" so the label matches the category name (URL is unchanged).

### Editorial Order and Plop Template Guidance
Reorders `componentCategories.json` from its historical ordering to an editorial sequence (Actions → Forms → Layout → Navigation → Feedback → Media → Data Viz → Helpers), surfacing the highest-traffic categories first in both the sidebar and the components index combobox. 

Adds a `category: TODO # one of: …` line to the Plop docs template so devs creating a new component see the valid options at the moment they need them.

### Fixing Miscategorized 3.8.0 Components
Corrects six newly-added components that landed with category values not defined in `componentCategories.json`: **Accordion** and **Accordion Item** move from `Organization` to `Layout`; **Known Date** and **Time Input** move from `Form Controls` to `Forms`. 

The Pro counterparts — Date Input and Date Picker — get the same fix in https://github.com/shoelace-style/webawesome-pro/pull/233.

### Taxonomy Adjustments
Moves **QR Code** from Actions to Media — it's a passive visual encoding, closer to Icon and Avatar than to Button or Dropdown. 

Moves **Markdown** from Helpers (formerly Utilities) to Media — it renders content for display, sitting alongside Include, Video, and Animated Image rather than the formatters and observers in Helpers.

### Discoverability Enrichments
Beefs up `synonyms` and `use-cases` on every component this PR touches, with a focus on the 3.8.0 additions whose metadata was thinner than the established baseline. 

New synonyms add terms users actually search for (`gfm`, `marked.js`, `clock picker`, `segmented date input`, `split
date input`, etc.) and use-cases describe concrete situations (`meeting time selection`, `documentation pages`, `expiration date entry`, etc.).