### PR TITLE
Fix known date validation bugs

### DIFF
--- a/packages/webawesome/docs/docs/components/known-date.md
+++ b/packages/webawesome/docs/docs/components/known-date.md
@@ -113,7 +113,7 @@ Constrain the accepted range with `min` and `max`. Values outside the range are 
 
 ### Required
 
-Set `required` to make the date input required for form submission. Submitting a form with an empty or partially filled date input triggers the standard browser validation flow and a localized error message appears inside the fieldset.
+Set `required` to make the date input required for form submission. Like other form controls, validation surfaces through the browser's native constraint validation flow: submitting a form with an empty or partially filled date input prevents submission and shows the browser's validation message. No error appears while the user is simply filling in or tabbing between the fields.
 
 ```html {.example}
 <form>

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -39,6 +39,8 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 - Fixed a bug in `<wa-carousel>` that caused the pagination controls to clip vertically by adding block padding around them [issue:2495]
 - Fixed a bug in `<wa-carousel>` with `loop` enabled that displayed the wrong slide, briefly flashing it on load, when the carousel was initialized inside a hidden container such as an inactive tab panel [issue:1163]
 - Fixed component API tables in the `webawesome` Agent Skill by generating them from the CEM instead of scraping the rendered HTML [issue:2475]
+- Fixed a bug in `<wa-known-date>` that showed validation errors while typing instead of on form submission like other form controls
+- Fixed a bug in `<wa-known-date>` where the validation tooltip always pointed to the first input regardless of which one was invalid
 
 :::
 

--- a/packages/webawesome/src/components/known-date/internal/partial-date-validator.ts
+++ b/packages/webawesome/src/components/known-date/internal/partial-date-validator.ts
@@ -2,12 +2,13 @@ import type { Validator } from '../../../internal/webawesome-form-associated-ele
 import type WaKnownDate from '../known-date.js';
 
 /**
- * Reports validity for the three-field model:
- *  - Partially filled (some but not all fields): `valueMissing` with a clearer message.
- *  - Fully filled but not a real calendar date (e.g. day 32, month 13, Feb 30): `badInput`, since the entry
- *    can't compose to a canonical value.
- * The empty + required case is left to the mirror validator so we inherit the browser-localized native
- * "Please fill out this field" message.
+ * Reports `badInput` for any entry that has digits but doesn't compose to a canonical date — a partially
+ * filled set of fields (some but not all) or a complete-but-impossible combination (e.g. day 32, month 13,
+ * Feb 30). Like `<wa-time-input>`, this surfaces through the native constraint validation flow (the browser
+ * popup on submit), not as live inline messaging.
+ *
+ * The empty case is valid here; the empty + required case is handled by `RequiredValidator`, so we inherit
+ * the browser-localized native "Please fill out this field" message.
  */
 export const PartialDateValidator = (): Validator => {
   return {
@@ -15,27 +16,19 @@ export const PartialDateValidator = (): Validator => {
       const host = element as unknown as WaKnownDate;
       const parts = host.parts;
       const empty = parts.day === '' && parts.month === '' && parts.year === '';
-      const complete = parts.day !== '' && parts.month !== '' && parts.year !== '';
 
+      // Empty is fine — required-ness is RequiredValidator's concern.
       if (empty) {
         return { isValid: true, invalidKeys: [], message: '' };
       }
 
-      // Fully filled but the value didn't compose — the combination isn't a real calendar date.
-      if (complete) {
-        if (host.value === '') {
-          const message = host.localize?.term('incompleteDate') || 'Enter a valid date.';
-          return { isValid: false, invalidKeys: ['badInput'], message };
-        }
-        return { isValid: true, invalidKeys: [], message: '' };
+      // Any digits present but the value didn't compose to a real, in-range calendar date.
+      if (host.value === '') {
+        const message = host.localize?.term('incompleteDate') || 'Enter a valid date.';
+        return { isValid: false, invalidKeys: ['badInput'], message };
       }
 
-      const message = host.localize?.term('incompleteDate') || 'Enter a complete date.';
-      return {
-        isValid: false,
-        invalidKeys: ['valueMissing'],
-        message,
-      };
+      return { isValid: true, invalidKeys: [], message: '' };
     },
   };
 };

--- a/packages/webawesome/src/components/known-date/known-date.styles.ts
+++ b/packages/webawesome/src/components/known-date/known-date.styles.ts
@@ -115,17 +115,6 @@ export default css`
     margin: 0;
   }
 
