### PR TITLE
Syncing `<wa-option>` visuals with `<wa-dropdown-item>`

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -39,6 +39,15 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 :::
 
+:::changed
+
+- Synced `<wa-option>` visuals with `<wa-dropdown-item>` so options and menu items read as the same primitive [issue:2413]
+  - `<wa-option>` now uses rounded corners and sits inset within `<wa-select>`'s listbox, with spacing between options
+  - The current (keyboard-highlighted) state now uses `--wa-form-control-activated-color` for its background and a new `--current-text-color` custom property for its text, so options track form control theming alongside `<wa-checkbox>`, `<wa-radio>`, `<wa-switch>`, and `<wa-slider>`
+  - Hover and current state changes now animate, matching `<wa-dropdown-item>`
+
+:::
+
 ## 3.9.0
 
 <small><time datetime="2026-06-18">June 18th, 2026</time></small>

--- a/packages/webawesome/src/components/option/option.styles.ts
+++ b/packages/webawesome/src/components/option/option.styles.ts
@@ -2,6 +2,8 @@ import { css } from 'lit';
 
 export default css`
   :host {
+    --current-text-color: var(--wa-color-brand-on-loud);
+
     display: block;
     color: var(--wa-color-text-normal);
     -webkit-user-select: none;
@@ -32,7 +34,7 @@ export default css`
   :host(:state(current)),
   :host(:state(disabled):state(current)) {
     background-color: var(--wa-form-control-activated-color);
-    color: var(--wa-color-brand-on-loud);
+    color: var(--current-text-color);
     opacity: 1;
   }
 

--- a/packages/webawesome/src/components/option/option.styles.ts
+++ b/packages/webawesome/src/components/option/option.styles.ts
@@ -12,8 +12,9 @@ export default css`
     align-items: center;
     font: inherit;
     padding: 0.5em 1em 0.5em 0.25em;
+    border-radius: var(--wa-border-radius-s);
     line-height: var(--wa-line-height-condensed);
-    transition: fill var(--wa-transition-normal) var(--wa-transition-easing);
+    transition: var(--wa-transition-fast) background-color var(--wa-transition-easing);
     cursor: pointer;
   }
 
@@ -30,7 +31,7 @@ export default css`
 
   :host(:state(current)),
   :host(:state(disabled):state(current)) {
-    background-color: var(--wa-color-brand-fill-loud);
+    background-color: var(--wa-form-control-activated-color);
     color: var(--wa-color-brand-on-loud);
     opacity: 1;
   }

--- a/packages/webawesome/src/components/option/option.ts
+++ b/packages/webawesome/src/components/option/option.ts
@@ -30,6 +30,8 @@ import styles from './option.styles.js';
  * @cssstate selected - The option is selected and has aria-selected="true"
  * @cssstate disabled - Applied when the option is disabled
  * @cssstate hover - Like `:hover` but works while dragging in Safari
+ *
+ * @cssproperty --current-text-color - The text color of the current (highlighted) option, paired with `--wa-form-control-activated-color`.
  */
 @customElement('wa-option')
 export default class WaOption extends WebAwesomeElement {

--- a/packages/webawesome/src/components/select/select.styles.ts
+++ b/packages/webawesome/src/components/select/select.styles.ts
@@ -256,8 +256,7 @@ export default css`
     border-radius: var(--wa-border-radius-m);
     border-style: var(--wa-border-style);
     border-width: var(--wa-border-width-s);
-    padding-block: 0.5em;
-    padding-inline: 0;
+    padding: 0.25em;
     overflow: auto;
     overscroll-behavior: none;
 
@@ -268,6 +267,13 @@ export default css`
     &::slotted(wa-divider) {
       --spacing: 0.5em;
     }
+  }
+
+  /* Space options with half the listbox's padding */
+  .listbox slot:not([name]) {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125em;
   }
 
   slot:not([name])::slotted(small) {

--- a/packages/webawesome/src/styles/themes/awesome.css
+++ b/packages/webawesome/src/styles/themes/awesome.css
@@ -577,6 +577,10 @@
       --checked-icon-color: var(--wa-color-surface-default);
     }
 
+    wa-option {
+      --current-text-color: var(--wa-color-surface-default);
+    }
+
     wa-switch {
       --height: 1.5em;
     }


### PR DESCRIPTION
Aligns `<wa-option>` and `<wa-select>`'s listbox visuals with `<wa-dropdown-item>` so options and menu items read as the same primitive (closes #2413). 

The keyboard-highlighted state now picks up the same form-control theming used by `<wa-checkbox>`, `<wa-radio>`, `<wa-switch>`, and `<wa-slider>`.

### Visual sync
- `<wa-option>` adopts `--wa-border-radius-s` corners and a fast background transition matching `<wa-dropdown-item>`.
- `<wa-select>`'s listbox swaps asymmetric block/inline padding for a uniform `0.25em` inset, and slotted options now flow as a flex column with `0.125em` gaps so rounded options sit visibly inside the listbox surface. This is needed because a hover-styled state may be adjacent to a current-styled state - `<wa-dropdown-item>` styling doesn't need to worry about this scenario.

### `:state(current)` theming
- The current (keyboard-highlighted) state now uses `--wa-form-control-activated-color` for its background, matching the rest of the form-control family.
- New `--current-text-color` custom property controls the text color on the current state, defaulting to `--wa-color-brand-on-loud`. Mirrors `--checked-icon-color` on `<wa-checkbox>` / `<wa-radio>`.
- Awesome theme overrides `--current-text-color` to `--wa-color-surface-default` so text contrasts against the neutral activated background.

| Before | After |
|--------|--------|
| <img width="1296" height="1314" alt="CleanShot 2026-06-22 at 15 34 21@2x" src="https://github.com/user-attachments/assets/3f29e977-f15d-4a40-bbf8-e79829cd0373" /> | <img width="1244" height="1302" alt="CleanShot 2026-06-22 at 15 33 52@2x" src="https://github.com/user-attachments/assets/cbc2c32e-19b5-448e-a77d-3d0b659780ab" /> |

## Companion PRs
- https://github.com/shoelace-style/webawesome-pro/pull/243