### PR TITLE
Docs: Polish Search

### DIFF
--- a/packages/webawesome/docs/_includes/search.njk
+++ b/packages/webawesome/docs/_includes/search.njk
@@ -111,11 +111,11 @@
             class="site-search-empty-icon wa-font-size-3xl" aria-hidden="true"></wa-icon>
           <p>D'oh! No results for &ldquo;<span id="site-search-empty-query"></span>&rdquo;</p>
           <wa-button-group>
-            <wa-button appearance="outlined" size="s" href="{{ site.github.ideas }}" target="_blank" rel="noopener">
+            <wa-button appearance="filled" size="s" href="{{ site.github.ideas }}" target="_blank" rel="noopener">
               <wa-icon name="lightbulb-on" variant="regular" slot="start"></wa-icon>
               Suggest on GitHub
             </wa-button>
-            <wa-button appearance="outlined" size="s" href="{{ site.urls.discord }}" target="_blank" rel="noopener">
+            <wa-button appearance="filled" size="s" href="{{ site.urls.discord }}" target="_blank" rel="noopener">
               <wa-icon name="message-question" variant="regular" slot="start"></wa-icon>
               Ask on Discord
             </wa-button>

--- a/packages/webawesome/docs/_includes/search.njk
+++ b/packages/webawesome/docs/_includes/search.njk
@@ -5,7 +5,7 @@
       <div id="site-search-input-wrapper">
         <wa-input id="site-search-input" type="search" with-clear placeholder="Search for&hellip;" autofocus
           autocomplete="off" autocorrect="off" autocapitalize="off" enterkeyhint="go" spellcheck="false" maxlength="100"
-          role="combobox" aria-autocomplete="list" aria-expanded="true" aria-controls="site-search-listbox"
+          role="combobox" aria-autocomplete="list" aria-expanded="true" aria-controls="site-search-suggested-list"
           aria-haspopup="listbox" aria-activedescendant>
           <wa-icon slot="start" name="magnifying-glass" class="de-emphasize"></wa-icon>
           <wa-icon slot="clear-icon" name="xmark" variant="regular"></wa-icon>
