### PR TITLE
Improve `<wa-random-content>`: Accessibility, API Consistency, and Docs

### DIFF
--- a/packages/webawesome/docs/docs/components/random-content.md
+++ b/packages/webawesome/docs/docs/components/random-content.md
@@ -2,282 +2,314 @@
 title: Random Content
 layout: component
 category: Helpers
+synonyms:
+  - rotate
+  - shuffle
+  - variety
+  - rotator
+use-cases:
+  - rotating testimonials
+  - tip of the day
+  - featured content
 ---
 
-Randomly selects and displays one or more of its slotted children. Transparent to layout by default (`display: contents`), so it composes naturally in both block and inline contexts.
+Randomly picks and displays one or more of its slotted children, hiding the rest. Use it to rotate testimonials, surface featured content, show a tip of the day, or add variety to an otherwise static page.
 
 ```html {.example}
-<wa-random-content id="initial" class="wa-grid" items="1" mode="unique" animation="fade-right" style="--animation-easing: ease-in-out; --animation-duration: 500ms">
-  <article class="wa-stack">
-    <div class="wa-frame wa-border-radius-l">
-      <img
-        src="https://images.unsplash.com/photo-1522075469751-3a6694fb2f61?q=80&w=2680&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
-      />
-    </div>
-    <div class="wa-stack wa-gap-3xs">
-      <span>Jeff Hanks</span>
-      <span>Product Designer</span>
-    </div>
-    <div class="wa-cluster wa-gap-3xs">
-      <wa-button appearance="plain" size="s">
-        <wa-icon name="bluesky" family="brands" label="link to Blusky profile"></wa-icon>
-      </wa-button>
-      <wa-button appearance="plain" size="s">
-        <wa-icon name="dribbble" family="brands" label="link to Dribbble profile"></wa-icon>
-      </wa-button>
-    </div>
-  </article>
-  <article class="wa-stack">
-    <div class="wa-frame wa-border-radius-l">
-      <img
-        src="https://images.unsplash.com/photo-1674044494331-8db2ecf18d46?q=80&w=3019&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
-      />
-    </div>
-    <div class="wa-stack wa-gap-3xs">
-      <span>Allen Bryant</span>
-      <span>Staff Engineer</span>
-    </div>
-    <div class="wa-cluster wa-gap-3xs">
-      <wa-button appearance="plain" size="s">
-        <wa-icon name="bluesky" family="brands" label="link to Blusky profile"></wa-icon>
-      </wa-button>
-      <wa-button appearance="plain" size="s">
-        <wa-icon name="dribbble" family="brands" label="link to Dribbble profile"></wa-icon>
-      </wa-button>
-    </div>
-  </article>
-  <article class="wa-stack">
-    <div class="wa-frame wa-border-radius-l">
-      <img
-        src="https://images.unsplash.com/photo-1645288059073-af3e9eb62a29?q=80&w=2936&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
-      />
-    </div>
-    <div class="wa-stack wa-gap-3xs">
-      <span>Mariah Greene</span>
-      <span>DevOps</span>
-    </div>
-    <div class="wa-cluster wa-gap-3xs">
-      <wa-button appearance="plain" size="s">
-        <wa-icon name="bluesky" family="brands" label="link to Blusky profile"></wa-icon>
-      </wa-button>
-      <wa-button appearance="plain" size="s">
-        <wa-icon name="dribbble" family="brands" label="link to Dribbble profile"></wa-icon>
-      </wa-button>
-    </div>
-  </article>
-  <article class="wa-stack">
-    <div class="wa-frame wa-border-radius-l">
-      <img
-        src="https://images.unsplash.com/photo-1613428800237-c86372070fab?q=80&w=3017&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
-      />
-    </div>
-    <div class="wa-stack wa-gap-3xs">
-      <span>Beverly Winslow</span>
-      <span>Design Systems Lead</span>
-    </div>
-    <div class="wa-cluster wa-gap-3xs">
-      <wa-button appearance="plain" size="s">
-        <wa-icon name="bluesky" family="brands" label="link to Blusky profile"></wa-icon>
-      </wa-button>
-      <wa-button appearance="plain" size="s">
-        <wa-icon name="dribbble" family="brands" label="link to Dribbble profile"></wa-icon>
-      </wa-button>
-    </div>
-  </article>
-  <article class="wa-stack">
-    <div class="wa-frame wa-border-radius-l">
-      <img
-        src="https://images.unsplash.com/photo-1614807547811-4174d3582092?q=80&w=2932&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
-      />
-    </div>
-    <div class="wa-stack wa-gap-3xs">
-      <span>Eric Masterson</span>
-      <span>Copy Writer</span>
-    </div>
-    <div class="wa-cluster wa-gap-3xs">
-      <wa-button appearance="plain" size="s">
-        <wa-icon name="bluesky" family="brands" label="link to Blusky profile"></wa-icon>
-      </wa-button>
-      <wa-button appearance="plain" size="s">
-        <wa-icon name="dribbble" family="brands" label="link to Dribbble profile"></wa-icon>
-      </wa-button>
-    </div>
-  </article>
-  <article class="wa-stack">
-    <div class="wa-frame wa-border-radius-l">
-      <img
-        src="https://images.unsplash.com/photo-1559188286-a173792c8340?q=80&w=2906&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
-      />
-    </div>
-    <div class="wa-stack wa-gap-3xs">
-      <span>Stephen Coffee</span>
-      <span>Visual Designer</span>
-    </div>
-    <div class="wa-cluster wa-gap-3xs">
-      <wa-button appearance="plain" size="s">
-        <wa-icon name="bluesky" family="brands" label="link to Blusky profile"></wa-icon>
-      </wa-button>
-      <wa-button appearance="plain" size="s">
-        <wa-icon name="dribbble" family="brands" label="link to Dribbble profile"></wa-icon>
-      </wa-button>
-    </div>
-  </article>
-</wa-random-content>
+<div>
+  <wa-random-content id="rc-overview">
+    <wa-callout variant="brand">
+      <wa-icon slot="icon" name="paperclip-vertical"></wa-icon>
+      <strong>It looks like you're writing a letter!</strong><br />
+      Want a hand with the formatting?
+    </wa-callout>
+    <wa-callout variant="brand">
+      <wa-icon slot="icon" name="paperclip-vertical"></wa-icon>
+      <strong>It looks like you're building a web app!</strong><br />
+      I can recommend a few components.
+    </wa-callout>
+    <wa-callout variant="brand">
+      <wa-icon slot="icon" name="paperclip-vertical"></wa-icon>
+      <strong>It looks like you're stuck.</strong><br />
+      Have you tried turning it off and on again?
+    </wa-callout>
+    <wa-callout variant="brand">
+      <wa-icon slot="icon" name="paperclip-vertical"></wa-icon>
+      <strong>It looks like you're shipping on a Friday.</strong><br />
+      Bold move. I respect it.
+    </wa-callout>
+  </wa-random-content>
 
-<wa-button size="s" style="margin-top:var(--wa-space-m)" onclick="document.getElementById('initial').randomize()" appearance="filled">Randomize</wa-button>
+  <wa-divider></wa-divider>
+
+  <wa-button appearance="filled" onclick="document.getElementById('rc-overview').randomize()">Shuffle</wa-button>
+</div>
 ```
