### PR TITLE
Reorder and cleanup component reference pages

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -47,6 +47,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
   - `<wa-option>` now uses rounded corners and sits inset within `<wa-select>`'s listbox, with spacing between options
   - The current (keyboard-highlighted) state now uses `--wa-form-control-activated-color` for its background and a new `--current-text-color` custom property for its text, so options track form control theming alongside `<wa-checkbox>`, `<wa-radio>`, `<wa-switch>`, and `<wa-slider>`
   - Hover and current state changes now animate, matching `<wa-dropdown-item>`
+- Reordered component reference pages in the `webawesome` Agent Skill to put the import instructions and API tables before the examples
 
 :::
 

--- a/packages/webawesome/scripts/agent-skill.js
+++ b/packages/webawesome/scripts/agent-skill.js
@@ -261,6 +261,21 @@ function renderComponentApiTable(section, component) {
 }
 
 /**
+ * Moves a component's `## Examples` section to the end of the doc so the API comes first.
+ *
+ * The component layout (docs/_layouts/component.njk) emits the page in this order: summary →
+ * Examples (the markdown body) → API sections (Importing, Slots, Attributes & Properties, …). The
+ * skill wants summary → API → Examples. The examples are one contiguous block — `## Examples` up to
+ * the next `## ` heading (`## Importing`) — so we just cut that block out and append it at the end.
+ */
+function moveExamplesToEnd(markdown) {
+  const match = markdown.match(/\n## Examples\n[\s\S]*?(?=\n## |$)/);
+  if (!match) return markdown;
+  const examples = match[0];
+  return (markdown.slice(0, match.index) + markdown.slice(match.index + examples.length)).trimEnd() + '\n' + examples;
+}
+
+/**
  * Processes rendered HTML from Eleventy output and converts it to clean Markdown.
  *
  * When `component` (a Custom Elements Manifest declaration) is provided, that component's API
@@ -427,6 +442,13 @@ function processHtmlToMarkdown(htmlContent, baseUrl, component = null) {
     )
     .forEach(el => el.remove());
 
+  // Drop the "Need a hand?" help footer and its leading divider
+  main.querySelectorAll('.component-help').forEach(el => {
+    const divider = el.previousElementSibling;
+    if (divider && divider.tagName === 'WA-DIVIDER') divider.remove();
+    el.remove();
+  });
+
   // Get the h1 title if present (we'll add it separately in the header)
   const h1 = main.querySelector('h1.title');
   const title = h1 ? h1.textContent.trim() : null;
@@ -446,6 +468,11 @@ function processHtmlToMarkdown(htmlContent, baseUrl, component = null) {
 
   // Clean up excessive blank lines
   markdown = markdown.replace(/\n{3,}/g, '\n\n').trim();
+
+  // For component docs, move the examples below the API reference.
+  if (component) {
+    markdown = moveExamplesToEnd(markdown);
+  }
 
   return { content: markdown, title };
 }


### PR DESCRIPTION
This PR reorders component reference skill files, so the overview comes first, followed by the API and then examples. This allows agents to get to the API information without having to parse long examples, potentially saving short-circuiting agents a large number of tokens for every request.

The order is now:

- Component name + summary
- API docs (slots, properties, events, methods, etc.)
- Examples