### PR TITLE
Support native buttons in `<wa-button-group>`

### DIFF
--- a/packages/webawesome/docs/_includes/visual-tests/native.njk
+++ b/packages/webawesome/docs/_includes/visual-tests/native.njk
@@ -163,6 +163,106 @@
 </div>
 <wa-divider></wa-divider>
 
+<h3>Button Group</h3>
+
+<div class="table-scroll">
+<table>
+  <thead>
+    <th></th>
+    <th><code>&lt;wa-button&gt;</code></th>
+    <th><code>&lt;button&gt;</code></th>
+  </thead>
+  <tbody>
+    <tr>
+      <th><em>default</em></th>
+      <td>
+        <wa-button-group label="Alignment">
+          <wa-button>Left</wa-button>
+          <wa-button>Center</wa-button>
+          <wa-button>Right</wa-button>
+        </wa-button-group>
+      </td>
+      <td>
+        <wa-button-group label="Alignment">
+          <button>Left</button>
+          <button>Center</button>
+          <button>Right</button>
+        </wa-button-group>
+      </td>
+    </tr>
+    <tr>
+      <th><code>filled</code></th>
+      <td>
+        <wa-button-group label="Alignment">
+          <wa-button appearance="filled">Left</wa-button>
+          <wa-button appearance="filled">Center</wa-button>
+          <wa-button appearance="filled">Right</wa-button>
+        </wa-button-group>
+      </td>
+      <td>
+        <wa-button-group label="Alignment">
+          <button class="wa-filled">Left</button>
+          <button class="wa-filled">Center</button>
+          <button class="wa-filled">Right</button>
+        </wa-button-group>
+      </td>
+    </tr>
+    <tr>
+      <th><code>outlined</code></th>
+      <td>
+        <wa-button-group label="Alignment">
+          <wa-button appearance="outlined">Left</wa-button>
+          <wa-button appearance="outlined">Center</wa-button>
+          <wa-button appearance="outlined">Right</wa-button>
+        </wa-button-group>
+      </td>
+      <td>
+        <wa-button-group label="Alignment">
+          <button class="wa-outlined">Left</button>
+          <button class="wa-outlined">Center</button>
+          <button class="wa-outlined">Right</button>
+        </wa-button-group>
+      </td>
+    </tr>
+    <tr>
+      <th><code>pill</code></th>
+      <td>
+        <wa-button-group label="Alignment">
+          <wa-button appearance="filled" pill>Left</wa-button>
+          <wa-button appearance="filled" pill>Center</wa-button>
+          <wa-button appearance="filled" pill>Right</wa-button>
+        </wa-button-group>
+      </td>
+      <td>
+        <wa-button-group label="Alignment">
+          <button class="wa-filled wa-pill">Left</button>
+          <button class="wa-filled wa-pill">Center</button>
+          <button class="wa-filled wa-pill">Right</button>
+        </wa-button-group>
+      </td>
+    </tr>
+    <tr>
+      <th><code>vertical</code></th>
+      <td>
+        <wa-button-group orientation="vertical" label="Alignment">
+          <wa-button appearance="filled">Top</wa-button>
+          <wa-button appearance="filled">Middle</wa-button>
+          <wa-button appearance="filled">Bottom</wa-button>
+        </wa-button-group>
+      </td>
+      <td>
+        <wa-button-group orientation="vertical" label="Alignment">
+          <button class="wa-filled">Top</button>
+          <button class="wa-filled">Middle</button>
+          <button class="wa-filled">Bottom</button>
+        </wa-button-group>
+      </td>
+    </tr>
+  </tbody>
+</table>
+</div>
+<wa-divider></wa-divider>
+
 <h3>Checkbox</h3>
 
 <div class="table-scroll">

