### PR TITLE
Align Segmented-Field Picker Trailing Icons

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -40,6 +40,9 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 - Fixed a bug in `<wa-carousel>` with `loop` enabled that displayed the wrong slide, briefly flashing it on load, when the carousel was initialized inside a hidden container such as an inactive tab panel [issue:1163]
 - Fixed component API tables in the `webawesome` Agent Skill by generating them from the CEM instead of scraping the rendered HTML [issue:2475]
 - Fixed a bug in `<wa-toast-item>` where the documented `--padding` custom property was unused in component styles
+- Aligned the `start` and `end` slot region in `<wa-date-input>` and `<wa-time-input>` with `<wa-input>` and `<wa-select>`
+  - The trailing calendar/clock and clear icons no longer sit a few pixels inward of where the other controls place them
+  - The `start` and `end` slots now use the same spacing as the other controls instead of a tighter gap
 
 :::
 

--- a/packages/webawesome/src/components/select/select.test.ts
+++ b/packages/webawesome/src/components/select/select.test.ts
@@ -1209,4 +1209,46 @@ describe('<wa-select>', () => {
       expect(el.displayInput.value).to.equal('Option 2');
     });
   });
+
+  describe('trailing affordance alignment', () => {
+    // <wa-select> and <wa-input> are the canonical trailing axis the other form controls line
+    // up against (date/time/combobox guards compare against <wa-select>). This anchors the two
+    // references together so the axis itself can't silently drift.
+    function iconCenterFromRight(host: HTMLElement, partSelector: string): number {
+      const part = host.shadowRoot!.querySelector(partSelector);
+      let icon: Element | null | undefined = part?.querySelector('wa-icon');
+      if (!icon && part instanceof HTMLSlotElement) icon = part.assignedElements()[0];
+      const target = icon ?? part!;
+      const iconRect = target.getBoundingClientRect();
+      const hostRect = host.getBoundingClientRect();
+      return hostRect.right - (iconRect.left + iconRect.right) / 2;
+    }
+
+    it('shares the trailing axis with <wa-input>', async () => {
+      const fixture = fixtures[0];
+      const container = await fixture(html`
+        <div>
+          <wa-select with-clear value="a"><wa-option value="a">A</wa-option></wa-select>
+          <wa-input with-clear value="text"><wa-icon slot="end" name="circle-info"></wa-icon></wa-input>
+        </div>
+      `);
+      const select = container.querySelector<HTMLElement & { updateComplete: Promise<unknown> }>('wa-select')!;
+      const input = container.querySelector<HTMLElement & { updateComplete: Promise<unknown> }>('wa-input')!;
+      await Promise.all([customElements.whenDefined('wa-select'), customElements.whenDefined('wa-input')]);
+      await select.updateComplete;
+      await input.updateComplete;
+      await aTimeout(50);
+
+      // input's trailing-most icon is the end-slot decoration; select's is the chevron.
+      const trailingDelta = Math.abs(
+        iconCenterFromRight(input, '[part~="end"]') - iconCenterFromRight(select, '[part~="expand-icon"]'),
+      );
+      const clearDelta = Math.abs(
+        iconCenterFromRight(input, '[part~="clear-button"]') - iconCenterFromRight(select, '[part~="clear-button"]'),
+      );
+
+      expect(trailingDelta, 'input end-slot icon is off the select trailing axis').to.be.lessThan(2);
+      expect(clearDelta, 'input clear button is off the select clear axis').to.be.lessThan(2);
+    });
+  });
 });