+
 ## Examples
 
-### Multiple items
+### Providing Content
 
-Use the `items` attribute to show more than one child at a time.
+Slot virtually any HTML — text, badges, cards, images, or other components — as long as each item is a **direct child**. Nested elements and bare text nodes are ignored. The host renders [`display: contents`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#contents), so it stays invisible to layout.
 
 ```html {.example}
-<wa-random-content items="2">
-  <wa-badge variant="brand">New</wa-badge>
-  <wa-badge variant="success">Sale</wa-badge>
-  <wa-badge variant="warning">Low stock</wa-badge>
-  <wa-badge>Beta</wa-badge>
-</wa-random-content>
+<div>
+  <wa-random-content id="rc-providing">
+    <p>Plain text works fine.</p>
+    <wa-badge variant="brand">So do components</wa-badge>
+    <wa-card>Even rich cards with their own content.</wa-card>
+  </wa-random-content>
+
+  <wa-divider></wa-divider>
+
+  <wa-button appearance="filled" onclick="document.getElementById('rc-providing').randomize()">Shuffle</wa-button>
+</div>
 ```
 
-### Sequence mode
+### Setting the Number of Items
 
-`mode="sequence"` advances through children in DOM order. Each call to `randomize()` moves the cursor forward by `items` positions, wrapping at the end.
-
-```html {.example}
-<wa-random-content id="slides" mode="sequence">
-  <img src="https://picsum.photos/seed/a/400/200" alt="Slide 1" style="display:block;width:100%;border-radius:var(--wa-border-radius-m)" />
-  <img src="https://picsum.photos/seed/b/400/200" alt="Slide 2" style="display:block;width:100%;border-radius:var(--wa-border-radius-m)" />
-  <img src="https://picsum.photos/seed/c/400/200" alt="Slide 3" style="display:block;width:100%;border-radius:var(--wa-border-radius-m)" />
-</wa-random-content>
-
-<wa-button size="s" style="margin-top:var(--wa-space-m)" onclick="document.getElementById('slides').randomize()" appearance="filled">Next</wa-button>
-```
-
-### Unique mode
-
-`mode="unique"` excludes the previously shown children from the candidate pool, so you never see the same item twice in a row. When the pool runs out, history resets and all children become eligible again.
+Set `items` to show more than one child at a time. The value is clamped to the number of available children.
 
 ```html {.example}
-<wa-random-content id="tip" mode="unique">
-  <p><strong>Tip:</strong> Use keyboard shortcuts to navigate faster.</p>
-  <p><strong>Tip:</strong> Dark mode is available in Settings.</p>
-  <p><strong>Tip:</strong> You can drag to reorder items.</p>
-  <p><strong>Tip:</strong> Hover over any icon to see its name.</p>
-</wa-random-content>
+<div class="rc-items-demo">
+  <wa-random-content id="rc-items" items="2">
+    <wa-badge variant="brand">New</wa-badge>
+    <wa-badge variant="success">Sale</wa-badge>
+    <wa-badge variant="warning">Low stock</wa-badge>
+    <wa-badge variant="neutral">Popular</wa-badge>
+    <wa-badge variant="danger">Last chance</wa-badge>
+  </wa-random-content>
 
-<wa-button size="s" onclick="document.getElementById('tip').randomize()" style="margin-top:var(--wa-space-m);" appearance="filled">Next tip</wa-button>
-```
+  <wa-divider></wa-divider>
 
-### Animations
-
-Use the `animation` attribute to add an entrance transition when new content is shown.
-
-```html {.example}
-<wa-random-content id="anim-demo" animation="fade">
-  <p>Good morning!</p>
-  <p>Welcome back.</p>
-  <p>What are you building today?</p>
-</wa-random-content>
-
-<div style="display:flex;gap:var(--wa-space-s);align-items:center;margin-top:var(--wa-space-m)">
-  <wa-button size="s" onclick="document.getElementById('anim-demo').randomize()" appearance="filled">Next</wa-button>
-  <wa-select id="anim-select" size="s" value="fade" style="min-width:9rem">
-    <wa-option value="none">None</wa-option>
-    <wa-option value="fade">Fade</wa-option>
-    <wa-option value="fade-up">Fade up</wa-option>
-    <wa-option value="fade-down">Fade down</wa-option>
-    <wa-option value="fade-left">Fade left</wa-option>
-    <wa-option value="fade-right">Fade right</wa-option>
-  </wa-select>
+  <div class="wa-cluster" style="align-items: flex-end">
+    <wa-select id="rc-items-count" label="Items" value="2" style="width: 8rem">
+      <wa-option value="1">1</wa-option>
+      <wa-option value="2">2</wa-option>
+      <wa-option value="3">3</wa-option>
+      <wa-option value="4">4</wa-option>
+    </wa-select>
+    <wa-button appearance="filled" onclick="document.getElementById('rc-items').randomize()">Shuffle</wa-button>
+  </div>
 </div>
 
 <script>
-  document.getElementById('anim-select').addEventListener('change', e => {
-    document.getElementById('anim-demo').animation = e.target.value;
+  document.getElementById('rc-items-count').addEventListener('change', event => {
+    document.getElementById('rc-items').items = Number(event.target.value);
   });
 </script>
 ```
 
-Directional animations (`fade-up`, `fade-down`, `fade-left`, `fade-right`) rely on CSS `transform`, which has no effect on `display: inline` elements. The component automatically promotes inline elements to `display: inline-block` when a directional animation is active, so they work in inline contexts without any extra markup.
+### Changing the Mode
 
-The duration, easing, and translate distance are customizable with CSS custom properties. Here's a slow, bouncy fade-up:
+The `mode` attribute controls how the next selection is chosen. Switch modes and shuffle a few times to feel the difference — the recent picks are listed underneath.
 
-```html {.example}
-<wa-random-content id="anim-custom" animation="fade-up" style="--animation-duration: 700ms; --animation-easing: cubic-bezier(0.34, 1.56, 0.64, 1); --animation-translate: 1.5em">
-  <p>Good morning!</p>
-  <p>Welcome back.</p>
-  <p>What are you building today?</p>
-</wa-random-content>
-
-<wa-button size="s" onclick="document.getElementById('anim-custom').randomize()" style="margin-top:var(--wa-space-m)" appearance="filled">Next</wa-button>
-```
-
-### Auto-play
-
-Set `interval` to a duration in milliseconds to rotate content automatically. Combine it with any `animation` value for a smooth entrance transition. The animation duration defaults to `300ms` and can be overridden with `--animation-duration`.
+| Mode                                                                                                                                                                                     | Behavior                                                                        | Best for                           |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ---------------------------------- |
+| <span class="wa-cluster wa-flex-nowrap wa-gap-3xs">`unique` <wa-badge appearance="outlined" variant="neutral" pill style="font-size: var(--wa-font-size-2xs);">default</wa-badge></span> | Never repeats the previous selection.                                           | Tip rotators and timed loops.      |
+| `random`                                                                                                                                                                                 | Picks at complete random, so the same item can appear twice in a row.           | A one-time shuffle on load.        |
+| `sequence`                                                                                                                                                                               | Steps through children in DOM order, wrapping at the end (advances by `items`). | Stepping through content in order. |
 
 ```html {.example}
-<p style="margin-bottom: 0;">
-  <wa-icon name="stars" family="sharp-duotone" variant="regular"></wa-icon>
-  Did you know? <wa-random-content mode="unique" animation="fade-up" interval="3000" style="--animation-easing: ease-in-out; --animation-duration: 500ms">
-    <span>Octopuses have three hearts.</span>
-    <span>Honey never spoils.</span>
-    <span>A group of flamingos is called a flamboyance.</span>
-    <span>Bananas are technically berries.</span>
-    <span>Cheetahs meow.</span>
-    <span>Almost every species of whale has lice.</span>
+<div class="rc-modes-demo">
+  <wa-random-content id="rc-modes" mode="unique">
+    <wa-tag variant="brand">A</wa-tag>
+    <wa-tag variant="success">B</wa-tag>
+    <wa-tag variant="warning">C</wa-tag>
+    <wa-tag variant="danger">D</wa-tag>
   </wa-random-content>
-</p>
+
+  <wa-divider></wa-divider>
+
+  <div class="wa-cluster" style="align-items: flex-end">
+    <wa-select id="rc-modes-mode" label="Mode" value="unique" style="width: 10rem">
+      <wa-option value="unique">unique</wa-option>
+      <wa-option value="random">random</wa-option>
+      <wa-option value="sequence">sequence</wa-option>
+    </wa-select>
+    <wa-button appearance="filled" onclick="document.getElementById('rc-modes').randomize()">Shuffle</wa-button>
+  </div>
+
+  <small style="display: block; margin-block-start: var(--wa-space-s)">
+    Recent picks: <span id="rc-modes-history"></span>
+  </small>
+</div>
+
+<script>
+  const rcModes = document.getElementById('rc-modes');
+  const rcModesHistory = document.getElementById('rc-modes-history');
+
+  document.getElementById('rc-modes-mode').addEventListener('change', event => {
+    rcModes.mode = event.target.value;
+  });
+
+  rcModes.addEventListener('wa-content-change', event => {
+    const labels = event.detail.items.map(item => item.textContent.trim()).join('');
+    const picks = (rcModesHistory.textContent + ' ' + labels).trim().split(/\s+/).slice(-16);
+    rcModesHistory.textContent = picks.join(' ');
+  });
+</script>
 ```
 
-### Inline usage
+### Animating New Content
 
-Because the host renders `display: contents`, the component is transparent to layout and works naturally inside inline contexts.
+Use the `animation` attribute to play an entrance transition when new content is shown.
 
 ```html {.example}
-<p>
-  Have a
-  <wa-random-content id="inline">
-    <span>wonderful</span>
-    <span>fantastic</span>
-    <span>great</span>
+<div class="rc-animation-demo">
+  <wa-random-content id="rc-animation" animation="fade-up">
+    <p>Good morning!</p>
+    <p>Welcome back.</p>
+    <p>What are you building today?</p>
   </wa-random-content>
-  day!
-</p>
 
-<wa-button size="s" onclick="document.getElementById('inline').randomize()" appearance="filled">Randomize</wa-button>
+  <wa-divider></wa-divider>
+
+  <div class="wa-cluster" style="align-items: flex-end">
+    <wa-select id="rc-animation-select" label="Animation" value="fade-up" style="width: 10rem">
+      <wa-option value="none">none</wa-option>
+      <wa-option value="fade">fade</wa-option>
+      <wa-option value="fade-up">fade-up</wa-option>
+      <wa-option value="fade-down">fade-down</wa-option>
+      <wa-option value="fade-left">fade-left</wa-option>
+      <wa-option value="fade-right">fade-right</wa-option>
+    </wa-select>
+    <wa-button appearance="filled" onclick="document.getElementById('rc-animation').randomize()">Next</wa-button>
+  </div>
+</div>
+
+<script>
+  document.getElementById('rc-animation-select').addEventListener('change', event => {
+    document.getElementById('rc-animation').animation = event.target.value;
+  });
+</script>
 ```
 
-### Imperative control
+Directional animations (`fade-up`, `fade-down`, `fade-left`, `fade-right`) rely on CSS `transform`, which has no effect on `display: inline` elements. The component promotes inline children to `inline-block` while a directional animation plays, so they work inline without extra markup.
 
-Call `randomize()` on the element at any time to trigger a new selection programmatically.
+Tune the duration, easing, and travel distance with the `--animation-duration`, `--animation-easing`, and `--animation-translate` custom properties. Animations are skipped automatically when the user [prefers reduced motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion).
+
+### Autoplay
+
+Add the `autoplay` attribute to rotate content on a timer, and set the cadence with `autoplay-interval` (milliseconds). It pauses while the pointer is over the component or focus is inside it, and resumes when the user moves away. It respects reduced motion, too: content still rotates, but the entrance animation is skipped.
 
 ```html {.example}
-<wa-random-content id="rc">
-  <wa-badge>
-  <wa-icon slot="start" name="earth-americas"></wa-icon>
-  Earth
-</wa-badge>
-<wa-badge>
-  <wa-icon slot="start" name="fire"></wa-icon>
-  Fire
-</wa-badge>
-<wa-badge>
-  <wa-icon slot="start" name="wind"></wa-icon>
-  Wind
-</wa-badge>
-<wa-badge>
-  <wa-icon slot="start" name="water"></wa-icon>
-  Water
-</wa-badge>
-<wa-badge>
-  <wa-icon slot="start" name="heart"></wa-icon>
-  Heart
-</wa-badge>
+<div class="rc-autoplay-demo">
+  <dl>
+    <dt>Did you know?</dt>
+    <wa-random-content id="rc-autoplay" mode="unique" animation="fade-up" autoplay autoplay-interval="3000">
+      <dd><wa-icon name="octopus"></wa-icon> Octopuses have three hearts.</dd>
+      <dd><wa-icon name="bee"></wa-icon> Honey never spoils.</dd>
+      <dd><wa-icon name="feather"></wa-icon> A group of flamingos is called a flamboyance.</dd>
+      <dd><wa-icon name="banana"></wa-icon> Bananas are botanically berries.</dd>
+      <dd><wa-icon name="cat"></wa-icon> Cheetahs meow rather than roar.</dd>
+    </wa-random-content>
+  </dl>
 
-</wa-random-content>
-<br />
-<wa-button size="s" onclick="document.getElementById('rc').randomize()" style="margin-top:var(--wa-space-m)" appearance="filled">Randomize</wa-button>
+  <wa-divider></wa-divider>
+
+  <wa-button id="rc-autoplay-toggle" appearance="filled">Pause</wa-button>
+</div>
+
+<style>
+  .rc-autoplay-demo dl {
+    margin: 0;
+  }
+  .rc-autoplay-demo dt {
+    font-weight: var(--wa-font-weight-semibold);
+    margin-block-end: var(--wa-space-2xs);
+  }
+  .rc-autoplay-demo dd {
+    margin-inline-start: 0;
+  }
+  .rc-autoplay-demo dd wa-icon {
+    margin-inline-end: var(--wa-space-2xs);
+    color: var(--wa-color-brand-fill-loud);
+  }
+</style>
+
+<script>
+  const rcAutoplay = document.getElementById('rc-autoplay');
+  const rcAutoplayToggle = document.getElementById('rc-autoplay-toggle');
+
+  rcAutoplayToggle.addEventListener('click', () => {
+    rcAutoplay.autoplay = !rcAutoplay.autoplay;
+    rcAutoplayToggle.textContent = rcAutoplay.autoplay ? 'Pause' : 'Play';
+  });
+</script>
 ```
+
+:::warning
+<strong>If you turn on `autoplay`, give people a way to pause it.</strong><br />
+The built-in hover and focus pausing doesn't help someone using a keyboard when the rotating content isn't focusable, so add a visible pause button like the one above.
+:::
+
+### Styling the Container
+
+The host is `display: contents` by default, so it adds no box of its own. To lay several shown items out as a row or grid, give the host its own `display` — that overrides the transparent default. Here it shows three of six people at random in a flex row.
+
+```html {.example}
+<div>
+  <wa-random-content id="rc-layout" items="3" style="display: flex; gap: var(--wa-space-m); flex-wrap: wrap">
+    <wa-avatar label="Jordan Hayes" initials="JH"></wa-avatar>
+    <wa-avatar label="Mara Goldberg" initials="MG"></wa-avatar>
+    <wa-avatar label="Beck Watts" initials="BW"></wa-avatar>
+    <wa-avatar label="Avi Lin" initials="AL"></wa-avatar>
+    <wa-avatar label="Rae Park" initials="RP"></wa-avatar>
+    <wa-avatar label="Sam Cho" initials="SC"></wa-avatar>
+  </wa-random-content>
+
+  <wa-divider></wa-divider>
+
+  <wa-button appearance="filled" onclick="document.getElementById('rc-layout').randomize()">Shuffle</wa-button>
+</div>
+```
+
+Because the host is transparent, the component also works inline within a sentence.
+
+```html {.example}
+<div>
+  <p>
+    Have a
+    <wa-random-content id="rc-inline">
+      <span>wonderful</span>
+      <span>fantastic</span>
+      <span>marvelous</span>
+      <span>splendid</span>
+    </wa-random-content>
+    day!
+  </p>
+
+  <wa-divider></wa-divider>
+
+  <wa-button appearance="filled" onclick="document.getElementById('rc-inline').randomize()">Shuffle</wa-button>
+</div>
+```
+
+Unselected children are hidden with the `hidden` attribute, so you can target whatever is currently shown with `:not([hidden])`:
+
+```css
+wa-random-content > :not([hidden]) {
+  outline: var(--wa-border-width-s) solid var(--wa-color-brand-fill-loud);
+}
+```
+
+### Reacting to Changes
+
+The component emits a `wa-content-change` event whenever the displayed selection changes — on first render, on `randomize()`, and on each autoplay tick. `event.detail.items` is the array of elements now shown.
+
+```javascript
+const rc = document.querySelector('wa-random-content');
+
+rc.addEventListener('wa-content-change', event => {
+  console.log('Now showing:', event.detail.items);
+});
+```
+
+### Server-Side Rendering
+
+Until the component upgrades on the client, every child is visible, which can flash on first paint. Add the [`wa-cloak`](/docs/utilities/fouce) class to hide content until Web Awesome is ready. Because the first selection is random, server- and client-rendered output can also differ; for a stable first paint, use `mode="sequence"`, which always starts at the first child.
+
+### Using a Framework
+
+The component selects from its slotted children by toggling the `hidden` attribute on them directly. Treat that content as static — if a framework owns and re-renders the children, its reconciliation can overwrite the hidden state. Render a fixed set of children, then drive the component imperatively: call `randomize()` through a ref and listen for `wa-content-change`.

--- a/packages/webawesome/docs/docs/components/random-content.md
+++ b/packages/webawesome/docs/docs/components/random-content.md
@@ -54,11 +54,13 @@ Slot virtually any HTML — text, badges, cards, images, or other components —
 
 ```html {.example}
 <div>
-  <wa-random-content id="rc-providing">
-    <p>Plain text works fine.</p>
-    <wa-badge variant="brand">So do components</wa-badge>
-    <wa-card>Even rich cards with their own content.</wa-card>
-  </wa-random-content>
+  <div class="wa-cluster wa-align-items-center" style="min-height: 5rem">
+    <wa-random-content id="rc-providing">
+      <p>Plain text works fine.</p>
+      <wa-badge variant="brand">So do components</wa-badge>
+      <wa-card>Even rich cards with their own content.</wa-card>
+    </wa-random-content>
+  </div>
 
   <wa-divider></wa-divider>
 

--- a/packages/webawesome/docs/docs/components/random-content.md
+++ b/packages/webawesome/docs/docs/components/random-content.md
@@ -191,7 +191,7 @@ Tune the duration, easing, and travel distance with the `--animation-duration`, 
 
 ### Autoplay
 
-Add the `autoplay` attribute to rotate content on a timer, and set the cadence with `autoplay-interval` (milliseconds). It pauses while the pointer is over the component or focus is inside it, and resumes when the user moves away. It respects reduced motion, too: content still rotates, but the entrance animation is skipped.
+Add the `autoplay` attribute to rotate content on a timer, and set the cadence with `autoplay-interval` (milliseconds). It pauses while the pointer is over the component or focus is inside it, and resumes when the user moves away. It respects reduced motion, too: content still rotates, but the entrance animation is skipped. Each new item is announced to screen readers using its text, so give icon-only content an accessible label (for example `<wa-icon label="…">`).
 
 ```html {.example}
 <div class="rc-autoplay-demo">

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -32,7 +32,10 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 ## Unreleased
 
 :::added
-- Added the `<wa-random-content>` experimental component
+
+- Added the experimental `<wa-random-content>` component, which randomly shows one or more of its children — handy for rotating testimonials, tips, or featured content
+
+:::
 
 :::fixed
 

--- a/packages/webawesome/src/components/random-content/random-content.styles.ts
+++ b/packages/webawesome/src/components/random-content/random-content.styles.ts
@@ -6,6 +6,15 @@ export default css`
   }
 
   /*
+   * Force-hide unselected children. A bare [hidden] (display: none from the UA sheet) loses to any
+   * author display set on the child — a utility class like .wa-flank, or a component's own
+   * :host display — so children with their own layout wouldn't actually hide without this.
+   */
+  ::slotted([hidden]) {
+    display: none !important;
+  }
+
+  /*
    * @keyframes are defined in both document scope (random-content.ts) and here:
    * Chromium resolves animation-name from the document for slotted elements;
    * WebKit resolves it from the shadow root. Both copies are needed.
@@ -64,29 +73,32 @@ export default css`
     }
   }
 
