### PR TITLE
Docs: Standardizing Example Controls

### DIFF
--- a/packages/webawesome/docs/docs/components/accordion.md
+++ b/packages/webawesome/docs/docs/components/accordion.md
@@ -270,17 +270,19 @@ To place HTML in an accordion item's header, use the `label` slot instead of the
 Use the `expandAll()` and `collapseAll()` methods to programmatically control all items at once. Note that `expandAll()` is a no-op when `mode` is `single` or `single-collapsible`.
 
 ```html {.example}
-<wa-accordion id="accordion-methods">
-  <wa-accordion-item label="Section one">Content for the first section.</wa-accordion-item>
-  <wa-accordion-item label="Section two">Content for the second section.</wa-accordion-item>
-  <wa-accordion-item label="Section three">Content for the third section.</wa-accordion-item>
-</wa-accordion>
+<div>
+  <wa-accordion id="accordion-methods">
+    <wa-accordion-item label="Section one">Content for the first section.</wa-accordion-item>
+    <wa-accordion-item label="Section two">Content for the second section.</wa-accordion-item>
+    <wa-accordion-item label="Section three">Content for the third section.</wa-accordion-item>
+  </wa-accordion>
 
-<br />
+  <wa-divider></wa-divider>
 
-<div class="wa-cluster">
-  <wa-button appearance="filled" id="expand-all">Expand All</wa-button>
-  <wa-button appearance="filled" id="collapse-all">Collapse All</wa-button>
+  <div class="wa-cluster">
+    <wa-button appearance="filled" id="expand-all">Expand All</wa-button>
+    <wa-button appearance="filled" id="collapse-all">Collapse All</wa-button>
+  </div>
 </div>
 
 <script>

--- a/packages/webawesome/docs/docs/components/animation.md
+++ b/packages/webawesome/docs/docs/components/animation.md
@@ -51,6 +51,8 @@ This example demonstrates all of the baked-in animations and easings. Animations
     <div class="box"></div>
   </wa-animation>
 
+  <wa-divider></wa-divider>
+
   <div class="controls">
     <wa-select label="Animation" value="bounce"></wa-select>
     <wa-select label="Easing" value="linear"></wa-select>
@@ -113,6 +115,8 @@ This example demonstrates all of the baked-in animations and easings. Animations
   <wa-animation name="bounce" easing="ease-in-out" duration="2000" play>
     <div class="box"></div>
   </wa-animation>
+
+  <wa-divider></wa-divider>
 
   <div class="controls">
     <wa-combobox label="Animation" placeholder="Select animation..."></wa-combobox>

--- a/packages/webawesome/docs/docs/components/carousel.md
+++ b/packages/webawesome/docs/docs/components/carousel.md
@@ -285,27 +285,24 @@ The `slides-per-page` attribute makes it possible to display multiple slides at 
 The content of the carousel can be changed by adding or removing carousel items. The carousel will update itself automatically.
 
 ```html {.example}
-<wa-carousel class="dynamic-carousel" pagination navigation>
-  <wa-carousel-item style="background: red">Slide 1</wa-carousel-item>
-  <wa-carousel-item style="background: orange">Slide 2</wa-carousel-item>
-  <wa-carousel-item style="background: yellow">Slide 3</wa-carousel-item>
-</wa-carousel>
+<div>
+  <wa-carousel class="dynamic-carousel" pagination navigation>
+    <wa-carousel-item style="background: red">Slide 1</wa-carousel-item>
+    <wa-carousel-item style="background: orange">Slide 2</wa-carousel-item>
+    <wa-carousel-item style="background: yellow">Slide 3</wa-carousel-item>
+  </wa-carousel>
 
