### PR TITLE
fix(tooltip): use relatedTarget instead of :hover matching in handleMouseOut

### DIFF
--- a/packages/webawesome/src/components/tooltip/tooltip.test.ts
+++ b/packages/webawesome/src/components/tooltip/tooltip.test.ts
@@ -441,6 +441,30 @@ describe('<wa-tooltip>', () => {
       await waitUntil(() => tooltip.open);
       expect(tooltip.open).to.be.true;
     });
+
+    it('should remain open when the pointer moves onto a slotted child element of the tooltip', async () => {
+      const el = await fixtures[0]<HTMLDivElement>(html`
+        <div>
+          <wa-button id="hover-child-btn">Hover me</wa-button>
+          <wa-tooltip for="hover-child-btn" trigger="hover" show-delay="0" hide-delay="0">
+            <a href="#" id="tooltip-link">A link inside the tooltip</a>
+          </wa-tooltip>
+        </div>
+      `);
+      const tooltip = el.querySelector<WaTooltip>('wa-tooltip')!;
+      const childLink = el.querySelector<HTMLElement>('#tooltip-link')!;
+
+      tooltip.open = true;
+      await waitUntil(() => tooltip.open);
+      expect(tooltip.open).to.be.true;
+
+      // Simulate the pointer moving off of the tooltip host and onto a slotted child element.
+      // relatedTarget is the element the pointer is moving to, which is how browsers report this.
+      tooltip.dispatchEvent(new MouseEvent('mouseout', { relatedTarget: childLink, bubbles: true }));
+      await aTimeout(50);
+
+      expect(tooltip.open).to.be.true;
+    });
   });
 
   describe('keyboard navigation', () => {

--- a/packages/webawesome/src/components/tooltip/tooltip.ts
+++ b/packages/webawesome/src/components/tooltip/tooltip.ts
@@ -198,22 +198,26 @@ export default class WaTooltip extends WebAwesomeElement {
     }
   };
 
-  private handleMouseOut = () => {
+  private handleMouseOut = (event: MouseEvent) => {
     if (this.hasTrigger('hover')) {
-      const anchorHovered = Boolean(this.anchor?.matches(':hover'));
-      const tooltipHovered = this.matches(':hover');
+      const relatedTarget = event.relatedTarget as Node | null;
 
-      if (anchorHovered || tooltipHovered) {
+      // Use the event's relatedTarget (the element the pointer moved to) to determine whether the
+      // pointer is still within the anchor or the tooltip itself. Relying on `:hover` matching here is
+      // unreliable in Chrome when the pointer moves onto a slotted child element of the tooltip, since
+      // the host's `:hover` state can briefly report false during that transition.
+      const movedIntoAnchor = Boolean(relatedTarget && this.anchor?.contains(relatedTarget));
+      const movedIntoTooltip = Boolean(relatedTarget && this.contains(relatedTarget));
+
+      if (movedIntoAnchor || movedIntoTooltip) {
         return;
       }
 
       clearTimeout(this.hoverTimeout);
 
-      if (!(anchorHovered || tooltipHovered)) {
-        this.hoverTimeout = window.setTimeout(() => {
-          this.hide();
-        }, this.hideDelay);
-      }
+      this.hoverTimeout = window.setTimeout(() => {
+        this.hide();
+      }, this.hideDelay);
     }
   };
 


### PR DESCRIPTION
Fixes #2507

### Root cause
`handleMouseOut` determined whether to keep the tooltip open by checking `this.anchor?.matches(':hover')` and `this.matches(':hover')` after the mouseout event fired. In Chrome, when the pointer moves from the tooltip host onto a slotted child element, the host's `:hover` pseudo-class can briefly evaluate to false during that transition, causing the tooltip to incorrectly close.

### Fix
`handleMouseOut` now reads `event.relatedTarget` — the element the pointer is moving to, which browsers provide reliably on `mouseout` — and checks whether that target is contained within the anchor or the tooltip using `Node.contains()`. This avoids the timing-dependent `:hover` matching issue entirely.

### Testing
Added a new test case in `tooltip.test.ts` that opens the tooltip, dispatches a `mouseout` event with `relatedTarget` set to a slotted child link, and asserts the tooltip remains open, directly reproducing the reported bug.

### Steps to test
1. Open the tooltip docs page: https://webawesome.com/docs/components/tooltip/
2. Try the "HTML in Tooltips" example in Chrome
3. Hover over the tooltip's child content — it should no longer close