### PR TITLE
Docs: Revise Page Metadata Details

### DIFF
--- a/packages/webawesome/docs/.eleventy.js
+++ b/packages/webawesome/docs/.eleventy.js
@@ -101,6 +101,8 @@ export default async function (eleventyConfig) {
     name: 'Web Awesome',
     description: 'Build better with Web Awesome, the open source library of web components from Font Awesome.',
     image: 'https://webawesome.com/assets/images/open-graph/default.png',
+    imageWidth: 2400,
+    imageHeight: 1260,
   };
 
   // Title composition/stripping config - single source of truth
@@ -146,6 +148,10 @@ export default async function (eleventyConfig) {
     ogTitle: data => composePageTitle(data.ogTitle || data.title),
     ogDescription: data => data.ogDescription || data.description,
     ogImage: data => data.ogImage || siteMetadata.image,
+    // Only emit dimensions when we know them: use the default if the page is using the
+    // default image, the explicit override if provided, otherwise null (suppresses emission).
+    ogImageWidth: data => data.ogImageWidth || (data.ogImage ? null : siteMetadata.imageWidth),
+    ogImageHeight: data => data.ogImageHeight || (data.ogImage ? null : siteMetadata.imageHeight),
     ogUrl: data => {
       // Strip template extensions: a page setting `permalink: /foo.njk` leaks the template
       // file path into page.url, which is never a valid public URL for og:url or canonical.

--- a/packages/webawesome/docs/.eleventy.js
+++ b/packages/webawesome/docs/.eleventy.js
@@ -153,8 +153,9 @@ export default async function (eleventyConfig) {
     ogImageWidth: data => data.ogImageWidth || (data.ogImage ? null : siteMetadata.imageWidth),
     ogImageHeight: data => data.ogImageHeight || (data.ogImage ? null : siteMetadata.imageHeight),
     ogUrl: data => {
-      // Strip template extensions: a page setting `permalink: /foo.njk` leaks the template
-      // file path into page.url, which is never a valid public URL for og:url or canonical.
+      // Strip template extensions: downstream consumers (e.g. webawesome-app) set
+      // `permalink: /foo.njk` for two-pass SSR, so page.url carries an `.njk` resolution
+      // artifact rather than the clean public URL — never what og:url or canonical should point at.
       // Also always emit an absolute URL — front-matter overrides like `ogUrl: /signup` should
       // resolve against siteMetadata.url so canonical/og:url consumers don't see relative hrefs.
       const raw = (data.ogUrl || data.page?.url || '').replace(/\.njk$/, '');

--- a/packages/webawesome/docs/.eleventy.js
+++ b/packages/webawesome/docs/.eleventy.js
@@ -147,9 +147,14 @@ export default async function (eleventyConfig) {
     ogDescription: data => data.ogDescription || data.description,
     ogImage: data => data.ogImage || siteMetadata.image,
     ogUrl: data => {
-      if (data.ogUrl) return data.ogUrl;
-      const url = data.page?.url || '';
-      return url ? `${siteMetadata.url}${url}` : siteMetadata.url;
+      // Strip template extensions: a page setting `permalink: /foo.njk` leaks the template
+      // file path into page.url, which is never a valid public URL for og:url or canonical.
+      // Also always emit an absolute URL — front-matter overrides like `ogUrl: /signup` should
+      // resolve against siteMetadata.url so canonical/og:url consumers don't see relative hrefs.
+      const raw = (data.ogUrl || data.page?.url || '').replace(/\.njk$/, '');
+      if (!raw) return siteMetadata.url;
+      if (/^https?:\/\//.test(raw)) return raw;
+      return `${siteMetadata.url}${raw.startsWith('/') ? '' : '/'}${raw}`;
     },
     ogType: data => data.ogType || 'website',
   });

--- a/packages/webawesome/docs/_includes/head.njk
+++ b/packages/webawesome/docs/_includes/head.njk
@@ -5,6 +5,8 @@
 
 <title>{{ pageTitle }}</title>
 
+<link rel="canonical" href="{{ ogUrl }}" />
+
 {# Skip OG tags for noindex pages to prevent social sharing #}
 {% if not noindex %}
   <meta property="og:type" content="{{ ogType }}" />

--- a/packages/webawesome/docs/_includes/head.njk
+++ b/packages/webawesome/docs/_includes/head.njk
@@ -14,7 +14,10 @@
   <meta property="og:title" content="{{ ogTitle }}" />
   <meta property="og:description" content="{{ ogDescription }}" />
   <meta property="og:image" content="{{ ogImage }}" />
+  {% if ogImageWidth %}<meta property="og:image:width" content="{{ ogImageWidth }}" />{% endif %}
+  {% if ogImageHeight %}<meta property="og:image:height" content="{{ ogImageHeight }}" />{% endif %}
   <meta property="og:site_name" content="{{ siteMetadata.name }}" />
+  <meta name="twitter:card" content="summary_large_image" />
 {% endif %}
 
 {# Dark mode #}


### PR DESCRIPTION
This work tightens head metadata in the docs framework after a single-page SEO audit flagged missing canonical tags, an `og:url` that leaked the internal template file path into social shares, no `twitter:card` declaration, and no `og:image` dimensions. 

The standalone webawesome docs site and any downstream consumer of `docs/.eleventy.js` (including `webawesome-app`) all pick this up automatically.

### Fix `og:url`
Two bugs in the `ogUrl` data function in `.eleventy.js` collapsed into one rewrite:

- A page declaring `permalink: /foo.njk` had its template extension leak into `page.url`, which the data function passed straight into `og:url`. Worst case was `/account/signup.njk` showing up in social shares and pointing at a 404. The function now strips `.njk` before composing the URL.
- Front-matter overrides like `ogUrl: /signup` were emitted verbatim, producing relative-href `og:url` and `canonical` values. The function now always returns an absolute URL, prefixing `siteMetadata.url` when the value isn't already `http(s)://`.

### Add Canonical Link
`_includes/head.njk` now emits `<link rel="canonical" href="{{ ogUrl }}" />` directly after `<title>`, outside the `{% if not noindex %}` guard. Canonical is intentionally emitted on noindex pages too so duplicate-URL consolidation still works.

### Set `og:image` Dimensions
`siteMetadata` declares `imageWidth: 2400` / `imageHeight: 1260` matching the bundled default OG image. New `ogImageWidth` / `ogImageHeight` data functions emit those defaults when the page is using the default `ogImage`, allow explicit per-page overrides, and emit nothing when a page supplies a custom `ogImage` without dimensions — safer than lying with the defaults.

### Set `twitter:card`
`_includes/head.njk` declares `<meta name="twitter:card" content="summary_large_image">`. The bundled OG image is well above the 600×314 minimum for the large card variant.


---

Companion PR - https://github.com/shoelace-style/webawesome-app/pull/393.