### PR TITLE
Docs: Suppressing Canonical Link on `noindex` Pages

### DIFF
--- a/packages/webawesome/docs/_includes/head.njk
+++ b/packages/webawesome/docs/_includes/head.njk
@@ -5,10 +5,9 @@
 
 <title>{{ pageTitle }}</title>
 
-<link rel="canonical" href="{{ ogUrl }}" />
-
-{# Skip OG tags for noindex pages to prevent social sharing #}
+{# Skip canonical + OG on noindex: permalinked templates leak the template path as ogUrl. #}
 {% if not noindex %}
+  <link rel="canonical" href="{{ ogUrl }}" />
   <meta property="og:type" content="{{ ogType }}" />
   <meta property="og:url" content="{{ ogUrl }}" />
   <meta property="og:title" content="{{ ogTitle }}" />


### PR DESCRIPTION
This work moves `<link rel="canonical">` inside the existing `{% if not noindex %}` guard in `_includes/head.njk` so noindex pages stop emitting a canonical alongside the OG tags they already suppress. Follow-up to https://github.com/shoelace-style/webawesome/pull/2545.

### Why
Canonical on a noindex'd page is redundant at best and misleading at worst.

### Inside the Core repo
The only `noindex` pages in `docs/` are `404.md` and `503.md`. Both stop emitting canonical, which is the desired outcome.

## Companion PRs
- https://github.com/shoelace-style/webawesome-app/pull/400 — flips the matching `/claim` test assertion