### PR TITLE
Docs: Design Nits + Bits

### DIFF
--- a/packages/webawesome/docs/_includes/page-footer-content.njk
+++ b/packages/webawesome/docs/_includes/page-footer-content.njk
@@ -50,7 +50,7 @@
       {% set madeWithElements = ['button', 'card', 'combobox', 'dialog', 'drawer', 'dropdown', 'page', 'popover',
       'split-panel', 'sabi', 'ffles', 'tooltip', 'ter'] %}
       {% set randomElement = madeWithElements | random %}
-      <span class="page-footer-made-with">Made with <wa-icon name="heart" variant="regular"></wa-icon> and <code
+      <span class="page-footer-made-with">Made with <wa-icon name="heart" animation="beat" class="heart-affection"></wa-icon> and <code
           class="appearance-plain">&lt;wa-{{ randomElement }}&gt;</code></span>
       {% endraw %}
       <wa-icon name="dot"></wa-icon>

--- a/packages/webawesome/docs/_includes/search.njk
+++ b/packages/webawesome/docs/_includes/search.njk
@@ -19,7 +19,7 @@
       <div id="site-search-default" class="wa-stack wa-gap-0">
         <div id="site-search-suggested-list" class="site-search-listing" role="listbox" aria-label="Suggested">
           <h3 class="site-search-section-label wa-caption-s">Quick Links</h3>
-          <ul id="site-search-suggested-listbox" class="wa-stack wa-gap-2xs" role="presentation">
+          <ul id="site-search-suggested-listbox" class="wa-stack wa-gap-3xs" role="presentation">
             <li class="site-search-result" role="option" id="suggested-item-1" data-selected="false">
               <a href="/docs/components" class="wa-cluster wa-flex-nowrap wa-gap-s">
                 <wa-icon class="site-search-result-icon de-emphasize wa-font-size-m" name="block" variant="regular"
@@ -94,14 +94,14 @@
         <div id="site-search-recent-list" class="site-search-listing" role="listbox" aria-label="Recent Searches"
           hidden>
           <h3 class="site-search-section-label wa-caption-s">Recent Searches</h3>
