### PR TITLE
feat: add useDefault: true to string reflect properties to prevent attribute sprouting

### DIFF
--- a/packages/webawesome/src/components/accordion-item/accordion-item.ts
+++ b/packages/webawesome/src/components/accordion-item/accordion-item.ts
@@ -62,16 +62,16 @@ export default class WaAccordionItem extends WebAwesomeElement {
   @property({ type: Boolean, reflect: true }) disabled = false;
 
   /** @internal Set by the parent accordion to control the heading level of the trigger. */
-  @property({ attribute: 'heading-level', reflect: true }) headingLevel = '3';
+  @property({ attribute: 'heading-level', reflect: true, useDefault: true }) headingLevel = '3';
 
   /** @internal Set by the parent accordion to control the roving tab index. */
   @property({ type: Boolean, attribute: false }) isTabbable = true;
 
   /** @internal Set by the parent accordion to control icon placement. */
-  @property({ attribute: 'icon-placement', reflect: true }) iconPlacement: 'start' | 'end' = 'end';
+  @property({ attribute: 'icon-placement', reflect: true, useDefault: true }) iconPlacement: 'start' | 'end' = 'end';
 
   /** @internal Set by the parent accordion to control the visual appearance. */
-  @property({ reflect: true }) appearance: 'filled' | 'outlined' | 'filled-outlined' | 'plain' = 'outlined';
+  @property({ reflect: true, useDefault: true }) appearance: 'filled' | 'outlined' | 'filled-outlined' | 'plain' = 'outlined';
 
   firstUpdated() {
     this.body.style.height = this.expanded ? 'auto' : '0';

--- a/packages/webawesome/src/components/accordion/accordion.ts
+++ b/packages/webawesome/src/components/accordion/accordion.ts
@@ -37,16 +37,16 @@ export default class WaAccordion extends WebAwesomeElement {
    * open one, and clicking an open item does not collapse it. `single-collapsible` is the same as `single`
    * except that clicking the open item collapses it, so zero open items is a valid state.
    */
-  @property({ reflect: true }) mode: 'single' | 'single-collapsible' | 'multiple' = 'multiple';
+  @property({ reflect: true, useDefault: true }) mode: 'single' | 'single-collapsible' | 'multiple' = 'multiple';
 
   /** The location of the expand/collapse icon in child items. */
-  @property({ attribute: 'icon-placement', reflect: true }) iconPlacement: 'start' | 'end' = 'end';
+  @property({ attribute: 'icon-placement', reflect: true, useDefault: true }) iconPlacement: 'start' | 'end' = 'end';
 
   /** The heading level for child item triggers (1–6), or "none" to omit the heading wrapper. Defaults to 3. */
-  @property({ attribute: 'heading-level', reflect: true }) headingLevel = '3';
+  @property({ attribute: 'heading-level', reflect: true, useDefault: true }) headingLevel = '3';
 
   /** The accordion's visual appearance. */
-  @property({ reflect: true }) appearance: 'filled' | 'outlined' | 'filled-outlined' | 'plain' = 'outlined';
+  @property({ reflect: true, useDefault: true }) appearance: 'filled' | 'outlined' | 'filled-outlined' | 'plain' = 'outlined';
 
   private getAllItems(): WaAccordionItem[] {
     return this.defaultSlot

--- a/packages/webawesome/src/components/avatar/avatar.ts
+++ b/packages/webawesome/src/components/avatar/avatar.ts
@@ -45,7 +45,7 @@ export default class WaAvatar extends WebAwesomeElement {
   @property() loading: 'eager' | 'lazy' = 'eager';
 
   /** The shape of the avatar. */
-  @property({ reflect: true }) shape: 'circle' | 'square' | 'rounded' = 'circle';
+  @property({ reflect: true, useDefault: true }) shape: 'circle' | 'square' | 'rounded' = 'circle';
 
   @watch('image')
   handleImageChange() {

--- a/packages/webawesome/src/components/badge/badge.ts
+++ b/packages/webawesome/src/components/badge/badge.ts
@@ -27,16 +27,16 @@ export default class WaBadge extends WebAwesomeElement {
   static css = [variantStyles, styles];
 
   /** The badge's theme variant. Defaults to `brand` if not within another element with a variant. */
-  @property({ reflect: true }) variant: 'brand' | 'neutral' | 'success' | 'warning' | 'danger' = 'brand';
+  @property({ reflect: true, useDefault: true }) variant: 'brand' | 'neutral' | 'success' | 'warning' | 'danger' = 'brand';
 
   /** The badge's visual appearance. */
-  @property({ reflect: true }) appearance: 'accent' | 'filled' | 'outlined' | 'filled-outlined' = 'accent';
+  @property({ reflect: true, useDefault: true }) appearance: 'accent' | 'filled' | 'outlined' | 'filled-outlined' = 'accent';
 
   /** Draws a pill-style badge with rounded edges. */
   @property({ type: Boolean, reflect: true }) pill = false;
 
   /** Adds an animation to draw attention to the badge. */
-  @property({ reflect: true }) attention: 'none' | 'pulse' | 'bounce' = 'none';
+  @property({ reflect: true, useDefault: true }) attention: 'none' | 'pulse' | 'bounce' = 'none';
 
   render() {
     return html`

--- a/packages/webawesome/src/components/button-group/button-group.ts
+++ b/packages/webawesome/src/components/button-group/button-group.ts
@@ -32,7 +32,7 @@ export default class WaButtonGroup extends WebAwesomeElement {
   @property() label = '';
 
   /** The button group's orientation. */
-  @property({ reflect: true }) orientation: 'horizontal' | 'vertical' = 'horizontal';
+  @property({ reflect: true, useDefault: true }) orientation: 'horizontal' | 'vertical' = 'horizontal';
 
   updated(changedProperties: PropertyValues<this>) {
     super.updated(changedProperties);

--- a/packages/webawesome/src/components/button/button.ts
+++ b/packages/webawesome/src/components/button/button.ts
@@ -68,13 +68,13 @@ export default class WaButton extends WebAwesomeFormAssociatedElement {
   @property() title = ''; // make reactive to pass through
 
   /** The button's theme variant. Defaults to `neutral` if not within another element with a variant. */
-  @property({ reflect: true }) variant: 'neutral' | 'brand' | 'success' | 'warning' | 'danger' = 'neutral';
+  @property({ reflect: true, useDefault: true }) variant: 'neutral' | 'brand' | 'success' | 'warning' | 'danger' = 'neutral';
 
   /** The button's visual appearance. */
-  @property({ reflect: true }) appearance: 'accent' | 'filled' | 'outlined' | 'filled-outlined' | 'plain' = 'accent';
+  @property({ reflect: true, useDefault: true }) appearance: 'accent' | 'filled' | 'outlined' | 'filled-outlined' | 'plain' = 'accent';
 
   /** The button's size. */
-  @property({ reflect: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
+  @property({ reflect: true, useDefault: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
 
   @watch('size')
   handleSizeChange() {
@@ -115,16 +115,16 @@ export default class WaButton extends WebAwesomeFormAssociatedElement {
    * The name of the button, submitted as a name/value pair with form data, but only when this button is the submitter.
    * This attribute is ignored when `href` is present.
    */
-  @property({ reflect: true }) name: string;
+  @property({ reflect: true, useDefault: true }) name: string;
 
   /**
    * The value of the button, submitted as a pair with the button's name as part of the form data, but only when this
    * button is the submitter. This attribute is ignored when `href` is present.
    */
-  @property({ reflect: true }) value: string;
+  @property({ reflect: true, useDefault: true }) value: string;
 
   /** When set, the underlying button will be rendered as an `<a>` with this `href` instead of a `<button>`. */
-  @property({ reflect: true }) href: string;
+  @property({ reflect: true, useDefault: true }) href: string;
 
   /** Tells the browser where to open the link. Only used when `href` is present. */
   @property() target: '_blank' | '_parent' | '_self' | '_top';

--- a/packages/webawesome/src/components/callout/callout.ts
+++ b/packages/webawesome/src/components/callout/callout.ts
@@ -25,13 +25,13 @@ export default class WaCallout extends WebAwesomeElement {
   static css = [styles, variantStyles, sizeStyles];
 
   /** The callout's theme variant. Defaults to `brand` if not within another element with a variant. */
-  @property({ reflect: true }) variant: 'brand' | 'neutral' | 'success' | 'warning' | 'danger' = 'brand';
+  @property({ reflect: true, useDefault: true }) variant: 'brand' | 'neutral' | 'success' | 'warning' | 'danger' = 'brand';
 
   /** The callout's visual appearance. */
-  @property({ reflect: true }) appearance: 'accent' | 'filled' | 'outlined' | 'plain' | 'filled-outlined';
+  @property({ reflect: true, useDefault: true }) appearance: 'accent' | 'filled' | 'outlined' | 'plain' | 'filled-outlined';
 
   /** The callout's size. */
-  @property({ reflect: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
+  @property({ reflect: true, useDefault: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
 
   @watch('size')
   handleSizeChange() {

--- a/packages/webawesome/src/components/card/card.ts
+++ b/packages/webawesome/src/components/card/card.ts
@@ -45,7 +45,7 @@ export default class WaCard extends WebAwesomeElement {
   );
 
   /** The card's visual appearance. */
-  @property({ reflect: true })
+  @property({ reflect: true, useDefault: true })
   appearance: 'accent' | 'filled' | 'outlined' | 'filled-outlined' | 'plain' = 'outlined';
 
   /**
@@ -79,7 +79,7 @@ export default class WaCard extends WebAwesomeElement {
   @property({ attribute: 'with-footer-actions', type: Boolean, reflect: true }) withFooterActions = false;
 
   /** Renders the card's orientation **/
-  @property({ reflect: true })
+  @property({ reflect: true, useDefault: true })
   orientation: 'horizontal' | 'vertical' = 'vertical';
 
   willUpdate(changedProperties: PropertyValues<this>) {

--- a/packages/webawesome/src/components/checkbox/checkbox.ts
+++ b/packages/webawesome/src/components/checkbox/checkbox.ts
@@ -76,7 +76,7 @@ export default class WaCheckbox extends WebAwesomeFormAssociatedElement {
   @property() title = ''; // make reactive to pass through
 
   /** The name of the checkbox, submitted as a name/value pair with form data. */
-  @property({ reflect: true }) name = null;
+  @property({ reflect: true, useDefault: true }) name = null;
 
   private _value: string | null = this.getAttribute('value') ?? null;
 
@@ -85,13 +85,13 @@ export default class WaCheckbox extends WebAwesomeFormAssociatedElement {
     return this._value ?? 'on';
   }
 
-  @property({ reflect: true })
+  @property({ reflect: true, useDefault: true })
   set value(val: string | null) {
     this._value = val;
   }
 
   /** The checkbox's size. */
-  @property({ reflect: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
+  @property({ reflect: true, useDefault: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
 
   @watch('size')
   handleSizeChange() {

--- a/packages/webawesome/src/components/color-picker/color-picker.ts
+++ b/packages/webawesome/src/components/color-picker/color-picker.ts
@@ -173,7 +173,7 @@ export default class WaColorPicker extends WebAwesomeFormAssociatedElement {
   }
 
   /** The default value of the form control. Primarily used for resetting the form control. */
-  @property({ attribute: 'value', reflect: true }) defaultValue: string | null = this.getAttribute('value') || null;
+  @property({ attribute: 'value', reflect: true, useDefault: true }) defaultValue: string | null = this.getAttribute('value') || null;
 
   /**
    * Only required for SSR. Set to `true` if you're slotting in a `label` element so the server-rendered markup
@@ -207,7 +207,7 @@ export default class WaColorPicker extends WebAwesomeFormAssociatedElement {
   @property() format: 'hex' | 'rgb' | 'hsl' | 'hsv' = 'hex';
 
   /** Determines the size of the color picker's trigger */
-  @property({ reflect: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
+  @property({ reflect: true, useDefault: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
 
   @watch('size')
   handleSizeChange() {
@@ -218,7 +218,7 @@ export default class WaColorPicker extends WebAwesomeFormAssociatedElement {
    * The preferred placement of the color picker's popup. Note that the actual placement will vary as configured to
    * keep the panel inside of the viewport.
    */
-  @property({ reflect: true }) placement:
+  @property({ reflect: true, useDefault: true }) placement:
     | 'top'
     | 'top-start'
     | 'top-end'
@@ -236,7 +236,7 @@ export default class WaColorPicker extends WebAwesomeFormAssociatedElement {
   @property({ attribute: 'without-format-toggle', type: Boolean }) withoutFormatToggle = false;
 
   /** The name of the form control, submitted as a name/value pair with form data. */
-  @property({ reflect: true }) name: string | null = null;
+  @property({ reflect: true, useDefault: true }) name: string | null = null;
 
   /** Disables the color picker. */
   @property({ type: Boolean }) disabled = false;

--- a/packages/webawesome/src/components/copy-button/copy-button.ts
+++ b/packages/webawesome/src/components/copy-button/copy-button.ts
@@ -110,7 +110,7 @@ export default class WaCopyButton extends WebAwesomeElement {
   @property({ attribute: 'feedback-duration', type: Number }) feedbackDuration = 1000;
 
   /** The preferred placement of the tooltip. */
-  @property({ attribute: 'tooltip-placement', reflect: true }) tooltipPlacement: 'top' | 'right' | 'bottom' | 'left' =
+  @property({ attribute: 'tooltip-placement', reflect: true, useDefault: true }) tooltipPlacement: 'top' | 'right' | 'bottom' | 'left' =
     'top';
 
   /**
@@ -118,7 +118,7 @@ export default class WaCopyButton extends WebAwesomeElement {
    * `copy` keeps the tooltip silent on hover/focus and only shows it briefly to confirm a successful or failed copy.
    * `none` disables the tooltip entirely. Applies to both the default and custom triggers.
    */
-  @property({ reflect: true }) tooltip: 'full' | 'copy' | 'none' = 'full';
+  @property({ reflect: true, useDefault: true }) tooltip: 'full' | 'copy' | 'none' = 'full';
 
   firstUpdated() {
     if (this.didSSR) {

--- a/packages/webawesome/src/components/details/details.ts
+++ b/packages/webawesome/src/components/details/details.ts
@@ -73,16 +73,16 @@ export default class WaDetails extends WebAwesomeElement {
   @property() summary: string;
 
   /** Groups related details elements. When one opens, others with the same name will close. */
-  @property({ reflect: true }) name: string;
+  @property({ reflect: true, useDefault: true }) name: string;
 
   /** Disables the details so it can't be toggled. */
   @property({ type: Boolean, reflect: true }) disabled = false;
 
   /** The element's visual appearance. */
-  @property({ reflect: true }) appearance: 'filled' | 'outlined' | 'filled-outlined' | 'plain' = 'outlined';
+  @property({ reflect: true, useDefault: true }) appearance: 'filled' | 'outlined' | 'filled-outlined' | 'plain' = 'outlined';
 
   /** The location of the expand/collapse icon. */
-  @property({ attribute: 'icon-placement', reflect: true }) iconPlacement: 'start' | 'end' = 'end';
+  @property({ attribute: 'icon-placement', reflect: true, useDefault: true }) iconPlacement: 'start' | 'end' = 'end';
 
   disconnectedCallback() {
     super.disconnectedCallback();

--- a/packages/webawesome/src/components/dialog/dialog.ts
+++ b/packages/webawesome/src/components/dialog/dialog.ts
@@ -71,7 +71,7 @@ export default class WaDialog extends WebAwesomeElement {
    * The dialog's label as displayed in the header. You should always include a relevant label, as it is required for
    * proper accessibility. If you need to display HTML, use the `label` slot instead.
    */
-  @property({ reflect: true }) label = '';
+  @property({ reflect: true, useDefault: true }) label = '';
 
   /** Disables the header. This will also remove the default close button. */
   @property({ attribute: 'without-header', type: Boolean, reflect: true }) withoutHeader = false;

--- a/packages/webawesome/src/components/divider/divider.ts
+++ b/packages/webawesome/src/components/divider/divider.ts
@@ -19,7 +19,7 @@ export default class WaDivider extends WebAwesomeElement {
   static css = styles;
 
   /** Sets the divider's orientation. */
-  @property({ reflect: true }) orientation: 'horizontal' | 'vertical' = 'horizontal';
+  @property({ reflect: true, useDefault: true }) orientation: 'horizontal' | 'vertical' = 'horizontal';
 
   connectedCallback() {
     super.connectedCallback();

--- a/packages/webawesome/src/components/drawer/drawer.ts
+++ b/packages/webawesome/src/components/drawer/drawer.ts
@@ -77,10 +77,10 @@ export default class WaDrawer extends WebAwesomeElement {
    * The drawer's label as displayed in the header. You should always include a relevant label, as it is required for
    * proper accessibility. If you need to display HTML, use the `label` slot instead.
    */
-  @property({ reflect: true }) label = '';
+  @property({ reflect: true, useDefault: true }) label = '';
 
   /** The direction from which the drawer will open. */
-  @property({ reflect: true }) placement: 'top' | 'end' | 'bottom' | 'start' = 'end';
+  @property({ reflect: true, useDefault: true }) placement: 'top' | 'end' | 'bottom' | 'start' = 'end';
 
   /** Disables the header. This will also remove the default close button. */
   @property({ attribute: 'without-header', type: Boolean, reflect: true }) withoutHeader = false;

--- a/packages/webawesome/src/components/dropdown-item/dropdown-item.ts
+++ b/packages/webawesome/src/components/dropdown-item/dropdown-item.ts
@@ -45,12 +45,12 @@ export default class WaDropdownItem extends WebAwesomeElement {
   @property({ type: Boolean }) active = false;
 
   /** The type of menu item to render. */
-  @property({ reflect: true }) variant: 'danger' | 'default' = 'default';
+  @property({ reflect: true, useDefault: true }) variant: 'danger' | 'default' = 'default';
 
   /**
    * @internal The dropdown item's size.
    */
-  @property({ reflect: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
+  @property({ reflect: true, useDefault: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
 
   @watch('size')
   handleSizeChange() {
@@ -76,7 +76,7 @@ export default class WaDropdownItem extends WebAwesomeElement {
   @property() value: string;
 
   /** Set to `checkbox` to make the item a checkbox. */
-  @property({ reflect: true }) type: 'normal' | 'checkbox' = 'normal';
+  @property({ reflect: true, useDefault: true }) type: 'normal' | 'checkbox' = 'normal';
 
   /** Set to true to check the dropdown item. Only valid when `type` is `checkbox`. */
   @property({ type: Boolean }) checked = false;

--- a/packages/webawesome/src/components/dropdown/dropdown.ts
+++ b/packages/webawesome/src/components/dropdown/dropdown.ts
@@ -69,7 +69,7 @@ export default class WaDropdown extends WebAwesomeElement {
   @property({ type: Boolean, reflect: true }) open = false;
 
   /** The dropdown's size. */
-  @property({ reflect: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
+  @property({ reflect: true, useDefault: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
 
   @watch('size')
   handleSizeChange() {
@@ -80,7 +80,7 @@ export default class WaDropdown extends WebAwesomeElement {
    * The placement of the dropdown menu in reference to the trigger. The menu will shift to a more optimal location if
    * the preferred placement doesn't have enough room.
    */
-  @property({ reflect: true }) placement:
+  @property({ reflect: true, useDefault: true }) placement:
     | 'top'
     | 'top-start'
     | 'top-end'

--- a/packages/webawesome/src/components/icon/icon.ts
+++ b/packages/webawesome/src/components/icon/icon.ts
@@ -79,7 +79,7 @@ export default class WaIcon extends WebAwesomeElement {
   @state() private svg: SVGElement | HTMLTemplateResult | null = null;
 
   /** The name of the icon to draw. Available names depend on the icon library being used. */
-  @property({ reflect: true }) name?: string;
+  @property({ reflect: true, useDefault: true }) name?: string;
 
   /**
    * The family of icons to choose from. For Font Awesome Free, valid options include `classic` and `brands`. For
@@ -87,14 +87,14 @@ export default class WaIcon extends WebAwesomeElement {
    * A valid kit code must be present to show pro icons via CDN. You can set `<html data-fa-kit-code="...">` to provide
    * one.
    */
-  @property({ reflect: true }) family: string;
+  @property({ reflect: true, useDefault: true }) family: string;
 
   /**
    * The name of the icon's variant. For Font Awesome, valid options include `thin`, `light`, `regular`, and `solid` for
    * the `classic` and `sharp` families. Some variants require a Font Awesome Pro subscription. Custom icon libraries
    * may or may not use this property.
    */
-  @property({ reflect: true }) variant: string;
+  @property({ reflect: true, useDefault: true }) variant: string;
 
   /** Sets the width of the icon to match the cropped SVG viewBox. This operates like the Font `fa-width-auto` class. */
   @property({ attribute: 'auto-width', type: Boolean, reflect: true }) autoWidth = false;
@@ -115,16 +115,16 @@ export default class WaIcon extends WebAwesomeElement {
   @property() label = '';
 
   /** The name of a registered custom icon library. */
-  @property({ reflect: true }) library = 'default';
+  @property({ reflect: true, useDefault: true }) library = 'default';
 
   /** Sets the rotation degree of the icon */
   @property({ type: Number, reflect: true }) rotate = 0;
 
   /** Sets the flip direction of the icon along the 'x' (horizontal), 'y' (vertical), or 'both' axes. */
-  @property({ type: String, reflect: true }) flip?: 'x' | 'y' | 'both';
+  @property({ type: String, reflect: true, useDefault: true }) flip?: 'x' | 'y' | 'both';
 
   /** Sets the animation for the icon */
-  @property({ type: String, reflect: true }) animation?: IconAnimation;
+  @property({ type: String, reflect: true, useDefault: true }) animation?: IconAnimation;
 
   connectedCallback() {
     super.connectedCallback();

--- a/packages/webawesome/src/components/input/input.ts
+++ b/packages/webawesome/src/components/input/input.ts
@@ -73,7 +73,7 @@ export default class WaInput extends WebAwesomeFormAssociatedElement {
    * The type of input. Works the same as a native `<input>` element, but only a subset of types are supported. Defaults
    * to `text`.
    */
-  @property({ reflect: true }) type:
+  @property({ reflect: true, useDefault: true }) type:
     | 'date'
     | 'datetime-local'
     | 'email'
@@ -121,10 +121,10 @@ export default class WaInput extends WebAwesomeFormAssociatedElement {
   }
 
   /** The default value of the form control. Primarily used for resetting the form control. */
-  @property({ attribute: 'value', reflect: true }) defaultValue: string | null = this.getAttribute('value') || null;
+  @property({ attribute: 'value', reflect: true, useDefault: true }) defaultValue: string | null = this.getAttribute('value') || null;
 
   /** The input's size. */
-  @property({ reflect: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
+  @property({ reflect: true, useDefault: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
 
   @watch('size')
   handleSizeChange() {
@@ -132,7 +132,7 @@ export default class WaInput extends WebAwesomeFormAssociatedElement {
   }
 
   /** The input's visual appearance. */
-  @property({ reflect: true }) appearance: 'filled' | 'outlined' | 'filled-outlined' = 'outlined';
+  @property({ reflect: true, useDefault: true }) appearance: 'filled' | 'outlined' | 'filled-outlined' = 'outlined';
 
   /** Draws a pill-style input with rounded edges. */
   @property({ type: Boolean, reflect: true }) pill = false;

--- a/packages/webawesome/src/components/known-date/known-date.ts
+++ b/packages/webawesome/src/components/known-date/known-date.ts
@@ -100,7 +100,7 @@ export default class WaKnownDate extends WebAwesomeFormAssociatedElement {
   //
 
   /** The name submitted with form data. */
-  @property({ reflect: true }) name = '';
+  @property({ reflect: true, useDefault: true }) name = '';
 
   private _value = '';
 
@@ -128,7 +128,7 @@ export default class WaKnownDate extends WebAwesomeFormAssociatedElement {
   }
 
   /** The default value used for form reset. */
-  @property({ attribute: 'value', reflect: true }) defaultValue: string = this.getAttribute('value') ?? '';
+  @property({ attribute: 'value', reflect: true, useDefault: true }) defaultValue: string = this.getAttribute('value') ?? '';
 
   /** Disables the known date. */
   @property({ type: Boolean }) disabled = false;
@@ -140,7 +140,7 @@ export default class WaKnownDate extends WebAwesomeFormAssociatedElement {
   @property({ type: Boolean, reflect: true }) readonly = false;
 
   /** The known date's size. */
-  @property({ reflect: true }) size: WaKnownDateSize | 'small' | 'medium' | 'large' = 'm';
+  @property({ reflect: true, useDefault: true }) size: WaKnownDateSize | 'small' | 'medium' | 'large' = 'm';
 
   @watch('size')
   handleSizeChange() {
@@ -148,7 +148,7 @@ export default class WaKnownDate extends WebAwesomeFormAssociatedElement {
   }
 
   /** The known date's visual appearance. */
-  @property({ reflect: true }) appearance: WaKnownDateAppearance = 'outlined';
+  @property({ reflect: true, useDefault: true }) appearance: WaKnownDateAppearance = 'outlined';
 
   /** Draws pill-style fields with rounded edges. */
   @property({ type: Boolean, reflect: true }) pill = false;
@@ -167,13 +167,13 @@ export default class WaKnownDate extends WebAwesomeFormAssociatedElement {
   @property() autocomplete = '';
 
   /** Earliest selectable date as `YYYY-MM-DD`. */
-  @property({ reflect: true }) min = '';
+  @property({ reflect: true, useDefault: true }) min = '';
 
   /** Latest selectable date as `YYYY-MM-DD`. */
-  @property({ reflect: true }) max = '';
+  @property({ reflect: true, useDefault: true }) max = '';
 
   /** BCP-47 locale override. When empty, the inherited `lang` attribute is used. */
-  @property({ reflect: true }) locale = '';
+  @property({ reflect: true, useDefault: true }) locale = '';
 
   /** Only required for SSR. Set to `true` if you're slotting in a `label` element. */
   @property({ attribute: 'with-label', type: Boolean }) withLabel = false;

--- a/packages/webawesome/src/components/mutation-observer/mutation-observer.ts
+++ b/packages/webawesome/src/components/mutation-observer/mutation-observer.ts
@@ -26,7 +26,7 @@ export default class WaMutationObserver extends WebAwesomeElement {
    * Watches for changes to attributes. To watch only specific attributes, separate them by a space, e.g.
    * `attr="class id title"`. To watch all attributes, use `*`.
    */
-  @property({ reflect: true }) attr: string;
+  @property({ reflect: true, useDefault: true }) attr: string;
 
   /** Indicates whether or not the attribute's previous value should be recorded when monitoring changes. */
   @property({ attribute: 'attr-old-value', type: Boolean, reflect: true }) attrOldValue = false;

--- a/packages/webawesome/src/components/number-input/number-input.ts
+++ b/packages/webawesome/src/components/number-input/number-input.ts
@@ -93,10 +93,10 @@ export default class WaNumberInput extends WebAwesomeFormAssociatedElement {
   }
 
   /** The default value of the form control. Primarily used for resetting the form control. */
-  @property({ attribute: 'value', reflect: true }) defaultValue: string | null = this.getAttribute('value') || null;
+  @property({ attribute: 'value', reflect: true, useDefault: true }) defaultValue: string | null = this.getAttribute('value') || null;
 
   /** The input's size. */
-  @property({ reflect: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
+  @property({ reflect: true, useDefault: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
 
   @watch('size')
   handleSizeChange() {
@@ -104,7 +104,7 @@ export default class WaNumberInput extends WebAwesomeFormAssociatedElement {
   }
 
   /** The input's visual appearance. */
-  @property({ reflect: true }) appearance: 'filled' | 'outlined' | 'filled-outlined' = 'outlined';
+  @property({ reflect: true, useDefault: true }) appearance: 'filled' | 'outlined' | 'filled-outlined' = 'outlined';
 
   /** Draws a pill-style input with rounded edges. */
   @property({ type: Boolean, reflect: true }) pill = false;

--- a/packages/webawesome/src/components/option/option.ts
+++ b/packages/webawesome/src/components/option/option.ts
@@ -51,7 +51,7 @@ export default class WaOption extends WebAwesomeElement {
    * from other options in the same group. Values may not contain spaces, as spaces are used as delimiters when listing
    * multiple values.
    */
-  @property({ reflect: true }) value = '';
+  @property({ reflect: true, useDefault: true }) value = '';
 
   /** Draws the option in a disabled state, preventing selection. */
   @property({ type: Boolean }) disabled = false;

--- a/packages/webawesome/src/components/page/page.ts
+++ b/packages/webawesome/src/components/page/page.ts
@@ -178,7 +178,7 @@ export default class WaPage extends WebAwesomeElement {
    * navigation. You can use additional media queries to make other adjustments to content as necessary.
    * The default is "desktop" because the "mobile navigation drawer" isn't accessible via SSR due to drawer requiring JS.
    */
-  @property({ attribute: 'view', reflect: true }) view: 'mobile' | 'desktop' = 'desktop';
+  @property({ attribute: 'view', reflect: true, useDefault: true }) view: 'mobile' | 'desktop' = 'desktop';
 
   /**
    * Whether or not the navigation drawer is open. Note, the navigation drawer is only "open" on mobile views.
@@ -195,7 +195,7 @@ export default class WaPage extends WebAwesomeElement {
   /**
    * Where to place the navigation when in the mobile viewport.
    */
-  @property({ attribute: 'navigation-placement', reflect: true }) navigationPlacement: 'start' | 'end' = 'start';
+  @property({ attribute: 'navigation-placement', reflect: true, useDefault: true }) navigationPlacement: 'start' | 'end' = 'start';
 
   /**
    * Determines whether or not to hide the default hamburger button.

--- a/packages/webawesome/src/components/popup/popup.ts
+++ b/packages/webawesome/src/components/popup/popup.ts
@@ -103,7 +103,7 @@ export default class WaPopup extends WebAwesomeElement {
    * The preferred placement of the popup. Note that the actual placement will vary as configured to keep the
    * panel inside of the viewport.
    */
-  @property({ reflect: true }) placement:
+  @property({ reflect: true, useDefault: true }) placement:
     | 'top'
     | 'top-start'
     | 'top-end'

--- a/packages/webawesome/src/components/radio-group/radio-group.ts
+++ b/packages/webawesome/src/components/radio-group/radio-group.ts
@@ -72,13 +72,13 @@ export default class WaRadioGroup extends WebAwesomeFormAssociatedElement {
   @property({ attribute: 'hint' }) hint = '';
 
   /** The name of the radio group, submitted as a name/value pair with form data. */
-  @property({ reflect: true }) name: string | null = null;
+  @property({ reflect: true, useDefault: true }) name: string | null = null;
 
   /** Disables the radio group and all child radios. */
   @property({ type: Boolean, reflect: true }) disabled = false;
 
   /** The orientation in which to show radio items. */
-  @property({ reflect: true }) orientation: 'horizontal' | 'vertical' = 'vertical';
+  @property({ reflect: true, useDefault: true }) orientation: 'horizontal' | 'vertical' = 'vertical';
 
   private _value: string | null = null;
 
@@ -99,10 +99,10 @@ export default class WaRadioGroup extends WebAwesomeFormAssociatedElement {
   }
 
   /** The default value of the form control. Primarily used for resetting the form control. */
-  @property({ attribute: 'value', reflect: true }) defaultValue: string | null = this.getAttribute('value') || null;
+  @property({ attribute: 'value', reflect: true, useDefault: true }) defaultValue: string | null = this.getAttribute('value') || null;
 
   /** The radio group's size. When present, this size will be applied to all `<wa-radio>` items inside. */
-  @property({ reflect: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large';
+  @property({ reflect: true, useDefault: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large';
 
   @watch('size')
   handleSizeChange() {

--- a/packages/webawesome/src/components/radio/radio.ts
+++ b/packages/webawesome/src/components/radio/radio.ts
@@ -43,16 +43,16 @@ export default class WaRadio extends WebAwesomeFormAssociatedElement {
   @state() forceDisabled = false;
 
   /** The radio's value. When selected, the radio group will receive this value. */
-  @property({ reflect: true }) value: string;
+  @property({ reflect: true, useDefault: true }) value: string;
 
   /** The radio's visual appearance. */
-  @property({ reflect: true }) appearance: 'default' | 'button' = 'default';
+  @property({ reflect: true, useDefault: true }) appearance: 'default' | 'button' = 'default';
 
   /**
    * The radio's size. When used inside a radio group, the size will be determined by the radio group's size, which will
    * override this attribute.
    */
-  @property({ reflect: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large';
+  @property({ reflect: true, useDefault: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large';
 
   @watch('size')
   handleSizeChange() {

--- a/packages/webawesome/src/components/rating/rating.ts
+++ b/packages/webawesome/src/components/rating/rating.ts
@@ -47,7 +47,7 @@ export default class WaRating extends WebAwesomeFormAssociatedElement {
 
   private readonly localize = new LocalizeController(this);
 
-  @property({ reflect: true }) role = 'slider';
+  @property({ reflect: true, useDefault: true }) role = 'slider';
 
   connectedCallback() {
     super.connectedCallback();
@@ -162,7 +162,7 @@ export default class WaRating extends WebAwesomeFormAssociatedElement {
   };
 
   /** The component's size. */
-  @property({ reflect: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
+  @property({ reflect: true, useDefault: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
 
   @watch('size')
   handleSizeChange() {

--- a/packages/webawesome/src/components/scroller/scroller.ts
+++ b/packages/webawesome/src/components/scroller/scroller.ts
@@ -30,7 +30,7 @@ export default class WaScroller extends WebAwesomeElement {
   @state() canScroll = false;
 
   /** The scroller's orientation. */
-  @property({ reflect: true }) orientation: 'horizontal' | 'vertical' = 'horizontal';
+  @property({ reflect: true, useDefault: true }) orientation: 'horizontal' | 'vertical' = 'horizontal';
 
   /** Removes the visible scrollbar. */
   @property({ attribute: 'without-scrollbar', type: Boolean, reflect: true }) withoutScrollbar = false;

--- a/packages/webawesome/src/components/select/select.ts
+++ b/packages/webawesome/src/components/select/select.ts
@@ -126,7 +126,7 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
   optionValues: Set<string | null> | undefined;
 
   /** The name of the select, submitted as a name/value pair with form data. */
-  @property({ reflect: true }) name = '';
+  @property({ reflect: true, useDefault: true }) name = '';
 
   private _defaultValue: null | string | string[] = null;
 
@@ -218,7 +218,7 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
   }
 
   /** The select's size. */
-  @property({ reflect: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
+  @property({ reflect: true, useDefault: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
 
   @watch('size')
   handleSizeChange() {
@@ -250,7 +250,7 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
   @property({ type: Boolean, reflect: true }) open = false;
 
   /** The select's visual appearance. */
-  @property({ reflect: true }) appearance: 'filled' | 'outlined' | 'filled-outlined' = 'outlined';
+  @property({ reflect: true, useDefault: true }) appearance: 'filled' | 'outlined' | 'filled-outlined' = 'outlined';
 
   /** Draws a pill-style select with rounded edges. */
   @property({ type: Boolean, reflect: true }) pill = false;
@@ -262,7 +262,7 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
    * The preferred placement of the select's menu. Note that the actual placement may vary as needed to keep the listbox
    * inside of the viewport.
    */
-  @property({ reflect: true }) placement: 'top' | 'bottom' = 'bottom';
+  @property({ reflect: true, useDefault: true }) placement: 'top' | 'bottom' = 'bottom';
 
   /** The select's hint. If you need to display HTML, use the `hint` slot instead. */
   @property({ attribute: 'hint' }) hint = '';

--- a/packages/webawesome/src/components/skeleton/skeleton.ts
+++ b/packages/webawesome/src/components/skeleton/skeleton.ts
@@ -20,7 +20,7 @@ export default class WaSkeleton extends WebAwesomeElement {
   static css = styles;
 
   /** Determines which effect the skeleton will use. */
-  @property({ reflect: true }) effect: 'pulse' | 'sheen' | 'none' = 'none';
+  @property({ reflect: true, useDefault: true }) effect: 'pulse' | 'sheen' | 'none' = 'none';
 
   render() {
     return html` <div part="indicator" class="indicator"></div> `;

--- a/packages/webawesome/src/components/slider/slider.ts
+++ b/packages/webawesome/src/components/slider/slider.ts
@@ -113,7 +113,7 @@ export default class WaSlider extends WebAwesomeFormAssociatedElement {
   @property({ attribute: 'hint' }) hint = '';
 
   /** The name of the slider. This will be submitted with the form as a name/value pair. */
-  @property({ reflect: true }) name: string;
+  @property({ reflect: true, useDefault: true }) name: string;
 
   /** The minimum value of a range selection. Used only when range attribute is set. */
   @property({ type: Number, attribute: 'min-value' }) minValue = 0;
@@ -165,10 +165,10 @@ export default class WaSlider extends WebAwesomeFormAssociatedElement {
   @property({ type: Boolean, reflect: true }) readonly = false;
 
   /** The orientation of the slider. */
-  @property({ reflect: true }) orientation: 'horizontal' | 'vertical' = 'horizontal';
+  @property({ reflect: true, useDefault: true }) orientation: 'horizontal' | 'vertical' = 'horizontal';
 
   /** The slider's size. */
-  @property({ reflect: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
+  @property({ reflect: true, useDefault: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
 
   @watch('size')
   handleSizeChange() {
@@ -194,7 +194,7 @@ export default class WaSlider extends WebAwesomeFormAssociatedElement {
   @property({ attribute: 'tooltip-distance', type: Number }) tooltipDistance = 8;
 
   /** The placement of the tooltip in reference to the slider's thumb. */
-  @property({ attribute: 'tooltip-placement', reflect: true }) tooltipPlacement: 'top' | 'right' | 'bottom' | 'left' =
+  @property({ attribute: 'tooltip-placement', reflect: true, useDefault: true }) tooltipPlacement: 'top' | 'right' | 'bottom' | 'left' =
     'top';
 
   /** Draws markers at each step along the slider. */

--- a/packages/webawesome/src/components/split-panel/split-panel.ts
+++ b/packages/webawesome/src/components/split-panel/split-panel.ts
@@ -56,7 +56,7 @@ export default class WaSplitPanel extends WebAwesomeElement {
   @property({ attribute: 'position-in-pixels', type: Number }) positionInPixels: number;
 
   /** Sets the split panel's orientation. */
-  @property({ reflect: true }) orientation: 'horizontal' | 'vertical' = 'horizontal';
+  @property({ reflect: true, useDefault: true }) orientation: 'horizontal' | 'vertical' = 'horizontal';
 
   /** Disables resizing. Note that the position may still change as a result of resizing the host element. */
   @property({ type: Boolean, reflect: true }) disabled = false;

--- a/packages/webawesome/src/components/switch/switch.ts
+++ b/packages/webawesome/src/components/switch/switch.ts
@@ -58,7 +58,7 @@ export default class WaSwitch extends WebAwesomeFormAssociatedElement {
   @property() title = ''; // make reactive to pass through
 
   /** The name of the switch, submitted as a name/value pair with form data. */
-  @property({ reflect: true }) name: string | null = null;
+  @property({ reflect: true, useDefault: true }) name: string | null = null;
 
   private _value: string | null = this.getAttribute('value') ?? null;
 
@@ -67,13 +67,13 @@ export default class WaSwitch extends WebAwesomeFormAssociatedElement {
     return this._value ?? 'on';
   }
 
-  @property({ reflect: true })
+  @property({ reflect: true, useDefault: true })
   set value(val: string | null) {
     this._value = val;
   }
 
   /** The switch's size. */
-  @property({ reflect: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
+  @property({ reflect: true, useDefault: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
 
   @watch('size')
   handleSizeChange() {

--- a/packages/webawesome/src/components/tab-group/tab-group.ts
+++ b/packages/webawesome/src/components/tab-group/tab-group.ts
@@ -67,7 +67,7 @@ export default class WaTabGroup extends WebAwesomeElement {
   @state() private hasScrollControls = false;
 
   /** Sets the active tab. */
-  @property({ reflect: true }) active = '';
+  @property({ reflect: true, useDefault: true }) active = '';
 
   /** The placement of the tabs. */
   @property() placement: 'top' | 'bottom' | 'start' | 'end' = 'top';

--- a/packages/webawesome/src/components/tab-panel/tab-panel.ts
+++ b/packages/webawesome/src/components/tab-panel/tab-panel.ts
@@ -27,12 +27,12 @@ export default class WaTabPanel extends WebAwesomeElement {
   private readonly componentId = `wa-tab-panel-${this.attrId}`;
 
   /** The tab panel's name. */
-  @property({ reflect: true }) name = '';
+  @property({ reflect: true, useDefault: true }) name = '';
 
   /** When true, the tab panel will be shown. */
   @property({ type: Boolean, reflect: true }) active = false;
 
-  @property({ reflect: true }) role = 'tabpanel';
+  @property({ reflect: true, useDefault: true }) role = 'tabpanel';
 
   connectedCallback() {
     super.connectedCallback();

--- a/packages/webawesome/src/components/tab/tab.ts
+++ b/packages/webawesome/src/components/tab/tab.ts
@@ -27,7 +27,7 @@ export default class WaTab extends WebAwesomeElement {
   @query('.tab') tab: HTMLElement;
 
   /** The name of the tab panel this tab is associated with. The panel must be located in the same tab group. */
-  @property({ reflect: true }) panel = '';
+  @property({ reflect: true, useDefault: true }) panel = '';
 
   /** @internal Draws the tab in an active state. */
   @property({ type: Boolean, reflect: true }) active = false;
@@ -43,11 +43,11 @@ export default class WaTab extends WebAwesomeElement {
 
   /**
    * @internal
-   * Need to wrap in @property({reflect: true}) otherwise it will not SSR properly.
+   * Need to wrap in @property({reflect: true, useDefault: true}) otherwise it will not SSR properly.
    */
-  @property({ reflect: true }) slot = 'nav';
+  @property({ reflect: true, useDefault: true }) slot = 'nav';
 
-  @property({ reflect: true }) role = 'tab';
+  @property({ reflect: true, useDefault: true }) role = 'tab';
 
   @watch('active')
   handleActiveChange() {

--- a/packages/webawesome/src/components/tag/tag.ts
+++ b/packages/webawesome/src/components/tag/tag.ts
@@ -35,13 +35,13 @@ export default class WaTag extends WebAwesomeElement {
   private readonly localize = new LocalizeController(this);
 
   /** The tag's theme variant. Defaults to `neutral` if not within another element with a variant. */
-  @property({ reflect: true }) variant: 'brand' | 'neutral' | 'success' | 'warning' | 'danger' = 'neutral';
+  @property({ reflect: true, useDefault: true }) variant: 'brand' | 'neutral' | 'success' | 'warning' | 'danger' = 'neutral';
 
   /** The tag's visual appearance. */
-  @property({ reflect: true }) appearance: 'accent' | 'filled' | 'outlined' | 'filled-outlined' = 'filled-outlined';
+  @property({ reflect: true, useDefault: true }) appearance: 'accent' | 'filled' | 'outlined' | 'filled-outlined' = 'filled-outlined';
 
   /** The tag's size. */
-  @property({ reflect: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
+  @property({ reflect: true, useDefault: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
 
   @watch('size')
   handleSizeChange() {

--- a/packages/webawesome/src/components/textarea/textarea.ts
+++ b/packages/webawesome/src/components/textarea/textarea.ts
@@ -62,7 +62,7 @@ export default class WaTextarea extends WebAwesomeFormAssociatedElement {
   @property() title = ''; // make reactive to pass through
 
   /** The name of the textarea, submitted as a name/value pair with form data. */
-  @property({ reflect: true }) name: string | null = null;
+  @property({ reflect: true, useDefault: true }) name: string | null = null;
 
   private _value: string | null = null;
 
@@ -86,10 +86,10 @@ export default class WaTextarea extends WebAwesomeFormAssociatedElement {
   }
 
   /** The default value of the form control. Primarily used for resetting the form control. */
-  @property({ attribute: 'value', reflect: true }) defaultValue: string = this.getAttribute('value') ?? '';
+  @property({ attribute: 'value', reflect: true, useDefault: true }) defaultValue: string = this.getAttribute('value') ?? '';
 
   /** The textarea's size. */
-  @property({ reflect: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
+  @property({ reflect: true, useDefault: true }) size: 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' = 'm';
 
   @watch('size')
   handleSizeChange() {
@@ -97,7 +97,7 @@ export default class WaTextarea extends WebAwesomeFormAssociatedElement {
   }
 
   /** The textarea's visual appearance. */
-  @property({ reflect: true }) appearance: 'filled' | 'outlined' | 'filled-outlined' = 'outlined';
+  @property({ reflect: true, useDefault: true }) appearance: 'filled' | 'outlined' | 'filled-outlined' = 'outlined';
 
   /** The textarea's label. If you need to display HTML, use the `label` slot instead. */
   @property() label = '';
@@ -112,7 +112,7 @@ export default class WaTextarea extends WebAwesomeFormAssociatedElement {
   @property({ type: Number }) rows = 4;
 
   /** Controls how the textarea can be resized. */
-  @property({ reflect: true }) resize: 'none' | 'vertical' | 'horizontal' | 'both' | 'auto' = 'vertical';
+  @property({ reflect: true, useDefault: true }) resize: 'none' | 'vertical' | 'horizontal' | 'both' | 'auto' = 'vertical';
 
   /** Disables the textarea. */
   @property({ type: Boolean }) disabled = false;

--- a/packages/webawesome/src/components/time-input/time-input.ts
+++ b/packages/webawesome/src/components/time-input/time-input.ts
@@ -202,7 +202,7 @@ export default class WaTimeInput extends WebAwesomeFormAssociatedElement {
   //
 
   /** The time picker's name, submitted as a name/value pair with form data. */
-  @property({ reflect: true }) name = '';
+  @property({ reflect: true, useDefault: true }) name = '';
 
   private _value = '';
 
@@ -230,7 +230,7 @@ export default class WaTimeInput extends WebAwesomeFormAssociatedElement {
   }
 
   /** The default value of the form control. Used for form reset. */
-  @property({ attribute: 'value', reflect: true }) defaultValue: string = this.getAttribute('value') ?? '';
+  @property({ attribute: 'value', reflect: true, useDefault: true }) defaultValue: string = this.getAttribute('value') ?? '';
 
   /** Disables the time picker. */
   @property({ type: Boolean }) disabled = false;
@@ -242,7 +242,7 @@ export default class WaTimeInput extends WebAwesomeFormAssociatedElement {
   @property({ type: Boolean, reflect: true }) readonly = false;
 
   /** The time picker's size. */
-  @property({ reflect: true }) size: WaTimeInputSize | 'small' | 'medium' | 'large' = 'm';
+  @property({ reflect: true, useDefault: true }) size: WaTimeInputSize | 'small' | 'medium' | 'large' = 'm';
 
   @watch('size')
   handleSizeChange() {
@@ -250,7 +250,7 @@ export default class WaTimeInput extends WebAwesomeFormAssociatedElement {
   }
 
   /** The time picker's visual appearance. */
-  @property({ reflect: true }) appearance: 'filled' | 'outlined' | 'filled-outlined' = 'outlined';
+  @property({ reflect: true, useDefault: true }) appearance: 'filled' | 'outlined' | 'filled-outlined' = 'outlined';
 
   /** Draws a pill-style time picker with rounded edges. */
   @property({ type: Boolean, reflect: true }) pill = false;
@@ -284,10 +284,10 @@ export default class WaTimeInput extends WebAwesomeFormAssociatedElement {
    * The earliest selectable time in wire format. May be later than `max` to represent an overnight range. The picker
    * delegates reversed-range semantics to the mirrored native `<input type="time">`.
    */
-  @property({ reflect: true }) min = '';
+  @property({ reflect: true, useDefault: true }) min = '';
 
   /** The latest selectable time in wire format. */
-  @property({ reflect: true }) max = '';
+  @property({ reflect: true, useDefault: true }) max = '';
 
   /**
    * The granularity, in seconds, matching HTML `<input type="time">`. Default `60` hides the seconds segment.
@@ -297,7 +297,7 @@ export default class WaTimeInput extends WebAwesomeFormAssociatedElement {
   step: number | 'any' = 60;
 
   /** Whether the UI uses a 12-hour or 24-hour clock. `auto` follows the resolved locale. */
-  @property({ attribute: 'hour-format', reflect: true }) hourFormat: WaTimeInputHourFormat = 'auto';
+  @property({ attribute: 'hour-format', reflect: true, useDefault: true }) hourFormat: WaTimeInputHourFormat = 'auto';
 
   //
   // Popup
@@ -307,7 +307,7 @@ export default class WaTimeInput extends WebAwesomeFormAssociatedElement {
   @property({ type: Boolean, reflect: true }) open = false;
 
   /** Preferred popup placement. */
-  @property({ reflect: true }) placement: WaTimeInputPlacement = 'bottom-start';
+  @property({ reflect: true, useDefault: true }) placement: WaTimeInputPlacement = 'bottom-start';
 
   /** Distance in pixels between the popup and the input. */
   @property({ type: Number, reflect: true }) distance = 0;

--- a/packages/webawesome/src/components/tooltip/tooltip.test.ts
+++ b/packages/webawesome/src/components/tooltip/tooltip.test.ts
@@ -441,6 +441,30 @@ describe('<wa-tooltip>', () => {
       await waitUntil(() => tooltip.open);
       expect(tooltip.open).to.be.true;
     });
+
+    it('should remain open when the pointer moves onto a slotted child element of the tooltip', async () => {
+      const el = await fixtures[0]<HTMLDivElement>(html`
+        <div>
+          <wa-button id="hover-child-btn">Hover me</wa-button>
+          <wa-tooltip for="hover-child-btn" trigger="hover" show-delay="0" hide-delay="0">
+            <a href="#" id="tooltip-link">A link inside the tooltip</a>
+          </wa-tooltip>
+        </div>
+      `);
+      const tooltip = el.querySelector<WaTooltip>('wa-tooltip')!;
+      const childLink = el.querySelector<HTMLElement>('#tooltip-link')!;
+
+      tooltip.open = true;
+      await waitUntil(() => tooltip.open);
+      expect(tooltip.open).to.be.true;
+
+      // Simulate the pointer moving off of the tooltip host and onto a slotted child element.
+      // relatedTarget is the element the pointer is moving to, which is how browsers report this.
+      tooltip.dispatchEvent(new MouseEvent('mouseout', { relatedTarget: childLink, bubbles: true }));
+      await aTimeout(50);
+
+      expect(tooltip.open).to.be.true;
+    });
   });
 
   describe('keyboard navigation', () => {

--- a/packages/webawesome/src/components/tooltip/tooltip.ts
+++ b/packages/webawesome/src/components/tooltip/tooltip.ts
@@ -198,22 +198,26 @@ export default class WaTooltip extends WebAwesomeElement {
     }
   };
 
-  private handleMouseOut = () => {
+  private handleMouseOut = (event: MouseEvent) => {
     if (this.hasTrigger('hover')) {
-      const anchorHovered = Boolean(this.anchor?.matches(':hover'));
-      const tooltipHovered = this.matches(':hover');
+      const relatedTarget = event.relatedTarget as Node | null;
 
-      if (anchorHovered || tooltipHovered) {
+      // Use the event's relatedTarget (the element the pointer moved to) to determine whether the
+      // pointer is still within the anchor or the tooltip itself. Relying on `:hover` matching here is
+      // unreliable in Chrome when the pointer moves onto a slotted child element of the tooltip, since
+      // the host's `:hover` state can briefly report false during that transition.
+      const movedIntoAnchor = Boolean(relatedTarget && this.anchor?.contains(relatedTarget));
+      const movedIntoTooltip = Boolean(relatedTarget && this.contains(relatedTarget));
+
+      if (movedIntoAnchor || movedIntoTooltip) {
         return;
       }
 
       clearTimeout(this.hoverTimeout);
 
-      if (!(anchorHovered || tooltipHovered)) {
-        this.hoverTimeout = window.setTimeout(() => {
-          this.hide();
-        }, this.hideDelay);
-      }
+      this.hoverTimeout = window.setTimeout(() => {
+        this.hide();
+      }, this.hideDelay);
     }
   };
 

--- a/packages/webawesome/src/components/tree-item/tree-item.ts
+++ b/packages/webawesome/src/components/tree-item/tree-item.ts
@@ -113,7 +113,7 @@ export default class WaTreeItem extends WebAwesomeElement {
   @query('.expand-button slot') expandButtonSlot: HTMLSlotElement;
 
   @property({ reflect: true, type: Number, attribute: 'tabindex' }) tabIndex = -1;
-  @property({ reflect: true }) role = 'treeitem';
+  @property({ reflect: true, useDefault: true }) role = 'treeitem';
 
   connectedCallback() {
     super.connectedCallback();

--- a/packages/webawesome/src/components/tree/tree.ts
+++ b/packages/webawesome/src/components/tree/tree.ts
@@ -97,7 +97,7 @@ export default class WaTree extends WebAwesomeElement {
   private readonly localize = new LocalizeController(this);
 
   @property({ attribute: 'tabindex', reflect: true, type: Number }) tabIndex = 0;
-  @property({ reflect: true }) role = 'tree';
+  @property({ reflect: true, useDefault: true }) role = 'tree';
 
   constructor() {
     super();


### PR DESCRIPTION
Fixes #2488

### Changes made
Added `useDefault: true` to all string `@property` decorators with `reflect: true` across 52 component files, following Lit's best practices for reflected attributes.

This prevents "attribute sprouting" where default values are written back to the DOM as attributes on initialization. For example, previously:
```html
<wa-button>  =>  <wa-button variant="neutral" appearance="accent" size="m">
```
After this change, default values are no longer reflected as attributes, which fixes compatibility issues with DOM morphing libraries (e.g. Alpine.js, Turbo, htmx).

Boolean and Number properties were intentionally left unchanged as `useDefault` only applies to string attributes.

### Note
This is a breaking change slated for the Web Awesome 4.0 milestone as noted in the issue. CSS selectors targeting default attribute values will need to be updated to also account for the absence of the attribute, as documented in the issue description.