### PR TITLE
Fix phantom gap in date and time inputs

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -29,6 +29,14 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 {% include "changelog-email-signup.njk" %}
 
+## Unreleased
+
+:::fixed
+
+- Fixed a bug in `<wa-date-input>` and `<wa-time-input>` where an empty `start`/`end` slot added a phantom gap causing it to be misaligned with other form controls [issue:2527]
+
+:::
+
 ## 3.9.0
 
 <small><time datetime="2026-06-18">June 18th, 2026</time></small>

--- a/packages/webawesome/src/components/time-input/time-input.styles.ts
+++ b/packages/webawesome/src/components/time-input/time-input.styles.ts
@@ -150,7 +150,6 @@ export default css`
     width: 100%;
     min-width: 0;
     align-items: center;
-    gap: 0.25em;
     min-height: var(--wa-form-control-height);
     background-color: var(--wa-form-control-background-color);
     border-color: var(--wa-form-control-border-color);
@@ -283,6 +282,8 @@ export default css`
     cursor: pointer;
     color: var(--wa-color-text-quiet);
     font: inherit;
+    /* Margin separates the button from the value so empty start/end slots don't add a phantom gap. */
+    margin-inline-start: 0.25em;
     padding: 0.25em;
     border-radius: var(--wa-border-radius-s);
     transition: color var(--wa-transition-fast);


### PR DESCRIPTION
Fixes #2527

Pro PR: https://github.com/shoelace-style/webawesome-pro/pull/240

Before:
<img width="1528" height="1096" alt="before" src="https://github.com/user-attachments/assets/c88fa2eb-86f4-4d28-8ae7-b53b4a4bed46" />

After:
<img width="1522" height="1094" alt="after" src="https://github.com/user-attachments/assets/0f68210b-be0d-472e-b448-e3fa00b3a293" />
