### PR TITLE
Add `wa-not-prose` to code examples

### DIFF
--- a/packages/webawesome/docs/_transformers/code-examples.js
+++ b/packages/webawesome/docs/_transformers/code-examples.js
@@ -151,7 +151,7 @@ export function codeExamplesTransformer(options = {}) {
             ${
               hasPreview
                 ? `
-              <div class="code-example-preview">
+              <div class="code-example-preview wa-not-prose">
                 <div>
                   ${preview}
                 </div>


### PR DESCRIPTION
Adds `wa-not-prose` to code example previews so that prose styling isn't applied by default. Prose styling can be added via wrapper with `class="wa-prose"` within the example code, such as [the examples in the Prose docs](https://webawesome.com/docs/utilities/prose/).

---

| Before | After |
| - | - |
| <img width="602" height="1026" alt="Screenshot 2026-06-24 at 5 09 03 PM" src="https://github.com/user-attachments/assets/685bee66-972e-47ba-a8c8-9fe627c0f8ea" /> | <img width="602" height="773" alt="Screenshot 2026-06-24 at 5 09 12 PM" src="https://github.com/user-attachments/assets/a30c43ed-b0da-48e9-b1d8-7d639d2638b8" /> |