### PR TITLE
Docs: Make Titles Flush Again 🚽

### DIFF
--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -133,12 +133,6 @@ wa-page > main:has(.modern-card-list) {
     font-size: var(--wa-font-size-l);
     margin-block-start: var(--wa-space-l);
   }
-
-  /* The breadcrumb is navigation, not prose flow — drop wa-prose's
-     previous-sibling top margin on the page title that follows it. */
-  .page-breadcrumbs + h1 {
-    margin-block-start: 0;
-  }
 }
 
 .component-ref {
@@ -211,6 +205,9 @@ wa-page > main:has(.modern-card-list) {
 }
 
 h1.title {
+  /* Siblings above own their block-end spacing — skip wa-prose's `* + h1` top margin. */
+  margin-block-start: 0;
+
   wa-badge {
     vertical-align: middle;
     font-size: 1.5rem;


### PR DESCRIPTION
The recent addition and application of `.wa-prose` added some extra top visual whitespace (via `margin-block-start` on `h1` elements) to our Docs' titles. This work fixes that with some surgical `docs.css` action.

| Before | After |
|--------|--------|
| <img width="2928" height="1636" alt="image" src="https://github.com/user-attachments/assets/dd9a5ced-a60b-4ca0-af7e-920f2abf0cc2" /> | <img width="2928" height="1636" alt="image" src="https://github.com/user-attachments/assets/aba3e276-b193-47d1-9bb8-d93ef21982a4" /> | 