-          <ul id="site-search-recent-listbox" class="wa-stack wa-gap-2xs" role="presentation">
+          <ul id="site-search-recent-listbox" class="wa-stack wa-gap-3xs" role="presentation">
           </ul>
         </div>
       </div>
 
       {# Results state #}
       <div class="site-search-listing">
-        <ul id="site-search-listbox" class="wa-stack wa-gap-2xs" role="listbox" aria-label="Search Results"></ul>
+        <ul id="site-search-listbox" class="wa-stack wa-gap-3xs" role="listbox" aria-label="Search Results"></ul>
       </div>
 
       {# Empty state — no results found #}

--- a/packages/webawesome/docs/_includes/search.njk
+++ b/packages/webawesome/docs/_includes/search.njk
@@ -108,9 +108,9 @@
       <div id="site-search-empty">
         <div class="wa-stack wa-align-items-center">
           <wa-icon name="face-monocle" family="duotone" variant="regular"
-            class="site-search-empty-icon wa-font-size-3xl" aria-hidden="true"></wa-icon>
+            class="site-search-empty-icon duotone-illustrated wa-font-size-3xl" aria-hidden="true"></wa-icon>
           <p>D'oh! No results for &ldquo;<span id="site-search-empty-query"></span>&rdquo;</p>
-          <wa-button-group>
+          <div class="wa-cluster wa-gap-s wa-justify-content-center">
             <wa-button appearance="filled" size="s" href="{{ site.github.ideas }}" target="_blank" rel="noopener"
               data-cta="github">
               <wa-icon name="lightbulb-on" variant="regular" slot="start"></wa-icon>
@@ -121,7 +121,7 @@
               <wa-icon name="message-question" variant="regular" slot="start"></wa-icon>
               Ask on Discord
             </wa-button>
-          </wa-button-group>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/webawesome/docs/_layouts/component.njk
+++ b/packages/webawesome/docs/_layouts/component.njk
@@ -176,20 +176,6 @@
 </wa-scroller>
 {% endif %}
 
-{# SSR #}
-{% if component.ssr.length > 0 %}
-  {# Purposefully hidden so that it populates TOC #}
-  <h2 style="visibility: collapse; margin: 0;">SSR</h2>
-  <wa-callout variant="neutral" size="s">
-    <wa-icon slot="icon" name="server" variant="regular"></wa-icon>
-    {% for obj in component.ssr %}
-      {{ obj.description | markdown | safe }}
-    {% endfor %}
-    <p><small>Learn more about <a href="/docs/ssr">Server-Side Rendering</a>.</small></p>
-  </wa-callout>
-{% endif %}
-
-
 {# Events #}
 {% if component.events.length %}
 <h2>Events</h2>
@@ -326,6 +312,16 @@
   <li><a href="/docs/components/{{ dependency | stripPrefix }}"><code>&lt;{{ dependency }}&gt;</code></a></li>
   {% endfor %}
 </ul>
+{% endif %}
+
+{# SSR #}
+{% if component.ssr.length > 0 %}
+<h2>SSR</h2>
+<p>Learn more about <a href="/docs/ssr">Server-Side Rendering (SSR)</a>.</p>
+
+{% for obj in component.ssr %}
+  {{ obj.description | markdown | safe }}
+{% endfor %}
 {% endif %}
 
 <wa-divider></wa-divider>

--- a/packages/webawesome/docs/_layouts/component.njk
+++ b/packages/webawesome/docs/_layouts/component.njk
@@ -180,20 +180,12 @@
 {% if component.ssr.length > 0 %}
   {# Purposefully hidden so that it populates TOC #}
   <h2 style="visibility: collapse; margin: 0;">SSR</h2>
-  <wa-callout variant="neutral">
+  <wa-callout variant="neutral" size="s">
     <wa-icon slot="icon" name="server" variant="regular"></wa-icon>
-
-    <div class="wa-stack wa-gap-s">
-      <p class="wa-heading-m">Using <code class="component-tag">&lt;{{ component.tagName }}&gt;</code> with <abbr title="Server-Side Rendering">SSR</abbr></p>
-
-      <div>
-        {% for obj in component.ssr %}
-          {{ obj.description | markdown | safe }}
-        {% endfor %}
-      </div>
-
-      <p>Learn more about <a href="/docs/ssr">Web Awesome and Server-Side Rendering</a>.</p>
-    </div>
+    {% for obj in component.ssr %}
+      {{ obj.description | markdown | safe }}
+    {% endfor %}
+    <p><small>Learn more about <a href="/docs/ssr">Server-Side Rendering</a>.</small></p>
   </wa-callout>
 {% endif %}
 

--- a/packages/webawesome/docs/_plugins/search.js
+++ b/packages/webawesome/docs/_plugins/search.js
@@ -47,6 +47,7 @@ export function searchPlugin(options = {}) {
           pending: true,
           synonyms: data.synonyms || [],
           useCases: data['use-cases'] || [],
+          category: data.category || '',
         });
       }
 
@@ -84,6 +85,7 @@ export function searchPlugin(options = {}) {
         url: normalizeDisplayUrl(rawUrl),
         synonyms: existing.synonyms || [],
         useCases: existing.useCases || [],
+        category: existing.category || '',
       });
 
       return content;
@@ -106,7 +108,12 @@ export function searchPlugin(options = {}) {
           // This works around the limitation of incremental builds not running transform on every file.
           const current = pagesToIndex.get(key);
           if (current?.pending) {
-            pagesToIndex.set(key, { ...value, synonyms: current.synonyms, useCases: current.useCases });
+            pagesToIndex.set(key, {
+              ...value,
+              synonyms: current.synonyms,
+              useCases: current.useCases,
+              category: current.category,
+            });
           }
         }
       }
@@ -130,7 +137,7 @@ export function searchPlugin(options = {}) {
           u: (page.useCases || []).join(' '),
           c: page.content,
         });
-        map[index] = { title: page.title, description: page.description, url: page.url };
+        map[index] = { title: page.title, description: page.description, url: page.url, category: page.category };
         index++;
       }
 

--- a/packages/webawesome/docs/assets/scripts/search.js
+++ b/packages/webawesome/docs/assets/scripts/search.js
@@ -47,16 +47,6 @@ const iconByPrefix = [
   ['/docs/customizing', 'rocket-launch'],
   ['/docs/form-controls', 'rocket-launch'],
   ['/docs/localization', 'rocket-launch'],
-  ['/docs/components/chart', 'chart-area'],
-  ['/docs/components/bar-chart', 'chart-area'],
-  ['/docs/components/line-chart', 'chart-area'],
-  ['/docs/components/bubble-chart', 'chart-area'],
-  ['/docs/components/doughnut-chart', 'chart-area'],
-  ['/docs/components/pie-chart', 'chart-area'],
-  ['/docs/components/polar-area-chart', 'chart-area'],
-  ['/docs/components/radar-chart', 'chart-area'],
-  ['/docs/components/scatter-chart', 'chart-area'],
-  ['/docs/components/sparkline', 'chart-area'],
   ['/docs/components', 'block'],
   ['/docs/patterns', 'block-brick'],
   ['/docs/patterns/layouts', 'table-layout'],
@@ -68,6 +58,20 @@ const iconByPrefix = [
   ['/docs/resources/support', 'life-ring'],
   ['/docs/resources', 'book-spine'],
 ].sort((a, b) => b[0].length - a[0].length);
+
+// Component category icons (mirrors _data/componentCategories.json). Component results
+// resolve their icon from this map via the page's `category` field; falls back to the
+// generic component icon if the category is missing or unrecognized.
+const iconByCategory = {
+  Actions: 'hand-pointer',
+  Forms: 'pen-field',
+  Layout: 'layer',
+  Navigation: 'compass',
+  Feedback: 'bell',
+  Media: 'photo-film',
+  'Data Viz': 'chart-line',
+  Helpers: 'wrench',
+};
 
 // We're using Turbo, so references to these elements aren't guaranteed to remain intact
 function getElements() {
@@ -574,7 +578,9 @@ async function updateResults(query = '') {
       li.setAttribute('data-selected', index === 0 ? 'true' : 'false');
       if (page.url === '/') icon = 'home';
       else if (page.url === '/docs') icon = 'rocket-launch';
-      else {
+      else if (page.url.startsWith('/docs/components/') && iconByCategory[page.category]) {
+        icon = iconByCategory[page.category];
+      } else {
         for (const [prefix, name] of iconByPrefix) {
           if (page.url.startsWith(prefix)) {
             icon = name;

--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -535,6 +535,8 @@ wa-scroller:has(.component-table) {
 
     code {
       white-space: inherit;
+      background: transparent;
+      padding-inline: 0;
     }
   }
 

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -1074,6 +1074,17 @@
     mask-image: linear-gradient(to bottom, #000 var(--wa-mask-fade-start), transparent var(--wa-mask-fade-end));
   }
 
+  /* Decorative heart that warms to brand orange and beats on hover. Pair with
+   * name="heart" animation="beat" — the animation is paused at rest. Use for
+   * affection / thank-you gestures (page footer, sign-offs, etc.). */
+  wa-icon.heart-affection {
+    --animation-iteration-count: 0;
+  }
+  wa-icon.heart-affection:hover {
+    --animation-iteration-count: infinite;
+    color: var(--wa-brand-orange);
+  }
+
   /* icon swap on hover/focus: plain buttons + dropdown items (pair .icon-default / .icon-hover in icon slot) */
   wa-button .icon-hover,
   wa-dropdown-item .icon-hover[slot='icon'] {

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -976,6 +976,7 @@
       position: absolute;
       inset: 0;
       z-index: 0;
+      border-radius: inherit;
       pointer-events: none;
     }
   }

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -1194,6 +1194,17 @@
   wa-icon.icon-shrink {
     font-size: round(0.875em, 1px);
   }
+
+  /* duotone icons styled as small illustrations: dark primary + brand secondary, fully opaque */
+  wa-icon.duotone-illustrated {
+    --primary-color: var(--wa-color-text-normal);
+    --secondary-color: var(--wa-color-brand-80);
+    --secondary-opacity: 1;
+
+    .wa-dark & {
+      --secondary-color: var(--wa-color-brand-60);
+    }
+  }
   /* #endregion */
 
   /* #region animations */

--- a/packages/webawesome/docs/docs/ai/index.md
+++ b/packages/webawesome/docs/docs/ai/index.md
@@ -52,4 +52,4 @@ This lets us ship better work more quickly, without giving up the human judgment
 
 **Human ideas. Human architecture. Human verification.** AI just helps us build what we were going to build anyway… only faster.
 
-<wa-icon name="heart" variant="regular" animation="beat" label="love" style="color: var(--wa-brand-orange);"></wa-icon> The Web Awesome Team
+<wa-icon name="heart" animation="beat" label="love" class="heart-affection"></wa-icon> The Web Awesome Team

--- a/packages/webawesome/docs/docs/components/index.njk
+++ b/packages/webawesome/docs/docs/components/index.njk
@@ -41,7 +41,7 @@ layout: docs
 </div>
 
 <style>
-  wa-page > main:has(> .component-list) > h1.title {
+  wa-page > main:has(.component-list) > .wa-prose > h1.title {
     text-align: center;
     margin-block-end: 0;
   }

--- a/packages/webawesome/docs/docs/resources/accessibility.md
+++ b/packages/webawesome/docs/docs/resources/accessibility.md
@@ -18,4 +18,4 @@ We’re fully aware that we may not get it right every time for every user, so w
 
 This is the path forward. Together, we will continue to make Web Awesome accessible to as many users as possible.
 
-<wa-icon name="heart" variant="regular" animation="beat" label="love" style="color: var(--wa-brand-orange);"></wa-icon> The Web Awesome Team
+<wa-icon name="heart" animation="beat" label="love" class="heart-affection"></wa-icon> The Web Awesome Team

--- a/packages/webawesome/docs/docs/resources/visual-tests.md
+++ b/packages/webawesome/docs/docs/resources/visual-tests.md
@@ -2,6 +2,7 @@
 title: Visual Tests
 description: A page to visually test component styles against native styles.
 layout: page
+hasProseContent: false
 ---
 
 <style>

--- a/packages/webawesome/src/components/animated-image/animated-image.ts
+++ b/packages/webawesome/src/components/animated-image/animated-image.ts
@@ -29,7 +29,7 @@ import styles from './animated-image.styles.js';
  * @cssproperty --control-box-size - The size of the icon box.
  * @cssproperty --icon-size - The size of the play/pause icons.
  *
- * @ssr - Due to limitations of the browser, this component is not able to be SSR'ed. You can use a `<video>` tag, but the controls will not work, and it will always auto-play the gif or webp.
+ * @ssr - Due to browser limitations, `<wa-animated-image>` can't render during SSR. As a fallback you can use a `<video>` tag, but its controls won't work, and the gif or webp will always auto-play.
  */
 @customElement('wa-animated-image')
 export default class WaAnimatedImage extends WebAwesomeElement {

--- a/packages/webawesome/src/components/animation/animation.ts
+++ b/packages/webawesome/src/components/animation/animation.ts
@@ -22,7 +22,7 @@ import { animations } from './animations.js';
  * @slot - The element to animate. Avoid slotting in more than one element, as subsequent ones will be ignored. To
  *  animate multiple elements, either wrap them in a single container or use multiple `<wa-animation>` elements.
  *
- * @ssr - Because the animation uses the JS API to start / stop animations, this component will SSR properly and not cause layout shift, but it will not play its animation until the component loads.
+ * @ssr - `<wa-animation>` renders during SSR without causing layout shift, but won't play its animation until the component hydrates on the client. Playback is driven by the Web Animations API, which is only available in the browser.
  */
 @customElement('wa-animation')
 export default class WaAnimation extends WebAwesomeElement {

--- a/packages/webawesome/src/components/card/card.ts
+++ b/packages/webawesome/src/components/card/card.ts
@@ -28,7 +28,7 @@ import styles from './card.styles.js';
  *
  * @cssproperty [--spacing=var(--wa-space-l)] - The amount of space around and between sections of the card. Expects a single value.
  *
- * @ssr - `<wa-card>` requires `with-header` / `with-media` / `with-footer` attributes to be set if you use any of these slots. This is a limitation of the platform not currently providing a `:has-slotted` CSS directive to allow us to apply things like borders based on slotted content. Without these attributes, only the body of the card will be rendered via SSR.
+ * @ssr - If you use the header, media, or footer slots, set the matching `with-header`, `with-media`, or `with-footer` attribute — otherwise only the card's body will render during SSR. This works around the lack of a `:has-slotted` CSS pseudo-class, which would normally let us style borders based on slotted content.
  */
 @customElement('wa-card')
 export default class WaCard extends WebAwesomeElement {

--- a/packages/webawesome/src/components/carousel/carousel.ts
+++ b/packages/webawesome/src/components/carousel/carousel.ts
@@ -49,7 +49,7 @@ import styles from './carousel.styles.js';
  *  partially visible as a scroll hint.
  * @cssproperty [--slide-gap=var(--wa-space-m)] - The space between each slide.
  *
- * @ssr - Carousel relies on scroll behaviors to work properly. Carousel will display the first image properly, but will not be interactive.
+ * @ssr - `<wa-carousel>` displays its first slide during SSR, but won't be interactive until it hydrates on the client.
  */
 @customElement('wa-carousel')
 export default class WaCarousel extends WebAwesomeElement {

--- a/packages/webawesome/src/components/include/include.ts
+++ b/packages/webawesome/src/components/include/include.ts
@@ -17,7 +17,7 @@ import { requestInclude } from './request.js';
  * @event wa-load - Emitted when the included file is loaded.
  * @event {{ status: number }} wa-include-error - Emitted when the included file fails to load due to an error.
  *
- * @ssr - `<wa-include>` uses fetch, but due to its asynchronous nature similar to `<wa-icon>`, there is no way to get the rendered content on your server.
+ * @ssr - `<wa-include>` fetches its content asynchronously (like `<wa-icon>`), so the rendered output isn't available during SSR.
  */
 @customElement('wa-include')
 export default class WaInclude extends WebAwesomeElement {

--- a/packages/webawesome/src/components/markdown/markdown.ts
+++ b/packages/webawesome/src/components/markdown/markdown.ts
@@ -14,7 +14,7 @@ const connectedInstances = new Set<WaMarkdown>();
  * @status experimental
  * @since 3.4
  *
- * @ssr - Because `<wa-markdown>` relies on the content of its children, it is not usable in an SSR context which does not have a DOM.
+ * @ssr - `<wa-markdown>` parses the content of its children at runtime, which requires a DOM. It can't render during SSR — use it on the client only.
  */
 @customElement('wa-markdown')
 export default class WaMarkdown extends WebAwesomeElement {

--- a/packages/webawesome/src/components/tab-group/tab-group.ts
+++ b/packages/webawesome/src/components/tab-group/tab-group.ts
@@ -45,7 +45,7 @@ import styles from './tab-group.styles.js';
  * @cssproperty --track-color - The color of the indicator's track (the line that separates tabs from panels).
  * @cssproperty --track-width - The width of the indicator's track (the line that separates tabs from panels).
  *
- * @ssr - In an SSR environment, there is no access to the children of a `<wa-tab-group>`, as such, it cannot set "active" on children and will not render any panels unless you manually set the "active" attribute on the appropriate `<wa-tab-panel>` + `<wa-tab>`.
+ * @ssr - During SSR, `<wa-tab-group>` can't access its children to determine which tab is active. To render the correct panel, manually set the `active` attribute on the matching `<wa-tab>` and `<wa-tab-panel>`.
  */
 @customElement('wa-tab-group')
 export default class WaTabGroup extends WebAwesomeElement {


### PR DESCRIPTION
A handful of small design and docs polish fixes for component docs, chrome and content...

### Hero background clips to rounded corners
The shared `::after` overlay used by `.background-grid`, `.background-dot-grid`, and `.background-wa-pattern` painted as a square inside `wa-card`'s rounded box and bled past the corners.  Added `border-radius: inherit` to the overlay so it picks up the host's rounding. Affects the homepage hero and the Pro patterns CTA, plus any future user of these utilities on a rounded host.

### Stripped code backgrounds inside component API tables
- Scoped `.component-table code` to `background: transparent` and `padding-inline: 0` so the dense `<code>` chips in Slots, Attributes & Properties, Methods, Events, CSS Parts, CSS States, CSS Custom Properties, and Dependencies stop reading like ghost pills.

### SSR documentation: callout → section
- The per-component SSR note rendered inside a `wa-callout` with a redundant heading restating the component's own tag name. Converted to a regular `<h2>SSR</h2>` documentation section after Dependencies, matching the convention of every other API section on the page. The TOC now gets a real "SSR" entry instead of relying on the prior `visibility: collapse` hack.
- Also tightened the per-component `@ssr` JSDoc descriptions for clarity and consistency
- One technical correctness fix in `<wa-card>`: `:has-slotted` is a CSS pseudo-class, not a "directive". 
- The `<wa-chart>` rewrite lives in the companion pro PR.

### Search no-results state
- Replaced the `wa-button-group` around "Suggest on GitHub" / "Ask on Discord" with `wa-cluster wa-gap-s wa-justify-content-center` so the CTAs read as separate suggestions instead of a segmented control.
- Added the `duotone-illustrated` treatment to the monocle icon for visual consistency with the existing components-index empty state.
- Pulled `duotone-illustrated`'s rule into docs `utils.css` so the class works in the free standalone build (it had only been defined in pro `site.css`).

### Search results render component category icons
- Component results in the search popover were all using the generic `block` icon. They now resolve from the page's `category` front matter via a new `iconByCategory` map.
- Removed the ten per-chart hardcoded `iconByPrefix` entries since `category: Data Viz` covers them.
- Components missing a category in front matter fall back to the generic `block` via the existing URL-prefix lookup.