### PR TITLE
Reverting Removal Wide Layout Support

### DIFF
--- a/packages/webawesome/docs/_includes/base.njk
+++ b/packages/webawesome/docs/_includes/base.njk
@@ -69,7 +69,7 @@
   </script>
 </head>
 <body
-  class="layout-{{ layout | stripExtension }} page-{{ pageType }}">
+  class="layout-{{ layout | stripExtension }} page-{{ pageType }}{{ ' page-wide' if wide }}">
 
   {% set defaultWaPageAttributes = defaultWaPageAttributes or { view: 'desktop', 'disable-navigation-toggle': true,
   'mobile-breakpoint': 1180, 'disable-sticky': 'banner' } %}

--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -82,8 +82,14 @@ wa-page > main {
   margin-inline: auto;
 }
 
+/* increase max-inline-size for index pages */
+wa-page > main:has(.modern-card-list) {
+  max-inline-size: var(--content-width-m);
+}
+
 /* The docs main column is wider than `wa-prose`'s default 65ch. Anchor the
-   reading-column custom property to the docs token to keep the established width. */
+   reading-column custom property to the docs token so existing layouts —
+   default, modern-card-list, and page-wide — keep their established widths. */
 #content {
   --wa-prose-line-length: var(--content-width-s);
 
@@ -513,6 +519,16 @@ wa-scroller:has(.component-table) {
 @media screen and (min-width: 73.75rem) {
   wa-page > main {
     padding: var(--wa-space-3xl);
+  }
+}
+
+.page-wide {
+  wa-page > main {
+    max-inline-size: var(--content-width-l);
+
+    .max-line-length {
+      max-inline-size: var(--line-length-l);
+    }
   }
 }
 

--- a/packages/webawesome/docs/docs/resources/visual-tests.md
+++ b/packages/webawesome/docs/docs/resources/visual-tests.md
@@ -2,6 +2,7 @@
 title: Visual Tests
 description: A page to visually test component styles against native styles.
 layout: page
+wide: true
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/tokens/index.njk
+++ b/packages/webawesome/docs/docs/tokens/index.njk
@@ -2,6 +2,7 @@
 title: Design Tokens
 description: CSS custom properties that control the look and feel of every Web Awesome component, giving your theme a consistent, customizable appearance.
 layout: page-outline
+wide: true
 hasBreadcrumbs: false
 hasOutline: false
 override:tags: []

--- a/packages/webawesome/docs/docs/tokens/index.njk
+++ b/packages/webawesome/docs/docs/tokens/index.njk
@@ -2,7 +2,6 @@
 title: Design Tokens
 description: CSS custom properties that control the look and feel of every Web Awesome component, giving your theme a consistent, customizable appearance.
 layout: page-outline
-wide: true
 hasBreadcrumbs: false
 hasOutline: false
 override:tags: []


### PR DESCRIPTION
This work reverts the wide-treatment removal from #2482 (https://github.com/shoelace-style/webawesome/pull/2482/changes/a393259d58321773645cabe206aea6b9e5d437ae). 

It restores the `page-wide` body class hook in `base.njk`, the `.page-wide` CSS rule and `:has(.modern-card-list)` auto-widening in `docs.css`, and the `wide: true` frontmatter on Visual Tests.

The Design Tokens index intentionally remains at the default width — the card-list layout appears fine without the wide bump.