--- a/packages/webawesome/src/components/time-input/time-input.styles.ts
+++ b/packages/webawesome/src/components/time-input/time-input.styles.ts
@@ -269,43 +269,9 @@ export default css`
     margin: 0;
   }
 
-  /* Buttons. font: inherit lifts the UA default button font-size so children that size with em
-     (e.g. the expand icon) resolve against the host size-driven font-size instead of ~13px. */
-  .clear-button,
-  .expand-button {
-    flex: 0 0 auto;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    background: transparent;
-    border: none;
-    cursor: pointer;
-    color: var(--wa-color-text-quiet);
-    font: inherit;
-    /* Margin separates the button from the value so empty start/end slots don't add a phantom gap. */
-    margin-inline-start: 0.25em;
-    padding: 0.25em;
-    border-radius: var(--wa-border-radius-s);
-    transition: color var(--wa-transition-fast);
-  }
-
-  .clear-button:hover,
-  .expand-button:hover {
-    color: var(--wa-color-text-loud);
-  }
-
-  .expand-button:focus-visible {
-    outline: var(--wa-focus-ring-style) var(--wa-focus-ring-width) var(--wa-color-focus);
-    outline-offset: 2px;
-  }
-
-  /* Scale the clock icon with the host's font-size (which is set by the size attribute) so it grows
-     and shrinks with the rest of the form control. Applies to both the default and any user-slotted icon. */
-  .expand-icon {
-    display: inline-flex;
-    color: var(--wa-color-text-quiet);
-    font-size: 1.25em;
-  }
+  /* Trailing buttons (.clear-button, .expand-button), the .expand-icon box, and the start/end
+     decoration slots are shared with <wa-date-input> via segmentedFieldStyles so both pickers
+     stay on <wa-select>'s trailing optical axis. See segmented-field.styles.ts. */
 
   /* Animations */
   .time-input-popup::part(popup).show {
@@ -359,21 +325,5 @@ export default css`
     clip: rect(0, 0, 0, 0);
     white-space: nowrap;
     border: 0;
