### PR TITLE
Fix looping carousel in tab group edge case

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -35,6 +35,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 - Fixed a bug in `<wa-select>` that prevented the dropdown menu from scrolling when using the keyboard [issue:2472]
 - Fixed a bug in `<wa-carousel>` that caused the pagination controls to clip vertically by adding block padding around them [issue:2495]
+- Fixed a bug in `<wa-carousel>` with `loop` enabled that displayed the wrong slide, briefly flashing it on load, when the carousel was initialized inside a hidden container such as an inactive tab panel [issue:1163]
 - Fixed component API tables in the `webawesome` Agent Skill by generating them from the CEM instead of scraping the rendered HTML [issue:2475]
 
 :::

--- a/packages/webawesome/src/components/carousel/carousel.styles.ts
+++ b/packages/webawesome/src/components/carousel/carousel.styles.ts
@@ -49,6 +49,22 @@ export default css`
     --slide-size: calc((100% - (var(--slides-per-page) - 1) * var(--slide-gap)) / var(--slides-per-page));
   }
 
+  /*
+   * While a looping carousel that initialized inside a hidden container waits to scroll past its leading clones, hide
+   * the slides and pagination to avoid flashing the wrong slide and active dot, then fade them in once the carousel has
+   * positioned itself.
+   */
+  .slides,
+  .pagination {
+    transition: opacity var(--wa-transition-fast) ease;
+  }
+
+  .slides-awaiting-position,
+  .pagination-awaiting-position {
+    opacity: 0;
+    transition: none;
+  }
+
   @media (prefers-reduced-motion) {
     :where(.slides) {
       scroll-behavior: auto;

--- a/packages/webawesome/src/components/carousel/carousel.ts
+++ b/packages/webawesome/src/components/carousel/carousel.ts
@@ -98,6 +98,11 @@ export default class WaCarousel extends WebAwesomeElement {
 
   @state() dragging = false;
 
+  // When a looping carousel is initialized inside a hidden container, it can't position itself past the leading clones
+  // until it becomes visible. This hides the slides until that corrective scroll lands, preventing a brief flash of the
+  // wrong slide. See firstUpdated() for details.
+  @state() awaitingInitialPosition = false;
+
   private autoplayController = new AutoplayController(this, () => this.next());
   private dragStartPosition: [number, number] = [-1, -1];
   private readonly localize = new LocalizeController(this);
@@ -129,16 +134,31 @@ export default class WaCarousel extends WebAwesomeElement {
       subtree: true,
     });
 
-    // When the carousel is placed inside a hidden container (e.g. an inactive tab panel),
-    // initializeSlides() runs before the element has layout dimensions. The IntersectionObserver
-    // inside synchronizeSlides() then reports all slides as non-intersecting and marks them
-    // `inert`, making their contents unclickable until the user interacts with the carousel.
-    // Re-run synchronizeSlides() once the carousel gains visible dimensions to correct this.
+    // Inside a hidden container (e.g. an inactive tab panel), initializeSlides() runs with zero dimensions, so the
+    // corrective scroll past the prepended `loop` clones never happens and the container rests on the leading clone of
+    // the last slide. Once visible, re-scroll to the active slide; goToSlide()'s `pendingSlideChange` suppresses the
+    // clone-recovery in synchronizeSlides() so this wins, while synchronizeSlides() clears the stale `inert` state. We
+    // hide the slides until that scroll lands to avoid flashing the wrong one.
+    const startedHidden = this.loop && !this.scrollContainer?.clientWidth && !this.scrollContainer?.clientHeight;
+    if (startedHidden) {
+      this.awaitingInitialPosition = true;
+    }
+
     this.resizeObserver = new ResizeObserver(() => {
       if (this.scrollContainer?.clientWidth || this.scrollContainer?.clientHeight) {
+        this.goToSlide(this.activeSlide, 'auto');
         this.synchronizeSlides();
         this.resizeObserver?.disconnect();
         this.resizeObserver = undefined;
+
+        // goToSlide() applies the scroll on the next frame; reveal once that frame has painted.
+        if (this.awaitingInitialPosition) {
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+              this.awaitingInitialPosition = false;
+            });
+          });
+        }
       }
     });
     this.resizeObserver.observe(this);
@@ -343,7 +363,7 @@ export default class WaCarousel extends WebAwesomeElement {
           this.activeSlide =
             (Math.ceil(normalizedIndex / this.slidesPerMove) * this.slidesPerMove + slidesCount) % slidesCount;
 
-          if (!this.scrolling) {
+          if (!this.scrolling && !this.pendingSlideChange) {
             if (this.loop && firstIntersecting.target.hasAttribute('data-clone')) {
               const clonePosition = Number(firstIntersecting.target.getAttribute('data-clone'));
               // Scrolls to the original slide without animating, so the user won't notice that the position has changed
@@ -599,6 +619,7 @@ export default class WaCarousel extends WebAwesomeElement {
             'slides-horizontal': this.orientation === 'horizontal',
             'slides-vertical': this.orientation === 'vertical',
             'slides-dragging': this.dragging,
+            'slides-awaiting-position': this.awaitingInitialPosition,
           })}"
           style=${styleMap({ '--slides-per-page': this.slidesPerPage })}
           aria-busy="${scrolling ? 'true' : 'false'}"
@@ -654,7 +675,15 @@ export default class WaCarousel extends WebAwesomeElement {
           : ''}
         ${this.pagination
           ? html`
-              <div part="pagination" role="tablist" class="pagination" aria-controls="scroll-container">
+              <div
+                part="pagination"
+                role="tablist"
+                class="${classMap({
+                  pagination: true,
+                  'pagination-awaiting-position': this.awaitingInitialPosition,
+                })}"
+                aria-controls="scroll-container"
+              >
                 ${map(range(pagesCount), index => {
                   const isActive = index === currentPage;
                   return html`


### PR DESCRIPTION
Fixes #1163.

Here is the manual test fixture I used to reproduce this, based on the original repro:

```html {.example}
<wa-tab-group>
  <wa-tab panel="general">General</wa-tab>
  <wa-tab panel="custom">Custom</wa-tab>
  <wa-tab panel="advanced">Advanced</wa-tab>
  <wa-tab panel="disabled" disabled>Disabled</wa-tab>

  <wa-tab-panel name="general">
    <wa-carousel pagination navigation mouse-dragging loop>
      <wa-carousel-item>Carousel item 1</wa-carousel-item>
      <wa-carousel-item>Carousel item 2</wa-carousel-item>
      <wa-carousel-item>Carousel item 3</wa-carousel-item>
    </wa-carousel>
  </wa-tab-panel>
  <wa-tab-panel name="custom">This is the custom tab panel.</wa-tab-panel>
  <wa-tab-panel name="advanced">This is the advanced tab panel.</wa-tab-panel>
  <wa-tab-panel name="disabled">This is a disabled tab panel.</wa-tab-panel>
</wa-tab-group>
```

To test, reload the page with the repro and look at the slide. It should be 3 before the fix and 1 after the fix. The pagination should also reflect the first slide.

I was not able to reproduce this in the test runner, so I wasn't able to add a test.