### PR TITLE
fix: add carousel pagination block padding

### DIFF
--- a/packages/webawesome/src/components/carousel/carousel.styles.ts
+++ b/packages/webawesome/src/components/carousel/carousel.styles.ts
@@ -29,6 +29,7 @@ export default css`
     flex-wrap: wrap;
     justify-content: center;
     gap: var(--wa-space-s);
+    padding-block: var(--wa-space-2xs);
   }
 
   .slides {


### PR DESCRIPTION
## Summary
- add block-axis padding to carousel pagination so the scaled active indicator is contained

Fixes #2495