@@ -15,12 +15,89 @@
 
     {# Body #}
     <div id="site-search-body">
+      {# Default state — Suggested starts + Recent searches #}
+      <div id="site-search-default" class="wa-stack wa-gap-0">
+        <div id="site-search-suggested-list" class="site-search-listing" role="listbox" aria-label="Suggested">
+          <h3 class="site-search-section-label wa-caption-s">Quick Links</h3>
+          <ul id="site-search-suggested-listbox" class="wa-stack wa-gap-3xs" role="presentation">
+            <li class="site-search-result" role="option" id="suggested-item-1" data-selected="false">
+              <a href="/docs/components" class="wa-cluster wa-flex-nowrap wa-gap-m">
+                <wa-icon class="site-search-result-icon de-emphasize" name="block" variant="regular"
+                  aria-hidden="true"></wa-icon>
+                <div class="site-search-result-details">
+                  <div class="site-search-result-title wa-heading-m">Components</div>
+                </div>
+                <wa-icon class="site-search-result-caret" name="chevron-right" variant="regular"
+                  aria-hidden="true"></wa-icon>
+              </a>
+            </li>
+            <li class="site-search-result" role="option" id="suggested-item-2" data-selected="false">
+              <a href="/docs/utilities" class="wa-cluster wa-flex-nowrap wa-gap-m">
+                <wa-icon class="site-search-result-icon de-emphasize" name="brush" variant="regular"
+                  aria-hidden="true"></wa-icon>
+                <div class="site-search-result-details">
+                  <div class="site-search-result-title wa-heading-m">CSS Utilities</div>
+                </div>
+                <wa-icon class="site-search-result-caret" name="chevron-right" variant="regular"
+                  aria-hidden="true"></wa-icon>
+              </a>
+            </li>
+            <li class="site-search-result" role="option" id="suggested-item-3" data-selected="false">
+              <a href="/docs/theming-overview" class="wa-cluster wa-flex-nowrap wa-gap-m">
+                <wa-icon class="site-search-result-icon de-emphasize" name="file-text" variant="regular"
+                  aria-hidden="true"></wa-icon>
+                <div class="site-search-result-details">
+                  <div class="site-search-result-title wa-heading-m">Theming Overview</div>
+                </div>
+                <wa-icon class="site-search-result-caret" name="chevron-right" variant="regular"
+                  aria-hidden="true"></wa-icon>
+              </a>
+            </li>
+            <li class="site-search-result" role="option" id="suggested-item-4" data-selected="false">
+              <a href="/docs/ai" class="wa-cluster wa-flex-nowrap wa-gap-m">
+                <wa-icon class="site-search-result-icon de-emphasize" name="sparkles" variant="regular"
+                  aria-hidden="true"></wa-icon>
+                <div class="site-search-result-details">
+                  <div class="site-search-result-title wa-heading-m">Using with AI</div>
+                </div>
+                <wa-icon class="site-search-result-caret" name="chevron-right" variant="regular"
+                  aria-hidden="true"></wa-icon>
+              </a>
+            </li>
+            <li class="site-search-result" role="option" id="suggested-item-5" data-selected="false">
+              <a href="/docs/resources/changelog" class="wa-cluster wa-flex-nowrap wa-gap-m">
+                <wa-icon class="site-search-result-icon de-emphasize" name="book-spine" variant="regular"
+                  aria-hidden="true"></wa-icon>
+                <div class="site-search-result-details">
+                  <div class="site-search-result-title wa-heading-m">Changelog</div>
+                </div>
+                <wa-icon class="site-search-result-caret" name="chevron-right" variant="regular"
+                  aria-hidden="true"></wa-icon>
+              </a>
+            </li>
+            <li class="site-search-result" role="option" id="suggested-item-6" data-selected="false">
+              <a href="{{ site.urls.support }}" class="wa-cluster wa-flex-nowrap wa-gap-m">
+                <wa-icon class="site-search-result-icon de-emphasize" name="book-spine" variant="regular"
+                  aria-hidden="true"></wa-icon>
+                <div class="site-search-result-details">
+                  <div class="site-search-result-title wa-heading-m">Help &amp; Support</div>
+                </div>
+                <wa-icon class="site-search-result-caret" name="chevron-right" variant="regular"
+                  aria-hidden="true"></wa-icon>
+              </a>
+            </li>
+          </ul>
+        </div>
+      </div>
+
       {# Results state #}
-      <ul id="site-search-listbox" class="wa-stack wa-gap-3xs" role="listbox" aria-label="Search results"></ul>
+      <div class="site-search-listing">
+        <ul id="site-search-listbox" class="wa-stack wa-gap-3xs" role="listbox" aria-label="Search Results"></ul>
+      </div>
 
       {# Empty state — no results found #}
       <div id="site-search-empty">
-        <div class="wa-stack wa-align-items-center wa-gap-l">
+        <div class="wa-stack wa-align-items-center">
           <wa-icon name="face-monocle" family="duotone" variant="regular"
             class="site-search-empty-icon wa-font-size-3xl" aria-hidden="true"></wa-icon>
           <p>D'oh! No results for &ldquo;<span id="site-search-empty-query"></span>&rdquo;</p>

--- a/packages/webawesome/docs/_includes/search.njk
+++ b/packages/webawesome/docs/_includes/search.njk
@@ -1,4 +1,4 @@
-<wa-dialog id="site-search" without-header light-dismiss>
+<wa-dialog id="site-search" without-header light-dismiss aria-label="Site Search">
   <div id="site-search-container">
     {# Header #}
     <header>
@@ -47,7 +47,7 @@
                 <wa-icon class="site-search-result-icon de-emphasize" name="file-text" variant="regular"
                   aria-hidden="true"></wa-icon>
                 <div class="site-search-result-details">
-                  <div class="site-search-result-title wa-heading-m">Theming Overview</div>
+                  <div class="site-search-result-title wa-heading-m">Theming</div>
                 </div>
                 <wa-icon class="site-search-result-caret" name="chevron-right" variant="regular"
                   aria-hidden="true"></wa-icon>
@@ -77,7 +77,7 @@
             </li>
             <li class="site-search-result" role="option" id="suggested-item-6" data-selected="false">
               <a href="{{ site.urls.support }}" class="wa-cluster wa-flex-nowrap wa-gap-m">
-                <wa-icon class="site-search-result-icon de-emphasize" name="book-spine" variant="regular"
+                <wa-icon class="site-search-result-icon de-emphasize" name="life-ring" variant="regular"
                   aria-hidden="true"></wa-icon>
                 <div class="site-search-result-details">
                   <div class="site-search-result-title wa-heading-m">Help &amp; Support</div>

--- a/packages/webawesome/docs/_includes/search.njk
+++ b/packages/webawesome/docs/_includes/search.njk
@@ -88,6 +88,15 @@
             </li>
           </ul>
         </div>
+
+        <wa-divider data-recent-divider hidden></wa-divider>
+
+        <div id="site-search-recent-list" class="site-search-listing" role="listbox" aria-label="Recent Searches"
+          hidden>
+          <h3 class="site-search-section-label wa-caption-s">Recent Searches</h3>
+          <ul id="site-search-recent-listbox" class="wa-stack wa-gap-3xs" role="presentation">
+          </ul>
+        </div>
       </div>
 
       {# Results state #}

--- a/packages/webawesome/docs/_includes/search.njk
+++ b/packages/webawesome/docs/_includes/search.njk
@@ -3,57 +3,57 @@
     {# Header #}
     <header>
       <div id="site-search-input-wrapper">
-        <wa-input
-          id="site-search-input"
-          type="search"
-          with-clear
-          placeholder="Search for&hellip;"
-          autofocus
-          autocomplete="off"
-          autocorrect="off"
-          autocapitalize="off"
-          enterkeyhint="go"
-          spellcheck="false"
-          maxlength="100"
-          role="combobox"
-          aria-autocomplete="list"
-          aria-expanded="true"
-          aria-controls="site-search-listbox"
-          aria-haspopup="listbox"
-          aria-activedescendant
-        >
-          <wa-icon slot="start" name="search"></wa-icon>
+        <wa-input id="site-search-input" type="search" with-clear placeholder="Search for&hellip;" autofocus
+          autocomplete="off" autocorrect="off" autocapitalize="off" enterkeyhint="go" spellcheck="false" maxlength="100"
+          role="combobox" aria-autocomplete="list" aria-expanded="true" aria-controls="site-search-listbox"
+          aria-haspopup="listbox" aria-activedescendant>
+          <wa-icon slot="start" name="magnifying-glass" class="de-emphasize"></wa-icon>
+          <wa-icon slot="clear-icon" name="xmark" variant="regular"></wa-icon>
         </wa-input>
       </div>
     </header>
 
     {# Body #}
     <div id="site-search-body">
-      <ul
-        id="site-search-listbox"
-        role="listbox"
-        aria-label="Search results"
-      ></ul>
+      {# Results state #}
+      <ul id="site-search-listbox" class="wa-stack wa-gap-3xs" role="listbox" aria-label="Search results"></ul>
+
+      {# Empty state — no results found #}
       <div id="site-search-empty">
-        <wa-icon name="web-awesome" family="brands"></wa-icon>
-        No results
+        <div class="wa-stack wa-align-items-center wa-gap-l">
+          <wa-icon name="face-monocle" family="duotone" variant="regular"
+            class="site-search-empty-icon wa-font-size-3xl" aria-hidden="true"></wa-icon>
+          <p>D'oh! No results for &ldquo;<span id="site-search-empty-query"></span>&rdquo;</p>
+          <wa-button-group>
+            <wa-button appearance="outlined" size="s" href="{{ site.github.ideas }}" target="_blank" rel="noopener">
+              <wa-icon name="lightbulb-on" variant="regular" slot="start"></wa-icon>
+              Suggest on GitHub
+            </wa-button>
+            <wa-button appearance="outlined" size="s" href="{{ site.urls.discord }}" target="_blank" rel="noopener">
+              <wa-icon name="message-question" variant="regular" slot="start"></wa-icon>
+              Ask on Discord
+            </wa-button>
+          </wa-button-group>
+        </div>
       </div>
     </div>
 
-    {# Footer #}
-    <footer class="wa-gap-xl">
-      <small>
-        <kbd aria-label="Up"><wa-icon name="arrow-up" family="micro"></wa-icon></kbd>
-        <kbd aria-label="Down"><wa-icon name="arrow-down" family="micro"></wa-icon></kbd>
-        Navigate
-      </small>
-
-      <small>
-        <kbd>Enter</kbd>
-        Select
-      </small>
-
-      <small><kbd>Esc</kbd> Close</small>
+    <footer class="wa-flank:end wa-flex-nowrap wa-color-text-quiet">
+      <div class="wa-cluster wa-flex-nowrap">
+        <small class="wa-cluster wa-flex-nowrap wa-gap-xs">
+          <span class="wa-cluster wa-flex-nowrap wa-gap-2xs">
+            <kbd class="kbd-modern" aria-label="Up"><wa-icon name="arrow-up"></wa-icon></kbd>
+            <kbd class="kbd-modern" aria-label="Down"><wa-icon name="arrow-down"></wa-icon></kbd>
+          </span>
+          Navigate
+        </small>
+        <small class="wa-cluster wa-flex-nowrap wa-gap-xs">
+          <kbd class="kbd-modern" aria-label="Enter"><wa-icon name="arrow-turn-down-left"></wa-icon></kbd>
+          Select
+        </small>
+      </div>
+      <small class="site-search-footer-end wa-cluster wa-flex-nowrap wa-gap-xs">Close <kbd
+          class="kbd-modern">Esc</kbd></small>
     </footer>
   </div>
 </wa-dialog>

--- a/packages/webawesome/docs/assets/scripts/search.js
+++ b/packages/webawesome/docs/assets/scripts/search.js
@@ -64,6 +64,7 @@ const iconByPrefix = [
   ['/docs/ai', 'sparkles'],
   ['/docs/ai/agent-skills', 'sparkles'],
   ['/docs/ai/llms', 'sparkles'],
+  ['/docs/resources/support', 'life-ring'],
   ['/docs/resources', 'book-spine'],
 ].sort((a, b) => b[0].length - a[0].length);
 
@@ -420,9 +421,12 @@ function handleDefaultListClick(event) {
     return;
   }
 
-  // Suggested row — close the dialog and navigate to the link's href
+  // Suggested row — close the dialog and navigate to the link's href.
+  // Respect target="_blank" so external links open in a new tab.
   const url = link.getAttribute('href');
   if (!url) return;
+
+  const opensInNewTab = link.target === '_blank';
 
   const { dialog } = getElements();
   if (dialog) {
@@ -432,7 +436,9 @@ function handleDefaultListClick(event) {
     dialog.open = false;
   }
 
-  if (window.Turbo) {
+  if (opensInNewTab) {
+    window.open(url, '_blank', 'noopener');
+  } else if (window.Turbo) {
     Turbo.visit(url);
   } else {
     location.href = url;

--- a/packages/webawesome/docs/assets/scripts/search.js
+++ b/packages/webawesome/docs/assets/scripts/search.js
@@ -74,7 +74,16 @@ function getElements() {
     input: document.getElementById('site-search-input'),
     results: document.getElementById('site-search-listbox'),
     emptyQuery: document.getElementById('site-search-empty-query'),
+    defaultContainer: document.getElementById('site-search-default'),
   };
+}
+
+// Returns the visible options container for keyboard nav: the results listbox
+// when there's an active query, otherwise the default-state container.
+function getActiveList() {
+  const { dialog, results, defaultContainer } = getElements();
+  if (!dialog) return null;
+  return dialog.classList.contains('has-results') ? results : defaultContainer;
 }
 
 function trackQuerySubmit(query, resultSelectedValue) {
@@ -119,7 +128,7 @@ document.addEventListener('click', event => {
 });
 
 function show() {
-  const { dialog, input, results } = getElements();
+  const { dialog, input, results, defaultContainer } = getElements();
   if (!dialog || !input || !results) return;
 
   const wasAlreadyOpen = dialog.open;
@@ -127,14 +136,20 @@ function show() {
   // Remove existing listeners before adding to prevent duplicates
   input.removeEventListener('input', handleInput);
   results.removeEventListener('click', handleSelection);
+  if (defaultContainer) defaultContainer.removeEventListener('click', handleDefaultListClick);
   dialog.removeEventListener('keydown', handleKeyDown);
   dialog.removeEventListener('wa-hide', handleClose);
   resultSelected = false;
   lastTrackedQuery = '';
   input.addEventListener('input', handleInput);
   results.addEventListener('click', handleSelection);
+  if (defaultContainer) defaultContainer.addEventListener('click', handleDefaultListClick);
   dialog.addEventListener('keydown', handleKeyDown);
   dialog.addEventListener('wa-hide', handleClose);
+
+  // Default state: point combobox controls at the visible Suggested listbox
+  input.setAttribute('aria-controls', 'site-search-suggested-list');
+
   dialog.open = true;
   if (!wasAlreadyOpen) {
     trackEvent('navigation:search_dialog_open');
@@ -142,12 +157,13 @@ function show() {
 }
 
 function cleanup() {
-  const { dialog, input, results } = getElements();
+  const { dialog, input, results, defaultContainer } = getElements();
   if (!dialog || !input || !results) return;
   clearTimeout(searchTimeout);
   clearTimeout(queryTrackTimeout);
   input.removeEventListener('input', handleInput);
   results.removeEventListener('click', handleSelection);
+  if (defaultContainer) defaultContainer.removeEventListener('click', handleDefaultListClick);
   dialog.removeEventListener('keydown', handleKeyDown);
   dialog.removeEventListener('wa-hide', handleClose);
 
@@ -210,15 +226,16 @@ function handleInput() {
 }
 
 function handleKeyDown(event) {
-  const { input, results } = getElements();
-  if (!input || !results) return;
+  const { input } = getElements();
+  const activeList = getActiveList();
+  if (!input || !activeList) return;
 
   // Handle keyboard selections
   if (['ArrowDown', 'ArrowUp', 'Home', 'End', 'Enter'].includes(event.key)) {
     event.preventDefault();
 
-    const currentEl = results.querySelector('[data-selected="true"]');
-    const items = [...results.querySelectorAll('li')];
+    const currentEl = activeList.querySelector('[data-selected="true"]');
+    const items = [...activeList.querySelectorAll('li')];
     const index = items.indexOf(currentEl);
     let nextEl;
 
@@ -243,7 +260,13 @@ function handleKeyDown(event) {
         if (currentEl) {
           const link = currentEl.querySelector('a');
           if (link) {
-            selectResult(link, 'keyboard_enter');
+            if (activeList.id === 'site-search-listbox') {
+              selectResult(link, 'keyboard_enter');
+            } else {
+              // Default state — delegate to the click handler so suggested vs
+              // recent rows pick the right action.
+              link.click();
+            }
           }
         }
         break;
@@ -302,6 +325,31 @@ function selectResult(link, selectionMethod) {
   }
 }
 
+// Click handler for the default-state list — close the dialog and navigate
+// to the suggested row's href.
+function handleDefaultListClick(event) {
+  const link = event.target.closest('a');
+  if (!link) return;
+  event.preventDefault();
+
+  const url = link.getAttribute('href');
+  if (!url) return;
+
+  const { dialog } = getElements();
+  if (dialog) {
+    dialog.removeEventListener('wa-hide', handleClose);
+    cleanup();
+    trackEvent('navigation:search_dialog_close');
+    dialog.open = false;
+  }
+
+  if (window.Turbo) {
+    Turbo.visit(url);
+  } else {
+    location.href = url;
+  }
+}
+
 function handleSelection(event) {
   const link = event.target.closest('a');
 
@@ -356,6 +404,17 @@ async function updateResults(query = '') {
     dialog.classList.toggle('has-results', hasQuery && hasResults);
     dialog.classList.toggle('no-results', hasQuery && !hasResults);
 
+    // Point aria-controls at whichever listbox the user is navigating now,
+    // and clear any stale data-selected on the default sub-lists when returning.
+    if (hasQuery) {
+      input.setAttribute('aria-controls', 'site-search-listbox');
+    } else {
+      input.setAttribute('aria-controls', 'site-search-suggested-list');
+      const { defaultContainer } = getElements();
+      if (defaultContainer) {
+        defaultContainer.querySelectorAll('li').forEach(item => item.setAttribute('data-selected', 'false'));
+      }
+    }
     input.setAttribute('aria-activedescendant', '');
 
     // Echo the user's query into the empty state when there are no results

--- a/packages/webawesome/docs/assets/scripts/search.js
+++ b/packages/webawesome/docs/assets/scripts/search.js
@@ -75,15 +75,85 @@ function getElements() {
     results: document.getElementById('site-search-listbox'),
     emptyQuery: document.getElementById('site-search-empty-query'),
     defaultContainer: document.getElementById('site-search-default'),
+    recentContainer: document.getElementById('site-search-recent-list'),
+    recentListbox: document.getElementById('site-search-recent-listbox'),
+    recentDivider: document.querySelector('[data-recent-divider]'),
   };
 }
 
 // Returns the visible options container for keyboard nav: the results listbox
-// when there's an active query, otherwise the default-state container.
+// when there's an active query, otherwise the default-state container which
+// wraps both the Suggested and Recent sublists.
 function getActiveList() {
   const { dialog, results, defaultContainer } = getElements();
   if (!dialog) return null;
   return dialog.classList.contains('has-results') ? results : defaultContainer;
+}
+
+// Recent searches — persisted in localStorage, capped at 5
+const recentSearchesKey = 'wa-search-recent';
+const recentSearchesMax = 5;
+
+function loadRecentSearches() {
+  try {
+    const raw = localStorage.getItem(recentSearchesKey);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter(q => typeof q === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveRecentSearch(query) {
+  const trimmed = (query || '').trim();
+  if (!trimmed) return;
+  try {
+    const current = loadRecentSearches();
+    const next = [trimmed, ...current.filter(q => q !== trimmed)].slice(0, recentSearchesMax);
+    localStorage.setItem(recentSearchesKey, JSON.stringify(next));
+  } catch {
+    // localStorage unavailable or full — skip silently
+  }
+}
+
+function renderRecentSearches() {
+  const { recentContainer, recentListbox, recentDivider } = getElements();
+  if (!recentContainer || !recentListbox) return;
+
+  const queries = loadRecentSearches();
+  recentListbox.innerHTML = '';
+
+  const hasRecents = queries.length > 0;
+  recentContainer.hidden = !hasRecents;
+  if (recentDivider) recentDivider.hidden = !hasRecents;
+
+  if (!hasRecents) return;
+
+  queries.forEach((query, index) => {
+    const li = document.createElement('li');
+    li.className = 'site-search-result';
+    li.setAttribute('role', 'option');
+    li.id = `recent-item-${index + 1}`;
+    li.dataset.recentQuery = query;
+    li.setAttribute('data-selected', 'false');
+
+    const a = document.createElement('a');
+    a.href = '#';
+    a.className = 'wa-cluster wa-flex-nowrap wa-gap-m';
+    a.innerHTML = `
+      <wa-icon class="site-search-result-icon de-emphasize" name="clock-rotate-left" variant="regular" aria-hidden="true"></wa-icon>
+      <div class="site-search-result-details">
+        <div class="site-search-result-title wa-heading-m"></div>
+      </div>
+      <wa-icon class="site-search-result-caret" name="chevron-right" variant="regular" aria-hidden="true"></wa-icon>
+    `;
+    // textContent — never innerHTML — for the user-supplied query string
+    a.querySelector('.site-search-result-title').textContent = query;
+
+    li.appendChild(a);
+    recentListbox.appendChild(li);
+  });
 }
 
 function trackQuerySubmit(query, resultSelectedValue) {
@@ -146,6 +216,9 @@ function show() {
   if (defaultContainer) defaultContainer.addEventListener('click', handleDefaultListClick);
   dialog.addEventListener('keydown', handleKeyDown);
   dialog.addEventListener('wa-hide', handleClose);
+
+  // Refresh the recent searches list from localStorage every time the dialog opens
+  renderRecentSearches();
 
   // Default state: point combobox controls at the visible Suggested listbox
   input.setAttribute('aria-controls', 'site-search-suggested-list');
@@ -302,6 +375,10 @@ function selectResult(link, selectionMethod) {
   const resultUrl = link.dataset.searchResultUrl || link.getAttribute('href');
   if (!resultUrl) return;
   lastTrackedQuery = query;
+
+  // Persist the query in recent searches so it shows up in the default view next time
+  saveRecentSearch(query);
+
   trackQuerySubmit(query, true);
   trackEvent('navigation:search_result_click', {
     query,
@@ -325,13 +402,25 @@ function selectResult(link, selectionMethod) {
   }
 }
 
-// Click handler for the default-state list — close the dialog and navigate
-// to the suggested row's href.
+// Click handler for the default-state list. Suggested rows navigate to their
+// href; recent-search rows populate the input and re-run the search.
 function handleDefaultListClick(event) {
   const link = event.target.closest('a');
   if (!link) return;
   event.preventDefault();
 
+  const li = link.closest('li');
+  const recentQuery = li?.dataset.recentQuery;
+
+  if (recentQuery) {
+    const { input } = getElements();
+    if (!input) return;
+    input.value = recentQuery;
+    updateResults(recentQuery);
+    return;
+  }
+
+  // Suggested row — close the dialog and navigate to the link's href
   const url = link.getAttribute('href');
   if (!url) return;
 

--- a/packages/webawesome/docs/assets/scripts/search.js
+++ b/packages/webawesome/docs/assets/scripts/search.js
@@ -73,6 +73,7 @@ function getElements() {
     dialog: document.getElementById('site-search'),
     input: document.getElementById('site-search-input'),
     results: document.getElementById('site-search-listbox'),
+    emptyQuery: document.getElementById('site-search-empty-query'),
   };
 }
 
@@ -354,7 +355,16 @@ async function updateResults(query = '') {
 
     dialog.classList.toggle('has-results', hasQuery && hasResults);
     dialog.classList.toggle('no-results', hasQuery && !hasResults);
+
     input.setAttribute('aria-activedescendant', '');
+
+    // Echo the user's query into the empty state when there are no results
+    // (safe: textContent, never innerHTML)
+    if (hasQuery && !hasResults) {
+      const { emptyQuery } = getElements();
+      if (emptyQuery) emptyQuery.textContent = trimmedQuery;
+    }
+
     results.innerHTML = '';
     matches.forEach((match, index) => {
       const page = map[match.id];
@@ -382,15 +392,15 @@ async function updateResults(query = '') {
         }
       }
       a.href = page.url;
+      a.className = 'wa-cluster wa-flex-nowrap';
       a.innerHTML = `
-        <div class="site-search-result-icon" aria-hidden="true">
-          <wa-icon name="${icon}" variant="regular"></wa-icon>
+        <wa-icon class="site-search-result-icon de-emphasize" name="${icon}" variant="regular" aria-hidden="true"></wa-icon>
+        <div class="site-search-result-details wa-stack wa-gap-3xs">
+          <div class="site-search-result-title wa-heading-m"></div>
+          <div class="site-search-result-description wa-font-size-s"></div>
+          <div class="site-search-result-url wa-font-size-xs"></div>
         </div>
-        <div class="site-search-result-details">
-          <div class="site-search-result-title"></div>
-          <div class="site-search-result-description"></div>
-          <div class="site-search-result-url"></div>
-        </div>
+        <wa-icon class="site-search-result-caret" name="chevron-right" variant="regular" aria-hidden="true"></wa-icon>
       `;
       a.querySelector('.site-search-result-title').textContent = displayTitle;
       a.querySelector('.site-search-result-description').textContent = displayDescription;
@@ -402,6 +412,12 @@ async function updateResults(query = '') {
       li.appendChild(a);
       results.appendChild(li);
     });
+
+    // After rendering, point aria-activedescendant at the first selected item
+    if (hasResults) {
+      const firstSelected = results.querySelector('[data-selected="true"]');
+      if (firstSelected) input.setAttribute('aria-activedescendant', firstSelected.id);
+    }
   } catch {
     // Ignore query errors as the user types
   }

--- a/packages/webawesome/docs/assets/styles/search.css
+++ b/packages/webawesome/docs/assets/styles/search.css
@@ -216,8 +216,8 @@
 #site-search footer {
   background: var(--wa-color-neutral-fill-quiet);
   border-block-start: var(--wa-panel-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
-  border-bottom-left-radius: var(--wa-border-radius-l);
-  border-bottom-right-radius: var(--wa-border-radius-l);
+  border-end-start-radius: var(--wa-border-radius-l);
+  border-end-end-radius: var(--wa-border-radius-l);
   padding: var(--wa-space-m);
   font-size: var(--wa-font-size-s);
 }

--- a/packages/webawesome/docs/assets/styles/search.css
+++ b/packages/webawesome/docs/assets/styles/search.css
@@ -65,10 +65,30 @@
   overflow-y: auto;
 }
 
-/* Region visibility — toggled by .has-results / .no-results on #site-search */
-#site-search-listbox,
+.site-search-listing {
+  padding: var(--wa-space-s);
+}
+
+.site-search-listing ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* Hide the results wrapper too, not just its inner UL — otherwise the
+   wrapper's padding shows through when there are no results. */
+.site-search-listing:has(#site-search-listbox),
 #site-search-empty {
   display: none;
+}
+
+#site-search.has-results #site-search-default,
+#site-search.no-results #site-search-default {
+  display: none;
+}
+
+#site-search.has-results .site-search-listing:has(#site-search-listbox) {
+  display: block;
 }
 
 #site-search.has-results #site-search-listbox {
@@ -79,9 +99,9 @@
   display: block;
 }
 
-#site-search-listbox {
-  list-style: none;
-  padding: var(--wa-space-s);
+.site-search-section-label {
+  padding-inline: var(--wa-space-s);
+  padding-block: var(--wa-space-xs);
   margin: 0;
 }
 

--- a/packages/webawesome/docs/assets/styles/search.css
+++ b/packages/webawesome/docs/assets/styles/search.css
@@ -205,23 +205,12 @@
 
 .site-search-empty-icon {
   --primary-color: var(--wa-color-text-normal);
-  --secondary-color: var(--wa-color-brand-80);
-  --secondary-opacity: 1;
-}
-
-.wa-dark .site-search-empty-icon {
-  --secondary-color: var(--wa-color-brand-60);
 }
 
 #site-search footer {
-  background: var(--wa-color-neutral-fill-quiet);
   border-block-start: var(--wa-panel-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
-  border-end-start-radius: var(--wa-border-radius-l);
-  border-end-end-radius: var(--wa-border-radius-l);
+  border-bottom-left-radius: var(--wa-border-radius-l);
+  border-bottom-right-radius: var(--wa-border-radius-l);
   padding: var(--wa-space-m);
   font-size: var(--wa-font-size-s);
-}
-
-.wa-dark #site-search footer {
-  background: var(--wa-color-neutral-fill-normal);
 }

--- a/packages/webawesome/docs/assets/styles/search.css
+++ b/packages/webawesome/docs/assets/styles/search.css
@@ -12,13 +12,9 @@
     margin-block-end: 0;
   }
 
-  &::part(body) {
-    padding: 0;
-  }
-
+  &::part(body),
   &::part(footer) {
-    justify-content: center;
-    gap: 0.5rem;
+    padding: 0;
   }
 
   @media screen and (max-width: 900px) {
@@ -28,8 +24,11 @@
       margin-block: 1rem;
     }
 
+    /* Keep the flex column bounded so body scrolls and header/footer stay
+       fixed — just give it nearly the full viewport instead of the
+       large-screen calc. */
     #site-search-container {
-      max-height: none;
+      max-height: calc(100vh - 2.5rem);
     }
   }
 }
@@ -40,32 +39,17 @@
   max-height: calc(100vh - 18rem);
 }
 
-/* Header */
 #site-search-container header {
   flex: 0 0 auto;
-  align-items: center;
-  /* Fixes an iOS Safari 16.4 bug that draws the parent element's border radius incorrectly when showing/hiding results */
-  border-radius: var(--wa-border-radius-l);
-}
-
-#site-search.has-results header {
   border-start-start-radius: var(--wa-border-radius-l);
   border-start-end-radius: var(--wa-border-radius-l);
-  border-end-start-radius: 0;
-  border-end-end-radius: 0;
-}
-
-#site-search-input-wrapper {
-  display: flex;
-  align-items: center;
+  border-bottom: var(--wa-panel-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
 }
 
 #site-search-input {
-  flex: 1 1 auto;
-  min-width: 0;
-  font-size: 1.25rem;
-  padding-block: 0.5rem;
+  padding: var(--wa-space-s) var(--wa-space-xs);
   margin: 0;
+  --wa-form-control-value-font-size: var(--wa-font-size-m);
 
   &::part(base) {
     border: none;
@@ -81,77 +65,50 @@
   overflow-y: auto;
 }
 
-#site-search.has-results,
-#site-search.no-results {
-  #site-search-body {
-    border-top: var(--wa-panel-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
-  }
+/* Region visibility — toggled by .has-results / .no-results on #site-search */
+#site-search-listbox,
+#site-search-empty {
+  display: none;
 }
 
-/* Results */
-#site-search-listbox {
-  line-height: 1.4;
-  list-style: none;
-  padding: 0;
-  margin: 0;
+#site-search.has-results #site-search-listbox {
+  display: flex;
+}
 
-  a {
-    display: flex;
-    gap: 1.5rem;
-    align-items: center;
+#site-search.no-results #site-search-empty {
+  display: block;
+}
+
+#site-search-listbox {
+  list-style: none;
+  padding: var(--wa-space-s);
+  margin: 0;
+}
+
+/* Result row — layout (cluster/gap) comes from utility classes on the anchor */
+.site-search-result {
+  > a {
     text-decoration: none;
-    padding: 0.5rem 1.5rem;
+    padding: var(--wa-space-xs) var(--wa-space-s);
+    border-radius: var(--wa-border-radius-m);
+    color: inherit;
+    transition: background-color var(--wa-transition-normal) var(--wa-transition-easing);
   }
 
-  a:focus-visible {
+  > a:focus-visible {
     outline: var(--wa-focus-ring);
     outline-offset: -2px;
   }
 
-  @media (hover: hover) {
-    li a:hover,
-    li a:hover small {
-      background-color: var(--wa-color-neutral-fill-normal);
-    }
-  }
-
-  li[data-selected='true'] a,
-  li[data-selected='true'] a * {
-    outline: none;
-    background-color: var(--wa-color-brand-fill-loud);
-    color: var(--wa-color-brand-on-loud);
-  }
-
-  h3 {
-    font-weight: var(--wa-font-weight-semibold);
-    margin: 0;
-  }
-
-  small {
-    display: block;
-    color: var(--wa-color-text-quiet);
-  }
-}
-
-#site-search.has-results #site-search-results {
-  display: block;
-}
-
-/* Search results */
-.site-search-result {
-  padding: 0;
-  margin: 0;
-
   .site-search-result-icon {
-    flex: 0 0 auto;
-    display: flex;
-    width: 1.75rem;
-    justify-content: center;
+    font-size: var(--wa-font-size-l);
+    color: var(--wa-color-on-quiet);
+    transition: color var(--wa-transition-normal) var(--wa-transition-easing);
+  }
 
-    wa-icon {
-      font-size: var(--wa-font-size-xl);
-      color: var(--wa-color-neutral-fill-loud);
-    }
+  .site-search-result-details {
+    min-width: 0;
+    flex: 1 1 auto;
   }
 
   .site-search-result-title,
@@ -163,73 +120,88 @@
     text-overflow: ellipsis;
   }
 
-  .site-search-result-details {
-    max-width: calc(100% - 4rem);
+  .site-search-result-url {
+    color: var(--wa-color-on-quiet);
+    transition: color var(--wa-transition-normal) var(--wa-transition-easing);
   }
 
-  .site-search-result-title {
-    font-size: var(--wa-font-size-l);
+  .site-search-result-caret {
+    flex: 0 0 auto;
+    font-size: var(--wa-font-size-s);
+    color: var(--wa-color-on-quiet);
+    opacity: 0;
+    transition: opacity var(--wa-transition-normal) var(--wa-transition-easing);
+  }
+}
+
+@media (hover: hover) {
+  .site-search-result > a:hover {
+    background: var(--wa-color-neutral-fill-quiet);
+
+    .site-search-result-icon,
+    .site-search-result-url {
+      color: var(--wa-color-brand-fill-loud);
+      opacity: 1;
+    }
+
+    .site-search-result-caret {
+      opacity: 1;
+    }
+  }
+
+  .wa-dark .site-search-result > a:hover {
+    background: var(--wa-color-neutral-fill-normal);
+  }
+}
+
+.site-search-result[data-selected='true'] > a {
+  background: var(--wa-color-brand-fill-quiet);
+
+  .site-search-result-icon,
+  .site-search-result-url {
+    color: var(--wa-color-brand-fill-loud);
+    opacity: 1;
+  }
+
+  .site-search-result-caret {
+    opacity: 1;
+  }
+}
+
+.wa-dark .site-search-result[data-selected='true'] > a {
+  background: var(--wa-color-brand-fill-normal);
+}
+
+#site-search-empty {
+  padding: var(--wa-space-xl) var(--wa-space-s);
+  color: var(--wa-color-on-quiet);
+  font-size: var(--wa-font-size-s);
+
+  p > span {
     font-weight: var(--wa-font-weight-semibold);
-    color: var(--wa-color-brand-on-normal);
-  }
-
-  .site-search-result-description {
-    font-size: 0.875rem;
     color: var(--wa-color-text-normal);
   }
-
-  .site-search-result-url {
-    font-size: 0.875rem;
-    color: var(--wa-color-text-quiet);
-  }
 }
 
-/* Empty state */
-#site-search-empty {
-  display: none;
-  text-align: center;
-  font-size: var(--wa-font-size-s);
-  color: var(--wa-color-text-quiet);
-  padding: var(--wa-space-3xl) var(--wa-space-2xl);
-
-  wa-icon {
-    display: block;
-    width: 2rem;
-    height: 2rem;
-    font-size: 1.5rem;
-    margin-inline: auto;
-    margin-block-end: 0.5rem;
-  }
+.site-search-empty-icon {
+  --primary-color: var(--wa-color-text-normal);
+  --secondary-color: var(--wa-color-brand-80);
+  --secondary-opacity: 1;
 }
 
-#site-search.no-results #site-search-empty {
-  display: block;
+.wa-dark .site-search-empty-icon {
+  --secondary-color: var(--wa-color-brand-60);
 }
 
-/* Footer */
 #site-search footer {
-  flex-direction: row;
-  justify-content: center;
-  color: var(--wa-color-text-quiet);
-  border-top: var(--wa-panel-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
+  background: var(--wa-color-neutral-fill-quiet);
+  border-block-start: var(--wa-panel-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
   border-bottom-left-radius: var(--wa-border-radius-l);
   border-bottom-right-radius: var(--wa-border-radius-l);
   padding: var(--wa-space-m);
+  font-size: var(--wa-font-size-s);
+}
 
-  kbd {
-    display: inline-flex;
-    height: 1.35rem;
-    justify-content: center;
-    align-items: center;
-    font-weight: var(--wa-font-weight-bold);
-
-    &:last-of-type {
-      margin-inline-end: 0.25rem;
-    }
-
-    > svg {
-      width: 1em;
-      height: 1em;
-    }
-  }
+.wa-dark #site-search footer {
+  background: var(--wa-color-neutral-fill-normal);
 }

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -590,6 +590,15 @@
     font-weight: var(--wa-font-weight-bold);
   }
 
+  .kbd-modern {
+    padding: var(--wa-space-2xs) var(--wa-space-xs);
+    line-height: 1;
+    background-color: color-mix(in oklab, var(--wa-color-surface-default), transparent 50%);
+    border: var(--wa-panel-border-style) var(--wa-panel-border-width) var(--wa-color-neutral-border-quiet);
+    border-radius: var(--wa-border-radius-s);
+    box-shadow: var(--wa-shadow-s);
+  }
+
   /* step icons for ordered instructions */
   .step-icon {
     --primary-color: var(--wa-color-neutral-20);


### PR DESCRIPTION
This work touches up the Docs Site Search Dialog with the following efforts:

  ### Dialog Redesign
  - Inset rounded pill selection with brand-tinted icon/url + a chevron affordance (replaces the loud orange full-bleed)
  - Custom `xmark` clear icon and input text sized to match result titles
  - Empty state: duotone `face-monocle` illustration, echoed query, and **Suggest on GitHub** / **Ask on Discord** CTAs
  - Footer chin uses `kbd-modern` chips for shortcuts on a tonal background with a top border that mirrors the header
  - Small viewports use nearly the full viewport height with header/footer pinned

| Before | After |
|--------|--------|
| <img width="1858" height="1636" alt="image" src="https://github.com/user-attachments/assets/121777cb-dd61-4705-b9fb-c8ae37f3f0dc" /> | <img width="1858" height="1636" alt="image" src="https://github.com/user-attachments/assets/71685f95-d14f-47c0-b941-98c646288a69" /> | 

### No Results
Standardizes the visuals of no results elsewhere (components listing) and adds some actions for searchers to take.

| Before | After |
|--------|--------|
| <img width="1858" height="1636" alt="image" src="https://github.com/user-attachments/assets/5f383483-12dd-4a2d-9d6b-845bf17ebfc2" /> | <img width="1858" height="1636" alt="image" src="https://github.com/user-attachments/assets/f85c8ef5-1392-4a71-850c-cc08a79b37ed" /> | 

  ### Default State
  - New **Quick Links** section with six common destinations, reusing the search-result row component
  - Icons drawn from the existing `iconByPrefix` map so Suggested and Results stay consistent
  - Unified keyboard + click handling across default and results states via `aria-controls` swapping

| Before | After |
|--------|--------|
| <img width="1858" height="1636" alt="image" src="https://github.com/user-attachments/assets/5e5dc74e-fae6-445b-a73f-c7cee96dce0e" /> |  <img width="1858" height="1636" alt="image" src="https://github.com/user-attachments/assets/2026c4c5-af5e-49e2-a207-1f2caf5f4eb5" /> | 

  ### Recent Searches
  - Persisted to `localStorage` (max 5, de-duplicated, XSS-safe)
  - Shown beneath Suggested with a `<wa-divider>`; both hidden until there's at least one recent
  - Click or Enter on a recent row repopulates the input and re-runs the search

| Before | After |
|--------|--------|
| <img width="1858" height="1636" alt="image" src="https://github.com/user-attachments/assets/5e5dc74e-fae6-445b-a73f-c7cee96dce0e" /> |  <img width="1858" height="1636" alt="image" src="https://github.com/user-attachments/assets/997848fc-db46-4fc2-b1b5-74c16b65af2e" /> | 

---

It also adds a `.kbd-modern` utility for inline keyboard chips (companion to `.tag-ui`)