### PR TITLE
Add `selection="leaf-multiple"` to `<wa-tree>`

### DIFF
--- a/packages/webawesome/docs/docs/components/tree.md
+++ b/packages/webawesome/docs/docs/components/tree.md
@@ -67,6 +67,7 @@ The `selection` attribute lets you change the selection behavior of the tree.
   <wa-option value="single">Single</wa-option>
   <wa-option value="multiple">Multiple</wa-option>
   <wa-option value="leaf">Leaf</wa-option>
+  <wa-option value="leaf-multiple">Leaf Multiple</wa-option>
 </wa-select>
 
 <br />

--- a/packages/webawesome/docs/docs/components/tree.md
+++ b/packages/webawesome/docs/docs/components/tree.md
@@ -61,13 +61,14 @@ The `selection` attribute lets you change the selection behavior of the tree.
 - Use `single` to allow the selection of a single item (default).
 - Use `multiple` to allow the selection of multiple items.
 - Use `leaf` to only allow leaf nodes to be selected.
+- Use `leaf-multiple` to allow the selection of multiple leaf nodes.
 
 ```html {.example}
 <wa-select id="selection-mode" value="single" label="Selection">
   <wa-option value="single">Single</wa-option>
   <wa-option value="multiple">Multiple</wa-option>
   <wa-option value="leaf">Leaf</wa-option>
-  <wa-option value="leaf-multiple">Leaf Multiple</wa-option>
+  <wa-option value="leaf-multiple">Leaf-multiple</wa-option>
 </wa-select>
 
 <br />

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -18,6 +18,12 @@ These are still finding their shape. APIs can change between minor versions, so 
 
 ## Unreleased
 
+:::added
+
+- Added `leaf-multiple` as a new `selection` option for `<wa-tree>`, allowing multiple leaf nodes to be selected while parent nodes only expand and collapse.
+
+:::
+
 :::fixed
 
 - Fixed a bug in `<wa-checkbox>` and `<wa-switch>` where `.checked` property would not properly update the shadow dom checkbox.

--- a/packages/webawesome/src/components/tree/tree.test.ts
+++ b/packages/webawesome/src/components/tree/tree.test.ts
@@ -67,6 +67,18 @@ describe('<wa-tree>', () => {
           }
         });
 
+        it('should set selectable on leaf items only when selection is "leaf-multiple"', async () => {
+          el.selection = 'leaf-multiple';
+          await el.updateComplete;
+
+          const items = el.querySelectorAll<WaTreeItem>('wa-tree-item');
+          await Promise.all([...items].map(item => item.updateComplete));
+
+          for (const item of items) {
+            expect(item.selectable).to.equal(item.isLeaf);
+          }
+        });
+
         it('should not focus collapsed child nodes', async () => {
           const parentNode = el.children[2] as WaTreeItem;
           const childNode = parentNode.children[1] as WaTreeItem;
@@ -341,6 +353,33 @@ describe('<wa-tree>', () => {
               expect(el.selectedItems.length).to.eq(6);
             });
           });
+
+          describe('and selection is "leaf-multiple"', () => {
+            it('should select multiple leaf items independently', async () => {
+              el.selection = 'leaf-multiple';
+              const node = el.children[0] as WaTreeItem;
+              node.focus();
+              await el.updateComplete;
+
+              await sendKeys({ press: 'Enter' });
+              await sendKeys({ press: 'ArrowRight' });
+              await sendKeys({ press: 'Enter' });
+
+              expect(el.selectedItems.length).to.eq(2);
+            });
+
+            it('should expand/collapse a parent node without selecting it', async () => {
+              el.selection = 'leaf-multiple';
+              const parentNode = el.children[2] as WaTreeItem;
+              parentNode.focus();
+              await el.updateComplete;
+
+              await sendKeys({ press: 'Enter' });
+
+              expect(el.selectedItems.length).to.eq(0);
+              expect(parentNode).to.have.attribute('expanded');
+            });
+          });
         });
 
         describe('when Space is pressed', () => {
@@ -401,6 +440,33 @@ describe('<wa-tree>', () => {
               expect(el.selectedItems.length).to.eq(2);
             });
           });
+
+          describe('and selection is "leaf-multiple"', () => {
+            it('should select multiple leaf items independently', async () => {
+              el.selection = 'leaf-multiple';
+              const node = el.children[0] as WaTreeItem;
+              node.focus();
+              await el.updateComplete;
+
+              await sendKeys({ press: ' ' });
+              await sendKeys({ press: 'ArrowRight' });
+              await sendKeys({ press: ' ' });
+
+              expect(el.selectedItems.length).to.eq(2);
+            });
+
+            it('should expand/collapse a parent node without selecting it', async () => {
+              el.selection = 'leaf-multiple';
+              const parentNode = el.children[2] as WaTreeItem;
+              parentNode.focus();
+              await el.updateComplete;
+
+              await sendKeys({ press: ' ' });
+
+              expect(el.selectedItems.length).to.eq(0);
+              expect(parentNode).to.have.attribute('expanded');
+            });
+          });
         });
       });
 
@@ -433,6 +499,36 @@ describe('<wa-tree>', () => {
             await Promise.all([node.updateComplete, el.updateComplete]);
 
             expect(selectedChangeSpy).to.not.have.been.called;
+          });
+        });
+
+        describe('when selection is "leaf-multiple"', () => {
+          it('should not emit wa-selection-change when clicking an expandable item', async () => {
+            el.selection = 'leaf-multiple';
+            await el.updateComplete;
+
+            const selectedChangeSpy = sinon.spy();
+            el.addEventListener('wa-selection-change', selectedChangeSpy);
+
+            const node = el.querySelector<WaTreeItem>('#expandable')!;
+
+            await clickOnElement(node);
+            await Promise.all([node.updateComplete, el.updateComplete]);
+
+            expect(selectedChangeSpy).to.not.have.been.called;
+          });
+
+          it('should emit wa-selection-change when clicking a leaf item', async () => {
+            el.selection = 'leaf-multiple';
+            await el.updateComplete;
+
+            const node = el.children[0] as WaTreeItem;
+            const events = await expectEvent(el, 'wa-selection-change', async () => {
+              await clickOnElement(node);
+            });
+
+            expect(events).to.have.lengthOf(1);
+            expect((events[0] as CustomEvent).detail.selection).to.deep.equal([node]);
           });
         });
       });

--- a/packages/webawesome/src/components/tree/tree.ts
+++ b/packages/webawesome/src/components/tree/tree.ts
@@ -83,8 +83,9 @@ export default class WaTree extends WebAwesomeElement {
   /**
    * The selection behavior of the tree. Single selection allows only one node to be selected at a time. Multiple
    * displays checkboxes and allows more than one node to be selected. Leaf allows only leaf nodes to be selected.
+   * Leaf-multiple allows multiple leaf nodes to be selected while parent nodes only expand and collapse.
    */
-  @property() selection: 'single' | 'multiple' | 'leaf' = 'single';
+  @property() selection: 'single' | 'multiple' | 'leaf' | 'leaf-multiple' = 'single';
 
   //
   // A collection of all the items in the tree, in the order they appear. The collection is live, meaning it is
@@ -149,7 +150,7 @@ export default class WaTree extends WebAwesomeElement {
   // Initializes new items by setting the `selectable` property and the expanded/collapsed icons if any
   private initTreeItem = (item: WaTreeItem) => {
     item.updateComplete.then(() => {
-      item.selectable = this.selection === 'multiple';
+      item.selectable = this.selection === 'multiple' || (this.selection === 'leaf-multiple' && item.isLeaf);
 
       ['expand', 'collapse']
         .filter(status => !!this.querySelector(`[slot="${status}-icon"]`))
@@ -194,6 +195,12 @@ export default class WaTree extends WebAwesomeElement {
         selectedItem.expanded = true;
       }
       syncCheckboxes(selectedItem);
+    } else if (this.selection === 'leaf-multiple') {
+      if (selectedItem.isLeaf) {
+        selectedItem.selected = !selectedItem.selected;
+      } else {
+        selectedItem.expanded = !selectedItem.expanded;
+      }
     } else if (this.selection === 'single' || selectedItem.isLeaf) {
       const items = this.getAllTreeItems();
       for (const item of items) {
@@ -361,13 +368,14 @@ export default class WaTree extends WebAwesomeElement {
   @watch('selection')
   async handleSelectionChange() {
     const isSelectionMultiple = this.selection === 'multiple';
+    const isSelectionLeafMultiple = this.selection === 'leaf-multiple';
     const items = this.getAllTreeItems();
 
-    this.setAttribute('aria-multiselectable', isSelectionMultiple ? 'true' : 'false');
+    this.setAttribute('aria-multiselectable', isSelectionMultiple || isSelectionLeafMultiple ? 'true' : 'false');
 
     for (const item of items) {
       item.updateComplete.then(() => {
-        item.selectable = isSelectionMultiple;
+        item.selectable = isSelectionMultiple || (isSelectionLeafMultiple && item.isLeaf);
       });
     }
 


### PR DESCRIPTION
Addresses #1989.

Adds `leaf-multiple` as a new option for the `selection` attribute of `<wa-tree>`. `leaf-multiple` allows multiple leaf nodes to be selected while parent nodes only expand and collapse without being selected.