-  [part~='error'] {
-    color: var(--wa-color-danger-text-loud, var(--wa-color-text-loud));
-    font-size: var(--wa-font-size-smaller);
-    line-height: var(--wa-form-control-hint-line-height);
-    margin-block: 0.5em 0;
-  }
-
-  [part~='error'][hidden] {
-    display: none;
-  }
-
   /* Hide the mirror used for native form-data + constraint validation. */
   .value-input {
     position: absolute;

--- a/packages/webawesome/src/components/known-date/known-date.test.ts
+++ b/packages/webawesome/src/components/known-date/known-date.test.ts
@@ -247,8 +247,25 @@ describe('<wa-known-date>', () => {
       await el.updateComplete;
       typeIn(getField(el, 'day'), '15');
       await el.updateComplete;
+      // A partial entry has digits but can't compose to a real date, so it reports as badInput — the same
+      // native flag a partially typed `<input type="date">` would report.
       expect(el.checkValidity()).to.equal(false);
-      expect(el.validity.valueMissing).to.equal(true);
+      expect(el.validity.badInput).to.equal(true);
+    });
+
+    it('reports the invalid-date message (not the required message) for an out-of-range entry', async () => {
+      // Even when required, an out-of-range entry must surface the "valid date" message rather than the
+      // RequiredValidator's "Please fill out this field" — the hidden mirror is empty because the entry
+      // never composed, so PartialDateValidator must take precedence.
+      const el = await fixture<WaKnownDate>(html`<wa-known-date required></wa-known-date>`);
+      await el.updateComplete;
+      typeIn(getField(el, 'day'), '15');
+      typeIn(getField(el, 'month'), '33');
+      typeIn(getField(el, 'year'), '2020');
+      await el.updateComplete;
+      expect(el.checkValidity()).to.equal(false);
+      expect(el.validity.badInput).to.equal(true);
+      expect(el.validationMessage).to.equal(el.localize.term('incompleteDate'));
     });
 
     it('is valid for a complete real date', async () => {
@@ -472,17 +489,15 @@ describe('<wa-known-date>', () => {
   });
 
   describe('user-invalid reflection on fields', () => {
-    it('sets aria-invalid="true" on the field inputs and shows the error region after interaction', async () => {
+    it('sets aria-invalid="true" on the field inputs after interaction', async () => {
       const el = await fixture<WaKnownDate>(html`<wa-known-date required></wa-known-date>`);
       await el.updateComplete;
 
-      // Before interaction: not user-invalid, fields not marked, error region hidden.
+      // Before interaction: not user-invalid, fields not marked.
       expect(el.customStates.has('user-invalid')).to.equal(false);
       for (const f of getFields(el)) {
         expect(f.getAttribute('aria-invalid')).to.not.equal('true');
       }
-      const errorBefore = el.shadowRoot!.querySelector<HTMLElement>('[part~="error"]')!;
-      expect(errorBefore.hidden).to.equal(true);
 
       // Interact: typing dispatches a composed `input`, flipping `hasInteracted`. The value stays
       // invalid (required + only a partial entry).
@@ -493,11 +508,18 @@ describe('<wa-known-date>', () => {
       for (const f of getFields(el)) {
         expect(f.getAttribute('aria-invalid')).to.equal('true');
       }
+    });
 
-      const errorAfter = el.shadowRoot!.querySelector<HTMLElement>('[part~="error"]')!;
-      expect(errorAfter.hidden).to.equal(false);
-      expect(errorAfter.textContent?.trim().length).to.be.greaterThan(0);
-      expect(errorAfter.textContent?.trim()).to.equal(el.validationMessage.trim());
+    it('never renders an inline error region — validation surfaces through the native popup', async () => {
+      // Unlike a custom inline message, validity is reported via the native constraint validation flow,
+      // matching <wa-time-input>. Interacting with an invalid control must not inject any error element.
+      const el = await fixture<WaKnownDate>(html`<wa-known-date required></wa-known-date>`);
+      await el.updateComplete;
+      typeIn(getField(el, 'day'), '15');
+      await el.updateComplete;
+
+      expect(el.customStates.has('user-invalid')).to.equal(true);
+      expect(el.shadowRoot!.querySelector('[part~="error"]')).to.equal(null);
     });
   });
 
@@ -541,6 +563,48 @@ describe('<wa-known-date>', () => {
       const el = await compose('15', '1', '0');
       expect(el.value).to.equal('');
       expect(el.checkValidity()).to.equal(false);
+    });
+  });
+
+  describe('validationTarget anchoring', () => {
+    async function compose(day: string, month: string, year: string, lang = 'en-GB') {
+      const el = await fixture<WaKnownDate>(html`<wa-known-date lang=${lang}></wa-known-date>`);
+      await el.updateComplete;
+      typeIn(getField(el, 'day'), day);
+      typeIn(getField(el, 'month'), month);
+      typeIn(getField(el, 'year'), year);
+      await el.updateComplete;
+      return el;
+    }
+
+    it('anchors on the out-of-range day (day 32)', async () => {
+      const el = await compose('32', '1', '2020');
+      expect((el.validationTarget as HTMLInputElement).dataset.field).to.equal('day');
+    });
+
+    it('anchors on the out-of-range month (month 13)', async () => {
+      const el = await compose('15', '13', '2020');
+      expect((el.validationTarget as HTMLInputElement).dataset.field).to.equal('month');
+    });
+
+    it('anchors on the day for a non-composing real-date combination (Feb 30)', async () => {
+      const el = await compose('30', '2', '2024');
+      expect((el.validationTarget as HTMLInputElement).dataset.field).to.equal('day');
+    });
+
+    it('anchors on the first empty field for a partial entry', async () => {
+      const el = await fixture<WaKnownDate>(html`<wa-known-date lang="en-GB"></wa-known-date>`);
+      await el.updateComplete;
+      // en-GB order is day/month/year; fill the day, leaving month as the first empty field.
+      typeIn(getField(el, 'day'), '15');
+      await el.updateComplete;
+      expect((el.validationTarget as HTMLInputElement).dataset.field).to.equal('month');
+    });
+
+    it('anchors on the offending field regardless of locale order (en-US)', async () => {
+      // en-US order is month/day/year, but the day is the out-of-range field.
+      const el = await compose('32', '1', '2020', 'en-US');
+      expect((el.validationTarget as HTMLInputElement).dataset.field).to.equal('day');
     });
   });
 

--- a/packages/webawesome/src/components/known-date/known-date.ts
+++ b/packages/webawesome/src/components/known-date/known-date.ts
@@ -7,6 +7,7 @@ import { uniqueId } from '../../internal/math.js';
 import { warnDeprecatedSize } from '../../internal/size.js';
 import { HasSlotController } from '../../internal/slot.js';
 import { MirrorValidator } from '../../internal/validators/mirror-validator.js';
+import { RequiredValidator } from '../../internal/validators/required-validator.js';
 import { watch } from '../../internal/watch.js';
 import { WebAwesomeFormAssociatedElement } from '../../internal/webawesome-form-associated-element.js';
 import formControlStyles from '../../styles/component/form-control.styles.js';
@@ -23,8 +24,8 @@ export type WaKnownDateAppearance = 'filled' | 'outlined' | 'filled-outlined';
 const generateId = (): string => uniqueId('wa-known-date-');
 
 /**
- * @summary Known dates let users enter dates they already know — birthdays, expirations, document
- *  dates — through three separate day, month, and year fields shown in the locale's natural order.
+ * @summary Known dates let users enter dates they already know - birthdays, expirations, document
+ *  dates - through three separate day, month, and year fields shown in the locale's natural order.
  * @documentation https://webawesome.com/docs/components/known-date
  * @status experimental
  * @since 3.8
@@ -53,10 +54,6 @@ const generateId = (): string => uniqueId('wa-known-date-');
  * @csspart field-year - Added to the year field block.
  * @csspart field-label - The text label above each field's input.
  * @csspart field-input - The native `<input>` inside a field.
- * @csspart error - The inline error message region. This is an intentional difference from `<wa-date-input>`
- *  and `<wa-time-input>`, which rely on the browser's native validation popup. Because this control is composed
- *  of three separate fields, an inline `role="alert"` region gives a single, predictable place to surface the
- *  validation message rather than anchoring a native popup on one of the three fields.
  *
  * @cssstate blank - The known date has no committed value.
  * @cssstate disabled - The known date is disabled.
@@ -71,19 +68,32 @@ export default class WaKnownDate extends WebAwesomeFormAssociatedElement {
   };
 
   static get validators() {
-    const validators = isServer ? [] : [MirrorValidator(), PartialDateValidator()];
+    const validators = isServer
+      ? []
+      : [
+          // Order matters: the first failing validator's message wins. `PartialDateValidator` comes first so a partial
+          // or out-of-range entry (day 32, Feb 30) reports "Enter a valid date" as `badInput`, rather than
+          // `RequiredValidator`'s "Please fill out this field" (the mirror is empty whenever the entry doesn't
+          // compose).
+          PartialDateValidator(),
+          RequiredValidator({
+            validationElement: Object.assign(document.createElement('input'), { required: true }),
+          }),
+          // Mirrors the hidden native `<input type="date">` so its min/max constraints surface as
+          // rangeUnderflow/rangeOverflow validity.
+          MirrorValidator(),
+        ];
     return [...super.validators, ...validators];
   }
 
   // Moving focus between the three internal fields shouldn't count as "leaving the group," so we key
-  // interaction off `input` alone — matching `<wa-date-input>` and `<wa-time-input>`.
+  // interaction off `input` alone - matching `<wa-date-input>` and `<wa-time-input>`.
   assumeInteractionOn = ['input'];
 
   readonly localize = new LocalizeController(this);
   private readonly hasSlotController = new HasSlotController(this, 'hint', 'label');
   private readonly groupId = generateId();
   private readonly hintId = `${this.groupId}-hint`;
-  private readonly errorId = `${this.groupId}-error`;
 
   /** Hidden mirror used for native constraint validation (min/max/required + valid-date roundtrip). */
   @query('.value-input') valueInput!: HTMLInputElement;
@@ -193,10 +203,9 @@ export default class WaKnownDate extends WebAwesomeFormAssociatedElement {
       this._value = this.defaultValue;
     }
     this.syncPartsFromCanonical();
-    // `MirrorValidator` reads `this.input` to mirror the hidden native `<input type="date">`'s constraint
-    // validity (min/max/required/valid-date). Unlike the picker siblings — which use `RequiredValidator` and
-    // therefore never set `this.input` — this control depends on this assignment. `validationTarget` is still
-    // overridden so the validation *popup* anchors on a visible field rather than the hidden mirror.
+    // `MirrorValidator` reads `this.input` to mirror the hidden native `<input type="date">`'s min/max constraint
+    // validity. `validationTarget` is overridden so the native validation *popup* anchors on a visible field rather
+    // than the hidden mirror - matching `<wa-time-input>`.
     this.input = this.valueInput;
     this.updateValidity();
     this.lastEmittedValue = this._value;
@@ -241,12 +250,12 @@ export default class WaKnownDate extends WebAwesomeFormAssociatedElement {
     if (!this.shadowRoot) return undefined;
     const inputs = Array.from(this.shadowRoot.querySelectorAll<HTMLInputElement>('input[part~="field-input"]'));
     if (inputs.length === 0) return undefined;
-    // Prefer the first empty field — that's the one the user needs to fix when partial.
-    for (const field of this.fieldOrder()) {
-      if (this.parts[field] === '') {
-        const el = inputs.find(i => i.dataset.field === field);
-        if (el) return el;
-      }
+    // Anchor on the specific field the user needs to fix: the first empty field when partial, or the first field whose
+    // value is out of range (month 13, day 32, …) when complete. Falls back to the first field.
+    const offending = this.firstInvalidField();
+    if (offending) {
+      const el = inputs.find(i => i.dataset.field === offending);
+      if (el) return el;
     }
     return inputs[0];
   }
@@ -310,7 +319,7 @@ export default class WaKnownDate extends WebAwesomeFormAssociatedElement {
     if (this.valueInput) {
       this.valueInput.value = this._value;
     }
-    // setValue(null) when blank — matches <wa-date-input> so FormData omits the entry instead of
+    // setValue(null) when blank - matches <wa-date-input> so FormData omits the entry instead of
     // submitting `name=`.
     this.setValue(this._value || null);
   }
@@ -344,6 +353,33 @@ export default class WaKnownDate extends WebAwesomeFormAssociatedElement {
       }
     }
     return inputs[0];
+  }
+
+  /**
+   * Returns the field to fix when the value doesn't compose, in locale order: the first empty field, else the first
+   * out-of-range field (year < 1, month not 1–12, day not 1–31), else the day (e.g. Feb 30). Null when the value
+   * composes cleanly.
+   */
+  private firstInvalidField(): SegmentField | null {
+    if (this._value) return null;
+
+    const order = this.fieldOrder();
+
+    // Partial entry - point at the first empty field.
+    const empty = order.find(field => this.parts[field] === '');
+    if (empty) return empty;
+
+    // Complete but non-composing - find the first single field that's out of range.
+    const inRange: Record<SegmentField, (n: number) => boolean> = {
+      year: n => Number.isInteger(n) && n >= 1 && n <= 9999,
+      month: n => Number.isInteger(n) && n >= 1 && n <= 12,
+      day: n => Number.isInteger(n) && n >= 1 && n <= 31,
+    };
+    const outOfRange = order.find(field => !inRange[field](Number(this.parts[field])));
+    if (outOfRange) return outOfRange;
+
+    // Every field is individually in range but the trio isn't a real date (e.g. Feb 30) - blame the day.
+    return 'day';
   }
 
   private autocompleteFor(field: SegmentField): string | undefined {
@@ -387,11 +423,12 @@ export default class WaKnownDate extends WebAwesomeFormAssociatedElement {
     const hasHint = !!this.hint || !!hasHintSlot;
     const groupAriaLabel = this.label || this.localize.term('date') || 'Date';
 
+    // Validity surfaces through the native constraint validation flow (the browser's popup on submit), anchored on
+    // `validationTarget` - matching `<wa-time-input>`. We only use `user-invalid` to mark the fields with
+    // `aria-invalid` for assistive tech; we never render an inline error message of our own.
     const userInvalid = !isServer && this.customStates.has('user-invalid');
-    const errorMessage = userInvalid ? this.validationMessage : '';
-    const showError = userInvalid && !!errorMessage;
 
-    const describedBy = [hasHint ? this.hintId : null, showError ? this.errorId : null].filter(Boolean).join(' ');
+    const describedBy = hasHint ? this.hintId : '';
 
     const fields = this.fieldOrder().map(field => this.renderField(field, describedBy, userInvalid));
 
@@ -407,10 +444,6 @@ export default class WaKnownDate extends WebAwesomeFormAssociatedElement {
       >
         ${this.hint}
       </slot>
-
-      <div part="error" id=${this.errorId} class="error" role="alert" aria-live="polite" ?hidden=${!showError}>
-        ${errorMessage}
-      </div>
     `;
 
     return html`

--- a/packages/webawesome/src/translations/ar.ts
+++ b/packages/webawesome/src/translations/ar.ts
@@ -37,7 +37,7 @@ const translation: Translation = {
   goToSlide: (slide, count) => `عرض شريحة رقم ${slide} من ${count}`,
   hidePassword: 'اخفاء كلمة المرور',
   hour: 'الساعة',
-  incompleteDate: 'أدخل تاريخًا كاملاً.',
+  incompleteDate: 'أدخل تاريخًا صالحًا.',
   increment: 'زيادة',
   loading: 'جاري التحميل',
   minute: 'الدقيقة',

--- a/packages/webawesome/src/translations/cs.ts
+++ b/packages/webawesome/src/translations/cs.ts
@@ -37,7 +37,7 @@ const translation: Translation = {
   goToSlide: (slide, count) => `Přejít na slide ${slide} z ${count}`,
   hidePassword: 'Skrýt heslo',
   hour: 'Hodina',
-  incompleteDate: 'Zadejte úplné datum.',
+  incompleteDate: 'Zadejte platné datum.',
   increment: 'Zvýšit',
   loading: 'Nahrává se',
   minute: 'Minuta',

--- a/packages/webawesome/src/translations/da.ts
+++ b/packages/webawesome/src/translations/da.ts
@@ -37,7 +37,7 @@ const translation: Translation = {
   goToSlide: (slide, count) => `Gå til dias ${slide} af ${count}`,
   hidePassword: 'Skjul adgangskode',
   hour: 'Time',
-  incompleteDate: 'Indtast en fuldstændig dato.',
+  incompleteDate: 'Indtast en gyldig dato.',
   increment: 'Forøg',
   loading: 'Indlæser',
   minute: 'Minut',

--- a/packages/webawesome/src/translations/de.ts
+++ b/packages/webawesome/src/translations/de.ts
@@ -38,7 +38,7 @@ const translation: Translation = {
   goToSlide: (slide, count) => `Zu Folie ${slide} von ${count} gehen`,
   hidePassword: 'Passwort verbergen',
   hour: 'Stunde',
-  incompleteDate: 'Geben Sie ein vollständiges Datum ein.',
+  incompleteDate: 'Geben Sie ein gültiges Datum ein.',
   increment: 'Erhöhen',
   loading: 'Wird geladen',
   minute: 'Minute',

--- a/packages/webawesome/src/translations/en.ts
+++ b/packages/webawesome/src/translations/en.ts
@@ -22,7 +22,7 @@ const translation: Translation = {
   date: 'Date',
   datePickerKeyboardHelp: 'Use arrow keys to change values; press Alt+Down Arrow to open the calendar.',
   day: 'Day',
-  incompleteDate: 'Enter a complete date.',
+  incompleteDate: 'Enter a valid date.',
   dropFileHere: 'Drop file here or click to browse',
   decrement: 'Decrement',
   dropFilesHere: 'Drop files here or click to browse',

--- a/packages/webawesome/src/translations/es.ts
+++ b/packages/webawesome/src/translations/es.ts
@@ -38,7 +38,7 @@ const translation: Translation = {
   goToSlide: (slide, count) => `Ir a la diapositiva ${slide} de ${count}`,
   hidePassword: 'Ocultar contraseña',
   hour: 'Hora',
-  incompleteDate: 'Introduzca una fecha completa.',
+  incompleteDate: 'Introduzca una fecha válida.',
   increment: 'Aumentar',
   loading: 'Cargando',
   minute: 'Minuto',

--- a/packages/webawesome/src/translations/fa.ts
+++ b/packages/webawesome/src/translations/fa.ts
@@ -38,7 +38,7 @@ const translation: Translation = {
   hour: 'ساعت',
   goToSlide: (slide, count) => `رفتن به اسلاید ${slide} از ${count}`,
   hidePassword: 'پنهان کردن رمز',
-  incompleteDate: 'یک تاریخ کامل وارد کنید.',
+  incompleteDate: 'یک تاریخ معتبر وارد کنید.',
   increment: 'افزایش',
   loading: 'بارگزاری',
   minute: 'دقیقه',

--- a/packages/webawesome/src/translations/fi.ts
+++ b/packages/webawesome/src/translations/fi.ts
@@ -37,7 +37,7 @@ const translation: Translation = {
   goToSlide: (slide, count) => `Siirry diaan ${slide} / ${count}`,
   hidePassword: 'Piilota salasana',
   hour: 'Tunti',
-  incompleteDate: 'Anna täydellinen päivämäärä.',
+  incompleteDate: 'Anna kelvollinen päivämäärä.',
   increment: 'Lisää',
   loading: 'Ladataan',
   minute: 'Minuutti',

--- a/packages/webawesome/src/translations/fr.ts
+++ b/packages/webawesome/src/translations/fr.ts
@@ -38,7 +38,7 @@ const translation: Translation = {
   goToSlide: (slide, count) => `Aller à la diapositive ${slide} de ${count}`,
   hidePassword: 'Masquer le mot de passe',
   hour: 'Heure',
-  incompleteDate: 'Saisissez une date complète.',
+  incompleteDate: 'Saisissez une date valide.',
   increment: 'Augmenter',
   loading: 'Chargement',
   minute: 'Minute',

--- a/packages/webawesome/src/translations/he.ts
+++ b/packages/webawesome/src/translations/he.ts
@@ -37,7 +37,7 @@ const translation: Translation = {
   goToSlide: (slide, count) => `עבור לשקופית ${slide} של ${count}`,
   hidePassword: 'הסתר סיסמא',
   hour: 'שעה',
-  incompleteDate: 'הזן תאריך מלא.',
+  incompleteDate: 'הזן תאריך תקין.',
   increment: 'הגדל',
   loading: 'טוען',
   minute: 'דקה',

--- a/packages/webawesome/src/translations/hi.ts
+++ b/packages/webawesome/src/translations/hi.ts
@@ -36,7 +36,7 @@ const translation: Translation = {
   goToSlide: (slide, count) => `${count} में से स्लाइड ${slide} पर जाएं`,
   hidePassword: 'पासवर्ड छुपाएं',
   hour: 'घंटा',
-  incompleteDate: 'पूरी तारीख़ दर्ज करें.',
+  incompleteDate: 'मान्य तारीख़ दर्ज करें.',
   increment: 'बढ़ाएं',
   loading: 'लोड हो रहा है',
   minute: 'मिनट',

--- a/packages/webawesome/src/translations/hr.ts
+++ b/packages/webawesome/src/translations/hr.ts
@@ -37,7 +37,7 @@ const translation: Translation = {
   goToSlide: (slide, count) => `Idi na slajd ${slide} od ${count}`,
   hidePassword: 'Sakrij lozinku',
   hour: 'Sat',
-  incompleteDate: 'Unesite potpuni datum.',
+  incompleteDate: 'Unesite valjani datum.',
   increment: 'Povećaj',
   loading: 'Učitavanje',
   minute: 'Minuta',

--- a/packages/webawesome/src/translations/hu.ts
+++ b/packages/webawesome/src/translations/hu.ts
@@ -37,7 +37,7 @@ const translation: Translation = {
   goToSlide: (slide, count) => `Ugrás a ${count}/${slide}. diára`,
   hidePassword: 'Jelszó elrejtése',
   hour: 'Óra',
-  incompleteDate: 'Adjon meg egy teljes dátumot.',
+  incompleteDate: 'Adjon meg egy érvényes dátumot.',
   increment: 'Növelés',
   loading: 'Betöltés',
   minute: 'Perc',

--- a/packages/webawesome/src/translations/id.ts
+++ b/packages/webawesome/src/translations/id.ts
@@ -37,7 +37,7 @@ const translation: Translation = {
   goToSlide: (slide, count) => `Pergi ke slide ${slide} dari ${count}`,
   hidePassword: 'Sembunyikan sandi',
   hour: 'Jam',
-  incompleteDate: 'Masukkan tanggal lengkap.',
+  incompleteDate: 'Masukkan tanggal yang valid.',
   increment: 'Tambah',
   loading: 'Memuat',
   minute: 'Menit',

--- a/packages/webawesome/src/translations/it.ts
+++ b/packages/webawesome/src/translations/it.ts
@@ -38,7 +38,7 @@ const translation: Translation = {
   goToSlide: (slide, count) => `Vai alla diapositiva ${slide} di ${count}`,
   hidePassword: 'Nascondi password',
   hour: 'Ora',
-  incompleteDate: 'Inserisci una data completa.',
+  incompleteDate: 'Inserisci una data valida.',
   increment: 'Aumenta',
   loading: 'In caricamento',
   minute: 'Minuto',

--- a/packages/webawesome/src/translations/ja.ts
+++ b/packages/webawesome/src/translations/ja.ts
@@ -37,7 +37,7 @@ const translation: Translation = {
   goToSlide: (slide, count) => `${count} 枚中 ${slide} 枚のスライドに移動`,
   hidePassword: 'パスワードを隠す',
   hour: '時',
-  incompleteDate: '完全な日付を入力してください。',
+  incompleteDate: '有効な日付を入力してください。',
   increment: '増やす',
   loading: '読み込み中',
   minute: '分',

--- a/packages/webawesome/src/translations/kk.ts
+++ b/packages/webawesome/src/translations/kk.ts
@@ -38,7 +38,7 @@ const translation: Translation = {
   goToSlide: (slide, count) => `${slide}/${count} слайдқа өту`,
   hidePassword: 'Құпиясөзді жасыру',
   hour: 'Сағат',
-  incompleteDate: 'Толық күнді енгізіңіз.',
+  incompleteDate: 'Жарамды күнді енгізіңіз.',
   increment: 'Арттыру',
   loading: 'Жүктелуде',
   minute: 'Минут',

--- a/packages/webawesome/src/translations/nb.ts
+++ b/packages/webawesome/src/translations/nb.ts
@@ -37,7 +37,7 @@ const translation: Translation = {
   goToSlide: (slide, count) => `Gå til visning ${slide} av ${count}`,
   hidePassword: 'Skjul passord',
   hour: 'Time',
-  incompleteDate: 'Skriv inn en fullstendig dato.',
+  incompleteDate: 'Skriv inn en gyldig dato.',
   increment: 'Øk',
   loading: 'Laster',
   minute: 'Minutt',

--- a/packages/webawesome/src/translations/nl.ts
+++ b/packages/webawesome/src/translations/nl.ts
@@ -38,7 +38,7 @@ const translation: Translation = {
   goToSlide: (slide, count) => `Ga naar slide ${slide} van ${count}`,
   hidePassword: 'Verberg wachtwoord',
   hour: 'Uur',
-  incompleteDate: 'Voer een volledige datum in.',
+  incompleteDate: 'Voer een geldige datum in.',
   increment: 'Verhogen',
   loading: 'Bezig met laden',
   minute: 'Minuut',

--- a/packages/webawesome/src/translations/nn.ts
+++ b/packages/webawesome/src/translations/nn.ts
@@ -37,7 +37,7 @@ const translation: Translation = {
   goToSlide: (slide, count) => `Gå til visning ${slide} av ${count}`,
   hidePassword: 'Gøym passord',
   hour: 'Time',
-  incompleteDate: 'Skriv inn ein fullstendig dato.',
+  incompleteDate: 'Skriv inn ein gyldig dato.',
   increment: 'Auk',
   loading: 'Lastar',
   minute: 'Minutt',

--- a/packages/webawesome/src/translations/pl.ts
+++ b/packages/webawesome/src/translations/pl.ts
@@ -38,7 +38,7 @@ const translation: Translation = {
   goToSlide: (slide, count) => `Przejdź do slajdu ${slide} z ${count}`,
   hidePassword: 'Ukryj hasło',
   hour: 'Godzina',
-  incompleteDate: 'Wprowadź pełną datę.',
+  incompleteDate: 'Wprowadź prawidłową datę.',
   increment: 'Zwiększ',
   loading: 'Ładowanie',
   minute: 'Minuta',

--- a/packages/webawesome/src/translations/pt.ts
+++ b/packages/webawesome/src/translations/pt.ts
@@ -38,7 +38,7 @@ const translation: Translation = {
   goToSlide: (slide, count) => `Vá para o slide ${slide} de ${count}`,
   hidePassword: 'Esconder a senha',
   hour: 'Hora',
-  incompleteDate: 'Introduza uma data completa.',
+  incompleteDate: 'Introduza uma data válida.',
   increment: 'Aumentar',
   loading: 'Carregando',
   minute: 'Minuto',

--- a/packages/webawesome/src/translations/ru.ts
+++ b/packages/webawesome/src/translations/ru.ts
@@ -38,7 +38,7 @@ const translation: Translation = {
   goToSlide: (slide, count) => `Перейти к слайду ${slide} из ${count}`,
   hidePassword: 'Скрыть пароль',
   hour: 'Час',
-  incompleteDate: 'Введите полную дату.',
+  incompleteDate: 'Введите корректную дату.',
   increment: 'Увеличить',
   loading: 'Загрузка',
   minute: 'Минута',

--- a/packages/webawesome/src/translations/sl.ts
+++ b/packages/webawesome/src/translations/sl.ts
@@ -38,7 +38,7 @@ const translation: Translation = {
   goToSlide: (slide, count) => `Pojdi na diapozitiv ${slide} od ${count}`,
   hidePassword: 'Skrij geslo',
   hour: 'Ura',
-  incompleteDate: 'Vnesite popoln datum.',
+  incompleteDate: 'Vnesite veljaven datum.',
   increment: 'Povečaj',
   loading: 'Nalaganje',
   minute: 'Minuta',

--- a/packages/webawesome/src/translations/sv.ts
+++ b/packages/webawesome/src/translations/sv.ts
@@ -37,7 +37,7 @@ const translation: Translation = {
   goToSlide: (slide, count) => `Gå till bild ${slide} av ${count}`,
   hidePassword: 'Dölj lösenord',
   hour: 'Timme',
-  incompleteDate: 'Ange ett fullständigt datum.',
+  incompleteDate: 'Ange ett giltigt datum.',
   increment: 'Öka',
   loading: 'Läser in',
   minute: 'Minut',

--- a/packages/webawesome/src/translations/tr.ts
+++ b/packages/webawesome/src/translations/tr.ts
@@ -38,7 +38,7 @@ const translation: Translation = {
   goToSlide: (slide, count) => `${count} slayttan ${slide} slayta gidin`,
   hidePassword: 'Şifreyi sakla',
   hour: 'Saat',
-  incompleteDate: 'Tam bir tarih girin.',
+  incompleteDate: 'Geçerli bir tarih girin.',
   increment: 'Artır',
   loading: 'Yükleme',
   minute: 'Dakika',

--- a/packages/webawesome/src/translations/uk.ts
+++ b/packages/webawesome/src/translations/uk.ts
@@ -38,7 +38,7 @@ const translation: Translation = {
   goToSlide: (slide, count) => `Перейти до слайда №${slide} з ${count}`,
   hidePassword: 'Приховати пароль',
   hour: 'Година',
-  incompleteDate: 'Введіть повну дату.',
+  incompleteDate: 'Введіть коректну дату.',
   increment: 'Збільшити',
   loading: 'Завантаження',
   minute: 'Хвилина',

--- a/packages/webawesome/src/translations/zh-cn.ts
+++ b/packages/webawesome/src/translations/zh-cn.ts
@@ -37,7 +37,7 @@ const translation: Translation = {
   goToSlide: (slide, count) => `转到第 ${slide} 张幻灯片，共 ${count} 张`,
   hidePassword: '隐藏密码',
   hour: '时',
-  incompleteDate: '请输入完整的日期。',
+  incompleteDate: '请输入有效的日期。',
   increment: '增加',
   loading: '加载中',
   minute: '分',

--- a/packages/webawesome/src/translations/zh-tw.ts
+++ b/packages/webawesome/src/translations/zh-tw.ts
@@ -37,7 +37,7 @@ const translation: Translation = {
   goToSlide: (slide, count) => `轉到第 ${slide} 張幻燈片，共 ${count} 張`,
   hidePassword: '隱藏密碼',
   hour: '小時',
-  incompleteDate: '請輸入完整的日期。',
+  incompleteDate: '請輸入有效的日期。',
   increment: '增加',
   loading: '載入中',
   minute: '分鐘',


### PR DESCRIPTION
This PR fixes some bugs in the experimental known date component we recently released:

- Validation was incorrectly being shown inline below the form control
- When an invalid month, day, or year was entered, the validation focus would always point to the first input

### How to test

It's probably easiest to reproduce the buggy behavior first. To do that, go here: https://webawesome.com/docs/components/known-date

Then:

1. Enter invalid and incomplete dates and you'll see the feedback appear below the inputs.

<img width="411" alt="CleanShot 2026-06-23 at 15 31 58@2x" src="https://github.com/user-attachments/assets/89406bb4-cde2-4294-a872-a73031341cbe" />

2. Go to the required example and submit the date with an invalid day.

<img width="499" alt="CleanShot 2026-06-23 at 15 31 05@2x" src="https://github.com/user-attachments/assets/210e2c1a-6262-4ff2-b8da-b6e27344140e" />

Follow the same steps for testing in this branch. You should observe no inline error for (1) and the invalid day should be correctly focused on submit for (2).
