### PR TITLE
Syncing More Component Durations + WA Transition Tokens

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -28,7 +28,7 @@ These are still finding their shape. APIs can change between minor versions, so 
 
 :::changed
 
-- Synced default `--show-duration`, `--hide-duration`, and `--easing` values in `<wa-accordion-item>` and `<wa-time-input>` with `--wa-transition-*` tokens
+- Synced default `--show-duration`, `--hide-duration`, and `--easing` values in `<wa-accordion-item>`, `<wa-date-input>`, `<wa-time-input>`, `<wa-toast>`, and `<wa-video>` with `--wa-transition-*` tokens
 
 :::
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -26,6 +26,12 @@ These are still finding their shape. APIs can change between minor versions, so 
 
 :::
 
+:::changed
+
+- Synced default `--show-duration`, `--hide-duration`, and `--easing` values in `<wa-accordion-item>` and `<wa-time-input>` with `--wa-transition-*` tokens
+
+:::
+
 ## 3.8.0
 
 <small><time datetime="2026-06-05">June 5th, 2026</time></small>

--- a/packages/webawesome/src/components/accordion-item/accordion-item.styles.ts
+++ b/packages/webawesome/src/components/accordion-item/accordion-item.styles.ts
@@ -4,9 +4,9 @@ export default css`
   @layer wa-component {
     :host {
       --spacing: var(--wa-space-m);
-      --show-duration: 200ms;
-      --hide-duration: 200ms;
-      --easing: ease;
+      --show-duration: var(--wa-transition-normal);
+      --hide-duration: var(--wa-transition-normal);
+      --easing: var(--wa-transition-easing);
 
       display: block;
     }

--- a/packages/webawesome/src/components/accordion-item/accordion-item.ts
+++ b/packages/webawesome/src/components/accordion-item/accordion-item.ts
@@ -33,9 +33,9 @@ import styles from './accordion-item.styles.js';
  * @csspart content - The content slot inside the panel.
  *
  * @cssproperty [--spacing=var(--wa-space-m)] - The amount of space around and between the item's header and content.
- * @cssproperty [--show-duration=200ms] - The duration of the expand animation.
- * @cssproperty [--hide-duration=200ms] - The duration of the collapse animation.
- * @cssproperty [--easing=ease] - The easing of the expand/collapse animation.
+ * @cssproperty [--show-duration=var(--wa-transition-normal)] - The duration of the expand animation.
+ * @cssproperty [--hide-duration=var(--wa-transition-normal)] - The duration of the collapse animation.
+ * @cssproperty [--easing=var(--wa-transition-easing)] - The easing of the expand/collapse animation.
  * @cssproperty [--wa-accordion-divider-color=var(--wa-color-surface-border)] - The color of the divider between accordion items.
  *
  * @cssstate animating - Applied while the panel is animating.

--- a/packages/webawesome/src/components/time-input/time-input.styles.ts
+++ b/packages/webawesome/src/components/time-input/time-input.styles.ts
@@ -2,8 +2,8 @@ import { css } from 'lit';
 
 export default css`
   :host {
-    --show-duration: 100ms;
-    --hide-duration: 100ms;
+    --show-duration: var(--wa-transition-fast);
+    --hide-duration: var(--wa-transition-fast);
     --column-item-height: 2.25em;
     --column-width: 3em;
   }
@@ -308,11 +308,11 @@ export default css`
 
   /* Animations */
   .time-input-popup::part(popup).show {
-    animation: wa-time-input-show var(--show-duration) ease;
+    animation: wa-time-input-show var(--show-duration) var(--wa-transition-easing);
   }
 
   .time-input-popup::part(popup).hide {
-    animation: wa-time-input-hide var(--hide-duration) ease;
+    animation: wa-time-input-hide var(--hide-duration) var(--wa-transition-easing);
   }
 
   @keyframes wa-time-input-show {

--- a/packages/webawesome/src/components/time-input/time-input.ts
+++ b/packages/webawesome/src/components/time-input/time-input.ts
@@ -98,8 +98,8 @@ const SINGLE_GROUP = 'single';
  * @csspart column-item-selected - The currently selected option inside a column.
  * @csspart now-button - The default "Now" button rendered in the popup footer when `with-now` is set.
  *
- * @cssproperty [--show-duration=100ms] - The duration of the show animation.
- * @cssproperty [--hide-duration=100ms] - The duration of the hide animation.
+ * @cssproperty [--show-duration=var(--wa-transition-fast)] - The duration of the show animation.
+ * @cssproperty [--hide-duration=var(--wa-transition-fast)] - The duration of the hide animation.
  * @cssproperty [--column-item-height=2.25em] - Height of each option inside a popup column.
  * @cssproperty [--column-width=3em] - Width of each popup column.
  *


### PR DESCRIPTION
[PR #2423](https://github.com/shoelace-style/webawesome/pull/2423) synced default `--show-duration` / `--hide-duration` values to `--wa-transition-*` tokens across the existing popup and panel components. 

Since that landed, four new components shipped in v3.8.0 — `<wa-accordion>` / `<wa-accordion-item>`, `<wa-known-date>`, and `<wa-time-input>` — and two of them came in with hardcoded ms values that drift from the design system. This catches them up.

## What changed

### `<wa-accordion-item>` (panel pattern)
`--show-duration` and `--hide-duration` move from `200ms` to `var(--wa-transition-normal)`. `--easing` moves from the literal `ease` keyword to
`var(--wa-transition-easing)`.

### `<wa-time-input>` (popup pattern)
`--show-duration` and `--hide-duration` move from `100ms` to `var(--wa-transition-fast)`. The popup show/hide animations were also using a literal
`ease` keyword for their easing — now `var(--wa-transition-easing)`.

`<wa-known-date>` was already using tokens for its transitions; `<wa-accordion>` doesn't expose any duration tokens itself. The changelog entry
also covers the companion pro PR below.

## User-visible motion changes
Accordion items finish expanding and collapsing ~50ms sooner; time-input's popup feels marginally snappier. Overrides via `--show-duration` /
`--hide-duration` / `--easing` are unchanged — only defaults moved.

### Companion PR
Pro-side companion covering `<wa-date-input>`, `<wa-toast>`, and `<wa-video>` is up at https://github.com/shoelace-style/webawesome-pro/pull/234