### PR TITLE
Docs: Add `sitemap.xml` and `robots.txt`

### DIFF
--- a/packages/webawesome/docs/.eleventy.js
+++ b/packages/webawesome/docs/.eleventy.js
@@ -22,6 +22,7 @@ import * as url from 'url';
 import { generateAgentSkill } from '../scripts/agent-skill.js';
 import { generateDesignSkill } from '../scripts/design-skill.js';
 import { getSiteDir } from '../scripts/utils.js';
+import { HtmlBasePlugin } from '@11ty/eleventy';
 import { replaceTextPlugin } from './_plugins/replace-text.js';
 import { searchPlugin } from './_plugins/search.js';
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
@@ -158,6 +159,51 @@ export default async function (eleventyConfig) {
   // With Prettier 3, this means a leading pipe will exist be present when the line wraps.
   eleventyConfig.addFilter('trimPipes', content => {
     return typeof content === 'string' ? content.replace(/^(\s|\|)/g, '').replace(/(\s|\|)$/g, '') : content;
+  });
+
+  // Sitemap collection: public, indexable URLs only.
+  // Filters out noindex pages, opted-out pages, and app-only paths (admin, workspaces,
+  // logged-in account pages, etc.). The template uses the htmlBaseUrl filter to absolutize.
+  const SITEMAP_EXCLUDE_PATTERNS = [
+    /^\/admin(\/|$)/,
+    /^\/workspaces(\/|$)/,
+    /^\/projects(\/|$)/,
+    /^\/purchase(\/|$)/,
+    /^\/invitations(\/|$)/,
+    /^\/patterns(\/|$)/,
+    /^\/dev-emails/,
+    /\.html$/i,
+  ];
+  // Per the SEO audit: of the public auth-gateway pages, only /signup belongs in the sitemap.
+  // /login, /claim, /account/reset-password, /account/update-password are returning-user or
+  // token-driven flows that don't need search indexing.
+  // Match on source file path so this holds even when ogUrl rewrites the public URL away
+  // from /account/* (e.g. signup.njk → /signup, login.njk → /login).
+  const isAccountSourceFile = inputPath => /[/\\]account[/\\]/.test(String(inputPath || ''));
+  const SITEMAP_ACCOUNT_FILE_ALLOW = new Set(['signup.njk']);
+  eleventyConfig.addCollection('sitemap', collection => {
+    return collection
+      .getAll()
+      .map(item => {
+        const raw = String(item.data.ogUrl || item.url || '').replace(/\.njk$/, '');
+        const path = raw.replace(/^https?:\/\/[^/]+/, '');
+        return { item, path };
+      })
+      .filter(({ item, path }) => {
+        if (!path) return false;
+        if (item.data.noindex) return false;
+        if (item.data.eleventyExcludeFromCollections) return false;
+        if (SITEMAP_EXCLUDE_PATTERNS.some(re => re.test(path))) return false;
+        if (isAccountSourceFile(item.inputPath)) {
+          const basename = String(item.inputPath || '').split(/[/\\]/).pop();
+          return SITEMAP_ACCOUNT_FILE_ALLOW.has(basename);
+        }
+        return true;
+      })
+      .map(({ item, path }) => ({
+        path,
+        lastmod: item.date ? item.date.toISOString().split('T')[0] : null,
+      }));
   });
 
   /**
@@ -311,6 +357,11 @@ export default async function (eleventyConfig) {
       },
     ]),
   );
+
+  // Provides the htmlBaseUrl filter used by sitemap.xml.njk to absolutize URLs.
+  // Bundled with Eleventy 2.0+, no install required. Also future-proofs against
+  // a future deployment under a path prefix.
+  eleventyConfig.addPlugin(HtmlBasePlugin);
 
   // Build the search index
   eleventyConfig.addPlugin(

--- a/packages/webawesome/docs/.eleventy.js
+++ b/packages/webawesome/docs/.eleventy.js
@@ -183,7 +183,7 @@ export default async function (eleventyConfig) {
   const SITEMAP_ACCOUNT_FILE_ALLOW = new Set(['signup.njk']);
   eleventyConfig.addCollection('sitemap', collection => {
     return collection
-      .getAll()
+      .getAllSorted()
       .map(item => {
         const raw = String(item.data.ogUrl || item.url || '').replace(/\.njk$/, '');
         const urlPath = raw.replace(/^https?:\/\/[^/]+/, '');

--- a/packages/webawesome/docs/.eleventy.js
+++ b/packages/webawesome/docs/.eleventy.js
@@ -185,6 +185,9 @@ export default async function (eleventyConfig) {
     return collection
       .getAllSorted()
       .map(item => {
+        // Strip .njk for pages that set `permalink: /foo.njk` — those pages emit
+        // page.url as the raw template path. Pages without a permalink override use
+        // 11ty's computed url like /foo/ and won't contain .njk in the first place.
         const raw = String(item.data.ogUrl || item.url || '').replace(/\.njk$/, '');
         const urlPath = raw.replace(/^https?:\/\/[^/]+/, '');
         return { item, urlPath };

--- a/packages/webawesome/docs/.eleventy.js
+++ b/packages/webawesome/docs/.eleventy.js
@@ -15,6 +15,7 @@ import { getComponents } from './_utils/manifest.js';
 import { markdown } from './_utils/markdown.js';
 import { SimulateWebAwesomeApp } from './_utils/simulate-webawesome-app.js';
 // import { formatCodePlugin } from './_plugins/format-code.js';
+import { HtmlBasePlugin } from '@11ty/eleventy';
 import litPlugin from '@lit-labs/eleventy-plugin-lit';
 import { readFile } from 'fs/promises';
 import process from 'process';
@@ -22,7 +23,6 @@ import * as url from 'url';
 import { generateAgentSkill } from '../scripts/agent-skill.js';
 import { generateDesignSkill } from '../scripts/design-skill.js';
 import { getSiteDir } from '../scripts/utils.js';
-import { HtmlBasePlugin } from '@11ty/eleventy';
 import { replaceTextPlugin } from './_plugins/replace-text.js';
 import { searchPlugin } from './_plugins/search.js';
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
@@ -186,22 +186,24 @@ export default async function (eleventyConfig) {
       .getAll()
       .map(item => {
         const raw = String(item.data.ogUrl || item.url || '').replace(/\.njk$/, '');
-        const path = raw.replace(/^https?:\/\/[^/]+/, '');
-        return { item, path };
+        const urlPath = raw.replace(/^https?:\/\/[^/]+/, '');
+        return { item, urlPath };
       })
-      .filter(({ item, path }) => {
-        if (!path) return false;
+      .filter(({ item, urlPath }) => {
+        if (!urlPath) return false;
         if (item.data.noindex) return false;
         if (item.data.eleventyExcludeFromCollections) return false;
-        if (SITEMAP_EXCLUDE_PATTERNS.some(re => re.test(path))) return false;
+        if (SITEMAP_EXCLUDE_PATTERNS.some(re => re.test(urlPath))) return false;
         if (isAccountSourceFile(item.inputPath)) {
-          const basename = String(item.inputPath || '').split(/[/\\]/).pop();
+          const basename = String(item.inputPath || '')
+            .split(/[/\\]/)
+            .pop();
           return SITEMAP_ACCOUNT_FILE_ALLOW.has(basename);
         }
         return true;
       })
-      .map(({ item, path }) => ({
-        path,
+      .map(({ item, urlPath }) => ({
+        path: urlPath,
         lastmod: item.date ? item.date.toISOString().split('T')[0] : null,
       }));
   });

--- a/packages/webawesome/docs/robots.txt.njk
+++ b/packages/webawesome/docs/robots.txt.njk
@@ -1,0 +1,9 @@
+---
+permalink: /robots.txt
+layout: false
+eleventyExcludeFromCollections: true
+---
+User-agent: *
+Allow: /
+
+Sitemap: {{ siteMetadata.url }}/sitemap.xml

--- a/packages/webawesome/docs/robots.txt.njk
+++ b/packages/webawesome/docs/robots.txt.njk
@@ -6,4 +6,4 @@ eleventyExcludeFromCollections: true
 User-agent: *
 Allow: /
 
-Sitemap: {{ siteMetadata.url }}/sitemap.xml
+Sitemap: {{ "/sitemap.xml" | htmlBaseUrl(siteMetadata.url) }}

--- a/packages/webawesome/docs/sitemap.xml.njk
+++ b/packages/webawesome/docs/sitemap.xml.njk
@@ -1,0 +1,16 @@
+---
+permalink: /sitemap.xml
+layout: false
+eleventyExcludeFromCollections: true
+---
+<?xml version="1.0" encoding="utf-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+{%- for entry in collections.sitemap %}
+  <url>
+    <loc>{{ entry.path | htmlBaseUrl(siteMetadata.url) }}</loc>
+    {%- if entry.lastmod %}
+    <lastmod>{{ entry.lastmod }}</lastmod>
+    {%- endif %}
+  </url>
+{%- endfor %}
+</urlset>

--- a/packages/webawesome/docs/sitemap.xml.njk
+++ b/packages/webawesome/docs/sitemap.xml.njk
@@ -4,7 +4,7 @@ layout: false
 eleventyExcludeFromCollections: true
 ---
 <?xml version="1.0" encoding="utf-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 {%- for entry in collections.sitemap %}
   <url>
     <loc>{{ entry.path | htmlBaseUrl(siteMetadata.url) }}</loc>


### PR DESCRIPTION
An SEO audit flagged both `/sitemap.xml` and `/robots.txt` as 404. This PR generates both at 11ty build time, so any consumer of the docs build pipeline (standalone webawesome docs, webawesome-app) ships them automatically.

### Add Sitemap Collection
New `addCollection('sitemap', ...)` in `.eleventy.js` filters `collections.all` down to public, indexable URLs. 

It drops pages with `noindex: true` or `eleventyExcludeFromCollections: true`, plus app-only URL prefixes (`/admin`, `/workspaces`, `/projects`, `/purchase`, `/invitations`, `/patterns`, `/dev-emails`) and error pages. 

Account-folder source files are gated to a small allowlist of public gateway pages (today: `signup.njk` only). The allowlist matches on source `inputPath` rather than the rendered URL so it still works correctly after the companion-PR `ogUrl:` overrides rewrite `/account/signup` → `/signup`.

### Add Template
New `sitemap.xml.njk` follows the canonical [11ty base-blog pattern](https://github.com/11ty/eleventy-base-blog/blob/main/content/sitemap.xml.njk), with two important details: `layout: false` in the front matter prevents the global `layout: 'page.njk'` from wrapping the XML in HTML, and `htmlBaseUrl(siteMetadata.url)` is used to absolutize URLs (idiomatic and future-proof against a path prefix). 

The required bundled `HtmlBasePlugin` is enabled in `.eleventy.js`.

### Add `robots.txt`
New `robots.txt.njk` declares `User-agent: *`, `Allow: /`, and the absolute sitemap URL.


---

Companion PR - https://github.com/shoelace-style/webawesome-app/pull/394.