--- a/packages/webawesome/docs/docs/components/button-group.md
+++ b/packages/webawesome/docs/docs/components/button-group.md
@@ -181,3 +181,15 @@ Create interactive toolbars with button groups.
   }
 </style>
 ```
+
+### Native Buttons
+
+Button groups also work with native `<button>` elements when [Native Styles](/docs/utilities/native) are included.
+
+```html {.example}
+<wa-button-group label="Alignment">
+  <button class="wa-filled">Left</button>
+  <button class="wa-filled">Center</button>
+  <button class="wa-filled">Right</button>
+</wa-button-group>
+```

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -34,6 +34,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 :::added
 
 - Added `leaf-multiple` as a new `selection` option for `<wa-tree>`, allowing multiple leaf nodes to be selected while parent nodes only expand and collapse.
+- Added support for grouping native `<button>` elements in `<wa-button-group>` when Native Styles are included [issue:2510]
 
 :::
 

--- a/packages/webawesome/src/components/button-group/button-group.test.ts
+++ b/packages/webawesome/src/components/button-group/button-group.test.ts
@@ -112,6 +112,39 @@ describe('<wa-button-group>', () => {
         });
       });
 
+      describe('native buttons', () => {
+        // The grouping styles are driven by custom properties that native.css consumes, so a button group should set
+        // the same radius overrides on slotted native `<button>` elements.
+        it('should apply radius custom properties to slotted native buttons', async () => {
+          const el = await fixture<WaButtonGroup>(html`
+            <wa-button-group label="Alignment">
+              <button class="wa-filled">Left</button>
+              <button class="wa-filled">Center</button>
+              <button class="wa-filled">Right</button>
+            </wa-button-group>
+          `);
+
+          const [first, middle, last] = [...el.querySelectorAll('button')];
+
+          // The middle button has all four corners squared off
+          const middleStyles = getComputedStyle(middle);
+          expect(middleStyles.getPropertyValue('--_button-start-start-radius').trim()).to.equal('0');
+          expect(middleStyles.getPropertyValue('--_button-start-end-radius').trim()).to.equal('0');
+          expect(middleStyles.getPropertyValue('--_button-end-start-radius').trim()).to.equal('0');
+          expect(middleStyles.getPropertyValue('--_button-end-end-radius').trim()).to.equal('0');
+
+          // The first button keeps its leading corners but squares off the trailing ones
+          const firstStyles = getComputedStyle(first);
+          expect(firstStyles.getPropertyValue('--_button-start-end-radius').trim()).to.equal('0');
+          expect(firstStyles.getPropertyValue('--_button-end-end-radius').trim()).to.equal('0');
+
+          // The last button keeps its trailing corners but squares off the leading ones
+          const lastStyles = getComputedStyle(last);
+          expect(lastStyles.getPropertyValue('--_button-start-start-radius').trim()).to.equal('0');
+          expect(lastStyles.getPropertyValue('--_button-end-start-radius').trim()).to.equal('0');
+        });
+      });
+
       describe('focus and hover behavior', () => {
         it('should add button-focus class on focusin and remove on focusout', async () => {
           const el = await fixture<WaButtonGroup>(html`

--- a/packages/webawesome/src/styles/native.css
+++ b/packages/webawesome/src/styles/native.css
@@ -648,7 +648,12 @@
 
       border-style: var(--wa-border-style);
       border-width: max(1px, var(--wa-form-control-border-width));
-      border-radius: var(--wa-form-control-border-radius);
+
+      /* These read the button group's internal custom properties so native buttons can be grouped */
+      border-start-start-radius: var(--_button-start-start-radius, var(--wa-form-control-border-radius));
+      border-start-end-radius: var(--_button-start-end-radius, var(--wa-form-control-border-radius));
+      border-end-start-radius: var(--_button-end-start-radius, var(--wa-form-control-border-radius));
+      border-end-end-radius: var(--_button-end-end-radius, var(--wa-form-control-border-radius));
 
       transition-property: background, border, box-shadow, color;
       transition-duration: var(--wa-transition-fast);
@@ -657,6 +662,19 @@
       cursor: pointer;
       user-select: none;
       -webkit-user-select: none;
+
+      /* Collapse adjacent borders */
+      margin-inline-start: var(--_button-horizontal-indent);
+      margin-block-start: var(--_button-vertical-indent);
+    }
+
+    /* Outlined variants use a negative indent so adjacent borders overlap */
+    &.wa-outlined {
+      &:not(input[type='file']),
+      &::file-selector-button {
+        margin-inline-start: var(--_button-horizontal-indent-outlined);
+        margin-block-start: var(--_button-vertical-indent-outlined);
+      }
     }
 
     /* Default styles for standard buttons */
@@ -847,7 +865,10 @@
     &.wa-pill {
       &:not(input[type='file']),
       &::file-selector-button {
-        border-radius: var(--wa-border-radius-pill);
+        border-start-start-radius: var(--_button-start-start-radius, var(--wa-border-radius-pill));
+        border-start-end-radius: var(--_button-start-end-radius, var(--wa-border-radius-pill));
+        border-end-start-radius: var(--_button-end-start-radius, var(--wa-border-radius-pill));
+        border-end-end-radius: var(--_button-end-end-radius, var(--wa-border-radius-pill));
       }
     }
 


### PR DESCRIPTION
As discussed in #2510:

- Added support for Native Style users to use native buttons inside `<wa-button-group>`.
- Added a visual test for button groups comparing WA + native buttons
- Added a section in the button group docs
- Updated tests
- Updated changelog

<img width="1028" alt="CleanShot 2026-06-17 at 14 30 49@2x" src="https://github.com/user-attachments/assets/cb8c260c-860a-4425-8a28-7d274e6dd3a9" />
