### PR TITLE
Checkbox Group

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -95,6 +95,7 @@
     "giga",
     "globby",
     "Grayscale",
+    "Groupable",
     "groupby",
     "haspopup",
     "heroicons",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13732,11 +13732,14 @@
     },
     "packages/webawesome-pro": {
       "name": "@awesome.me/webawesome-pro",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "dependencies": {
         "@ctrl/tinycolor": "4.1.0",
         "@floating-ui/dom": "^1.6.13",
         "@konnorr/qr-creator": "^1.0.1",
+        "@lit-labs/ssr": "^4.1.0",
+        "@lit-labs/ssr-client": "^1.1.8",
+        "@lit/context": "^1.1.6",
         "@lit/react": "^1.0.8",
         "@shoelace-style/animations": "^1.2.0",
         "@shoelace-style/localize": "^3.2.2",
@@ -13751,6 +13754,7 @@
         "@wc-toolkit/cem-validator": "^1.0.3",
         "@wc-toolkit/jsx-types": "^1.3.0",
         "@web/dev-server-rollup": "^0.6.4",
+        "cookie-parser": "^1.4.7",
         "eleventy-plugin-git-commit-date": "^0.1.3",
         "esbuild": "^0.25.11",
         "gray-matter": "^4.0.3",
@@ -14165,6 +14169,17 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "packages/webawesome-pro/node_modules/@lit-labs/ssr-client": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-client/-/ssr-client-1.1.8.tgz",
+      "integrity": "sha512-PjGh81oKsoI64m3IDjTqqjhC7dr2uC/o0jrllUb5gRAyp/RlAHxapgJrjq9kWz97faCHLQ8jUlTi6tGm+8fgyA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit": "^3.1.2",
+        "lit-html": "^3.1.2"
       }
     },
     "packages/webawesome-pro/node_modules/@web/dev-server-core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13732,14 +13732,11 @@
     },
     "packages/webawesome-pro": {
       "name": "@awesome.me/webawesome-pro",
-      "version": "3.8.0",
+      "version": "3.7.0",
       "dependencies": {
         "@ctrl/tinycolor": "4.1.0",
         "@floating-ui/dom": "^1.6.13",
         "@konnorr/qr-creator": "^1.0.1",
-        "@lit-labs/ssr": "^4.1.0",
-        "@lit-labs/ssr-client": "^1.1.8",
-        "@lit/context": "^1.1.6",
         "@lit/react": "^1.0.8",
         "@shoelace-style/animations": "^1.2.0",
         "@shoelace-style/localize": "^3.2.2",
@@ -13754,7 +13751,6 @@
         "@wc-toolkit/cem-validator": "^1.0.3",
         "@wc-toolkit/jsx-types": "^1.3.0",
         "@web/dev-server-rollup": "^0.6.4",
-        "cookie-parser": "^1.4.7",
         "eleventy-plugin-git-commit-date": "^0.1.3",
         "esbuild": "^0.25.11",
         "gray-matter": "^4.0.3",
@@ -14169,17 +14165,6 @@
       ],
       "engines": {
         "node": ">=18"
-      }
-    },
-    "packages/webawesome-pro/node_modules/@lit-labs/ssr-client": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-client/-/ssr-client-1.1.8.tgz",
-      "integrity": "sha512-PjGh81oKsoI64m3IDjTqqjhC7dr2uC/o0jrllUb5gRAyp/RlAHxapgJrjq9kWz97faCHLQ8jUlTi6tGm+8fgyA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit/reactive-element": "^2.0.4",
-        "lit": "^3.1.2",
-        "lit-html": "^3.1.2"
       }
     },
     "packages/webawesome-pro/node_modules/@web/dev-server-core": {

--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -230,6 +230,7 @@
 </h2>
 <ul>
     <li><a href="/docs/components/checkbox/">Checkbox</a></li>
+    <li><a href="/docs/components/checkbox-group/">Checkbox Group</a></li>
     <li><a href="/docs/components/color-picker/">Color Picker</a></li>
     <li>
       <span class="wa-split">

--- a/packages/webawesome/docs/assets/scripts/code-examples.js
+++ b/packages/webawesome/docs/assets/scripts/code-examples.js
@@ -51,8 +51,10 @@ function getCodeExampleDurations(source) {
 function setCodeExampleSourceAccessibility(source, open) {
   if (open) {
     source.removeAttribute('aria-hidden');
+    source.inert = false;
   } else {
     source.setAttribute('aria-hidden', 'true');
+    source.inert = true;
   }
 }
 

--- a/packages/webawesome/docs/docs/components/checkbox-group.md
+++ b/packages/webawesome/docs/docs/components/checkbox-group.md
@@ -66,15 +66,29 @@ Checkbox groups stack vertically by default. Set the `orientation` attribute to 
 
 ### Sizes
 
-Set the `size` attribute on each checkbox to change its size.
+The size of grouped checkboxes and switches is determined by the checkbox group's `size` attribute. Any `size` set on individual items will be overridden.
 
 ```html {.example}
-<wa-checkbox-group label="Amenities">
-  <wa-checkbox name="wifi" size="xl">Wi-Fi</wa-checkbox>
-  <wa-checkbox name="parking" size="xl">Parking</wa-checkbox>
-  <wa-checkbox name="breakfast" size="xl">Breakfast</wa-checkbox>
-  <wa-checkbox name="pool" size="xl">Pool</wa-checkbox>
+<wa-checkbox-group id="checkbox-group-size" label="Options" hint="Use the select below to change the size." size="m">
+  <wa-checkbox>Option 1</wa-checkbox>
+  <wa-checkbox>Option 2</wa-checkbox>
+  <wa-checkbox>Option 3</wa-checkbox>
 </wa-checkbox-group>
+
+<wa-select label="Size" value="m" style="max-width: 200px; margin-top: 2rem;">
+  <wa-option value="xs">Extra small</wa-option>
+  <wa-option value="s">Small</wa-option>
+  <wa-option value="m">Medium</wa-option>
+  <wa-option value="l">Large</wa-option>
+  <wa-option value="xl">Extra large</wa-option>
+</wa-select>
+
+<script>
+  const checkboxGroup = document.getElementById('checkbox-group-size');
+  const sizeSelect = checkboxGroup.nextElementSibling;
+
+  sizeSelect.addEventListener('change', () => (checkboxGroup.size = sizeSelect.value));
+</script>
 ```
 
 ### Disabling

--- a/packages/webawesome/docs/docs/components/checkbox-group.md
+++ b/packages/webawesome/docs/docs/components/checkbox-group.md
@@ -1,0 +1,117 @@
+---
+title: Checkbox Group
+description: Checkbox groups give a set of related checkboxes or switches a shared label, hint, and grouping semantics.
+layout: component
+category: Forms
+synonyms:
+  - checkbox list
+  - option group
+  - multi-select
+use-cases:
+  - interest pickers
+  - permission lists
+  - filter panels
+---
+
+Checkboxes in a group remain independent form controls with their own `name`, `value`, and validation. The group exists to provide a shared label, hint, and accessible grouping.
+
+```html {.example}
+<wa-checkbox-group label="Interests">
+  <wa-checkbox name="design">Design</wa-checkbox>
+  <wa-checkbox name="development">Development</wa-checkbox>
+  <wa-checkbox name="marketing">Marketing</wa-checkbox>
+</wa-checkbox-group>
+```
+
+## Examples
+
+### Labels
+
+Use the `label` attribute to give the group an accessible label. For labels that contain HTML, use the `label` slot instead.
+
+```html {.example}
+<wa-checkbox-group label="Toppings">
+  <wa-checkbox name="pepperoni">Pepperoni</wa-checkbox>
+  <wa-checkbox name="mushrooms">Mushrooms</wa-checkbox>
+  <wa-checkbox name="onions">Onions</wa-checkbox>
+  <wa-checkbox name="peppers">Peppers</wa-checkbox>
+  <wa-checkbox name="sausage">Sausage</wa-checkbox>
+  <wa-checkbox name="extra-cheese">Extra cheese</wa-checkbox>
+</wa-checkbox-group>
+```
+
+### Hint
+
+Add a descriptive hint to a checkbox group with the `hint` attribute. For hints that contain HTML, use the `hint` slot instead.
+
+```html {.example}
+<wa-checkbox-group label="Workdays" hint="Choose as many as you like.">
+  <wa-checkbox name="monday">Monday</wa-checkbox>
+  <wa-checkbox name="wednesday">Wednesday</wa-checkbox>
+  <wa-checkbox name="friday">Friday</wa-checkbox>
+</wa-checkbox-group>
+```
+
+### Orientation
+
+Checkbox groups stack vertically by default. Set the `orientation` attribute to `horizontal` to lay them out in a row.
+
+```html {.example}
+<wa-checkbox-group label="Sizes" orientation="horizontal">
+  <wa-checkbox name="small">Small</wa-checkbox>
+  <wa-checkbox name="medium">Medium</wa-checkbox>
+  <wa-checkbox name="large">Large</wa-checkbox>
+</wa-checkbox-group>
+```
+
+### Sizes
+
+Set the `size` attribute on each checkbox to change its size.
+
+```html {.example}
+<wa-checkbox-group label="Amenities">
+  <wa-checkbox name="wifi" size="xl">Wi-Fi</wa-checkbox>
+  <wa-checkbox name="parking" size="xl">Parking</wa-checkbox>
+  <wa-checkbox name="breakfast" size="xl">Breakfast</wa-checkbox>
+  <wa-checkbox name="pool" size="xl">Pool</wa-checkbox>
+</wa-checkbox-group>
+```
+
+### Disabling
+
+A checkbox group itself can't be disabled. Add the `disabled` attribute to individual checkboxes to disable them.
+
+```html {.example}
+<wa-checkbox-group label="Add-ons">
+  <wa-checkbox name="insurance" disabled>Insurance</wa-checkbox>
+  <wa-checkbox name="gift-wrap" disabled>Gift wrap</wa-checkbox>
+  <wa-checkbox name="express-shipping">Express shipping</wa-checkbox>
+  <wa-checkbox name="extended-warranty">Extended warranty</wa-checkbox>
+</wa-checkbox-group>
+```
+
+### Switches
+
+A checkbox group also works with [switches](/docs/components/switch).
+
+```html {.example}
+<wa-checkbox-group label="Notifications" hint="Pick at least one channel.">
+  <wa-switch name="email">Email</wa-switch>
+  <wa-switch name="sms">SMS</wa-switch>
+  <wa-switch name="push">Push</wa-switch>
+</wa-checkbox-group>
+```
+
+### Required
+
+The `required` attribute adds a visual indicator to the group's label. Because each checkbox is an independent control, the checkbox group doesn't enforce the requirement. Set the `required` property on the checkbox or call its `setCustomValidity()` method to control validation.
+
+```html {.example}
+<form>
+  <wa-checkbox-group label="Accept terms" required>
+    <wa-checkbox name="terms" required>I agree to the terms and conditions</wa-checkbox>
+  </wa-checkbox-group>
+  <br />
+  <wa-button type="submit" appearance="filled">Submit</wa-button>
+</form>
+```

--- a/packages/webawesome/docs/docs/components/dialog.md
+++ b/packages/webawesome/docs/docs/components/dialog.md
@@ -19,7 +19,7 @@ use-cases:
 ```html {.example}
 <wa-dialog label="Dialog" id="dialog-overview">
   This is a standard dialog. You can put any content you want in here!
-  <wa-button appearance="filled" slot="footer" variant="brand" data-dialog="close">Close</wa-button>
+  <wa-button slot="footer" variant="brand" data-dialog="close">Close</wa-button>
 </wa-dialog>
 
 <wa-button appearance="filled">Open Dialog</wa-button>
@@ -105,7 +105,7 @@ Just use the `--width` custom property to set the dialog's width.
 ```html {.example}
 <wa-dialog label="Dialog" class="dialog-width" style="--width: 50vw;">
   This dialog is wider than the default — handy when you need more room for content.
-  <wa-button appearance="filled" slot="footer" variant="brand" data-dialog="close">Close</wa-button>
+  <wa-button slot="footer" variant="brand" data-dialog="close">Close</wa-button>
 </wa-dialog>
 
 <wa-button appearance="filled">Open Dialog</wa-button>

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -33,7 +33,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 :::added
 
-- Added the `<wa-checkbox-group>` component for grouping related checkboxes or switches under a shared label and hint.
+- Added the `<wa-checkbox-group>` component
 - Added `leaf-multiple` as a new `selection` option for `<wa-tree>`, allowing multiple leaf nodes to be selected while parent nodes only expand and collapse.
 
 :::

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -33,6 +33,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 :::added
 
+- Added the `<wa-checkbox-group>` component for grouping related checkboxes or switches under a shared label and hint.
 - Added `leaf-multiple` as a new `selection` option for `<wa-tree>`, allowing multiple leaf nodes to be selected while parent nodes only expand and collapse.
 
 :::

--- a/packages/webawesome/src/components/checkbox-group/checkbox-group.styles.ts
+++ b/packages/webawesome/src/components/checkbox-group/checkbox-group.styles.ts
@@ -1,0 +1,57 @@
+import { css } from 'lit';
+
+export default css`
+  :host {
+    --gap: 0.5em;
+
+    display: block;
+  }
+
+  :host([orientation='horizontal']) {
+    --gap: 1em;
+  }
+
+  .form-control {
+    position: relative;
+    border: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .label {
+    padding: 0;
+  }
+
+  .checkbox-group-required .label::after {
+    content: var(--wa-form-control-required-content);
+    margin-inline-start: var(--wa-form-control-required-content-offset);
+  }
+
+  /* The group of checkboxes */
+  [part~='form-control-input'] {
+    display: flex;
+    flex-direction: column;
+    /* Keep items sized to their content so the clickable label doesn't span the full width */
+    align-items: start;
+    gap: var(--gap);
+    margin-block-start: 0.5em;
+  }
+
+  /* Horizontal */
+  :host([orientation='horizontal']) [part~='form-control-input'] {
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+
+  /* Hint */
+  [part~='hint'] {
+    margin-block-start: 0.5em;
+  }
+
+  /* Hide the required asterisk on individual controls; the group's label carries the indicator instead. */
+  ::slotted(wa-checkbox[required]),
+  ::slotted(wa-switch[required]) {
+    --wa-form-control-required-content: '';
+  }
+`;

--- a/packages/webawesome/src/components/checkbox-group/checkbox-group.test.ts
+++ b/packages/webawesome/src/components/checkbox-group/checkbox-group.test.ts
@@ -47,7 +47,7 @@ describe('<wa-checkbox-group>', () => {
     expect(el.orientation).to.equal('vertical');
   });
 
-  it('should not change the size of grouped checkboxes', async () => {
+  it('should not change the size of grouped checkboxes when no group size is set', async () => {
     const el = await fixture<WaCheckboxGroup>(html`
       <wa-checkbox-group label="Toppings">
         <wa-checkbox value="cheese" size="xs">Cheese</wa-checkbox>
@@ -59,5 +59,69 @@ describe('<wa-checkbox-group>', () => {
     const checkboxes = [...el.querySelectorAll('wa-checkbox')];
     expect(checkboxes[0].getAttribute('size')).to.equal('xs');
     expect(checkboxes[1].getAttribute('size')).to.equal('xl');
+  });
+
+  it('should apply the group size to all grouped checkboxes', async () => {
+    const el = await fixture<WaCheckboxGroup>(html`
+      <wa-checkbox-group label="Toppings" size="l">
+        <wa-checkbox value="cheese">Cheese</wa-checkbox>
+        <wa-checkbox value="olives" size="xs">Olives</wa-checkbox>
+      </wa-checkbox-group>
+    `);
+
+    await el.updateComplete;
+    const checkboxes = [...el.querySelectorAll('wa-checkbox')];
+    // The group always wins, mirroring <wa-radio-group>, even when a child declares its own size.
+    expect(checkboxes[0].getAttribute('size')).to.equal('l');
+    expect(checkboxes[1].getAttribute('size')).to.equal('l');
+  });
+
+  it('should apply the group size to grouped switches', async () => {
+    const el = await fixture<WaCheckboxGroup>(html`
+      <wa-checkbox-group label="Settings" size="s">
+        <wa-switch value="wifi">Wi-Fi</wa-switch>
+        <wa-switch value="bluetooth">Bluetooth</wa-switch>
+      </wa-checkbox-group>
+    `);
+
+    await el.updateComplete;
+    const switches = [...el.querySelectorAll('wa-switch')];
+    expect(switches[0].getAttribute('size')).to.equal('s');
+    expect(switches[1].getAttribute('size')).to.equal('s');
+  });
+
+  it('should update grouped checkboxes when the group size changes at runtime', async () => {
+    const el = await fixture<WaCheckboxGroup>(html`
+      <wa-checkbox-group label="Toppings" size="s">
+        <wa-checkbox value="cheese">Cheese</wa-checkbox>
+        <wa-checkbox value="olives">Olives</wa-checkbox>
+      </wa-checkbox-group>
+    `);
+
+    await el.updateComplete;
+    el.size = 'xl';
+    await el.updateComplete;
+
+    const checkboxes = [...el.querySelectorAll('wa-checkbox')];
+    expect(checkboxes[0].getAttribute('size')).to.equal('xl');
+    expect(checkboxes[1].getAttribute('size')).to.equal('xl');
+  });
+
+  it('should apply the group size to checkboxes added after initial render', async () => {
+    const el = await fixture<WaCheckboxGroup>(html`
+      <wa-checkbox-group label="Toppings" size="l">
+        <wa-checkbox value="cheese">Cheese</wa-checkbox>
+      </wa-checkbox-group>
+    `);
+
+    await el.updateComplete;
+
+    const added = document.createElement('wa-checkbox');
+    added.setAttribute('value', 'olives');
+    el.appendChild(added);
+    await el.updateComplete;
+    await added.updateComplete;
+
+    expect(added.getAttribute('size')).to.equal('l');
   });
 });

--- a/packages/webawesome/src/components/checkbox-group/checkbox-group.test.ts
+++ b/packages/webawesome/src/components/checkbox-group/checkbox-group.test.ts
@@ -1,0 +1,63 @@
+import { expect, fixture, html } from '@open-wc/testing';
+import type WaCheckboxGroup from './checkbox-group.js';
+
+describe('<wa-checkbox-group>', () => {
+  it('should render a labeled group of checkboxes', async () => {
+    const el = await fixture<WaCheckboxGroup>(html`
+      <wa-checkbox-group label="Toppings">
+        <wa-checkbox value="cheese">Cheese</wa-checkbox>
+        <wa-checkbox value="olives">Olives</wa-checkbox>
+      </wa-checkbox-group>
+    `);
+
+    expect(el).to.exist;
+  });
+
+  it('should be accessible', async () => {
+    const el = await fixture<WaCheckboxGroup>(html`
+      <wa-checkbox-group label="Toppings" hint="Choose any you like.">
+        <wa-checkbox value="cheese">Cheese</wa-checkbox>
+        <wa-checkbox value="olives">Olives</wa-checkbox>
+      </wa-checkbox-group>
+    `);
+
+    await expect(el).to.be.accessible();
+  });
+
+  it('should expose a role="group" wrapper labeled by the label', async () => {
+    const el = await fixture<WaCheckboxGroup>(html`
+      <wa-checkbox-group label="Toppings">
+        <wa-checkbox value="cheese">Cheese</wa-checkbox>
+      </wa-checkbox-group>
+    `);
+
+    const group = el.shadowRoot!.querySelector('[role="group"]')!;
+    expect(group).to.exist;
+    expect(group.getAttribute('aria-labelledby')).to.equal('label');
+    expect(group.getAttribute('aria-describedby')).to.equal('hint');
+  });
+
+  it('should default to vertical orientation', async () => {
+    const el = await fixture<WaCheckboxGroup>(html`
+      <wa-checkbox-group label="Toppings">
+        <wa-checkbox value="cheese">Cheese</wa-checkbox>
+      </wa-checkbox-group>
+    `);
+
+    expect(el.orientation).to.equal('vertical');
+  });
+
+  it('should not change the size of grouped checkboxes', async () => {
+    const el = await fixture<WaCheckboxGroup>(html`
+      <wa-checkbox-group label="Toppings">
+        <wa-checkbox value="cheese" size="xs">Cheese</wa-checkbox>
+        <wa-checkbox value="olives" size="xl">Olives</wa-checkbox>
+      </wa-checkbox-group>
+    `);
+
+    await el.updateComplete;
+    const checkboxes = [...el.querySelectorAll('wa-checkbox')];
+    expect(checkboxes[0].getAttribute('size')).to.equal('xs');
+    expect(checkboxes[1].getAttribute('size')).to.equal('xl');
+  });
+});

--- a/packages/webawesome/src/components/checkbox-group/checkbox-group.ts
+++ b/packages/webawesome/src/components/checkbox-group/checkbox-group.ts
@@ -1,10 +1,15 @@
+import type { PropertyValues } from 'lit';
 import { html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { warnDeprecatedSize } from '../../internal/size.js';
 import { HasSlotController } from '../../internal/slot.js';
+import { watch } from '../../internal/watch.js';
 import WebAwesomeElement from '../../internal/webawesome-element.js';
 import formControlStyles from '../../styles/component/form-control.styles.js';
+import sizeStyles from '../../styles/component/size.styles.js';
 import '../checkbox/checkbox.js';
+import type WaCheckbox from '../checkbox/checkbox.js';
 import styles from './checkbox-group.styles.js';
 
 /**
@@ -30,7 +35,7 @@ import styles from './checkbox-group.styles.js';
  */
 @customElement('wa-checkbox-group')
 export default class WaCheckboxGroup extends WebAwesomeElement {
-  static css = [formControlStyles, styles];
+  static css = [sizeStyles, formControlStyles, styles];
 
   private readonly hasSlotController = new HasSlotController(this, 'hint', 'label');
 
@@ -45,6 +50,16 @@ export default class WaCheckboxGroup extends WebAwesomeElement {
 
   /** The orientation in which to show grouped checkboxes. */
   @property({ reflect: true }) orientation: 'horizontal' | 'vertical' = 'vertical';
+
+  /**
+   * The group's size. When present, this size will be applied to all `<wa-checkbox>` and `<wa-switch>` items inside.
+   */
+  @property({ reflect: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large';
+
+  @watch('size')
+  handleSizeChange() {
+    warnDeprecatedSize(this.localName, this.size);
+  }
 
   /**
    * Indicates that at least one option should be selected. This only adds a visual indicator to the label. To enforce
@@ -64,6 +79,28 @@ export default class WaCheckboxGroup extends WebAwesomeElement {
    * the hint before the component hydrates on the client.
    */
   @property({ type: Boolean, attribute: 'with-hint' }) withHint = false;
+
+  updated(changedProperties: PropertyValues<this>) {
+    if (changedProperties.has('size')) {
+      this.syncCheckboxElements();
+    }
+  }
+
+  /** Returns all grouped checkbox and switch elements. */
+  private getAllCheckboxes() {
+    return [...this.querySelectorAll<WaCheckbox>(':is(wa-checkbox, wa-switch)')];
+  }
+
+  /**
+   * Applies the group's size to each grouped checkbox/switch
+   */
+  private syncCheckboxElements = () => {
+    if (!this.size) return;
+
+    for (const checkbox of this.getAllCheckboxes()) {
+      checkbox.setAttribute('size', this.size);
+    }
+  };
 
   render() {
     const hasLabelSlot = this.hasSlotController.test('label', 'withLabel');
@@ -93,7 +130,7 @@ export default class WaCheckboxGroup extends WebAwesomeElement {
         </label>
 
         <div part="form-control-input" role="group" aria-labelledby="label" aria-describedby="hint">
-          <slot></slot>
+          <slot @slotchange=${this.syncCheckboxElements}></slot>
         </div>
 
         <slot

--- a/packages/webawesome/src/components/checkbox-group/checkbox-group.ts
+++ b/packages/webawesome/src/components/checkbox-group/checkbox-group.ts
@@ -1,0 +1,122 @@
+import { html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
+import { HasSlotController } from '../../internal/slot.js';
+import WebAwesomeElement from '../../internal/webawesome-element.js';
+import formControlStyles from '../../styles/component/form-control.styles.js';
+import '../checkbox/checkbox.js';
+import styles from './checkbox-group.styles.js';
+
+/**
+ * @summary Checkbox groups wrap a set of related checkboxes or switches so they share a label, hint, and grouping
+ *  semantics.
+ * @documentation https://webawesome.com/docs/components/checkbox-group
+ * @status stable
+ * @since 3.9
+ *
+ * @dependency wa-checkbox
+ *
+ * @slot - The default slot where `<wa-checkbox>` or `<wa-switch>` elements are placed.
+ * @slot label - The checkbox group's label. Required for proper accessibility. Alternatively, you can use the `label`
+ *  attribute.
+ * @slot hint - Text that describes how to use the checkbox group. Alternatively, you can use the `hint` attribute.
+ *
+ * @csspart form-control - The form control that wraps the label, group, and hint.
+ * @csspart form-control-label - The label's wrapper.
+ * @csspart form-control-input - The element that wraps the grouped checkboxes, exposed as a `role="group"`.
+ * @csspart hint - The hint's wrapper.
+ *
+ * @cssproperty [--gap=0.5em] - The gap between grouped checkboxes.
+ */
+@customElement('wa-checkbox-group')
+export default class WaCheckboxGroup extends WebAwesomeElement {
+  static css = [formControlStyles, styles];
+
+  private readonly hasSlotController = new HasSlotController(this, 'hint', 'label');
+
+  /**
+   * The checkbox group's label. Required for proper accessibility. If you need to display HTML, use the `label` slot
+   * instead.
+   */
+  @property() label = '';
+
+  /** The checkbox group's hint. If you need to display HTML, use the `hint` slot instead. */
+  @property({ attribute: 'hint' }) hint = '';
+
+  /** The orientation in which to show grouped checkboxes. */
+  @property({ reflect: true }) orientation: 'horizontal' | 'vertical' = 'vertical';
+
+  /**
+   * Indicates that at least one option should be selected. This only adds a visual indicator to the label. To enforce
+   * the requirement, use the `required` attribute on the individual checkboxes and/or their `setCustomValidity()`
+   * method.
+   */
+  @property({ type: Boolean, reflect: true }) required = false;
+
+  /**
+   * Only required for SSR. Set to `true` if you're slotting in a `label` element so the server-rendered markup includes
+   * the label before the component hydrates on the client.
+   */
+  @property({ type: Boolean, attribute: 'with-label' }) withLabel = false;
+
+  /**
+   * Only required for SSR. Set to `true` if you're slotting in a `hint` element so the server-rendered markup includes
+   * the hint before the component hydrates on the client.
+   */
+  @property({ type: Boolean, attribute: 'with-hint' }) withHint = false;
+
+  render() {
+    const hasLabelSlot = this.hasSlotController.test('label', 'withLabel');
+    const hasHintSlot = this.hasSlotController.test('hint', 'withHint');
+    const hasLabel = this.label ? true : !!hasLabelSlot;
+    const hasHint = this.hint ? true : !!hasHintSlot;
+
+    return html`
+      <fieldset
+        part="form-control"
+        class=${classMap({
+          'form-control': true,
+          'checkbox-group-required': this.required,
+          'form-control-has-label': hasLabel,
+        })}
+      >
+        <label
+          part="form-control-label"
+          id="label"
+          class=${classMap({
+            label: true,
+            'has-label': hasLabel,
+          })}
+          aria-hidden=${hasLabel ? 'false' : 'true'}
+        >
+          <slot name="label">${this.label}</slot>
+        </label>
+
+        <div part="form-control-input" role="group" aria-labelledby="label" aria-describedby="hint">
+          <slot></slot>
+        </div>
+
+        <slot
+          id="hint"
+          name="hint"
+          part="hint"
+          class=${classMap({
+            'has-slotted': hasHint,
+          })}
+          aria-hidden=${hasHint ? 'false' : 'true'}
+          >${this.hint}</slot
+        >
+      </fieldset>
+    `;
+  }
+}
+
+// HasSlotController calls requestUpdate() in response to slotchange events after first render. See
+// https://lit.dev/docs/tools/development/#development-build-runtime-warnings
+WaCheckboxGroup.disableWarning?.('change-in-update');
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'wa-checkbox-group': WaCheckboxGroup;
+  }
+}


### PR DESCRIPTION
Adds the `<wa-checkbox-group>` component as [previously discussed](https://github.com/shoelace-style/webawesome/discussions/947).

<img width="745" alt="CleanShot 2026-06-17 at 12 47 58@2x" src="https://github.com/user-attachments/assets/bb42b8ea-8cad-4376-98e9-069f186e9c19" />


Unrelated fixes:

- Fixed a bug in the code examples logic that allowed the copy button to receive focus when collapsed
- Fixes button styles in the dialog example for consistency

Related: 

- #1076