### PR TITLE
Remove `--wa-accordion-divider-color`

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -51,6 +51,12 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 :::
 
+:::removed
+
+- Removed `--wa-accordion-divider-color` from `<wa-accordion-item>` due to improper scope and limited usage [pr:2491]
+
+:::
+
 ## 3.8.0
 
 <small><time datetime="2026-06-05">June 5th, 2026</time></small>

--- a/packages/webawesome/src/components/accordion-item/accordion-item.styles.ts
+++ b/packages/webawesome/src/components/accordion-item/accordion-item.styles.ts
@@ -13,7 +13,7 @@ export default css`
 
     :host(:not(:first-child)) {
       border-top: var(--wa-panel-border-width) var(--wa-panel-border-style)
-        var(--wa-accordion-divider-color, var(--wa-color-surface-border));
+        var(--wa-color-surface-border);
     }
 
     :host([appearance='filled']) {

--- a/packages/webawesome/src/components/accordion-item/accordion-item.styles.ts
+++ b/packages/webawesome/src/components/accordion-item/accordion-item.styles.ts
@@ -12,8 +12,7 @@ export default css`
     }
 
     :host(:not(:first-child)) {
-      border-top: var(--wa-panel-border-width) var(--wa-panel-border-style)
-        var(--wa-color-surface-border);
+      border-top: var(--wa-panel-border-width) var(--wa-panel-border-style) var(--wa-color-surface-border);
     }
 
     :host([appearance='filled']) {

--- a/packages/webawesome/src/components/accordion-item/accordion-item.ts
+++ b/packages/webawesome/src/components/accordion-item/accordion-item.ts
@@ -36,7 +36,6 @@ import styles from './accordion-item.styles.js';
  * @cssproperty [--show-duration=var(--wa-transition-normal)] - The duration of the expand animation.
  * @cssproperty [--hide-duration=var(--wa-transition-normal)] - The duration of the collapse animation.
  * @cssproperty [--easing=var(--wa-transition-easing)] - The easing of the expand/collapse animation.
- * @cssproperty [--wa-accordion-divider-color=var(--wa-color-surface-border)] - The color of the divider between accordion items.
  *
  * @cssstate animating - Applied while the panel is animating.
  */


### PR DESCRIPTION
Removes improperly scoped `--wa-accordion-divider-color` from `<wa-accordion-item>`.
Style customizations can be applied directly to the host element with `wa-accordion-item:not(:first-child) { ... }`