-  ::slotted([data-wa-animation]) {
-    animation-duration: var(--animation-duration, 300ms);
-    animation-timing-function: var(--animation-easing, ease);
-    animation-fill-mode: both;
-  }
+  /* The JS already skips animations under reduced motion; this guards CSS-only consumers too. */
+  @media (prefers-reduced-motion: no-preference) {
+    ::slotted([data-wa-animation]) {
+      animation-duration: var(--animation-duration, 300ms);
+      animation-timing-function: var(--animation-easing, ease);
+      animation-fill-mode: both;
+    }
 
-  ::slotted([data-wa-animation='fade']) {
-    animation-name: wa-rc-fade;
-  }
+    ::slotted([data-wa-animation='fade']) {
+      animation-name: wa-rc-fade;
+    }
 
-  ::slotted([data-wa-animation='fade-up']) {
-    animation-name: wa-rc-fade-up;
-  }
+    ::slotted([data-wa-animation='fade-up']) {
+      animation-name: wa-rc-fade-up;
+    }
 
-  ::slotted([data-wa-animation='fade-down']) {
-    animation-name: wa-rc-fade-down;
-  }
+    ::slotted([data-wa-animation='fade-down']) {
+      animation-name: wa-rc-fade-down;
+    }
 
-  ::slotted([data-wa-animation='fade-left']) {
-    animation-name: wa-rc-fade-left;
-  }
+    ::slotted([data-wa-animation='fade-left']) {
+      animation-name: wa-rc-fade-left;
+    }
 
-  ::slotted([data-wa-animation='fade-right']) {
-    animation-name: wa-rc-fade-right;
+    ::slotted([data-wa-animation='fade-right']) {
+      animation-name: wa-rc-fade-right;
+    }
   }
 `;

--- a/packages/webawesome/src/components/random-content/random-content.test.ts
+++ b/packages/webawesome/src/components/random-content/random-content.test.ts
@@ -1,14 +1,33 @@
 import { expect } from '@open-wc/testing';
 import { html } from 'lit';
+import sinon from 'sinon';
 import { fixtures } from '../../internal/test/fixture.js';
 import type WaRandomContent from './random-content.js';
 
 function visibleChildren(el: WaRandomContent): Element[] {
-  return Array.from(el.children).filter(c => (c as HTMLElement).style.display !== 'none');
+  return Array.from(el.children).filter(c => !(c as HTMLElement).hidden);
 }
 
 function hiddenChildren(el: WaRandomContent): Element[] {
-  return Array.from(el.children).filter(c => (c as HTMLElement).style.display === 'none');
+  return Array.from(el.children).filter(c => (c as HTMLElement).hidden);
+}
+
+// Force a known prefers-reduced-motion result without touching the real OS setting. Only the
+// reduced-motion query is overridden; other media queries fall through to their default.
+function stubReducedMotion(matches: boolean) {
+  return sinon.stub(window, 'matchMedia').callsFake(
+    (query: string) =>
+      ({
+        matches: query.includes('prefers-reduced-motion') ? matches : false,
+        media: query,
+        onchange: null,
+        addEventListener() {},
+        removeEventListener() {},
+        addListener() {},
+        removeListener() {},
+        dispatchEvent: () => false,
+      }) as unknown as MediaQueryList,
+  );
 }
 
 describe('<wa-random-content>', () => {
@@ -86,15 +105,22 @@ describe('<wa-random-content>', () => {
 
       describe('animation', () => {
         it('plays a fade animation on shown elements when animation="fade"', async () => {
-          const el = await fixture<WaRandomContent>(html`
-            <wa-random-content animation="fade">
-              <span>A</span>
-              <span>B</span>
-              <span>C</span>
-            </wa-random-content>
-          `);
-          const shown = visibleChildren(el)[0] as HTMLElement;
-          expect(shown.getAnimations().length).to.be.greaterThan(0);
+          // Force motion on so the test doesn't depend on the runner's OS setting.
+          const stub = stubReducedMotion(false);
+          try {
+            const el = await fixture<WaRandomContent>(html`
+              <wa-random-content animation="fade">
+                <span>A</span>
+                <span>B</span>
+                <span>C</span>
+              </wa-random-content>
+            `);
+            el.randomize();
+            const shown = visibleChildren(el)[0] as HTMLElement;
+            expect(shown.getAnimations().length).to.be.greaterThan(0);
+          } finally {
+            stub.restore();
+          }
         });
 
         it('plays no animation by default', async () => {
@@ -111,7 +137,7 @@ describe('<wa-random-content>', () => {
       });
 
       describe('margin', () => {
-        it('removes margin-block-end from the last shown element', async () => {
+        it('strips the leading and trailing block margins from a single shown element', async () => {
           const el = await fixture<WaRandomContent>(html`
             <wa-random-content mode="sequence">
               <p>A</p>
@@ -120,10 +146,11 @@ describe('<wa-random-content>', () => {
             </wa-random-content>
           `);
           const shown = visibleChildren(el)[0] as HTMLElement;
+          expect(parseFloat(shown.style.marginBlockStart)).to.equal(0);
           expect(parseFloat(shown.style.marginBlockEnd)).to.equal(0);
         });
 
-        it('preserves margin-block-end on non-last shown elements when items > 1', async () => {
+        it('keeps inner margins between shown elements when items > 1', async () => {
           const el = await fixture<WaRandomContent>(html`
             <wa-random-content mode="sequence" items="2">
               <p>A</p>
@@ -132,7 +159,11 @@ describe('<wa-random-content>', () => {
             </wa-random-content>
           `);
           const shown = visibleChildren(el) as HTMLElement[];
+          // First shown: leading margin stripped, trailing margin preserved.
+          expect(parseFloat(shown[0].style.marginBlockStart)).to.equal(0);
           expect(shown[0].style.marginBlockEnd).to.equal('');
+          // Last shown: trailing margin stripped, leading margin preserved.
+          expect(shown[1].style.marginBlockStart).to.equal('');
           expect(parseFloat(shown[1].style.marginBlockEnd)).to.equal(0);
         });
       });
@@ -294,6 +325,153 @@ describe('<wa-random-content>', () => {
             const curr = visibleChildren(el)[0];
             expect(curr).not.to.equal(prev, `duplicate at iteration ${i}`);
             prev = curr;
+          }
+        });
+      });
+
+      describe('defaults', () => {
+        it('defaults to unique mode', async () => {
+          const el = await fixture<WaRandomContent>(html`
+            <wa-random-content>
+              <span>A</span>
+              <span>B</span>
+            </wa-random-content>
+          `);
+          expect(el.mode).to.equal('unique');
+        });
+      });
+
+      describe('hiding', () => {
+        it('hides unselected children with the hidden attribute, not inline display', async () => {
+          const el = await fixture<WaRandomContent>(html`
+            <wa-random-content>
+              <span>A</span>
+              <span>B</span>
+              <span>C</span>
+            </wa-random-content>
+          `);
+          const hidden = hiddenChildren(el) as HTMLElement[];
+          expect(hidden).to.have.lengthOf(2);
+          hidden.forEach(c => expect(c.hasAttribute('hidden')).to.be.true);
+          const shown = visibleChildren(el)[0] as HTMLElement;
+          expect(shown.hasAttribute('hidden')).to.be.false;
+          expect(shown.style.display).to.not.equal('none');
+        });
+
+        it('visually hides children that set their own display (e.g. a layout class)', async () => {
+          // A bare [hidden] loses to an author `display`; the component must still hide these.
+          const el = await fixture<WaRandomContent>(html`
+            <wa-random-content>
+              <div style="display: flex">A</div>
+              <div style="display: flex">B</div>
+              <div style="display: flex">C</div>
+            </wa-random-content>
+          `);
+          const hidden = hiddenChildren(el) as HTMLElement[];
+          expect(hidden.length).to.be.greaterThan(0);
+          hidden.forEach(c => expect(getComputedStyle(c).display).to.equal('none'));
+        });
+      });
+
+      describe('wa-content-change event', () => {
+        it('emits with the shown items and matches the randomize() return value', async () => {
+          const el = await fixture<WaRandomContent>(html`
+            <wa-random-content items="2">
+              <span>A</span>
+              <span>B</span>
+              <span>C</span>
+              <span>D</span>
+            </wa-random-content>
+          `);
+          const emitted: Element[][] = [];
+          el.addEventListener('wa-content-change', (e: Event) => emitted.push((e as CustomEvent).detail.items));
+          const returned = el.randomize();
+          // randomize() dispatches synchronously, so the last emitted detail is from this call.
+          expect(returned).to.have.lengthOf(2);
+          expect(emitted[emitted.length - 1]).to.deep.equal(returned);
+          returned.forEach(item => expect((item as HTMLElement).hidden).to.be.false);
+        });
+      });
+
+      describe('autoplay', () => {
+        it('rotates automatically on the configured interval', async () => {
+          const el = await fixture<WaRandomContent>(html`
+            <wa-random-content mode="sequence">
+              <span>A</span>
+              <span>B</span>
+              <span>C</span>
+            </wa-random-content>
+          `);
+          const first = visibleChildren(el)[0];
+          const clock = sinon.useFakeTimers();
+          try {
+            el.autoplay = true;
+            el.autoplayInterval = 1000;
+            await el.updateComplete;
+            clock.tick(1000);
+            expect(visibleChildren(el)[0]).to.not.equal(first);
+          } finally {
+            clock.restore();
+          }
+        });
+
+        it('pauses on pointer interaction and resumes after', async () => {
+          const el = await fixture<WaRandomContent>(html`
+            <wa-random-content mode="sequence">
+              <span>A</span>
+              <span>B</span>
+              <span>C</span>
+            </wa-random-content>
+          `);
+          const clock = sinon.useFakeTimers();
+          try {
+            el.autoplay = true;
+            el.autoplayInterval = 1000;
+            await el.updateComplete;
+            el.dispatchEvent(new MouseEvent('mouseenter'));
+            const paused = visibleChildren(el)[0];
+            clock.tick(3000);
+            expect(visibleChildren(el)[0]).to.equal(paused);
+            el.dispatchEvent(new MouseEvent('mouseleave'));
+            clock.tick(1000);
+            expect(visibleChildren(el)[0]).to.not.equal(paused);
+          } finally {
+            clock.restore();
+          }
+        });
+      });
+
+      describe('reduced motion', () => {
+        it('skips the entrance animation but keeps autoplaying', async () => {
+          const stub = stubReducedMotion(true);
+          try {
+            const el = await fixture<WaRandomContent>(html`
+              <wa-random-content animation="fade" mode="sequence">
+                <span>A</span>
+                <span>B</span>
+                <span>C</span>
+              </wa-random-content>
+            `);
+            // No entrance animation is applied under reduced motion.
+            el.randomize();
+            const shown = visibleChildren(el)[0] as HTMLElement;
+            expect(shown.getAnimations().length).to.equal(0);
+            expect(shown.dataset['waAnimation']).to.be.undefined;
+
+            // ...but autoplay still advances (matching <wa-carousel>).
+            const before = visibleChildren(el)[0];
+            const clock = sinon.useFakeTimers();
+            try {
+              el.autoplay = true;
+              el.autoplayInterval = 1000;
+              await el.updateComplete;
+              clock.tick(1000);
+              expect(visibleChildren(el)[0]).to.not.equal(before);
+            } finally {
+              clock.restore();
+            }
+          } finally {
+            stub.restore();
           }
         });
       });

--- a/packages/webawesome/src/components/random-content/random-content.test.ts
+++ b/packages/webawesome/src/components/random-content/random-content.test.ts
@@ -477,4 +477,23 @@ describe('<wa-random-content>', () => {
       });
     });
   }
+
+  // Not part of the CSR/SSR fixture loop: the listener must be attached before the element mounts,
+  // which the fixture helpers don't allow.
+  describe('initial render', () => {
+    it('emits wa-content-change on first render', async () => {
+      await customElements.whenDefined('wa-random-content');
+      const emitted: Element[][] = [];
+      const el = document.createElement('wa-random-content') as WaRandomContent;
+      el.addEventListener('wa-content-change', (e: Event) => emitted.push((e as CustomEvent).detail.items));
+      el.innerHTML = '<span>A</span><span>B</span>';
+      document.body.append(el);
+      await el.updateComplete;
+      // Covers the first-render emission specifically (the other event test only checks an explicit
+      // randomize()). The listener has to be attached before mount to observe it.
+      expect(emitted.length).to.be.at.least(1);
+      expect(emitted[0]).to.have.lengthOf(1);
+      el.remove();
+    });
+  });
 });

--- a/packages/webawesome/src/components/random-content/random-content.ts
+++ b/packages/webawesome/src/components/random-content/random-content.ts
@@ -1,10 +1,14 @@
-import { html } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { html, type PropertyValues } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { WaContentChangeEvent } from '../../events/random-content-change.js';
+import { prefersReducedMotion } from '../../internal/animate.js';
 import { watch } from '../../internal/watch.js';
 import WebAwesomeElement from '../../internal/webawesome-element.js';
+import visuallyHidden from '../../styles/component/visually-hidden.styles.js';
+import { AutoplayController } from '../carousel/autoplay-controller.js';
 import styles from './random-content.styles.js';
 
-// Keyframes must live in the document scope, Chromium does not resolve shadow-root-scoped
+// Keyframes must live in the document scope: Chromium does not resolve shadow-root-scoped
 // @keyframes for slotted elements, even when applied via ::slotted() rules.
 if (typeof document !== 'undefined') {
   const sheet = new CSSStyleSheet();
@@ -34,12 +38,16 @@ if (typeof document !== 'undefined') {
 }
 
 /**
- * @summary Random content selects one or more child elements at random and displays them.
+ * @summary Selects one or more child elements at random and displays them, hiding the rest.
  * @documentation https://webawesome.com/docs/components/random-content
  * @status experimental
  * @since 3.9
  *
- * @slot - The pool of children to randomize from. Unselected children are hidden with `display: none`.
+ * @slot - The pool of children to choose from. Only direct element children are eligible; unselected
+ *  children are hidden with the `hidden` attribute.
+ *
+ * @event {{ items: Element[] }} wa-content-change - Emitted whenever the displayed selection changes,
+ *  including on first render, on `randomize()`, and on each autoplay tick.
  *
  * @cssproperty --animation-duration - Duration of the entrance animation. Default is `300ms`.
  * @cssproperty --animation-easing - Easing function for the entrance animation. Default is `ease`.
@@ -47,21 +55,28 @@ if (typeof document !== 'undefined') {
  */
 @customElement('wa-random-content')
 export default class WaRandomContent extends WebAwesomeElement {
-  static css = styles;
+  static css = [styles, visuallyHidden];
 
   private sequenceCursor = 0;
   private uniqueQueue: Element[] = [];
   private currentSelection = new Set<Element>();
-  private intervalId: ReturnType<typeof setInterval> | undefined;
+  private isInitialSelection = true;
+  private autoplayController = new AutoplayController(this, () => this.randomize());
+
+  /** Text pushed to a visually-hidden live region so screen readers hear rotations. */
+  @state() private liveAnnouncement = '';
 
   /** Number of children to show simultaneously. Clamped to [1, childCount]. */
   @property({ type: Number }) items = 1;
 
-  /** Auto-rotation interval in milliseconds. Set to `0` (default) to disable. */
-  @property({ type: Number }) interval = 0;
+  /** Selection strategy: `unique` (default), `random`, or `sequence`. */
+  @property({ reflect: true }) mode: 'random' | 'unique' | 'sequence' = 'unique';
 
-  /** Selection strategy: `random` (default), `unique`, or `sequence`. */
-  @property({ reflect: true }) mode: 'random' | 'unique' | 'sequence' = 'random';
+  /** Rotate the content automatically. Set the cadence with `autoplay-interval`. */
+  @property({ type: Boolean, reflect: true }) autoplay = false;
+
+  /** Autoplay cadence in milliseconds. */
+  @property({ type: Number, attribute: 'autoplay-interval' }) autoplayInterval = 3000;
 
   /** Entrance animation for newly shown children. */
   @property({ reflect: true }) animation: 'none' | 'fade' | 'fade-up' | 'fade-down' | 'fade-left' | 'fade-right' =
@@ -69,18 +84,25 @@ export default class WaRandomContent extends WebAwesomeElement {
 
   connectedCallback() {
     super.connectedCallback();
-    this.startInterval();
+    // Restart autoplay on reconnect; the initial start happens in firstUpdated().
+    if (this.hasUpdated) this.syncAutoplay();
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    this.stopInterval();
+    this.autoplayController.stop();
   }
 
-  @watch('interval', { waitUntilFirstUpdate: true })
-  handleIntervalChange() {
-    this.stopInterval();
-    this.startInterval();
+  firstUpdated(changedProperties: PropertyValues<this>) {
+    // The base class dispatches the initial `slotchange` here (an SSR workaround), which drives the
+    // first selection — so calling super is required for server-rendered content to render correctly.
+    super.firstUpdated(changedProperties);
+    this.syncAutoplay();
+  }
+
+  @watch(['autoplay', 'autoplayInterval'], { waitUntilFirstUpdate: true })
+  handleAutoplayChange() {
+    this.syncAutoplay();
   }
 
   @watch('mode', { waitUntilFirstUpdate: true })
@@ -97,10 +119,10 @@ export default class WaRandomContent extends WebAwesomeElement {
     this.randomize();
   }
 
-  /** Trigger a new selection using the current mode. */
-  randomize() {
+  /** Selects a new set of children using the current mode. Returns the elements now shown. */
+  randomize(): Element[] {
     const children = this.assignedChildren();
-    if (!children.length) return;
+    if (!children.length) return [];
 
     const count = Math.min(Math.max(1, this.items), children.length);
     let selected: Element[];
@@ -132,23 +154,27 @@ export default class WaRandomContent extends WebAwesomeElement {
       this.currentSelection = new Set(selected);
     }
 
+    const firstShown = selected[0];
+    const lastShown = selected[selected.length - 1];
     children.forEach(el => {
       const htmlEl = el as HTMLElement;
       const isSelected = selected.includes(el);
-      htmlEl.style.display = isSelected ? '' : 'none';
-      if (!isSelected) {
-        delete htmlEl.dataset['waAnimation'];
-      }
-      // Strip bottom margin from the last shown element so hidden siblings don't
-      // leave a phantom gap (e.g. <p> elements that aren't the last DOM child).
-      htmlEl.style.marginBlockEnd = isSelected && selected[selected.length - 1] === el ? '0' : '';
+      // Reset per-pick inline styles we own, so a previously promoted/hidden element is clean.
+      delete htmlEl.dataset['waAnimation'];
+      htmlEl.style.display = '';
+      htmlEl.hidden = !isSelected;
+      // Strip the leading/trailing block margins of the shown set so the hidden siblings don't leave
+      // a phantom gap (e.g. a <p> or <wa-callout> whose own margin would otherwise show before the
+      // first shown item or after the last). Items between keep their margins for spacing.
+      htmlEl.style.marginBlockStart = isSelected && el === firstShown ? '0' : '';
+      htmlEl.style.marginBlockEnd = isSelected && el === lastShown ? '0' : '';
     });
 
-    if (this.animation !== 'none') {
+    if (this.animation !== 'none' && !prefersReducedMotion()) {
       selected.forEach(el => {
         const htmlEl = el as HTMLElement;
-        // CSS transforms don't apply to display:inline elements. Upgrade to inline-block
-        // so directional animations work.
+        // CSS transforms don't apply to display:inline elements. Promote to inline-block so
+        // directional animations work. (An explicit display also keeps `hidden` overridable.)
         if (this.animation !== 'fade' && getComputedStyle(el).display === 'inline') {
           htmlEl.style.display = 'inline-block';
         }
@@ -158,17 +184,28 @@ export default class WaRandomContent extends WebAwesomeElement {
         htmlEl.addEventListener('animationend', () => delete htmlEl.dataset['waAnimation'], { once: true });
       });
     }
-  }
 
-  private startInterval() {
-    if (this.interval > 0) {
-      this.intervalId = setInterval(() => this.randomize(), this.interval);
+    // Announce the new content to screen readers — but not the initial render, which would be noise.
+    if (this.isInitialSelection) {
+      this.isInitialSelection = false;
+    } else {
+      this.liveAnnouncement = selected
+        .map(el => el.textContent?.trim())
+        .filter(Boolean)
+        .join(', ');
     }
+
+    this.dispatchEvent(new WaContentChangeEvent({ items: selected }));
+    return selected;
   }
 
-  private stopInterval() {
-    clearInterval(this.intervalId);
-    this.intervalId = undefined;
+  private syncAutoplay() {
+    this.autoplayController.stop();
+    // Reduced motion is handled by skipping the entrance animation (see randomize), not by stopping
+    // autoplay — matching <wa-carousel>, which keeps advancing but without the smooth transition.
+    if (this.autoplay && this.autoplayInterval > 0) {
+      this.autoplayController.start(this.autoplayInterval);
+    }
   }
 
   private assignedChildren(): Element[] {
@@ -176,7 +213,7 @@ export default class WaRandomContent extends WebAwesomeElement {
     return slot?.assignedElements() ?? [];
   }
 
-  // Fisher-Yates partial shuffle — picks `count` unique items from `pool`
+  // Fisher-Yates partial shuffle — picks `count` unique items from `pool`.
   private sample(pool: Element[], count: number): Element[] {
     const arr = [...pool];
     Array.from({ length: count }).forEach((_, i) => {
@@ -191,7 +228,10 @@ export default class WaRandomContent extends WebAwesomeElement {
   }
 
   render() {
-    return html`<slot @slotchange=${this.handleSlotChange}></slot>`;
+    return html`
+      <slot @slotchange=${this.handleSlotChange}></slot>
+      <div class="wa-visually-hidden" role="status" aria-live="polite" aria-atomic="true">${this.liveAnnouncement}</div>
+    `;
   }
 }
 

--- a/packages/webawesome/src/components/random-content/random-content.ts
+++ b/packages/webawesome/src/components/random-content/random-content.ts
@@ -62,6 +62,10 @@ export default class WaRandomContent extends WebAwesomeElement {
   private currentSelection = new Set<Element>();
   private isInitialSelection = true;
   private autoplayController = new AutoplayController(this, () => this.randomize());
+  // Tracks the pending "clear animation attribute" listener per child so rapid re-animation
+  // (e.g. fast autoplay) doesn't stack listeners — `cancel()` fires `animationcancel`, not the
+  // `animationend` the listener waits for, so it wouldn't otherwise be removed.
+  private animationCleanups = new WeakMap<Element, AbortController>();
 
   /** Text pushed to a visually-hidden live region so screen readers hear rotations. */
   @state() private liveAnnouncement = '';
@@ -86,11 +90,6 @@ export default class WaRandomContent extends WebAwesomeElement {
     super.connectedCallback();
     // Restart autoplay on reconnect; the initial start happens in firstUpdated().
     if (this.hasUpdated) this.syncAutoplay();
-  }
-
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this.autoplayController.stop();
   }
 
   firstUpdated(changedProperties: PropertyValues<this>) {
@@ -181,7 +180,14 @@ export default class WaRandomContent extends WebAwesomeElement {
         // Cancel any in-progress animation so the CSS animation restarts cleanly.
         el.getAnimations().forEach(a => a.cancel());
         htmlEl.dataset['waAnimation'] = this.animation;
-        htmlEl.addEventListener('animationend', () => delete htmlEl.dataset['waAnimation'], { once: true });
+        // Drop the previous (un-fired) listener before adding a new one so they don't accumulate.
+        this.animationCleanups.get(el)?.abort();
+        const cleanup = new AbortController();
+        this.animationCleanups.set(el, cleanup);
+        htmlEl.addEventListener('animationend', () => delete htmlEl.dataset['waAnimation'], {
+          once: true,
+          signal: cleanup.signal,
+        });
       });
     }
 

--- a/packages/webawesome/src/events/events.ts
+++ b/packages/webawesome/src/events/events.ts
@@ -23,6 +23,7 @@ export type { WaLazyChangeEvent } from './lazy-change.js';
 export type { WaLazyLoadEvent } from './lazy-load.js';
 export type { WaLoadEvent } from './load.js';
 export type { WaMutationEvent } from './mutation.js';
+export type { WaContentChangeEvent } from './random-content-change.js';
 export type { WaRemoveEvent } from './remove.js';
 export type { WaRepositionEvent } from './reposition.js';
 export type { WaResizeEvent } from './resize.js';

--- a/packages/webawesome/src/events/random-content-change.ts
+++ b/packages/webawesome/src/events/random-content-change.ts
@@ -1,0 +1,19 @@
+export class WaContentChangeEvent extends Event {
+  readonly detail: WaContentChangeEventDetails;
+
+  constructor(detail: WaContentChangeEventDetails) {
+    super('wa-content-change', { bubbles: true, cancelable: false, composed: true });
+    this.detail = detail;
+  }
+}
+
+interface WaContentChangeEventDetails {
+  /** The elements currently shown after the selection. */
+  items: Element[];
+}
+
+declare global {
+  interface GlobalEventHandlersEventMap {
+    'wa-content-change': WaContentChangeEvent;
+  }
+}


### PR DESCRIPTION
### Live Preview
https://webawesome-git-talbs-rando-calrissian-font-awesome.vercel.app/docs/components/random-content

---

Builds on #2513, refining the experimental `<wa-random-content>` component before it ships in the following ways...

### API
- Default `mode` is now `unique` (was `random`), so repeated selections don't show the same item twice in a row — the right default for tip rotators and timed loops.
- Replaced the single `interval` number with `autoplay` (Boolean) + `autoplay-interval` (ms), matching `<wa-carousel>`. Toggling `autoplay` doubles as the pause hook.
- Added a `wa-content-change` event (`detail.items`), emitted on first render, on `randomize()`, and on each autoplay tick. Follows the library's `wa-<noun>-change` convention (there is no bare `wa-change`).
- `randomize()` now returns the elements it selected.
- Unselected children are now hidden with the `hidden` attribute instead of inline `display:none`, exposing a `:not([hidden])` styling hook for the current item. A `::slotted([hidden]) { display: none !important }` rule keeps hiding reliable even when a child sets its own `display` (e.g. `.wa-flank`, a component's `:host`).

### Accessibility
- Autoplay now uses carousel's `AutoplayController`, so it pauses on hover, focus, and touch.
- Reduced motion skips the entrance animation but keeps autoplay running, matching `<wa-carousel>`'s behavior (motion is removed, content still advances).
- Added a visually-hidden `role="status"` live region (the `copy-button`/`textarea` pattern) so screen readers hear rotations.
- Documented that autoplay needs a visible pause control for keyboard users, since hover/focus pausing can't help when the rotating content isn't focusable.

### Fixes
- Call `super.firstUpdated()` — the base class dispatches the initial `slotchange` there as an SSR workaround, so skipping it left server-rendered content unselected. Caught by the `ssr-client-hydrated` test variant.
- Strip the leading *and* trailing block margins of the shown set (previously only the trailing one), so a shown `<p>`/`<wa-callout>` doesn't leave a phantom gap above or below the component.

### Docs
Rewrote `random-content.md` to follow our conventions and approachable structure: 

- Title-Case task-oriented headings in a logical order
-  the `<wa-divider>` example-control convention from carousel
- asset-free examples
- a modes comparison table
- notes for SSR (`wa-cloak`) and framework usage. 

### Tests
54 tests across CSR and SSR covering the new default, the event, autoplay pause/reduced-motion, attribute-based hiding (including children with their own `display`), the symmetric margin handling, and `randomize()`'s return value.