### PR TITLE
Scope `<th>` border to column headers only

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -48,6 +48,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 :::changed
 
 - Synced default `--show-duration`, `--hide-duration`, and `--easing` values in `<wa-accordion-item>`, `<wa-date-input>`, `<wa-time-input>`, `<wa-toast>`, and `<wa-video>` with `--wa-transition-*` tokens
+- Updated Native Styles so that `<th>` borders only apply to column headers [pr:2492]
 
 :::
 

--- a/packages/webawesome/src/styles/native.css
+++ b/packages/webawesome/src/styles/native.css
@@ -403,7 +403,7 @@
 
   tbody {
     tr {
-      border-top: solid var(--wa-border-width-s) var(--wa-color-border-quiet);
+      border-block-start: var(--wa-border-style) var(--wa-border-width-s) var(--wa-color-border-quiet);
 
       :where(table.wa-zebra-rows) &:nth-child(odd) {
         background-color: color-mix(in oklab, var(--wa-color-fill-quiet) 60%, transparent);
@@ -416,7 +416,7 @@
 
             &,
             + tr {
-              border-top-color: var(--wa-color-border-normal);
+              border-block-start-color: var(--wa-color-border-normal);
             }
           }
         }
@@ -433,12 +433,13 @@
   }
 
   th {
-    padding-block: 0.75em;
-
     font-size: var(--wa-font-size-smaller);
     font-weight: var(--wa-font-weight-bold);
 
-    border-block-end: var(--wa-border-style) var(--wa-border-width-s) var(--wa-color-border-normal);
+    /* Adds a stronger border below column headers but not row headers */
+    &:not(:has(+ td)):not([scope="row"]) {
+      border-block-end: var(--wa-border-style) var(--wa-border-width-s) var(--wa-color-border-normal);
+    }
   }
   /* #endregion */
 

--- a/packages/webawesome/src/styles/native.css
+++ b/packages/webawesome/src/styles/native.css
@@ -439,7 +439,7 @@
     /* Adds a stronger border below column headers only
      * Row headers are avoided with [scope="row"]
      * or when the next sibling is a non-header cell */
-    &:not([scope="row"]):not(:has(+ td)) {
+    &:not([scope='row']):not(:has(+ td)) {
       border-block-end: var(--wa-border-style) var(--wa-border-width-s) var(--wa-color-border-normal);
     }
   }

--- a/packages/webawesome/src/styles/native.css
+++ b/packages/webawesome/src/styles/native.css
@@ -436,8 +436,10 @@
     font-size: var(--wa-font-size-smaller);
     font-weight: var(--wa-font-weight-bold);
 
-    /* Adds a stronger border below column headers but not row headers */
-    &:not(:has(+ td)):not([scope="row"]) {
+    /* Adds a stronger border below column headers only
+     * Row headers are avoided with [scope="row"]
+     * or when the next sibling is a non-header cell */
+    &:not([scope="row"]):not(:has(+ td)) {
       border-block-end: var(--wa-border-style) var(--wa-border-width-s) var(--wa-color-border-normal);
     }
   }


### PR DESCRIPTION
Scopes the `border-block-end` styles previously applied to `<th>` elements to only those `<th>` elements that don't serve as row headers.

Additionally:
- Removes redundant `padding-block` from `th` selector (already applied in a prior rule)
- Replaces physical properties with logical properties
- Specifies `var(--wa-border-style)` for row borders instead of `solid`