### PR TITLE
Add Agent-Orientation Note to `llms.txt`

### DIFF
--- a/packages/webawesome/scripts/llms.js
+++ b/packages/webawesome/scripts/llms.js
@@ -178,6 +178,12 @@ Constraint Validation API.
 
 Font Awesome is the default icon library, so \`<wa-icon name="...">\` values should reference Font Awesome
 icon names.
+
+For AI agents and coding assistants building with Web Awesome: two Agent Skills ship with the package. The
+\`webawesome\` skill is this component reference in progressive, on-demand form; the companion \`webawesome-design\`
+skill covers full-page layout (\`<wa-page>\`), theming, brand color, and visual composition. After installing
+\`@awesome.me/webawesome\`, register them with \`npx skills add ./node_modules/@awesome.me/webawesome/dist/skills/webawesome\`
+and \`npx skills add ./node_modules/@awesome.me/webawesome/dist/skills/webawesome-design\`. See ${baseUrl}/docs/ai/agent-skills for both.
 `.trim(),
   );
   lines.push('');


### PR DESCRIPTION
The build already generates a spec-formed `llms.txt` (per [llmstxt.org](https://llmstxt.org): `H1` → blockquote → `## Documentation` / `## Components` link sections, with the full per-component API under a skippable `## Optional`). 

Prompted by https://github.com/shoelace-style/webawesome-app/pull/394#discussion_r3467388965, this adds a short paragraph to its intro that orients AI agents and coding assistants to the two **Web Awesome Agent Skills** we ship — so an agent reading `llms.txt` while building UI learns the skills exist and how to install them.

### What changed
`scripts/llms.js` — a paragraph appended to the generated overview block, between the Font Awesome note and `## Documentation`, naming both skills and their install commands:

> For AI agents and coding assistants building with Web Awesome: two Agent Skills ship with the package. The `webawesome` skill is this component reference in progressive, on-demand form; the companion `webawesome-design` skill covers full-page layout (`<wa-page>`), theming, brand color, and visual composition. After installing `@awesome.me/webawesome`, register them with `npx skills add ./node_modules/@awesome.me/webawesome/dist/skills/webawesome` and `npx skills add ./node_modules/@awesome.me/webawesome/dist/skills/webawesome-design`. See https://webawesome.com/docs/ai/agent-skills for both.

This mirrors the cross-reference the `webawesome` skill already emits about `webawesome-design`, and links the canonical [Agent Skills](https://webawesome.com/docs/ai/agent-skills) page. Output flows to both `dist-cdn/llms.txt` and `dist/llms.txt` as before.

## Companion PRs
- https://github.com/shoelace-style/webawesome-app/pull/398 — serves this file at the site root
