### PR TITLE
fix(carousel): Pagination block height fix

### DIFF
--- a/packages/webawesome/src/components/carousel/carousel.styles.ts
+++ b/packages/webawesome/src/components/carousel/carousel.styles.ts
@@ -29,6 +29,7 @@ export default css`
     flex-wrap: wrap;
     justify-content: center;
     gap: var(--wa-space-s);
+    padding-block: var(--wa-space-3xs);
   }
 
   .slides {


### PR DESCRIPTION
## Summary

This PR fixes the height of the pagination container in the carousel component to ensure that the active pagination item is always fully visible.

## Changes
Added a small amount of vertical padding to the pagination container:
```
padding-block: var(--wa-space-3xs);
```

## Impact
Prevents the active pagination item from being cropped.

Fixes #2495