-  }
-
-  /* Start / end slots */
-  [part~='start'],
-  [part~='end'] {
-    display: inline-flex;
-    align-items: center;
-    color: var(--wa-color-text-quiet);
-  }
-
-  [part~='start']::slotted(*) {
-    margin-inline-end: 0.25em;
-  }
-
-  [part~='end']::slotted(*) {
-    margin-inline-start: 0.25em;
   }
 `;

--- a/packages/webawesome/src/components/time-input/time-input.test.ts
+++ b/packages/webawesome/src/components/time-input/time-input.test.ts
@@ -968,8 +968,12 @@ describe('<wa-time-input>', () => {
     // segmented-field styles against silent regressions.
     function iconCenterFromRight(host: HTMLElement, partSelector: string): number {
       const part = host.shadowRoot!.querySelector(partSelector);
-      const icon = part?.querySelector('wa-icon') ?? part;
-      const iconRect = icon!.getBoundingClientRect();
+      // The trailing parts are <slot> elements; a custom-slotted icon is assigned content, not a
+      // child, so fall back to assignedElements() before measuring the slot wrapper itself.
+      let icon: Element | null | undefined = part?.querySelector('wa-icon');
+      if (!icon && part instanceof HTMLSlotElement) icon = part.assignedElements()[0];
+      const target = icon ?? part!;
+      const iconRect = target.getBoundingClientRect();
       const hostRect = host.getBoundingClientRect();
       return hostRect.right - (iconRect.left + iconRect.right) / 2;
     }
@@ -997,6 +1001,29 @@ describe('<wa-time-input>', () => {
 
       expect(expandDelta, 'expand icon is off the select trailing axis').to.be.lessThan(2);
       expect(clearDelta, 'clear button is off the select trailing axis').to.be.lessThan(2);
+    });
+
+    it('keeps the expand icon on the <wa-select> axis with no clear button', async () => {
+      // No with-clear/value: only the expand button is rendered. Confirms the expand button stays
+      // anchored to the trailing edge independently of whether the clear button is present.
+      const container = await fixture(html`
+        <div>
+          <wa-select><wa-option value="a">A</wa-option></wa-select>
+          <wa-time-input></wa-time-input>
+        </div>
+      `);
+      const select = container.querySelector<HTMLElement & { updateComplete: Promise<unknown> }>('wa-select')!;
+      const time = container.querySelector<WaTimeInput>('wa-time-input')!;
+      await Promise.all([customElements.whenDefined('wa-select'), customElements.whenDefined('wa-time-input')]);
+      await select.updateComplete;
+      await time.updateComplete;
+      await aTimeout(50);
+
+      expect(time.shadowRoot!.querySelector('[part~="clear-button"]'), 'clear button should be absent').to.equal(null);
+      const expandDelta = Math.abs(
+        iconCenterFromRight(time, '[part~="expand-icon"]') - iconCenterFromRight(select, '[part~="expand-icon"]'),
+      );
+      expect(expandDelta, 'expand icon is off the select trailing axis without a clear button').to.be.lessThan(2);
     });
   });
 });

--- a/packages/webawesome/src/components/time-input/time-input.test.ts
+++ b/packages/webawesome/src/components/time-input/time-input.test.ts
@@ -1,4 +1,4 @@
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { aTimeout, expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { sendKeys } from '@web/test-runner-commands';
 import sinon from 'sinon';
 import { fixtures } from '../../internal/test/fixture.js';
@@ -961,4 +961,42 @@ describe('<wa-time-input>', () => {
       });
     });
   }
+
+  describe('trailing affordance alignment', () => {
+    // The expand and clear icons must sit on the same vertical axis as <wa-select>'s, so a
+    // time input lines up with the surrounding form controls. Guards the shared
+    // segmented-field styles against silent regressions.
+    function iconCenterFromRight(host: HTMLElement, partSelector: string): number {
+      const part = host.shadowRoot!.querySelector(partSelector);
+      const icon = part?.querySelector('wa-icon') ?? part;
+      const iconRect = icon!.getBoundingClientRect();
+      const hostRect = host.getBoundingClientRect();
+      return hostRect.right - (iconRect.left + iconRect.right) / 2;
+    }
+
+    it('aligns the expand icon and clear button with <wa-select>', async () => {
+      const container = await fixture(html`
+        <div>
+          <wa-select with-clear value="a"><wa-option value="a">A</wa-option></wa-select>
+          <wa-time-input with-clear value="22:03:00"></wa-time-input>
+        </div>
+      `);
+      const select = container.querySelector<HTMLElement & { updateComplete: Promise<unknown> }>('wa-select')!;
+      const time = container.querySelector<WaTimeInput>('wa-time-input')!;
+      await Promise.all([customElements.whenDefined('wa-select'), customElements.whenDefined('wa-time-input')]);
+      await select.updateComplete;
+      await time.updateComplete;
+      await aTimeout(50);
+
+      const expandDelta = Math.abs(
+        iconCenterFromRight(time, '[part~="expand-icon"]') - iconCenterFromRight(select, '[part~="expand-icon"]'),
+      );
+      const clearDelta = Math.abs(
+        iconCenterFromRight(time, '[part~="clear-button"]') - iconCenterFromRight(select, '[part~="clear-button"]'),
+      );
+
+      expect(expandDelta, 'expand icon is off the select trailing axis').to.be.lessThan(2);
+      expect(clearDelta, 'clear button is off the select trailing axis').to.be.lessThan(2);
+    });
+  });
 });

--- a/packages/webawesome/src/components/time-input/time-input.ts
+++ b/packages/webawesome/src/components/time-input/time-input.ts
@@ -21,6 +21,7 @@ import { RequiredValidator } from '../../internal/validators/required-validator.
 import { watch } from '../../internal/watch.js';
 import { WebAwesomeFormAssociatedElement } from '../../internal/webawesome-form-associated-element.js';
 import formControlStyles from '../../styles/component/form-control.styles.js';
+import segmentedFieldStyles from '../../styles/component/segmented-field.styles.js';
 import sizeStyles from '../../styles/component/size.styles.js';
 import { LocalizeController } from '../../utilities/localize.js';
 import {
@@ -109,7 +110,7 @@ const SINGLE_GROUP = 'single';
  */
 @customElement('wa-time-input')
 export default class WaTimeInput extends WebAwesomeFormAssociatedElement {
-  static css = [sizeStyles, formControlStyles, styles];
+  static css = [sizeStyles, formControlStyles, segmentedFieldStyles, styles];
 
   static shadowRootOptions = {
     ...WebAwesomeFormAssociatedElement.shadowRootOptions,

--- a/packages/webawesome/src/styles/component/segmented-field.styles.ts
+++ b/packages/webawesome/src/styles/component/segmented-field.styles.ts
@@ -1,0 +1,92 @@
+import { css } from 'lit';
+
+/**
+ * Shared trailing-affordance styling for segmented-field pickers (`<wa-date-input>`,
+ * `<wa-time-input>`). Keeps their clear and expand buttons — and their start/end decoration
+ * slots — on the same trailing optical axis as `<wa-select>`'s chevron and end-slot icons,
+ * while preserving each button's padded hit target and focus ring.
+ *
+ * How the alignment works:
+ *  - Each button keeps `0.25em` padding (hit area + focus-ring breathing room).
+ *  - `margin-inline-end: -0.25em` lets that trailing padding overhang the trailing content
+ *    edge instead of pushing the glyph inboard.
+ *  - Each button is given a fixed `inline-size` equal to its natural width (glyph + 2×padding):
+ *    `1.75em` for the expand glyph (1.25em) and `1.5em` for the clear glyph (1em). Because the
+ *    width is fixed and the glyph is centered, a custom-slotted icon of any width stays centered
+ *    on the axis — the alignment is glyph-agnostic, not tuned to one icon.
+ *  - The expand button's `margin-inline-start` sets the gap that positions the clear button onto
+ *    `<wa-select>`'s clear axis given those fixed widths.
+ */
+export default css`
+  /* font: inherit lifts the UA default button font-size so children that size with em
+     (e.g. the expand icon) resolve against the host size-driven font-size instead of ~13px. */
+  [part~='clear-button'],
+  [part~='expand-button'] {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: var(--wa-color-text-quiet);
+    font: inherit;
+    padding: 0.25em;
+    /* Trailing padding overhangs the content edge rather than displacing the glyph. */
+    margin-inline-end: -0.25em;
+    border-radius: var(--wa-border-radius-s);
+    transition: color var(--wa-transition-fast);
+  }
+
+  /* Fixed widths (= glyph + 2×0.25em padding) keep each glyph centered on the trailing axis
+     regardless of the slotted icon's intrinsic width. */
+  [part~='expand-button'] {
+    inline-size: 1.75em;
+    /* Leading gap that lands the clear button on <wa-select>'s clear axis. Scales with the
+       form-control padding token (like select's own spacing) so it holds across themes; the
+       0.125em offset accounts for the fixed button widths. */
+    margin-inline-start: calc(var(--wa-form-control-padding-inline) - 0.125em);
+  }
+
+  [part~='clear-button'] {
+    inline-size: 1.5em;
+    margin-inline-start: var(--wa-form-control-padding-inline);
+  }
+
+  [part~='clear-button']:hover,
+  [part~='expand-button']:hover {
+    color: var(--wa-color-text-loud);
+  }
+
+  [part~='expand-button']:focus-visible {
+    outline: var(--wa-focus-ring-style) var(--wa-focus-ring-width) var(--wa-color-focus);
+    outline-offset: 2px;
+  }
+
+  /* font-size scales the glyph with the host size attribute; the button width handles centering. */
+  [part~='expand-icon'] {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--wa-color-text-quiet);
+    font-size: 1.25em;
+  }
+
+  /* Start / end decoration slots. Spaced with the same --wa-form-control-padding-inline gap as
+     <wa-input>/<wa-select> so slotted icons line up with the rest of the form controls, rather
+     than the tighter 0.25em the pickers used before. */
+  [part~='start'],
+  [part~='end'] {
+    display: inline-flex;
+    align-items: center;
+    color: var(--wa-color-text-quiet);
+  }
+
+  [part~='start']::slotted(*) {
+    margin-inline-end: var(--wa-form-control-padding-inline);
+  }
+
+  [part~='end']::slotted(*) {
+    margin-inline-start: var(--wa-form-control-padding-inline);
+  }
+`;


### PR DESCRIPTION
The trailing icons in `<wa-time-input>` — the clock toggle and the clear button — didn't sit on the same vertical axis as `<wa-select>`'s chevron or `<wa-input>`'s end-slot icons. So a row of mixed form controls looked subtly misaligned down the right edge. 

This adds a shared `segmented-field.styles.ts` module that places the picker buttons on that shared axis while preserving their padded hit targets and focus rings, and wires `<wa-time-input>` up to it. 

`<wa-date-input>` adopts the same module in the companion https://github.com/shoelace-style/webawesome-pro/pull/245 PR.

### Adds Shared Trailing-Affordance Module
`styles/component/segmented-field.styles.ts` is imported by both segmented-field pickers (`<wa-time-input>` here, `<wa-date-input>` via the `$webawesome` alias in pro). 

- Instead of the previous per-glyph nudge, each button gets a fixed `inline-size` equal to its natural width (`1.75em` expand, `1.5em` clear) with the glyph centered, so the icon stays on the axis regardless of its intrinsic width — a custom-slotted `expand-icon` no longer drifts. `
- margin-inline-end: -0.25em` lets the button padding overhang the trailing edge rather than displacing the glyph, and the leading gap is expressed against `--wa-form-control-padding-inline` so the alignment holds across sizes and themes.

### Revises `<wa-time-input>`
- Adopts the shared module and drops its duplicated trailing-button rules. 
- The `start`/`end` decoration slots now use the standard `--wa-form-control-padding-inline` gap to match `<wa-input>` and `<wa-select>` (previously a tighter `0.25em`).

### Adds Alignment Guards
Adds tests that render each control next to `<wa-select>` and assert their expand/clear glyph centers match within a pixel: one for `<wa-time-input>`, and an anchor test pinning `<wa-select>` and `<wa-input>` to the same axis — so the reference the other guards compare against can't silently drift.