### PR TITLE
Remove Prose's `margin-block-start` Non-First `h1` Rule

### DIFF
--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -180,12 +180,6 @@ wa-page:not([view='mobile']) > main {
     background-color: transparent;
     white-space: nowrap;
   }
-
-  /* The breadcrumb is navigation, not prose flow — drop wa-prose's
-     previous-sibling top margin on the page title that follows it. */
-  .page-breadcrumbs + h1 {
-    margin-block-start: 0;
-  }
 }
 
 .component-ref {
@@ -257,14 +251,9 @@ wa-page:not([view='mobile']) > main {
   }
 }
 
-h1.title {
-  /* Siblings above own their block-end spacing — skip wa-prose's `* + h1` top margin. */
-  margin-block-start: 0;
-
-  wa-badge {
-    vertical-align: middle;
-    font-size: 1.5rem;
-  }
+h1.title wa-badge {
+  vertical-align: middle;
+  font-size: 1.5rem;
 }
 
 .component-info {

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -57,6 +57,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 - Synced default `--show-duration`, `--hide-duration`, and `--easing` values in `<wa-accordion-item>`, `<wa-date-input>`, `<wa-time-input>`, `<wa-toast>`, and `<wa-video>` with `--wa-transition-*` tokens [pr:2485]
 - Updated Native Styles so that `<th>` borders only apply to column headers [pr:2492]
+- Removed `wa-prose`'s top margin on `h1` elements that follow a sibling
 
 :::
 

--- a/packages/webawesome/src/styles/utilities/prose.css
+++ b/packages/webawesome/src/styles/utilities/prose.css
@@ -62,9 +62,6 @@
     }
 
     /* Headings hug what they introduce: generous above, tight below. */
-    & * + :where(h1) {
-      margin-block-start: var(--wa-prose-rhythm-3xl);
-    }
     & :where(h1):has(+ *) {
       margin-block-end: var(--wa-prose-rhythm-s);
     }


### PR DESCRIPTION
This work drops `wa-prose`'s prescriptive top-margin rule on `h1` elements that follow a sibling. 

In well-formed prose, there's one h1, and it's first; when something does precede it (breadcrumb, hero, auto-title slot, badge bar) the preceding element should own the gap.

### Library
`src/styles/utilities/prose.css` drops the `& * + :where(h1)` selector and gains a short comment explaining why h1 intentionally omits the `* + h1` pattern that h2/h3/h4 still use. The companion `h1:has(+ *)` "tight below" rule stays — that one's about what the h1 introduces, not what precedes it.

  ### Docs
Two overrides in `docs/assets/styles/docs.css` become dead code and are removed: the `.page-breadcrumbs + h1` reset and the `margin-block-start: 0` line on `h1.title`. The `h1.title wa-badge` styling stays.