-<div class="carousel-options">
-  <wa-button appearance="filled" id="dynamic-add">Add slide</wa-button>
-  <wa-button appearance="filled" id="dynamic-remove">Remove slide</wa-button>
+  <wa-divider></wa-divider>
+
+  <div class="wa-cluster">
+    <wa-button appearance="filled" id="dynamic-add">Add slide</wa-button>
+    <wa-button appearance="filled" id="dynamic-remove">Remove slide</wa-button>
+  </div>
 </div>
 
 <style>
   .dynamic-carousel {
     --aspect-ratio: 3 / 2;
-  }
-
-  .dynamic-carousel ~ .carousel-options {
-    display: flex;
-    justify-content: center;
-    gap: var(--wa-space-xs);
-    margin-top: var(--wa-space-l);
   }
 
   .dynamic-carousel wa-carousel-item {
@@ -414,46 +411,50 @@ Setting the `orientation` attribute to `vertical` will render the carousel in a 
 Use the `--aspect-ratio` custom property to customize the size of the carousel's viewport from the default value of 16/9.
 
 ```html {.example}
-<wa-carousel class="aspect-ratio" navigation pagination style="--aspect-ratio: 3/2;">
-  <wa-carousel-item>
-    <img
-      alt="The sun shines on the mountains and trees (by Adam Kool on Unsplash)"
-      src="https://images.unsplash.com/photo-1426604966848-d7adac402bff?q=10"
-    />
-  </wa-carousel-item>
-  <wa-carousel-item>
-    <img
-      alt="A river winding through an evergreen forest (by Luca Bravo on Unsplash)"
-      src="https://images.unsplash.com/photo-1473448912268-2022ce9509d8?q=10"
-    />
-  </wa-carousel-item>
-  <wa-carousel-item>
-    <img
-      alt="The sun is setting over a lavender field (by Leonard Cotte on Unsplash)"
-      src="https://images.unsplash.com/photo-1499002238440-d264edd596ec?q=10"
-    />
-  </wa-carousel-item>
-  <wa-carousel-item>
-    <img
-      alt="A field of grass with the sun setting in the background (by Sapan Patel on Unsplash)"
-      src="https://images.unsplash.com/photo-1475113548554-5a36f1f523d6?q=10"
-    />
-  </wa-carousel-item>
-  <wa-carousel-item>
-    <img
-      alt="A scenic view of a mountain with clouds rolling in (by V2osk on Unsplash)"
-      src="https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?q=10"
-    />
-  </wa-carousel-item>
-</wa-carousel>
+<div>
+  <wa-carousel class="aspect-ratio" navigation pagination style="--aspect-ratio: 3/2;">
+    <wa-carousel-item>
+      <img
+        alt="The sun shines on the mountains and trees (by Adam Kool on Unsplash)"
+        src="https://images.unsplash.com/photo-1426604966848-d7adac402bff?q=10"
+      />
+    </wa-carousel-item>
+    <wa-carousel-item>
+      <img
+        alt="A river winding through an evergreen forest (by Luca Bravo on Unsplash)"
+        src="https://images.unsplash.com/photo-1473448912268-2022ce9509d8?q=10"
+      />
+    </wa-carousel-item>
+    <wa-carousel-item>
+      <img
+        alt="The sun is setting over a lavender field (by Leonard Cotte on Unsplash)"
+        src="https://images.unsplash.com/photo-1499002238440-d264edd596ec?q=10"
+      />
+    </wa-carousel-item>
+    <wa-carousel-item>
+      <img
+        alt="A field of grass with the sun setting in the background (by Sapan Patel on Unsplash)"
+        src="https://images.unsplash.com/photo-1475113548554-5a36f1f523d6?q=10"
+      />
+    </wa-carousel-item>
+    <wa-carousel-item>
+      <img
+        alt="A scenic view of a mountain with clouds rolling in (by V2osk on Unsplash)"
+        src="https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?q=10"
+      />
+    </wa-carousel-item>
+  </wa-carousel>
 
-<wa-divider></wa-divider>
+  <wa-divider></wa-divider>
 
-<wa-select label="Aspect ratio" name="aspect" value="3/2">
-  <wa-option value="1/1">1/1</wa-option>
-  <wa-option value="3/2">3/2</wa-option>
-  <wa-option value="16/9">16/9</wa-option>
-</wa-select>
+  <div class="wa-cluster">
+    <wa-select label="Aspect ratio" name="aspect" value="3/2">
+      <wa-option value="1/1">1/1</wa-option>
+      <wa-option value="3/2">3/2</wa-option>
+      <wa-option value="16/9">16/9</wa-option>
+    </wa-select>
+  </div>
+</div>
 
 <script>
   (() => {

--- a/packages/webawesome/docs/docs/components/checkbox-group.md
+++ b/packages/webawesome/docs/docs/components/checkbox-group.md
@@ -69,23 +69,27 @@ Checkbox groups stack vertically by default. Set the `orientation` attribute to 
 The size of grouped checkboxes and switches is determined by the checkbox group's `size` attribute. Any `size` set on individual items will be overridden.
 
 ```html {.example}
-<wa-checkbox-group id="checkbox-group-size" label="Options" hint="Use the select below to change the size." size="m">
-  <wa-checkbox>Option 1</wa-checkbox>
-  <wa-checkbox>Option 2</wa-checkbox>
-  <wa-checkbox>Option 3</wa-checkbox>
-</wa-checkbox-group>
+<div>
+  <wa-checkbox-group id="checkbox-group-size" label="Options" hint="Use the select below to change the size." size="m">
+    <wa-checkbox>Option 1</wa-checkbox>
+    <wa-checkbox>Option 2</wa-checkbox>
+    <wa-checkbox>Option 3</wa-checkbox>
+  </wa-checkbox-group>
 
-<wa-select label="Size" value="m" style="max-width: 200px; margin-top: 2rem;">
-  <wa-option value="xs">Extra small</wa-option>
-  <wa-option value="s">Small</wa-option>
-  <wa-option value="m">Medium</wa-option>
-  <wa-option value="l">Large</wa-option>
-  <wa-option value="xl">Extra large</wa-option>
-</wa-select>
+  <wa-divider></wa-divider>
+
+  <wa-select label="Size" value="m" style="max-width: 200px;">
+    <wa-option value="xs">Extra small</wa-option>
+    <wa-option value="s">Small</wa-option>
+    <wa-option value="m">Medium</wa-option>
+    <wa-option value="l">Large</wa-option>
+    <wa-option value="xl">Extra large</wa-option>
+  </wa-select>
+</div>
 
 <script>
   const checkboxGroup = document.getElementById('checkbox-group-size');
-  const sizeSelect = checkboxGroup.nextElementSibling;
+  const sizeSelect = checkboxGroup.parentElement.querySelector('wa-select');
 
   sizeSelect.addEventListener('change', () => (checkboxGroup.size = sizeSelect.value));
 </script>

--- a/packages/webawesome/docs/docs/components/format-bytes.md
+++ b/packages/webawesome/docs/docs/components/format-bytes.md
@@ -14,7 +14,10 @@ use-cases:
 
 ```html {.example}
 <div class="format-bytes-overview">
-  The file is <wa-format-bytes value="1000"></wa-format-bytes> in size. <br /><br />
+  The file is <wa-format-bytes value="1000"></wa-format-bytes> in size.
+
+  <wa-divider></wa-divider>
+
   <wa-input type="number" value="1000" label="Number to Format" style="max-width: 180px;"></wa-input>
 </div>
 

--- a/packages/webawesome/docs/docs/components/format-number.md
+++ b/packages/webawesome/docs/docs/components/format-number.md
@@ -17,7 +17,9 @@ Localization is handled by the browser's [`Intl.NumberFormat` API](https://devel
 ```html {.example}
 <div class="format-number-overview">
   <wa-format-number value="1000"></wa-format-number>
-  <br /><br />
+
+  <wa-divider></wa-divider>
+
   <wa-input type="number" value="1000" label="Number to Format" style="max-width: 180px;"></wa-input>
 </div>
 

--- a/packages/webawesome/docs/docs/components/popup.md
+++ b/packages/webawesome/docs/docs/components/popup.md
@@ -27,20 +27,24 @@ Popup is a low-level utility built specifically for positioning elements. Do not
     <div class="box"></div>
   </wa-popup>
 
-  <div class="popup-overview-options">
-    <wa-combobox
-      label="Placement"
-      name="placement"
-      placeholder="Select placement..."
-      class="popup-overview-select"
-    ></wa-combobox>
-    <wa-input type="number" name="distance" label="distance" value="0"></wa-input>
-    <wa-input type="number" name="skidding" label="Skidding" value="0"></wa-input>
-  </div>
+  <wa-divider></wa-divider>
 
-  <div class="popup-overview-options">
-    <wa-switch name="active" checked>Active</wa-switch>
-    <wa-switch name="arrow">Arrow</wa-switch>
+  <div class="wa-cluster">
+    <div class="popup-overview-options">
+      <wa-combobox
+        label="Placement"
+        name="placement"
+        placeholder="Select placement..."
+        class="popup-overview-select"
+      ></wa-combobox>
+      <wa-input type="number" name="distance" label="distance" value="0"></wa-input>
+      <wa-input type="number" name="skidding" label="Skidding" value="0"></wa-input>
+    </div>
+
+    <div class="popup-overview-options">
+      <wa-switch name="active" checked>Active</wa-switch>
+      <wa-switch name="arrow">Arrow</wa-switch>
+    </div>
   </div>
 </div>
 
@@ -147,7 +151,8 @@ Popups are inactive and hidden until the `active` attribute is applied. Removing
     <div class="box"></div>
   </wa-popup>
 
-  <br />
+  <wa-divider></wa-divider>
+
   <wa-switch checked>Active</wa-switch>
 </div>
 
@@ -218,6 +223,8 @@ Since placement is preferred when using `flip`, you can observe the popup's curr
     <span slot="anchor"></span>
     <div class="box"></div>
   </wa-popup>
+
+  <wa-divider></wa-divider>
 
   <wa-combobox name="placement" label="Placement" placeholder="Select placement..."></wa-combobox>
 </div>
@@ -292,6 +299,8 @@ Use the `distance` attribute to change the distance between the popup and its an
     <div class="box"></div>
   </wa-popup>
 
+  <wa-divider></wa-divider>
+
   <wa-slider min="-50" max="50" step="1" value="0" label="Distance"></wa-slider>
 </div>
 
@@ -335,6 +344,8 @@ The `skidding` attribute is similar to `distance`, but instead allows you to off
     <span slot="anchor"></span>
     <div class="box"></div>
   </wa-popup>
+
+  <wa-divider></wa-divider>
 
   <wa-slider min="-50" max="50" step="1" value="0" label="Skidding"></wa-slider>
 </div>
@@ -382,24 +393,28 @@ By default, the arrow will be aligned as close to the center of the _anchor_ as 
     <div class="box"></div>
   </wa-popup>
 
-  <div class="popup-arrow-options">
-    <wa-combobox
-      label="Placement"
-      name="placement"
-      placeholder="Select placement..."
-      class="popup-overview-select"
-    ></wa-combobox>
+  <wa-divider></wa-divider>
 
-    <wa-select label="Arrow Placement" name="arrow-placement" value="anchor">
-      <wa-option value="anchor">anchor</wa-option>
-      <wa-option value="start">start</wa-option>
-      <wa-option value="end">end</wa-option>
-      <wa-option value="center">center</wa-option>
-    </wa-select>
-  </div>
+  <div class="wa-cluster">
+    <div class="popup-arrow-options">
+      <wa-combobox
+        label="Placement"
+        name="placement"
+        placeholder="Select placement..."
+        class="popup-overview-select"
+      ></wa-combobox>
 
-  <div class="popup-arrow-options">
-    <wa-switch name="arrow" checked>Arrow</wa-switch>
+      <wa-select label="Arrow Placement" name="arrow-placement" value="anchor">
+        <wa-option value="anchor">anchor</wa-option>
+        <wa-option value="start">start</wa-option>
+        <wa-option value="end">end</wa-option>
+        <wa-option value="center">center</wa-option>
+      </wa-select>
+    </div>
+
+    <div class="popup-arrow-options">
+      <wa-switch name="arrow" checked>Arrow</wa-switch>
+    </div>
   </div>
 
   <style>
@@ -494,6 +509,8 @@ When adding borders to the popup element which has an arrow, make sure to set th
     <span slot="anchor"></span>
     <div class="box"></div>
   </wa-popup>
+
+  <wa-divider></wa-divider>
 
   <div class="popup-border-options">
     <wa-combobox
@@ -658,7 +675,8 @@ Scroll the container to see how the popup flips to prevent clipping.
     </wa-popup>
   </div>
 
-  <br />
+  <wa-divider></wa-divider>
+
   <wa-switch checked>Flip</wa-switch>
 </div>
 
@@ -766,6 +784,8 @@ Toggle the switch to see the difference.
     </wa-popup>
   </div>
 
+  <wa-divider></wa-divider>
+
   <wa-switch checked>Shift</wa-switch>
 </div>
 
@@ -822,7 +842,8 @@ Scroll the container to see the popup resize as its available space changes.
     </wa-popup>
   </div>
 
-  <br />
+  <wa-divider></wa-divider>
+
   <wa-switch checked>Auto-size</wa-switch>
 </div>
 
@@ -876,10 +897,14 @@ When a gap exists between the anchor and the popup element, this option will add
     <span slot="anchor"></span>
     <div class="box"></div>
   </wa-popup>
-  <br />
-  <wa-switch checked>Hover Bridge</wa-switch><br />
-  <wa-slider min="0" max="50" step="1" value="10" label="Distance"></wa-slider>
-  <wa-slider min="-50" max="50" step="1" value="0" label="Skidding"></wa-slider>
+
+  <wa-divider></wa-divider>
+
+  <div class="wa-cluster">
+    <wa-switch checked>Hover Bridge</wa-switch>
+    <wa-slider min="0" max="50" step="1" value="10" label="Distance"></wa-slider>
+    <wa-slider min="-50" max="50" step="1" value="0" label="Skidding"></wa-slider>
+  </div>
 </div>
 <style>
   .popup-hover-bridge span[slot='anchor'] {
@@ -939,6 +964,8 @@ This example anchors a popup to the mouse cursor using a virtual element. As suc
   <wa-popup placement="right-start">
     <div class="circle"></div>
   </wa-popup>
+
+  <wa-divider></wa-divider>
 
   <wa-switch>Highlight mouse cursor</wa-switch>
 </div>

--- a/packages/webawesome/docs/docs/components/progress-bar.md
+++ b/packages/webawesome/docs/docs/components/progress-bar.md
@@ -42,7 +42,9 @@ Use the default slot to show a value.
 <div class="wa-stack">
   <wa-progress-bar value="50" id="progress-bar-demo">50%</wa-progress-bar>
 
-  <div>
+  <wa-divider></wa-divider>
+
+  <div class="wa-cluster">
     <wa-button pill appearance="filled">
       <wa-icon name="minus" label="Decrease"></wa-icon>
     </wa-button>

--- a/packages/webawesome/docs/docs/components/progress-ring.md
+++ b/packages/webawesome/docs/docs/components/progress-ring.md
@@ -54,17 +54,21 @@ To change the color, use the `--track-color` and `--indicator-color` custom prop
 Use the default slot to show a label inside the progress ring.
 
 ```html {.example}
-<wa-progress-ring value="50" class="progress-ring-values" style="margin-bottom: .5rem;">50%</wa-progress-ring>
+<div class="progress-ring-overview">
+  <wa-progress-ring value="50" class="progress-ring-values">50%</wa-progress-ring>
 
-<br />
+  <wa-divider></wa-divider>
 
-<wa-button appearance="filled" circle><wa-icon name="minus" variant="solid" label="Decrease"></wa-icon></wa-button>
-<wa-button appearance="filled" circle><wa-icon name="plus" variant="solid" label="Increase"></wa-icon></wa-button>
+  <div class="wa-cluster">
+    <wa-button appearance="filled" circle><wa-icon name="minus" variant="solid" label="Decrease"></wa-icon></wa-button>
+    <wa-button appearance="filled" circle><wa-icon name="plus" variant="solid" label="Increase"></wa-icon></wa-button>
+  </div>
+</div>
 
 <script>
   const progressRing = document.querySelector('.progress-ring-values');
-  const subtractButton = progressRing.nextElementSibling.nextElementSibling;
-  const addButton = subtractButton.nextElementSibling;
+  const subtractButton = document.querySelector('.progress-ring-overview wa-button:has(wa-icon[name="minus"])');
+  const addButton = document.querySelector('.progress-ring-overview wa-button:has(wa-icon[name="plus"])');
 
   addButton.addEventListener('click', () => {
     const value = Math.min(100, progressRing.value + 10);

--- a/packages/webawesome/docs/docs/components/qr-code.md
+++ b/packages/webawesome/docs/docs/components/qr-code.md
@@ -16,7 +16,8 @@ QR codes are useful for providing small pieces of information to users who can q
 ```html {.example}
 <div class="qr-overview">
   <wa-qr-code value="https://webawesome.com/" label="Scan this code to visit Web Awesome on the web!"></wa-qr-code>
-  <br />
+
+  <wa-divider></wa-divider>
 
   <wa-input maxlength="255" with-clear label="Value">
     <wa-icon slot="start" name="link"></wa-icon>

--- a/packages/webawesome/docs/docs/components/select.md
+++ b/packages/webawesome/docs/docs/components/select.md
@@ -365,7 +365,9 @@ Here's a comprehensive example showing different lazy loading scenarios:
       <wa-option value="bar">Bar</wa-option>
       <wa-option value="baz">Baz</wa-option>
     </wa-select>
-    <br />
+
+    <wa-divider></wa-divider>
+
     <wa-button appearance="filled" type="button">Add "foo" option</wa-button>
   </div>
 
@@ -373,7 +375,9 @@ Here's a comprehensive example showing different lazy loading scenarios:
 
   <div>
     <wa-select name="select-2" value="foo" label="Single select (with no existing options)"> </wa-select>
-    <br />
+
+    <wa-divider></wa-divider>
+
     <wa-button appearance="filled" type="button">Add "foo" option</wa-button>
   </div>
 
@@ -384,7 +388,9 @@ Here's a comprehensive example showing different lazy loading scenarios:
       <wa-option value="bar" selected>Bar</wa-option>
       <wa-option value="baz" selected>Baz</wa-option>
     </wa-select>
-    <br />
+
+    <wa-divider></wa-divider>
+
     <wa-button appearance="filled" type="button">Add "foo" option (selected)</wa-button>
   </div>
 
@@ -392,7 +398,9 @@ Here's a comprehensive example showing different lazy loading scenarios:
 
   <div>
     <wa-select name="select-4" value="foo" multiple label="Multiple Select (with no existing options)"> </wa-select>
-    <br />
+
+    <wa-divider></wa-divider>
+
     <wa-button appearance="filled" type="button">Add "foo" option</wa-button>
   </div>
 

--- a/packages/webawesome/docs/docs/components/split-panel.md
+++ b/packages/webawesome/docs/docs/components/split-panel.md
@@ -204,7 +204,9 @@ Try resizing the example below with each option and notice how the panels respon
     </div>
   </wa-split-panel>
 
-  <wa-select label="Primary Panel" style="max-width: 200px; margin-top: 1rem;">
+  <wa-divider></wa-divider>
+
+  <wa-select label="Primary Panel" style="max-width: 200px;">
     <wa-option value="" selected>None</wa-option>
     <wa-option value="start">Start</wa-option>
     <wa-option value="end">End</wa-option>

--- a/packages/webawesome/docs/docs/components/tooltip.md
+++ b/packages/webawesome/docs/docs/components/tooltip.md
@@ -107,14 +107,18 @@ Set the `trigger` attribute to `click` to toggle the tooltip on click instead of
 Tooltips can be controller programmatically by setting the `trigger` attribute to `manual`. Use the `open` attribute to control when the tooltip is shown.
 
 ```html {.example}
-<wa-button appearance="filled" style="margin-right: 4rem;">Toggle Manually</wa-button>
+<div class="manual-trigger-example">
+  <wa-tooltip for="manual-trigger-tooltip" trigger="manual" class="manual-tooltip">This is an avatar!</wa-tooltip>
+  <wa-avatar id="manual-trigger-tooltip" label="User"></wa-avatar>
 
-<wa-tooltip for="manual-trigger-tooltip" trigger="manual" class="manual-tooltip">This is an avatar!</wa-tooltip>
-<wa-avatar id="manual-trigger-tooltip" label="User"></wa-avatar>
+  <wa-divider></wa-divider>
+
+  <wa-button appearance="filled" class="manual-toggle">Toggle Manually</wa-button>
+</div>
 
 <script>
   const tooltip = document.querySelector('.manual-tooltip');
-  const toggle = tooltip.previousElementSibling;
+  const toggle = document.querySelector('.manual-toggle');
 
   toggle.addEventListener('click', () => (tooltip.open = !tooltip.open));
 </script>

--- a/packages/webawesome/docs/docs/components/tree.md
+++ b/packages/webawesome/docs/docs/components/tree.md
@@ -64,38 +64,40 @@ The `selection` attribute lets you change the selection behavior of the tree.
 - Use `leaf-multiple` to allow the selection of multiple leaf nodes.
 
 ```html {.example}
-<wa-select id="selection-mode" value="single" label="Selection">
-  <wa-option value="single">Single</wa-option>
-  <wa-option value="multiple">Multiple</wa-option>
-  <wa-option value="leaf">Leaf</wa-option>
-  <wa-option value="leaf-multiple">Leaf-multiple</wa-option>
-</wa-select>
-
-<br />
-
-<wa-tree class="tree-selectable">
-  <wa-tree-item expanded>
-    Electronics
+<div>
+  <wa-tree class="tree-selectable">
     <wa-tree-item expanded>
-      Computers
-      <wa-tree-item>Laptops</wa-tree-item>
-      <wa-tree-item>Desktops</wa-tree-item>
-      <wa-tree-item>Tablets</wa-tree-item>
+      Electronics
+      <wa-tree-item expanded>
+        Computers
+        <wa-tree-item>Laptops</wa-tree-item>
+        <wa-tree-item>Desktops</wa-tree-item>
+        <wa-tree-item>Tablets</wa-tree-item>
+      </wa-tree-item>
+      <wa-tree-item>
+        Phones
+        <wa-tree-item>Smartphones</wa-tree-item>
+        <wa-tree-item>Accessories</wa-tree-item>
+      </wa-tree-item>
     </wa-tree-item>
     <wa-tree-item>
-      Phones
-      <wa-tree-item>Smartphones</wa-tree-item>
-      <wa-tree-item>Accessories</wa-tree-item>
+      Clothing
+      <wa-tree-item>Shirts</wa-tree-item>
+      <wa-tree-item>Pants</wa-tree-item>
+      <wa-tree-item>Shoes</wa-tree-item>
     </wa-tree-item>
-  </wa-tree-item>
-  <wa-tree-item>
-    Clothing
-    <wa-tree-item>Shirts</wa-tree-item>
-    <wa-tree-item>Pants</wa-tree-item>
-    <wa-tree-item>Shoes</wa-tree-item>
-  </wa-tree-item>
-  <wa-tree-item>Books</wa-tree-item>
-</wa-tree>
+    <wa-tree-item>Books</wa-tree-item>
+  </wa-tree>
+
+  <wa-divider></wa-divider>
+
+  <wa-select id="selection-mode" value="single" label="Selection">
+    <wa-option value="single">Single</wa-option>
+    <wa-option value="multiple">Multiple</wa-option>
+    <wa-option value="leaf">Leaf</wa-option>
+    <wa-option value="leaf-multiple">Leaf-multiple</wa-option>
+  </wa-select>
+</div>
 
 <script>
   const selectionMode = document.querySelector('#selection-mode');


### PR DESCRIPTION
This work standardizes how component docs present examples that pair a live demo with separate controls, rolling out the convention established in the `<wa-random-content>` PR (#2547): 

- a `<wa-divider>` separates the demo from the controls that drive it
- multi-control rows align with `wa-cluster`, and control buttons normalize to `appearance="filled"`.

### What changed

14 component docs, covering every example where a demo is driven by *separate* controls:

- `popup` (12 examples — switches/sliders/comboboxes configuring the popup), `carousel`, `accordion`, `animation`, `checkbox-group`, `format-bytes`, `format-number`, `progress-bar`, `progress-ring`, `qr-code`, `select` (lazy-loading), `split-panel`, `tooltip`, `tree`.
- Multi-control rows use a bare `wa-cluster` (it centers by default — no inline alignment needed). Single controls sit directly after the divider.
- A few examples whose scripts located controls via `nextElementSibling` traversal were switched to scoped queries, since the new wrapper changes sibling order. Behavior is unchanged.

### What's intentionally excluded

The divider separates a *visible demo* from its controls, so examples without that shape are left alone: intrinsic triggers (`dialog`/`drawer`/`toast` "Open"/"Show" buttons with nothing persistent above them), and pages where the interactive element *is* the demo (`button`, `switch`, `select`, `slider`, etc.). `animation` keeps its divider but not `wa-cluster` — its controls have a deliberate fixed-width column layout.

## Companion PRs

-  https://github.com/shoelace-style/webawesome-pro/pull/246 — same convention across `chart`, `file-input`, and `video-playlist` docs (branch `talbs/example-control-sweep`).
