### PR TITLE
Update `<wa-icon>` for Font Awesome `7.3.0` + Docs Overhaul

### DIFF
--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -565,3 +565,9 @@ wa-scroller:has(.component-table) {
 #content .hosted-project-instructions table {
   margin-block: 0;
 }
+
+/* Icon docs: copy-button-wrapped icon previews. The copy button hosts a quiet
+   neutral color; reset it so the slotted icons match a default wa-icon. */
+#content .icon-copy-row wa-copy-button {
+  color: inherit;
+}

--- a/packages/webawesome/docs/docs/components/icon.md
+++ b/packages/webawesome/docs/docs/components/icon.md
@@ -13,34 +13,74 @@ use-cases:
   - navigation icon
 ---
 
-Web Awesome comes bundled with over 2,000 free icons courtesy of [Font Awesome](https://fontawesome.com/). These icons are part of the `default` icon library. Font Awesome Pro users can unlock additional icon families. Or, if you prefer, you can register your own [custom icon library](#icon-library).
+Web Awesome comes bundled with over 2,000 free icons courtesy of [Font Awesome](https://fontawesome.com/). These icons are part of the `default` icon library. Font Awesome Pro users can unlock additional [icon families](#families-and-variants). Or, if you prefer, you can register your own [custom icon library](#third-party-icon-libraries).
 
 ```html {.example}
-<wa-icon name="star" label="Star" style="font-size: 2em;"></wa-icon>
-```
-
-:::info
-Not sure which icon to use? [Find the perfect icon over at {{ site.siblings.fontAwesome.name }}!](https://fontawesome.com/search?o=r&m=free&f=brands%2Cclassic)
-:::
-
-## Examples
-
-### Sizing
-
-Icons are sized relative to the current font size. To change their size, set the `font-size` property on the icon itself or on a parent element as shown below.
-
-```html {.example}
-<div class="wa-cluster" style="font-size: 44px;">
-  <wa-icon name="bell"></wa-icon>
-  <wa-icon name="heart"></wa-icon>
-  <wa-icon name="image"></wa-icon>
-  <wa-icon name="microphone"></wa-icon>
-  <wa-icon name="search"></wa-icon>
-  <wa-icon name="star"></wa-icon>
+<div class="wa-cluster" style="font-size: 2em;">
+  <wa-icon name="star" label="Star"></wa-icon>
+  <wa-icon name="heart" label="Heart"></wa-icon>
+  <wa-icon name="bell" label="Bell"></wa-icon>
+  <wa-icon name="cloud" label="Cloud"></wa-icon>
+  <wa-icon name="camera" label="Camera"></wa-icon>
+  <wa-icon name="rocket" label="Rocket"></wa-icon>
+  <wa-icon name="face-smile" label="Smile"></wa-icon>
+  <wa-icon name="paw" label="Paw"></wa-icon>
 </div>
 ```
 
-### Colors
+<wa-callout variant="brand">
+  <wa-icon slot="icon" family="brands" name="font-awesome"></wa-icon>
+  Not sure which icon to use?
+  <a href="https://fontawesome.com/search?o=r&m=free&f=brands%2Cclassic">Find the perfect icon over at {{ site.siblings.fontAwesome.name }}!</a>
+</wa-callout>
+
+## Sizing
+
+Icons are sized relative to the current font size. To change their size, set the `font-size` property on the icon itself or on a parent element — drag the slider to see it in action.
+
+```html {.example}
+<div class="icon-sizing">
+  <div class="wa-cluster icon-sizing-preview" style="font-size: 2rem;">
+    <wa-icon name="bell"></wa-icon>
+    <wa-icon name="heart"></wa-icon>
+    <wa-icon name="image"></wa-icon>
+    <wa-icon name="microphone"></wa-icon>
+    <wa-icon name="search"></wa-icon>
+    <wa-icon name="star"></wa-icon>
+  </div>
+
+  <wa-divider></wa-divider>
+
+  <wa-slider label="Font size" min="0" max="4" value="2" with-markers>
+    <span slot="reference">1rem</span>
+    <span slot="reference">1.5rem</span>
+    <span slot="reference">2rem</span>
+    <span slot="reference">3rem</span>
+    <span slot="reference">4rem</span>
+  </wa-slider>
+</div>
+
+<style>
+  .icon-sizing-preview {
+    min-height: 6rem;
+    align-items: center;
+    justify-content: center;
+    margin-block-end: 1.5rem;
+  }
+</style>
+
+<script>
+  (() => {
+    const container = document.querySelector('.icon-sizing');
+    const preview = container.querySelector('.icon-sizing-preview');
+    const slider = container.querySelector('wa-slider');
+    const sizes = ['1rem', '1.5rem', '2rem', '3rem', '4rem'];
+    slider.addEventListener('input', () => (preview.style.fontSize = sizes[slider.value]));
+  })();
+</script>
+```
+
+## Colors
 
 Icons inherit their color from the current text color. Thus, you can set the `color` property on the `<wa-icon>` element or an ancestor to change the color.
 
@@ -55,145 +95,305 @@ Icons inherit their color from the current text color. Thus, you can set the `co
 </div>
 ```
 
-### Labels
+## Families & Variants
 
-For non-decorative icons, use the `label` attribute to announce it to assistive devices.
+A _family_ sets an icon's overall style; a _variant_ sets its weight. Set them with the `family` and `variant` attributes — `family` defaults to `classic` and `variant` to `solid`.
+
+<table>
+  <thead>
+    <tr>
+      <th>Family</th>
+      <th>Variants</th>
+      <th>Plan</th>
+      <th>Preview</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>classic</code></td>
+      <td><code>solid</code>, <code>regular</code>, <code>light</code>, <code>thin</code></td>
+      <td>Free</td>
+      <td>
+        <div class="wa-cluster icon-copy-row" style="font-size: 1.25em; gap: 0.75rem; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;gem&quot;></wa-icon>"><wa-icon variant="solid" name="gem"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon variant=&quot;regular&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon variant="regular" name="gem"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon variant=&quot;light&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon variant="light" name="gem"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon variant=&quot;thin&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon variant="thin" name="gem"></wa-icon></wa-copy-button>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td><code>brands</code></td>
+      <td>—</td>
+      <td>Free</td>
+      <td>
+        <div class="wa-cluster icon-copy-row" style="font-size: 1.25em; gap: 0.75rem; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;brands&quot; name=&quot;font-awesome&quot;></wa-icon>"><wa-icon family="brands" name="font-awesome"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;brands&quot; name=&quot;github&quot;></wa-icon>"><wa-icon family="brands" name="github"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;brands&quot; name=&quot;discord&quot;></wa-icon>"><wa-icon family="brands" name="discord"></wa-icon></wa-copy-button>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td><code>duotone</code></td>
+      <td><code>solid</code>, <code>regular</code>, <code>light</code>, <code>thin</code></td>
+      <td>Pro</td>
+      <td>
+        <div class="wa-cluster icon-copy-row" style="font-size: 1.25em; gap: 0.75rem; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;duotone&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="duotone" variant="solid" name="gem"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;duotone&quot; variant=&quot;regular&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="duotone" variant="regular" name="gem"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;duotone&quot; variant=&quot;light&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="duotone" variant="light" name="gem"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;duotone&quot; variant=&quot;thin&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="duotone" variant="thin" name="gem"></wa-icon></wa-copy-button>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td><code>sharp</code></td>
+      <td><code>solid</code>, <code>regular</code>, <code>light</code>, <code>thin</code></td>
+      <td>Pro</td>
+      <td>
+        <div class="wa-cluster icon-copy-row" style="font-size: 1.25em; gap: 0.75rem; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="sharp" variant="solid" name="gem"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp&quot; variant=&quot;regular&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="sharp" variant="regular" name="gem"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp&quot; variant=&quot;light&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="sharp" variant="light" name="gem"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp&quot; variant=&quot;thin&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="sharp" variant="thin" name="gem"></wa-icon></wa-copy-button>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td><code>sharp-duotone</code></td>
+      <td><code>solid</code>, <code>regular</code>, <code>light</code>, <code>thin</code></td>
+      <td>Pro</td>
+      <td>
+        <div class="wa-cluster icon-copy-row" style="font-size: 1.25em; gap: 0.75rem; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp-duotone&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="sharp-duotone" variant="solid" name="gem"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp-duotone&quot; variant=&quot;regular&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="sharp-duotone" variant="regular" name="gem"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp-duotone&quot; variant=&quot;light&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="sharp-duotone" variant="light" name="gem"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp-duotone&quot; variant=&quot;thin&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="sharp-duotone" variant="thin" name="gem"></wa-icon></wa-copy-button>
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<wa-callout variant="brand">
+  <wa-icon slot="icon" family="brands" name="font-awesome"></wa-icon>
+  The <code>light</code> and <code>thin</code> variants, the <code>sharp</code>, <code>duotone</code>, and
+  <code>sharp-duotone</code> families, and the <a href="#font-awesome-pro-icons">Pro+ packs</a> require a Font Awesome Pro
+  plan. <a href="/docs/#using-font-awesome-kit-codes">Provide a Kit code</a> to unlock them.
+</wa-callout>
+
+## Canvas
+
+The _canvas_ is the box an icon sits in. Choose one of four mutually exclusive modes with the `canvas` attribute (the default is `fixed`). It mirrors [{{ site.siblings.fontAwesome.name }}'s icon canvas](https://docs.fontawesome.com/web/style/icon-canvas/) and scales with `font-size`, independent of [sizing](#sizing). The tinted box below shows each canvas's extent.
+
+<table>
+  <thead>
+    <tr>
+      <th>Canvas</th>
+      <th>Box</th>
+      <th>Best For</th>
+      <th>Example</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>fixed</code></td>
+      <td><code>1.25 × 1em</code></td>
+      <td>Aligning icons in lists, menus, and toolbars</td>
+      <td>
+        <div class="wa-cluster icon-copy-row" style="font-size: 1.75em; align-items: center; justify-content: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;bookmark&quot;></wa-icon>"><wa-icon name="bookmark" style="background: var(--wa-color-brand-fill-quiet);"></wa-icon></wa-copy-button>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td><code>auto</code></td>
+      <td><code>auto × 1em</code></td>
+      <td>Matching the icon's natural width</td>
+      <td>
+        <div class="wa-cluster icon-copy-row" style="font-size: 1.75em; align-items: center; justify-content: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;bookmark&quot; canvas=&quot;auto&quot;></wa-icon>"><wa-icon name="bookmark" canvas="auto" style="background: var(--wa-color-brand-fill-quiet);"></wa-icon></wa-copy-button>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td><code>square</code></td>
+      <td><code>1.25 × 1.25em</code></td>
+      <td>Standalone icons on a square footprint</td>
+      <td>
+        <div class="wa-cluster icon-copy-row" style="font-size: 1.75em; align-items: center; justify-content: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;bookmark&quot; canvas=&quot;square&quot;></wa-icon>"><wa-icon name="bookmark" canvas="square" style="background: var(--wa-color-brand-fill-quiet);"></wa-icon></wa-copy-button>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td><code>roomy</code></td>
+      <td><code>1.5 × 1.5em</code></td>
+      <td>Standalone icons that need more breathing room</td>
+      <td>
+        <div class="wa-cluster icon-copy-row" style="font-size: 1.75em; align-items: center; justify-content: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;bookmark&quot; canvas=&quot;roomy&quot;></wa-icon>"><wa-icon name="bookmark" canvas="roomy" style="background: var(--wa-color-brand-fill-quiet);"></wa-icon></wa-copy-button>
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 ```html {.example}
-<wa-icon name="star" label="Favorite" style="font-size: 1.5em;"></wa-icon>
-```
-
-### Families & Variants
-
-The default icon library is Font Awesome Free, which comes with two icon families: `classic` and `brands`. Use the `family` attribute to set the icon family.
-
-Many Font Awesome Pro icon families have variants such as `thin`, `light`, `regular`, and `solid`. Font Awesome Pro users can [provide their kit code](/docs/#using-font-awesome-kit-codes) to unlock additional premium icon families, including `sharp`, `duotone`, `sharp-duotone`, and additional Pro+ icon packs.
-
-For families that support multiple weights, use the `variant` attribute to set the variant.
-
-```html {.example}
-<div class="wa-stack wa-gap-xl">
-  <div class="wa-flank" style="--flank-size: 12ch;">
-    <span>Classic</span>
-    <div class="wa-cluster" style="font-size: 1.5em;">
-      <wa-icon name="eyedropper"></wa-icon>
-      <wa-icon variant="regular" name="grip-vertical"></wa-icon>
-      <wa-icon variant="light" name="play"></wa-icon>
-      <wa-icon variant="thin" name="star"></wa-icon>
-    </div>
+<div class="canvas-demo">
+  <div class="canvas-demo-preview wa-cluster">
+    <wa-icon name="ruler-horizontal" style="background: var(--wa-color-brand-fill-quiet);"></wa-icon>
+    <wa-icon name="ruler-vertical" style="background: var(--wa-color-brand-fill-quiet);"></wa-icon>
+    <wa-icon name="face-smile" style="background: var(--wa-color-brand-fill-quiet);"></wa-icon>
   </div>
-  <div class="wa-flank" style="--flank-size: 12ch;">
-    <span>Duotone</span>
-    <div class="wa-cluster" style="font-size: 1.5em;">
-      <wa-icon family="duotone" name="eyedropper"></wa-icon>
-      <wa-icon family="duotone" variant="regular" name="grip-vertical"></wa-icon>
-      <wa-icon family="duotone" variant="light" name="play"></wa-icon>
-      <wa-icon family="duotone" variant="thin" name="star"></wa-icon>
-    </div>
-  </div>
-  <div class="wa-flank" style="--flank-size: 12ch;">
-    <span>Sharp</span>
-    <div class="wa-cluster" style="font-size: 1.5em;">
-      <wa-icon family="sharp" name="eyedropper"></wa-icon>
-      <wa-icon family="sharp" variant="regular" name="grip-vertical"></wa-icon>
-      <wa-icon family="sharp" variant="light" name="play"></wa-icon>
-      <wa-icon family="sharp" variant="thin" name="star"></wa-icon>
-    </div>
-  </div>
-  <div class="wa-flank" style="--flank-size: 12ch;">
-    <span>Sharp Duotone</span>
-    <div class="wa-cluster" style="font-size: 1.5em;">
-      <wa-icon family="sharp-duotone" name="eyedropper"></wa-icon>
-      <wa-icon family="sharp-duotone" variant="regular" name="grip-vertical"></wa-icon>
-      <wa-icon family="sharp-duotone" variant="light" name="play"></wa-icon>
-      <wa-icon family="sharp-duotone" variant="thin" name="star"></wa-icon>
-    </div>
-  </div>
-  <div class="wa-flank" style="--flank-size: 12ch;">
-    <span>Brands</span>
-    <div class="wa-cluster" style="font-size: 1.5em;">
-      <wa-icon family="brands" name="font-awesome"></wa-icon>
-      <wa-icon family="brands" name="web-awesome"></wa-icon>
-      <wa-icon family="brands" name="github"></wa-icon>
-      <wa-icon family="brands" name="discord"></wa-icon>
-    </div>
+
+  <wa-divider></wa-divider>
+
+  <div class="wa-cluster wa-gap-xl" style="align-items: start;">
+    <wa-select label="Canvas" name="canvas" value="fixed">
+      <wa-option value="fixed">fixed</wa-option>
+      <wa-option value="auto">auto</wa-option>
+      <wa-option value="square">square</wa-option>
+      <wa-option value="roomy">roomy</wa-option>
+    </wa-select>
+    <wa-slider label="Size" min="0" max="4" value="2" with-markers style="flex: 1 1 14rem;">
+      <span slot="reference">1.5rem</span>
+      <span slot="reference">2rem</span>
+      <span slot="reference">3rem</span>
+      <span slot="reference">4rem</span>
+      <span slot="reference">5rem</span>
+    </wa-slider>
   </div>
 </div>
+
+<style>
+  .canvas-demo-preview {
+    margin-block-end: 1.5rem;
+    font-size: 3rem;
+  }
+</style>
+
+<script>
+  (() => {
+    const demo = document.querySelector('.canvas-demo');
+    const preview = demo.querySelector('.canvas-demo-preview');
+    const icons = preview.querySelectorAll('wa-icon');
+    const sizes = ['1.5rem', '2rem', '3rem', '4rem', '5rem'];
+
+    demo.querySelector('wa-select[name="canvas"]').addEventListener('change', event => {
+      icons.forEach(icon => (icon.canvas = event.target.value));
+    });
+    demo.querySelector('wa-slider').addEventListener('input', event => {
+      preview.style.fontSize = sizes[event.target.value];
+    });
+  })();
+</script>
 ```
 
-### Auto Width
+:::info
+The `auto-width` attribute still works but is deprecated — prefer `canvas="auto"`, which renders the same way.
+:::
 
-By default, icons have a `1em` height and a fixed `1.25em` width. Use the `auto-width` attribute to allow the icon to use its natural variable width.
+## Rotating & Flipping
 
-```html {.example}
-Without auto-width<br />
-<div style="font-size: 1.5em; color: #193154;">
-  <wa-icon family="solid" name="exclamation" style="background: lightsalmon;"></wa-icon>
-  <wa-icon family="solid" name="circle-check" style="background: lightsalmon;"></wa-icon>
-  <wa-icon family="solid" name="magnifying-glass" style="background: lightsalmon;"></wa-icon>
-  <wa-icon family="solid" name="ruler-vertical" style="background: lightsalmon;"></wa-icon>
-  <wa-icon family="solid" name="ruler-horizontal" style="background: lightsalmon;"></wa-icon>
-  <wa-icon family="solid" name="envelope" style="background: lightsalmon;"></wa-icon>
-</div>
+Web Awesome supports [{{ site.siblings.fontAwesome.name }}'s rotation and flip utilities](https://docs.fontawesome.com/web/style/rotate/) for adjusting icon orientation. Use the `rotate` attribute to turn an icon by **any** number of degrees — not just the quarter-turns below — and the `flip` attribute to mirror it across the `x`, `y`, or `both` axes.
 
-<br />
+<table>
+  <thead>
+    <tr>
+      <th>Attribute</th>
+      <th>Value</th>
+      <th>Preview</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>rotate</code></td>
+      <td><code>90</code></td>
+      <td>
+        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;hand-point-up&quot; rotate=&quot;90&quot;></wa-icon>"><wa-icon name="hand-point-up" rotate="90"></wa-icon></wa-copy-button>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td><code>rotate</code></td>
+      <td><code>180</code></td>
+      <td>
+        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;hand-point-up&quot; rotate=&quot;180&quot;></wa-icon>"><wa-icon name="hand-point-up" rotate="180"></wa-icon></wa-copy-button>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td><code>rotate</code></td>
+      <td><code>270</code></td>
+      <td>
+        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;hand-point-up&quot; rotate=&quot;270&quot;></wa-icon>"><wa-icon name="hand-point-up" rotate="270"></wa-icon></wa-copy-button>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td><code>flip</code></td>
+      <td><code>x</code></td>
+      <td>
+        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;hand-point-up&quot; flip=&quot;x&quot;></wa-icon>"><wa-icon name="hand-point-up" flip="x"></wa-icon></wa-copy-button>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td><code>flip</code></td>
+      <td><code>y</code></td>
+      <td>
+        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;hand-point-up&quot; flip=&quot;y&quot;></wa-icon>"><wa-icon name="hand-point-up" flip="y"></wa-icon></wa-copy-button>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td><code>flip</code></td>
+      <td><code>both</code></td>
+      <td>
+        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;hand-point-up&quot; flip=&quot;both&quot;></wa-icon>"><wa-icon name="hand-point-up" flip="both"></wa-icon></wa-copy-button>
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
-With auto-width<br />
-<div style="font-size: 1.5em; color: #193154;">
-  <wa-icon auto-width family="solid" name="exclamation" style="background: lightsalmon;"></wa-icon>
-  <wa-icon auto-width family="solid" name="circle-check" style="background: lightsalmon;"></wa-icon>
-  <wa-icon auto-width family="solid" name="magnifying-glass" style="background: lightsalmon;"></wa-icon>
-  <wa-icon auto-width family="solid" name="ruler-vertical" style="background: lightsalmon;"></wa-icon>
-  <wa-icon auto-width family="solid" name="ruler-horizontal" style="background: lightsalmon;"></wa-icon>
-  <wa-icon auto-width family="solid" name="envelope" style="background: lightsalmon;"></wa-icon>
-</div>
-```
-
-### Rotating & Flipping
-
-Web Awesome supports [{{ site.siblings.fontAwesome.name }}'s rotation and flip utilities](https://docs.fontawesome.com/web/style/rotate/) for adjusting icon orientation. To rotate or flip icons, use the `rotate` and `flip` attributes when you reference an icon.
+Rotate by any angle — and combine `rotate` and `flip` on the same icon:
 
 ```html {.example}
 <wa-icon name="snowboarding" label="Snowboarding" style="font-size: 2em;"></wa-icon>
-<wa-icon name="snowboarding" rotate="90" label="Snowboarding" style="font-size: 2em;"></wa-icon>
-<wa-icon name="snowboarding" rotate="180" label="Snowboarding" style="font-size: 2em;"></wa-icon>
+<wa-icon name="snowboarding" rotate="45" label="Snowboarding" style="font-size: 2em;"></wa-icon>
+<wa-icon name="snowboarding" rotate="135" label="Snowboarding" style="font-size: 2em;"></wa-icon>
 <wa-icon name="snowboarding" rotate="270" label="Snowboarding" style="font-size: 2em;"></wa-icon>
-<wa-icon name="snowboarding" flip="x" label="Snowboarding" style="font-size: 2em;"></wa-icon>
-<wa-icon name="snowboarding" flip="y" label="Snowboarding" style="font-size: 2em;"></wa-icon>
 <wa-icon name="snowboarding" flip="both" label="Snowboarding" style="font-size: 2em;"></wa-icon>
+<wa-icon name="snowboarding" rotate="45" flip="x" label="Snowboarding" style="font-size: 2em;"></wa-icon>
 ```
 
-### Animating
+## Animating
 
 Web Awesome supports [{{ site.siblings.fontAwesome.name }}'s animation utilities](https://docs.fontawesome.com/web/style/animate/) for adding visual interest to icons. To select different types of animations, use the `animation` attribute when you reference an icon.
 
-:::info
-All [icon animations respect](https://docs.fontawesome.com/web/style/animate/#accessibility) `prefers-reduced-motion` and are automatically disabled when set to `reduce`.
-:::
+Every animation accepts the same timing controls — `--animation-delay`, `--animation-direction`, `--animation-duration`, `--animation-iteration-count`, and `--animation-timing` — plus the animation-specific custom properties shown in each example below. All animations respect `prefers-reduced-motion` (see [Accessibility Considerations](#accessibility-considerations)).
 
-#### Beat
+### Beat
 
 Use the `beat` animation to scale an icon up or down. This is useful for grabbing attention or for use with health/heart-centric icons.
 
 ```html {.example}
-<wa-icon name="circle-plus" animation="beat" label="Beating Circle Plus" style="font-size: 2em;"></wa-icon>
 <wa-icon name="heart" animation="beat" label="Beating Heart" style="font-size: 2em;"></wa-icon>
-<wa-icon
-  name="heart"
-  animation="beat"
-  label="Beating Heart"
-  style="font-size: 2em; --animation-duration: 0.5s;"
-></wa-icon>
-<wa-icon
-  name="heart"
-  animation="beat"
-  label="Beating Heart"
-  style="font-size: 2em; --animation-duration: 2s;"
-></wa-icon>
+<wa-icon name="circle-plus" animation="beat" label="Beating Circle Plus" style="font-size: 2em;"></wa-icon>
+<!-- Use --beat-scale to control how far it grows -->
 <wa-icon name="heart" animation="beat" label="Beating Heart" style="font-size: 2em; --beat-scale: 2;"></wa-icon>
 ```
 
-#### Fade
+### Fade
 
 Use the `fade` animation to fade an icon in and out visually to grab attention in a subtle (or not so subtle) way.
 
@@ -209,7 +409,7 @@ Use the `fade` animation to fade an icon in and out visually to grab attention i
 ></wa-icon>
 ```
 
-#### Beat-Fade
+### Beat-Fade
 
 Use the `beat-fade` animation to grab attention by visually scaling and pulsing an icon in and out.
 
@@ -217,9 +417,9 @@ Use the `beat-fade` animation to grab attention by visually scaling and pulsing 
 <wa-icon name="person-digging" animation="beat-fade" label="Beat-Fading Construction" style="font-size: 2em;"></wa-icon>
 <wa-icon name="circle-exclamation" animation="beat-fade" label="Beat-Fading Alert" style="font-size: 2em;"></wa-icon>
 <wa-icon
-  name="poo-bolt"
+  name="square-exclamation"
   animation="beat-fade"
-  label="Beat-Fading Lightning"
+  label="Beat-Fading Alert"
   style="font-size: 2em; --beat-fade-opacity: 0.1;--beat-fade-scale: 1.25"
 ></wa-icon>
 <wa-icon
@@ -230,7 +430,7 @@ Use the `beat-fade` animation to grab attention by visually scaling and pulsing 
 ></wa-icon>
 ```
 
-#### Bounce
+### Bounce
 
 Use the `bounce` animation to grab attention by visually bouncing an icon up and down.
 
@@ -262,7 +462,7 @@ Use the `bounce` animation to grab attention by visually bouncing an icon up and
 ></wa-icon>
 ```
 
-#### Flip
+### Flip
 
 Use the `flip` animation to rotate an icon in 3D space. By default, flip rotates an icon about the Y axis 180 degrees. Flipping is helpful for transitions, processing states, or for using physical objects that one flips in the real world.
 
@@ -284,7 +484,28 @@ Use the `flip` animation to rotate an icon in 3D space. By default, flip rotates
 ></wa-icon>
 ```
 
-#### Shake
+### Flip 360
+
+Use the `flip-360` animation to flip an icon all the way around in one smooth rotation — an extension of `flip` that gives it some extra oomph. It shares the same `--flip-x`, `--flip-y`, and `--flip-z` axis properties.
+
+```html {.example}
+<wa-icon name="compact-disc" animation="flip-360" label="Flipping Compact Disc" style="font-size: 2em;"></wa-icon>
+<wa-icon name="camera-rotate" animation="flip-360" label="Flipping Camera Rotate" style="font-size: 2em;"></wa-icon>
+<wa-icon
+  name="scroll"
+  animation="flip-360"
+  label="Flipping Scroll"
+  style="font-size: 2em; --flip-x: 1; --flip-y: 0;"
+></wa-icon>
+<wa-icon
+  name="compact-disc"
+  animation="flip-360"
+  label="Flipping Compact Disc"
+  style="font-size: 2em; --animation-duration: 3s;"
+></wa-icon>
+```
+
+### Shake
 
 Use the `shake` animation to grab attention or note that something is not allowed by shaking an icon back and forth.
 
@@ -295,7 +516,7 @@ Use the `shake` animation to grab attention or note that something is not allowe
 <wa-icon name="bomb" animation="shake" label="Shaking Bomb" style="font-size: 2em;"></wa-icon>
 ```
 
-#### Spin
+### Spin
 
 Use the `spin` animation to get any icon to rotate, and use `spin-pulse` to have it rotate with eight steps. Use `spin-reverse` to rotate counter-clockwise. This works especially well with `spinner` and everything in the spinner icons category.
 
@@ -311,306 +532,389 @@ Use the `spin` animation to get any icon to rotate, and use `spin-pulse` to have
   label="Pulse Spinning Spinner"
   style="font-size: 2em; --animation-direction: reverse"
 ></wa-icon>
+
+<!-- spin a set number of times, then stop -->
+<wa-icon
+  name="compact-disc"
+  animation="spin"
+  label="Spinning Compact Disc"
+  style="font-size: 2em; --animation-duration: 3s; --animation-iteration-count: 5; --animation-timing: ease-in-out;"
+></wa-icon>
 ```
 
-### Duotone
+### Spin Snap
 
-{{ site.siblings.fontAwesome.name }}'s [Duotone icons](https://docs.fontawesome.com/web/style/duotone) change with the `color` property as well, but you can customize the primary and secondary colors independently using the `--primary-color` and `--secondary-color` custom properties. To change the opacity of either, use `--primary-opacity` and `--secondary-opacity`.
-
-Note that these custom properties will not inherit and _must be applied directly to the icon_.
+Use `spin-snap` to rotate in distinct steps with a pause on each, like a clock's second hand. `spin-snap-4` stops at four positions and `spin-snap-8` at eight. Unlike `spin-pulse` — a continuous eight-step rotation — the snap animations ease into each stop. Add `--animation-direction: reverse` to any of them to run counter-clockwise.
 
 ```html {.example}
-<div class="wa-stack">
-  <div class="wa-cluster" style="font-size: 1.5em;">
-    <wa-icon
-      family="duotone"
-      name="crow"
-      style="--primary-color: dodgerblue; --secondary-color: gold; --secondary-opacity: 1.0;"
-    ></wa-icon>
-    <wa-icon
-      family="duotone"
-      name="campfire"
-      style="--primary-color: sienna; --secondary-color: red; --secondary-opacity: 1.0;"
-    ></wa-icon>
-    <wa-icon
-      family="duotone"
-      name="birthday-cake"
-      style="--primary-color: pink; --secondary-color: palevioletred; --secondary-opacity: 1.0;"
-    ></wa-icon>
-    <wa-icon
-      family="duotone"
-      name="ear"
-      style="--primary-color: sandybrown; --secondary-color: bisque; --secondary-opacity: 1.0;"
-    ></wa-icon>
-    <wa-icon
-      family="duotone"
-      name="corn"
-      style="--primary-color: mediumseagreen; --secondary-color: gold; --secondary-opacity: 1.0;"
-    ></wa-icon>
-    <wa-icon
-      family="duotone"
-      name="cookie-bite"
-      style="--primary-color: saddlebrown; --secondary-color: burlywood; --secondary-opacity: 1.0;"
-    ></wa-icon>
-  </div>
-
-  <div class="wa-cluster" style="font-size: 1.5em;">
-    <wa-icon
-      family="duotone"
-      variant="regular"
-      name="crow"
-      style="--primary-color: dodgerblue; --secondary-color: gold; --secondary-opacity: 1.0;"
-    ></wa-icon>
-    <wa-icon
-      family="duotone"
-      variant="regular"
-      name="campfire"
-      style="--primary-color: sienna; --secondary-color: red; --secondary-opacity: 1.0;"
-    ></wa-icon>
-    <wa-icon
-      family="duotone"
-      variant="regular"
-      name="birthday-cake"
-      style="--primary-color: pink; --secondary-color: palevioletred; --secondary-opacity: 1.0;"
-    ></wa-icon>
-    <wa-icon
-      family="duotone"
-      variant="regular"
-      name="ear"
-      style="--primary-color: sandybrown; --secondary-color: bisque; --secondary-opacity: 1.0;"
-    ></wa-icon>
-    <wa-icon
-      family="duotone"
-      variant="regular"
-      name="corn"
-      style="--primary-color: mediumseagreen; --secondary-color: gold; --secondary-opacity: 1.0;"
-    ></wa-icon>
-    <wa-icon
-      family="duotone"
-      variant="regular"
-      name="cookie-bite"
-      style="--primary-color: saddlebrown; --secondary-color: burlywood; --secondary-opacity: 1.0;"
-    ></wa-icon>
-  </div>
-
-  <div class="wa-cluster" style="font-size: 1.5em;">
-    <wa-icon
-      family="duotone"
-      variant="light"
-      name="crow"
-      style="--primary-color: dodgerblue; --secondary-color: gold; --secondary-opacity: 1.0;"
-    ></wa-icon>
-    <wa-icon
-      family="duotone"
-      variant="light"
-      name="campfire"
-      style="--primary-color: sienna; --secondary-color: red; --secondary-opacity: 1.0;"
-    ></wa-icon>
-    <wa-icon
-      family="duotone"
-      variant="light"
-      name="birthday-cake"
-      style="--primary-color: pink; --secondary-color: palevioletred; --secondary-opacity: 1.0;"
-    ></wa-icon>
-    <wa-icon
-      family="duotone"
-      variant="light"
-      name="ear"
-      style="--primary-color: sandybrown; --secondary-color: bisque; --secondary-opacity: 1.0;"
-    ></wa-icon>
-    <wa-icon
-      family="duotone"
-      variant="light"
-      name="corn"
-      style="--primary-color: mediumseagreen; --secondary-color: gold; --secondary-opacity: 1.0;"
-    ></wa-icon>
-    <wa-icon
-      family="duotone"
-      variant="light"
-      name="cookie-bite"
-      style="--primary-color: saddlebrown; --secondary-color: burlywood; --secondary-opacity: 1.0;"
-    ></wa-icon>
-  </div>
-
-  <div class="wa-cluster" style="font-size: 1.5em;">
-    <wa-icon
-      family="duotone"
-      variant="thin"
-      name="crow"
-      style="--primary-color: dodgerblue; --secondary-color: gold; --secondary-opacity: 1.0;"
-    ></wa-icon>
-    <wa-icon
-      family="duotone"
-      variant="thin"
-      name="campfire"
-      style="--primary-color: sienna; --secondary-color: red; --secondary-opacity: 1.0;"
-    ></wa-icon>
-    <wa-icon
-      family="duotone"
-      variant="thin"
-      name="birthday-cake"
-      style="--primary-color: pink; --secondary-color: palevioletred; --secondary-opacity: 1.0;"
-    ></wa-icon>
-    <wa-icon
-      family="duotone"
-      variant="thin"
-      name="ear"
-      style="--primary-color: sandybrown; --secondary-color: bisque; --secondary-opacity: 1.0;"
-    ></wa-icon>
-    <wa-icon
-      family="duotone"
-      variant="thin"
-      name="corn"
-      style="--primary-color: mediumseagreen; --secondary-color: gold; --secondary-opacity: 1.0;"
-    ></wa-icon>
-    <wa-icon
-      family="duotone"
-      variant="thin"
-      name="cookie-bite"
-      style="--primary-color: saddlebrown; --secondary-color: burlywood; --secondary-opacity: 1.0;"
-    ></wa-icon>
-  </div>
-</div>
+<wa-icon name="gear" animation="spin-snap" label="Snapping Gear" style="font-size: 2em;"></wa-icon>
+<wa-icon name="gear" animation="spin-snap-4" label="Snapping Gear, four stops" style="font-size: 2em;"></wa-icon>
+<wa-icon name="gear" animation="spin-snap-8" label="Snapping Gear, eight stops" style="font-size: 2em;"></wa-icon>
+<wa-icon
+  name="gear"
+  animation="spin-snap"
+  label="Snapping Gear, reversed"
+  style="font-size: 2em; --animation-direction: reverse;"
+></wa-icon>
 ```
 
-:::info
-Duotone icons can be unlocked by [providing a valid {{ site.siblings.fontAwesome.name }} kit code](/docs/#using-font-awesome-kit-codes).
-:::
+### Buzz
 
-### Swap Duotone Opacity
+Use the `buzz` animation for a fast, tight vibration with rapid decay — quick attention without being loud, like a phone buzzing on a table or an expiring timer. Set `--buzz-distance` to control how far it travels.
+
+```html {.example}
+<wa-icon name="bell" animation="buzz" label="Buzzing Bell" style="font-size: 2em;"></wa-icon>
+<wa-icon name="mobile" animation="buzz" label="Buzzing Phone" style="font-size: 2em;"></wa-icon>
+<wa-icon
+  name="triangle-exclamation"
+  animation="buzz"
+  label="Buzzing Warning"
+  style="font-size: 2em; --buzz-distance: 9px;"
+></wa-icon>
+```
+
+### Float
+
+Use the `float` animation for a slow, drifting motion — great for empty states, subtle attention, and adding a bit of playful lightness. Adjust `--float-height`, `--float-drift`, and `--float-tilt` to shape the motion.
+
+```html {.example}
+<wa-icon name="feather" animation="float" label="Floating Feather" style="font-size: 2em;"></wa-icon>
+<wa-icon name="ghost" animation="float" label="Floating Ghost" style="font-size: 2em;"></wa-icon>
+<wa-icon
+  name="feather"
+  animation="float"
+  label="Floating Feather"
+  style="font-size: 2em; --animation-duration: 2s; --float-height: 0.5em;"
+></wa-icon>
+```
+
+### Jello
+
+Use the `jello` animation for a playful jiggle — great for calling attention to something new, fun, or interactive. Set `--jello-scale-x` and `--jello-scale-y` to control how far it deforms.
+
+```html {.example}
+<wa-icon name="cube" animation="jello" label="Jiggling Cube" style="font-size: 2em;"></wa-icon>
+<wa-icon name="droplet" animation="jello" label="Jiggling Droplet" style="font-size: 2em;"></wa-icon>
+<wa-icon
+  name="star"
+  animation="jello"
+  label="Jiggling Star"
+  style="font-size: 2em; --animation-duration: 2s; --jello-scale-x: 1.3;"
+></wa-icon>
+```
+
+### Swing
+
+Use the `swing` animation for a subtle dangle with a slow decay — great for things that physically dangle, like keys or a hanging sign. Set `--swing-angle` to control the peak rotation.
+
+```html {.example}
+<wa-icon name="bell" animation="swing" label="Swinging Bell" style="font-size: 2em;"></wa-icon>
+<wa-icon name="key" animation="swing" label="Swinging Key" style="font-size: 2em;"></wa-icon>
+<wa-icon
+  name="bell"
+  animation="swing"
+  label="Swinging Bell"
+  style="font-size: 2em; --animation-duration: 2s; --swing-angle: 45deg;"
+></wa-icon>
+```
+
+### Wag
+
+Use the `wag` animation, a cousin of `swing`, for a bottom-anchored wag — the top of the icon sways back and forth with a slow decay. Set `--wag-angle` to control the peak rotation.
+
+```html {.example}
+<wa-icon name="hand-pointer" animation="wag" label="Wagging Pointer" style="font-size: 2em;"></wa-icon>
+<wa-icon name="hand-point-up" animation="wag" label="Wagging Finger" style="font-size: 2em;"></wa-icon>
+<wa-icon
+  name="hand-point-right"
+  animation="wag"
+  label="Wagging Finger"
+  style="font-size: 2em; --animation-duration: 2s; --wag-angle: 45deg;"
+></wa-icon>
+```
+
+## Duotone
+
+Duotone icons render on two layers — a primary and a secondary — that you can recolor and fade independently. By default both layers use `currentColor`, with the secondary layer at 40% opacity. These properties don't inherit, so set them directly on the icon.
+
+| Property              | Description                                              | Default        |
+| --------------------- | -------------------------------------------------------- | -------------- |
+| `--primary-color`     | Color of the primary (foreground) layer                  | `currentColor` |
+| `--secondary-color`   | Color of the secondary (background) layer                | `currentColor` |
+| `--primary-opacity`   | Opacity of the primary layer                             | `1`            |
+| `--secondary-opacity` | Opacity of the secondary layer                           | `0.4`          |
+| `swap-opacity`        | Attribute that swaps the primary and secondary opacities | `false`        |
+
+```html {.example}
+<div class="duotone-demo">
+  <div class="duotone-demo-preview wa-cluster">
+    <wa-icon
+      family="duotone"
+      name="palette"
+      label="Palette"
+      style="--primary-color: #3b82f6; --secondary-color: #3b82f6;"
+    ></wa-icon>
+    <wa-icon
+      family="duotone"
+      name="crow"
+      label="Crow"
+      style="--primary-color: #3b82f6; --secondary-color: #3b82f6;"
+    ></wa-icon>
+    <wa-icon
+      family="duotone"
+      name="campfire"
+      label="Campfire"
+      style="--primary-color: #3b82f6; --secondary-color: #3b82f6;"
+    ></wa-icon>
+    <wa-icon
+      family="duotone"
+      name="cloud-sun"
+      label="Cloud and sun"
+      style="--primary-color: #3b82f6; --secondary-color: #3b82f6;"
+    ></wa-icon>
+    <wa-icon
+      family="duotone"
+      name="bell"
+      label="Bell"
+      style="--primary-color: #3b82f6; --secondary-color: #3b82f6;"
+    ></wa-icon>
+  </div>
+
+  <wa-divider></wa-divider>
+
+  <div class="wa-cluster wa-gap-xl duotone-demo-controls">
+    <wa-color-picker label="Primary color" value="#3b82f6"></wa-color-picker>
+    <wa-color-picker label="Secondary color" value="#3b82f6"></wa-color-picker>
+    <wa-slider label="Primary opacity" min="0" max="1" step="0.1" value="1"></wa-slider>
+    <wa-slider label="Secondary opacity" min="0" max="1" step="0.1" value="0.4"></wa-slider>
+  </div>
+</div>
+
+<style>
+  .duotone-demo-preview {
+    justify-content: center;
+    font-size: 4rem;
+    min-height: 6rem;
+    margin-block-end: 1.5rem;
+  }
+  .duotone-demo-controls {
+    align-items: end;
+  }
+  .duotone-demo-controls wa-slider {
+    flex: 1 1 10rem;
+  }
+</style>
+
+<script>
+  (() => {
+    const demo = document.querySelector('.duotone-demo');
+    const icons = demo.querySelectorAll('.duotone-demo-preview wa-icon');
+    const [primary, secondary] = demo.querySelectorAll('wa-color-picker');
+    const [primaryOpacity, secondaryOpacity] = demo.querySelectorAll('wa-slider');
+
+    const apply = () => {
+      icons.forEach(icon => {
+        icon.style.setProperty('--primary-color', primary.value);
+        icon.style.setProperty('--secondary-color', secondary.value);
+        icon.style.setProperty('--primary-opacity', primaryOpacity.value);
+        icon.style.setProperty('--secondary-opacity', secondaryOpacity.value);
+      });
+    };
+
+    [primary, secondary, primaryOpacity, secondaryOpacity].forEach(control => control.addEventListener('input', apply));
+  })();
+</script>
+```
+
+<wa-callout variant="brand">
+  <wa-icon slot="icon" family="brands" name="font-awesome"></wa-icon>
+  Duotone icons can be unlocked by
+  <a href="/docs/#using-font-awesome-kit-codes">providing a valid {{ site.siblings.fontAwesome.name }} Kit code</a>.
+</wa-callout>
+
+## Swap Duotone Opacity
 
 For duotone icons, you can swap the primary and secondary opacity values using the `swap-opacity` attribute. This is useful when you want to emphasize the secondary layer of the icon.
 
 ```html {.example}
-Normal duotone<br />
-<div class="wa-cluster" style="font-size: 1.5em;">
-  <wa-icon family="duotone" name="home"></wa-icon>
-  <wa-icon family="duotone" name="user"></wa-icon>
-  <wa-icon family="duotone" name="envelope"></wa-icon>
-  <wa-icon family="duotone" name="calendar"></wa-icon>
-</div>
-
-<br />
-
-Swapped duotone<br />
-<div class="wa-cluster" style="font-size: 1.5em;">
-  <wa-icon family="duotone" name="home" swap-opacity></wa-icon>
-  <wa-icon family="duotone" name="user" swap-opacity></wa-icon>
-  <wa-icon family="duotone" name="envelope" swap-opacity></wa-icon>
-  <wa-icon family="duotone" name="calendar" swap-opacity></wa-icon>
-</div>
-```
-
-### Font Awesome Pro+ Icons
-
-If you're a [Font Awesome Pro+ customer](https://fontawesome.com/), you have access to even more icons! Just set the appropriate `family`, `variant`, and `name` on the icon.
-
-```html {.example}
-<div class="wa-stack wa-gap-xl">
-  <div class="wa-flank" style="--flank-size: 10ch;">
-    <a href="https://fontawesome.com/icons/packs/chisel" target="_blank">Chisel</a>
-    <div class="wa-cluster" style="font-size: 1.5em;">
-      <wa-icon family="chisel" variant="regular" name="house"></wa-icon>
-    </div>
+<div class="wa-stack">
+  <div class="wa-cluster" style="font-size: 1.5em;">
+    <wa-icon family="duotone" name="home"></wa-icon>
+    <wa-icon family="duotone" name="user"></wa-icon>
+    <wa-icon family="duotone" name="envelope"></wa-icon>
+    <wa-icon family="duotone" name="calendar"></wa-icon>
+    <span style="font-size: 1rem;">Normal</span>
   </div>
-
-  <div class="wa-flank" style="--flank-size: 10ch;">
-    <a href="https://fontawesome.com/icons/packs/etch" target="_blank">Etch</a>
-    <div class="wa-cluster" style="font-size: 1.5em;">
-      <wa-icon family="etch" variant="solid" name="house"></wa-icon>
-    </div>
-  </div>
-
-  <div class="wa-flank" style="--flank-size: 10ch;">
-    <a href="https://fontawesome.com/icons/packs/graphite" target="_blank">Graphite</a>
-    <div class="wa-cluster" style="font-size: 1.5em;">
-      <wa-icon family="graphite" variant="thin" name="house"></wa-icon>
-    </div>
-  </div>
-
-  <div class="wa-flank" style="--flank-size: 10ch;">
-    <a href="https://fontawesome.com/icons/packs/jelly" target="_blank">Jelly</a>
-    <div class="wa-cluster" style="font-size: 1.5em;">
-      <wa-icon family="jelly" variant="regular" name="house"></wa-icon>
-      <wa-icon
-        family="jelly"
-        variant="duo-regular"
-        name="house"
-        style="--secondary-color: skyblue; --secondary-opacity: 0.8;"
-      ></wa-icon>
-      <wa-icon family="jelly" variant="fill-regular" name="house"></wa-icon>
-    </div>
-  </div>
-
-  <div class="wa-flank" style="--flank-size: 10ch;">
-    <a href="https://fontawesome.com/icons/packs/notdog" target="_blank">Notdog</a>
-    <div class="wa-cluster" style="font-size: 1.5em;">
-      <wa-icon family="notdog" variant="solid" name="house"></wa-icon>
-      <wa-icon
-        family="notdog-duo"
-        variant="solid"
-        name="house"
-        style="--secondary-color: skyblue; --secondary-opacity: 0.8;"
-      ></wa-icon>
-    </div>
-  </div>
-
-  <div class="wa-flank" style="--flank-size: 10ch;">
-    <a href="https://fontawesome.com/icons/packs/slab" target="_blank">Slab</a>
-    <div class="wa-cluster" style="font-size: 1.5em;">
-      <wa-icon family="slab" variant="regular" name="house"></wa-icon>
-      <wa-icon family="slab" variant="press-regular" name="house"></wa-icon>
-    </div>
-  </div>
-
-  <div class="wa-flank" style="--flank-size: 10ch;">
-    <a href="https://fontawesome.com/icons/packs/thumbprint" target="_blank">Thumbprint</a>
-    <div class="wa-cluster" style="font-size: 1.5em;">
-      <wa-icon
-        family="thumbprint"
-        variant="light"
-        name="house"
-        style="--secondary-color: skyblue; --secondary-opacity: 0.8;"
-      ></wa-icon>
-    </div>
-  </div>
-
-  <div class="wa-flank" style="--flank-size: 10ch;">
-    <a href="https://fontawesome.com/icons/packs/utility" target="_blank">Utility</a>
-    <div class="wa-cluster" style="font-size: 1.5em;">
-      <wa-icon family="utility" variant="semibold" name="house"></wa-icon>
-      <wa-icon
-        family="utility-duo"
-        variant="semibold"
-        name="house"
-        style="--secondary-color: skyblue; --secondary-opacity: 0.8;"
-      ></wa-icon>
-      <wa-icon family="utility-fill" variant="semibold" name="house"></wa-icon>
-    </div>
-  </div>
-
-  <div class="wa-flank" style="--flank-size: 10ch;">
-    <a href="https://fontawesome.com/icons/packs/whiteboard" target="_blank">Whiteboard</a>
-    <div class="wa-cluster" style="font-size: 1.5em;">
-      <wa-icon family="whiteboard" variant="semibold" name="house"></wa-icon>
-    </div>
+  <div class="wa-cluster" style="font-size: 1.5em;">
+    <wa-icon family="duotone" name="home" swap-opacity></wa-icon>
+    <wa-icon family="duotone" name="user" swap-opacity></wa-icon>
+    <wa-icon family="duotone" name="envelope" swap-opacity></wa-icon>
+    <wa-icon family="duotone" name="calendar" swap-opacity></wa-icon>
+    <span style="font-size: 1rem;">Swapped opacity</span>
   </div>
 </div>
 ```
 
-:::info
-Pro+ icons can be unlocked by [providing a valid {{ site.siblings.fontAwesome.name }} kit code](/docs/#using-font-awesome-kit-codes).
-:::
+## Font Awesome Pro+ Icons
 
-### Custom Icons
+If you're a [Font Awesome Pro+ customer](https://fontawesome.com/), you have access to whole packs of distinctive icons. Set the pack's `family` and `variant` like any other icon.
 
-Custom icons can be loaded individually with the `src` attribute. Only SVGs on a local or CORS-enabled endpoint are supported. If you're using more than one custom icon, it might make sense to register a [custom icon library](#icon-libraries).
+<table>
+  <thead>
+    <tr>
+      <th>Pack</th>
+      <th>Family</th>
+      <th>Variant</th>
+      <th>Preview</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><a href="https://fontawesome.com/icons/packs/chisel" target="_blank">Chisel</a></td>
+      <td><code>chisel</code></td>
+      <td><code>regular</code></td>
+      <td>
+        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;chisel&quot; variant=&quot;regular&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="chisel" variant="regular" name="house"></wa-icon></wa-copy-button>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td><a href="https://fontawesome.com/icons/packs/etch" target="_blank">Etch</a></td>
+      <td><code>etch</code></td>
+      <td><code>solid</code></td>
+      <td>
+        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;etch&quot; variant=&quot;solid&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="etch" variant="solid" name="house"></wa-icon></wa-copy-button>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td><a href="https://fontawesome.com/icons/packs/graphite" target="_blank">Graphite</a></td>
+      <td><code>graphite</code></td>
+      <td><code>thin</code></td>
+      <td>
+        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;graphite&quot; variant=&quot;thin&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="graphite" variant="thin" name="house"></wa-icon></wa-copy-button>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td><a href="https://fontawesome.com/icons/packs/jelly" target="_blank">Jelly</a></td>
+      <td><code>jelly</code>, <code>jelly-duo</code>, <code>jelly-fill</code></td>
+      <td><code>regular</code></td>
+      <td>
+        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;jelly&quot; variant=&quot;regular&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="jelly" variant="regular" name="house"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;jelly-duo&quot; variant=&quot;regular&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="jelly-duo" variant="regular" name="house" style="--secondary-color: skyblue; --secondary-opacity: 0.8;"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;jelly-fill&quot; variant=&quot;regular&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="jelly-fill" variant="regular" name="house"></wa-icon></wa-copy-button>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td><a href="https://fontawesome.com/icons/packs/mosaic" target="_blank">Mosaic</a></td>
+      <td><code>mosaic</code></td>
+      <td><code>solid</code></td>
+      <td>
+        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;mosaic&quot; variant=&quot;solid&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="mosaic" variant="solid" name="house"></wa-icon></wa-copy-button>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td><a href="https://fontawesome.com/icons/packs/notdog" target="_blank">Notdog</a></td>
+      <td><code>notdog</code>, <code>notdog-duo</code></td>
+      <td><code>solid</code></td>
+      <td>
+        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;notdog&quot; variant=&quot;solid&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="notdog" variant="solid" name="house"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;notdog-duo&quot; variant=&quot;solid&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="notdog-duo" variant="solid" name="house" style="--secondary-color: skyblue; --secondary-opacity: 0.8;"></wa-icon></wa-copy-button>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td><a href="https://fontawesome.com/icons/packs/pixel" target="_blank">Pixel</a></td>
+      <td><code>pixel</code></td>
+      <td><code>regular</code></td>
+      <td>
+        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;pixel&quot; variant=&quot;regular&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="pixel" variant="regular" name="house"></wa-icon></wa-copy-button>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td><a href="https://fontawesome.com/icons/packs/slab" target="_blank">Slab</a></td>
+      <td><code>slab</code>, <code>slab-press</code>, <code>slab-duo</code>, <code>slab-press-duo</code></td>
+      <td><code>regular</code></td>
+      <td>
+        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;slab&quot; variant=&quot;regular&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="slab" variant="regular" name="house"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;slab-press&quot; variant=&quot;regular&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="slab-press" variant="regular" name="house"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;slab-duo&quot; variant=&quot;regular&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="slab-duo" variant="regular" name="house" style="--secondary-color: skyblue; --secondary-opacity: 0.8;"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;slab-press-duo&quot; variant=&quot;regular&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="slab-press-duo" variant="regular" name="house" style="--secondary-color: skyblue; --secondary-opacity: 0.8;"></wa-icon></wa-copy-button>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td><a href="https://fontawesome.com/icons/packs/thumbprint" target="_blank">Thumbprint</a></td>
+      <td><code>thumbprint</code></td>
+      <td><code>light</code></td>
+      <td>
+        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;thumbprint&quot; variant=&quot;light&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="thumbprint" variant="light" name="house" style="--secondary-color: skyblue; --secondary-opacity: 0.8;"></wa-icon></wa-copy-button>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td><a href="https://fontawesome.com/icons/packs/utility" target="_blank">Utility</a></td>
+      <td><code>utility</code>, <code>utility-duo</code>, <code>utility-fill</code></td>
+      <td><code>semibold</code></td>
+      <td>
+        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;utility&quot; variant=&quot;semibold&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="utility" variant="semibold" name="house"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;utility-duo&quot; variant=&quot;semibold&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="utility-duo" variant="semibold" name="house" style="--secondary-color: skyblue; --secondary-opacity: 0.8;"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;utility-fill&quot; variant=&quot;semibold&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="utility-fill" variant="semibold" name="house"></wa-icon></wa-copy-button>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td><a href="https://fontawesome.com/icons/packs/vellum" target="_blank">Vellum</a></td>
+      <td><code>vellum</code></td>
+      <td><code>solid</code></td>
+      <td>
+        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;vellum&quot; variant=&quot;solid&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="vellum" variant="solid" name="house"></wa-icon></wa-copy-button>
+        </div>
+      </td>
+    </tr>
+    <tr>
+      <td><a href="https://fontawesome.com/icons/packs/whiteboard" target="_blank">Whiteboard</a></td>
+      <td><code>whiteboard</code></td>
+      <td><code>semibold</code></td>
+      <td>
+        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;whiteboard&quot; variant=&quot;semibold&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="whiteboard" variant="semibold" name="house"></wa-icon></wa-copy-button>
+        </div>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<wa-callout variant="brand">
+  <wa-icon slot="icon" family="brands" name="font-awesome"></wa-icon>
+  Pro+ icons can be unlocked by
+  <a href="/docs/#using-font-awesome-kit-codes">providing a valid {{ site.siblings.fontAwesome.name }} Kit code</a>.
+</wa-callout>
+
+## Custom Icons
+
+Custom icons can be loaded individually with the `src` attribute. Only SVGs on a local or CORS-enabled endpoint are supported. If you're using more than one custom icon, it might make sense to register a [custom icon library](#third-party-icon-libraries).
 
 ```html {.example}
 <wa-icon src="https://shoelace.style/assets/images/shoe.svg" style="font-size: 4rem;"></wa-icon>
 ```
 
-### Self-hosting the Default Library
+## Self-hosting the Default Library
 
 By default, icons are loaded from the {{ site.siblings.fontAwesome.name }} CDN. If you'd prefer to [download the icons](https://fontawesome.com/download) and serve them from your own server, you can use the `setIconPath()` function to point the default icon library at your self-hosted directory.
 
@@ -646,7 +950,7 @@ For more control over how icon URLs are constructed, you can use the `getIconFol
 `setIconPath()` must be called before Web Awesome components are loaded, similar to `setBasePath()` and `setKitCode()`.
 :::
 
-### Customizing the Default Library
+## Customizing the Default Library
 
 The default icon library contains over 2,000 icons courtesy of [{{ site.siblings.fontAwesome.name }}]({{ site.siblings.fontAwesome.url }}). These are the icons that display when you use `<wa-icon>` without the `library` attribute. If you prefer to have these icons resolve elsewhere or to a different icon library, register an icon library using the `default` name and a custom resolver.
 
@@ -665,7 +969,7 @@ For example, this will change the default icon library to use [Bootstrap Icons](
 </script>
 ```
 
-#### Customize the default library to use SVG sprites
+### Customize the default library to use SVG sprites
 
 To improve performance you can use a SVG sprites to avoid multiple trips for each SVG. The browser will load the sprite sheet once and then you reference the particular SVG within the sprite sheet using hash selector.
 
@@ -689,7 +993,7 @@ For security reasons, browsers may apply the same-origin policy on `<use>` eleme
 </script>
 ```
 
-### Customizing the System Library
+## Customizing the System Library
 
 The system library contains only the icons used internally by Web Awesome components. Unlike the default icon library, the system library does not rely on physical assets. Instead, its icons are hard-coded as data URIs into the resolver to ensure their availability.
 
@@ -705,9 +1009,11 @@ If you want to change the icons Web Awesome uses internally, you can register an
 </script>
 ```
 
-### Third-party Icon Libraries
+## Third-party Icon Libraries
 
 You can register additional icons to use with the `<wa-icon>` component through icon libraries. Icon files can exist locally or on a CORS-enabled endpoint (e.g. a CDN). There is no limit to how many icon libraries you can register and there is no cost associated with registering them, as individual icons are only requested when they're used.
+
+[Sizing](#sizing), [colors](#colors), [the canvas](#canvas), [rotating and flipping](#rotating-and-flipping), and [animations](#animating) work with icons from any library — they're applied to the `<wa-icon>` host, so they don't depend on where the icon comes from. (Only the duotone color properties are specific to Font Awesome's duotone icons.)
 
 Web Awesome ships with two built-in icon libraries, `default` and `system`. The [default icon library](#customizing-the-default-library) is provided courtesy of [{{ site.siblings.fontAwesome.name }}]({{ site.siblings.fontAwesome.url }}). The [system icon library](#customizing-the-system-library) contains only a small subset of icons that are used internally by Web Awesome components.
 
@@ -739,7 +1045,7 @@ If an icon is used before registration occurs, it will be empty initially but sh
 
 The following examples demonstrate how to register a number of popular, open source icon libraries via CDN. Feel free to adapt the code as you see fit to use your own origin or naming conventions.
 
-#### Bootstrap Icons
+### Bootstrap Icons
 
 This will register the [Bootstrap Icons](https://icons.getbootstrap.com/) library using the jsDelivr CDN. This library has two families: `regular` and `filled`.
 
@@ -774,7 +1080,7 @@ Icons in this library are licensed under the [MIT License](https://github.com/tw
 </div>
 ```
 
-#### Boxicons
+### Boxicons
 
 This will register the [Boxicons](https://boxicons.com/) library using the jsDelivr CDN. This library has three variations: regular (`bx-*`), solid (`bxs-*`), and logos (`bxl-*`). A mutator function is required to set the SVG's `fill` to `currentColor`.
 
@@ -819,7 +1125,7 @@ Icons in this library are licensed under the [Creative Commons 4.0 License](http
 </div>
 ```
 
-#### Lucide
+### Lucide
 
 This will register the [Lucide](https://lucide.dev/) icon library using the jsDelivr CDN. This project is a community-maintained fork of the popular [Feather](https://feathericons.com/) icon library.
 
@@ -849,7 +1155,7 @@ Icons in this library are licensed under the [MIT License](https://github.com/lu
 </div>
 ```
 
-#### Heroicons
+### Heroicons
 
 This will register the [Heroicons](https://heroicons.com/) library using the jsDelivr CDN.
 
@@ -879,7 +1185,7 @@ Icons in this library are licensed under the [MIT License](https://github.com/ta
 </div>
 ```
 
-#### Iconoir
+### Iconoir
 
 This will register the [Iconoir](https://iconoir.com/) library using the jsDelivr CDN.
 
@@ -911,7 +1217,7 @@ Icons in this library are licensed under the [MIT License](https://github.com/lu
 </div>
 ```
 
-#### Ionicons
+### Ionicons
 
 This will register the [Ionicons](https://ionicons.com/) library using the jsDelivr CDN. This library has three variations: outline (default), filled (`*-filled`), and sharp (`*-sharp`). A mutator function is required to polyfill a handful of styles we're not including.
 
@@ -956,7 +1262,7 @@ Icons in this library are licensed under the [MIT License](https://github.com/io
 </div>
 ```
 
-#### Jam Icons
+### Jam Icons
 
 This will register the [Jam Icons](https://jam-icons.com/) library using the jsDelivr CDN. This library has two variations: regular (default) and filled (`*-f`). A mutator function is required to set the SVG's `fill` to `currentColor`.
 
@@ -989,7 +1295,7 @@ Icons in this library are licensed under the [MIT License](https://github.com/mi
 </div>
 ```
 
-#### Material Icons
+### Material Icons
 
 This will register the [Material Icons](https://material.io/resources/icons/?style=baseline) library using the jsDelivr CDN. This library has three variations: outline (default), round (`*_round`), and sharp (`*_sharp`). A mutator function is required to set the SVG's `fill` to `currentColor`.
 
@@ -1032,7 +1338,7 @@ Icons in this library are licensed under the [Apache 2.0 License](https://github
 </div>
 ```
 
-#### Remix Icon
+### Remix Icon
 
 This will register the [Remix Icon](https://remixicon.com/) library using the jsDelivr CDN. This library groups icons by categories, so the name must include the category and icon separated by a slash, as well as the `-line` or `-fill` suffix as needed. A mutator function is required to set the SVG's `fill` to `currentColor`.
 
@@ -1069,7 +1375,7 @@ Icons in this library are licensed under the [Apache 2.0 License](https://github
 </div>
 ```
 
-#### Tabler Icons
+### Tabler Icons
 
 This will register the [Tabler Icons](https://tabler-icons.io/) library using the jsDelivr CDN. This library features over 1,950 open source icons.
 
@@ -1105,7 +1411,7 @@ Icons in this library are licensed under the [MIT License](https://github.com/ta
 </div>
 ```
 
-#### Unicons
+### Unicons
 
 This will register the [Unicons](https://iconscout.com/unicons) library using the jsDelivr CDN. This library has two variations: line (default) and solid (`*-s`). A mutator function is required to set the SVG's `fill` to `currentColor`.
 
@@ -1142,3 +1448,74 @@ Icons in this library are licensed under the [Apache 2.0 License](https://github
   <wa-icon library="unicons" name="star-s"></wa-icon>
 </div>
 ```
+
+## Accessibility Considerations
+
+Web Awesome hides an unlabeled `<wa-icon>` from assistive devices, so an icon is presentational unless you give it a name. The two things to get right are labeling icons that carry meaning and respecting users who prefer less motion.
+
+### Labeling Icons
+
+Give an icon a `label` when it carries meaning on its own — when it's the only content of a control, or conveys status. Omit it when nearby text already says the same; unlabeled icons are hidden from assistive devices.
+
+<table>
+  <thead>
+    <tr>
+      <th>Scenario</th>
+      <th>Label?</th>
+      <th>In Context</th>
+      <th>Why</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Icon-only control</td>
+      <td>Yes</td>
+      <td style="white-space: nowrap;">
+        <wa-button appearance="outlined" size="s"><wa-icon name="gear" label="Settings"></wa-icon></wa-button>
+      </td>
+      <td><small>The icon is the button's only content, so the <code>label</code> gives it an accessible name.</small></td>
+    </tr>
+    <tr>
+      <td>Status icon</td>
+      <td>Yes</td>
+      <td style="white-space: nowrap;">
+        <wa-badge variant="success"><wa-icon name="circle-check" label="Paid"></wa-icon> Invoice #1042</wa-badge>
+      </td>
+      <td><small>The icon conveys status the nearby text doesn't.</small></td>
+    </tr>
+    <tr>
+      <td>Icon beside its own text</td>
+      <td>No</td>
+      <td style="white-space: nowrap;">
+        <wa-button appearance="outlined" size="s">
+          <wa-icon slot="start" name="arrow-up-from-bracket"></wa-icon> Share
+        </wa-button>
+      </td>
+      <td><small>The visible “Share” text already names the action; a label would be announced twice.</small></td>
+    </tr>
+    <tr>
+      <td>Decorative</td>
+      <td>No</td>
+      <td style="white-space: nowrap;">
+        <wa-callout variant="brand" size="s" style="padding: 0.5em 0.75em;">
+          <wa-icon slot="icon" name="circle-info"></wa-icon>
+          Check your inbox
+        </wa-callout>
+      </td>
+      <td><small>It only decorates text that already carries the meaning.</small></td>
+    </tr>
+  </tbody>
+</table>
+
+Set the `label` attribute to the text a screen reader should announce:
+
+```html {.example}
+<wa-icon name="circle-check" label="Task complete" style="font-size: 2em;"></wa-icon>
+<wa-icon name="triangle-exclamation" label="Warning" style="font-size: 2em;"></wa-icon>
+<wa-icon name="trash" label="Delete" style="font-size: 2em;"></wa-icon>
+<wa-icon name="bell" label="Notifications" style="font-size: 2em;"></wa-icon>
+```
+
+### Reduced Motion
+
+All [icon animations](#animating) honor the user's `prefers-reduced-motion` setting — when it's set to `reduce`, Web Awesome disables them automatically so motion never becomes a barrier. See [{{ site.siblings.fontAwesome.name }}'s animation accessibility notes](https://docs.fontawesome.com/web/style/animate/#accessibility) for more.

--- a/packages/webawesome/docs/docs/components/icon.md
+++ b/packages/webawesome/docs/docs/components/icon.md
@@ -16,33 +16,30 @@ use-cases:
 Web Awesome comes bundled with over 2,000 free icons courtesy of [Font Awesome](https://fontawesome.com/). These icons are part of the `default` icon library. Font Awesome Pro users can unlock additional [icon families](#families-and-variants). Or, if you prefer, you can register your own [custom icon library](#third-party-icon-libraries).
 
 ```html {.example}
-<!-- A few icon rebuses — can you read them? -->
-<div class="wa-cluster wa-gap-xl" style="font-size: 2em;">
-  <!-- Raining cats and dogs -->
-  <span class="wa-cluster wa-gap-0">
-    <wa-icon name="cloud-rain"></wa-icon>
-    <wa-icon name="cat"></wa-icon>
-    <wa-icon name="dog"></wa-icon>
-  </span>
+<div class="icon-rebuses" style="font-size: 2em;">
+  <!-- Catfish -->
+  <wa-icon name="cat"></wa-icon>
+  <wa-icon name="fish"></wa-icon>
 
   <!-- Brainstorm -->
-  <span class="wa-cluster wa-gap-0">
-    <wa-icon name="brain"></wa-icon>
-    <wa-icon name="cloud-bolt"></wa-icon>
-  </span>
+  <wa-icon name="brain"></wa-icon>
+  <wa-icon name="cloud-bolt"></wa-icon>
 
   <!-- Bookworm -->
-  <span class="wa-cluster wa-gap-0">
-    <wa-icon name="book"></wa-icon>
-    <wa-icon name="worm"></wa-icon>
-  </span>
+  <wa-icon name="book"></wa-icon>
+  <wa-icon name="worm"></wa-icon>
 
   <!-- Moonwalk -->
-  <span class="wa-cluster wa-gap-0">
-    <wa-icon name="moon"></wa-icon>
-    <wa-icon name="person-walking"></wa-icon>
-  </span>
+  <wa-icon name="moon"></wa-icon>
+  <wa-icon name="person-walking"></wa-icon>
 </div>
+
+<style>
+  /* Space between each rebus pair: trailing margin on every 2nd icon */
+  .icon-rebuses wa-icon:nth-of-type(2n):not(:last-of-type) {
+    margin-inline-end: var(--wa-space-m);
+  }
+</style>
 ```
 
 <wa-callout variant="brand">
@@ -137,10 +134,10 @@ A _family_ sets an icon's overall style; a _variant_ sets its weight. Set them w
       <td>Free</td>
       <td>
         <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.25em; align-items: center;">
-          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;gem&quot;></wa-icon>"><wa-icon variant="solid" name="gem"></wa-icon></wa-copy-button>
-          <wa-copy-button copy-label="Copy code" value="<wa-icon variant=&quot;regular&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon variant="regular" name="gem"></wa-icon></wa-copy-button>
-          <wa-copy-button copy-label="Copy code" value="<wa-icon variant=&quot;light&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon variant="light" name="gem"></wa-icon></wa-copy-button>
-          <wa-copy-button copy-label="Copy code" value="<wa-icon variant=&quot;thin&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon variant="thin" name="gem"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;house&quot;></wa-icon>"><wa-icon variant="solid" name="house"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon variant=&quot;regular&quot; name=&quot;house&quot;></wa-icon>"><wa-icon variant="regular" name="house"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon variant=&quot;light&quot; name=&quot;house&quot;></wa-icon>"><wa-icon variant="light" name="house"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon variant=&quot;thin&quot; name=&quot;house&quot;></wa-icon>"><wa-icon variant="thin" name="house"></wa-icon></wa-copy-button>
         </div>
       </td>
     </tr>
@@ -162,10 +159,10 @@ A _family_ sets an icon's overall style; a _variant_ sets its weight. Set them w
       <td>Pro</td>
       <td>
         <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.25em; align-items: center;">
-          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;duotone&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="duotone" variant="solid" name="gem"></wa-icon></wa-copy-button>
-          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;duotone&quot; variant=&quot;regular&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="duotone" variant="regular" name="gem"></wa-icon></wa-copy-button>
-          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;duotone&quot; variant=&quot;light&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="duotone" variant="light" name="gem"></wa-icon></wa-copy-button>
-          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;duotone&quot; variant=&quot;thin&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="duotone" variant="thin" name="gem"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;duotone&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="duotone" variant="solid" name="house"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;duotone&quot; variant=&quot;regular&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="duotone" variant="regular" name="house"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;duotone&quot; variant=&quot;light&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="duotone" variant="light" name="house"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;duotone&quot; variant=&quot;thin&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="duotone" variant="thin" name="house"></wa-icon></wa-copy-button>
         </div>
       </td>
     </tr>
@@ -175,10 +172,10 @@ A _family_ sets an icon's overall style; a _variant_ sets its weight. Set them w
       <td>Pro</td>
       <td>
         <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.25em; align-items: center;">
-          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="sharp" variant="solid" name="gem"></wa-icon></wa-copy-button>
-          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp&quot; variant=&quot;regular&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="sharp" variant="regular" name="gem"></wa-icon></wa-copy-button>
-          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp&quot; variant=&quot;light&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="sharp" variant="light" name="gem"></wa-icon></wa-copy-button>
-          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp&quot; variant=&quot;thin&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="sharp" variant="thin" name="gem"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="sharp" variant="solid" name="house"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp&quot; variant=&quot;regular&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="sharp" variant="regular" name="house"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp&quot; variant=&quot;light&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="sharp" variant="light" name="house"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp&quot; variant=&quot;thin&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="sharp" variant="thin" name="house"></wa-icon></wa-copy-button>
         </div>
       </td>
     </tr>
@@ -188,10 +185,10 @@ A _family_ sets an icon's overall style; a _variant_ sets its weight. Set them w
       <td>Pro</td>
       <td>
         <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.25em; align-items: center;">
-          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp-duotone&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="sharp-duotone" variant="solid" name="gem"></wa-icon></wa-copy-button>
-          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp-duotone&quot; variant=&quot;regular&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="sharp-duotone" variant="regular" name="gem"></wa-icon></wa-copy-button>
-          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp-duotone&quot; variant=&quot;light&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="sharp-duotone" variant="light" name="gem"></wa-icon></wa-copy-button>
-          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp-duotone&quot; variant=&quot;thin&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="sharp-duotone" variant="thin" name="gem"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp-duotone&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="sharp-duotone" variant="solid" name="house"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp-duotone&quot; variant=&quot;regular&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="sharp-duotone" variant="regular" name="house"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp-duotone&quot; variant=&quot;light&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="sharp-duotone" variant="light" name="house"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp-duotone&quot; variant=&quot;thin&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="sharp-duotone" variant="thin" name="house"></wa-icon></wa-copy-button>
         </div>
       </td>
     </tr>
@@ -275,11 +272,19 @@ The _canvas_ is the box an icon sits in. Choose one of four mutually exclusive m
       style="background: var(--wa-color-brand-fill-quiet); border: var(--wa-border-width-s) dashed var(--wa-color-brand-border-loud);"
     ></wa-icon>
     <wa-icon
-      name="ruler-vertical"
+      name="image"
       style="background: var(--wa-color-brand-fill-quiet); border: var(--wa-border-width-s) dashed var(--wa-color-brand-border-loud);"
     ></wa-icon>
     <wa-icon
       name="face-smile"
+      style="background: var(--wa-color-brand-fill-quiet); border: var(--wa-border-width-s) dashed var(--wa-color-brand-border-loud);"
+    ></wa-icon>
+    <wa-icon
+      name="file"
+      style="background: var(--wa-color-brand-fill-quiet); border: var(--wa-border-width-s) dashed var(--wa-color-brand-border-loud);"
+    ></wa-icon>
+    <wa-icon
+      name="ruler-vertical"
       style="background: var(--wa-color-brand-fill-quiet); border: var(--wa-border-width-s) dashed var(--wa-color-brand-border-loud);"
     ></wa-icon>
   </div>
@@ -350,8 +355,9 @@ Web Awesome supports [{{ site.siblings.fontAwesome.name }}'s rotation and flip u
       <td>
         <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.5em; align-items: center;">
           <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;paper-plane&quot; rotate=&quot;90&quot;></wa-icon>"><wa-icon name="paper-plane" rotate="90"></wa-icon></wa-copy-button>
-          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;location-arrow&quot; rotate=&quot;90&quot;></wa-icon>"><wa-icon name="location-arrow" rotate="90"></wa-icon></wa-copy-button>
-          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;hand-point-up&quot; rotate=&quot;90&quot;></wa-icon>"><wa-icon name="hand-point-up" rotate="90"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;car-side&quot; rotate=&quot;90&quot;></wa-icon>"><wa-icon name="car-side" rotate="90"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;fish&quot; rotate=&quot;90&quot;></wa-icon>"><wa-icon name="fish" rotate="90"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;sailboat&quot; rotate=&quot;90&quot;></wa-icon>"><wa-icon name="sailboat" rotate="90"></wa-icon></wa-copy-button>
         </div>
       </td>
     </tr>
@@ -361,8 +367,9 @@ Web Awesome supports [{{ site.siblings.fontAwesome.name }}'s rotation and flip u
       <td>
         <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.5em; align-items: center;">
           <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;paper-plane&quot; rotate=&quot;180&quot;></wa-icon>"><wa-icon name="paper-plane" rotate="180"></wa-icon></wa-copy-button>
-          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;location-arrow&quot; rotate=&quot;180&quot;></wa-icon>"><wa-icon name="location-arrow" rotate="180"></wa-icon></wa-copy-button>
-          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;hand-point-up&quot; rotate=&quot;180&quot;></wa-icon>"><wa-icon name="hand-point-up" rotate="180"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;car-side&quot; rotate=&quot;180&quot;></wa-icon>"><wa-icon name="car-side" rotate="180"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;fish&quot; rotate=&quot;180&quot;></wa-icon>"><wa-icon name="fish" rotate="180"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;sailboat&quot; rotate=&quot;180&quot;></wa-icon>"><wa-icon name="sailboat" rotate="180"></wa-icon></wa-copy-button>
         </div>
       </td>
     </tr>
@@ -372,8 +379,9 @@ Web Awesome supports [{{ site.siblings.fontAwesome.name }}'s rotation and flip u
       <td>
         <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.5em; align-items: center;">
           <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;paper-plane&quot; rotate=&quot;270&quot;></wa-icon>"><wa-icon name="paper-plane" rotate="270"></wa-icon></wa-copy-button>
-          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;location-arrow&quot; rotate=&quot;270&quot;></wa-icon>"><wa-icon name="location-arrow" rotate="270"></wa-icon></wa-copy-button>
-          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;hand-point-up&quot; rotate=&quot;270&quot;></wa-icon>"><wa-icon name="hand-point-up" rotate="270"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;car-side&quot; rotate=&quot;270&quot;></wa-icon>"><wa-icon name="car-side" rotate="270"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;fish&quot; rotate=&quot;270&quot;></wa-icon>"><wa-icon name="fish" rotate="270"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;sailboat&quot; rotate=&quot;270&quot;></wa-icon>"><wa-icon name="sailboat" rotate="270"></wa-icon></wa-copy-button>
         </div>
       </td>
     </tr>
@@ -383,8 +391,9 @@ Web Awesome supports [{{ site.siblings.fontAwesome.name }}'s rotation and flip u
       <td>
         <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.5em; align-items: center;">
           <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;paper-plane&quot; flip=&quot;x&quot;></wa-icon>"><wa-icon name="paper-plane" flip="x"></wa-icon></wa-copy-button>
-          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;location-arrow&quot; flip=&quot;x&quot;></wa-icon>"><wa-icon name="location-arrow" flip="x"></wa-icon></wa-copy-button>
-          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;hand-point-up&quot; flip=&quot;x&quot;></wa-icon>"><wa-icon name="hand-point-up" flip="x"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;car-side&quot; flip=&quot;x&quot;></wa-icon>"><wa-icon name="car-side" flip="x"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;fish&quot; flip=&quot;x&quot;></wa-icon>"><wa-icon name="fish" flip="x"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;sailboat&quot; flip=&quot;x&quot;></wa-icon>"><wa-icon name="sailboat" flip="x"></wa-icon></wa-copy-button>
         </div>
       </td>
     </tr>
@@ -394,8 +403,9 @@ Web Awesome supports [{{ site.siblings.fontAwesome.name }}'s rotation and flip u
       <td>
         <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.5em; align-items: center;">
           <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;paper-plane&quot; flip=&quot;y&quot;></wa-icon>"><wa-icon name="paper-plane" flip="y"></wa-icon></wa-copy-button>
-          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;location-arrow&quot; flip=&quot;y&quot;></wa-icon>"><wa-icon name="location-arrow" flip="y"></wa-icon></wa-copy-button>
-          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;hand-point-up&quot; flip=&quot;y&quot;></wa-icon>"><wa-icon name="hand-point-up" flip="y"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;car-side&quot; flip=&quot;y&quot;></wa-icon>"><wa-icon name="car-side" flip="y"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;fish&quot; flip=&quot;y&quot;></wa-icon>"><wa-icon name="fish" flip="y"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;sailboat&quot; flip=&quot;y&quot;></wa-icon>"><wa-icon name="sailboat" flip="y"></wa-icon></wa-copy-button>
         </div>
       </td>
     </tr>
@@ -405,8 +415,9 @@ Web Awesome supports [{{ site.siblings.fontAwesome.name }}'s rotation and flip u
       <td>
         <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.5em; align-items: center;">
           <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;paper-plane&quot; flip=&quot;both&quot;></wa-icon>"><wa-icon name="paper-plane" flip="both"></wa-icon></wa-copy-button>
-          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;location-arrow&quot; flip=&quot;both&quot;></wa-icon>"><wa-icon name="location-arrow" flip="both"></wa-icon></wa-copy-button>
-          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;hand-point-up&quot; flip=&quot;both&quot;></wa-icon>"><wa-icon name="hand-point-up" flip="both"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;car-side&quot; flip=&quot;both&quot;></wa-icon>"><wa-icon name="car-side" flip="both"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;fish&quot; flip=&quot;both&quot;></wa-icon>"><wa-icon name="fish" flip="both"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;sailboat&quot; flip=&quot;both&quot;></wa-icon>"><wa-icon name="sailboat" flip="both"></wa-icon></wa-copy-button>
         </div>
       </td>
     </tr>
@@ -438,7 +449,12 @@ Use the `beat` animation to scale an icon up or down. This is useful for grabbin
 <wa-icon name="heart" animation="beat" label="Beating Heart" style="font-size: 2em;"></wa-icon>
 <wa-icon name="circle-plus" animation="beat" label="Beating Circle Plus" style="font-size: 2em;"></wa-icon>
 <!-- Use --beat-scale to control how far it grows -->
-<wa-icon name="heart" animation="beat" label="Beating Heart" style="font-size: 2em; --beat-scale: 2;"></wa-icon>
+<wa-icon
+  name="face-grin-hearts"
+  animation="beat"
+  label="Beating Smiley"
+  style="font-size: 2em; --beat-scale: 1.5;"
+></wa-icon>
 ```
 
 ### Fade
@@ -664,16 +680,16 @@ Use the `jello` animation for a playful jiggle — great for calling attention t
 
 ### Swing
 
-Use the `swing` animation for a subtle dangle with a slow decay — great for things that physically dangle, like keys or a hanging sign. Set `--swing-angle` to control the peak rotation.
+Use the `swing` animation for a subtle dangle with a slow decay — great for things that physically dangle, like keys or a price tag. Set `--swing-angle` to control the peak rotation.
 
 ```html {.example}
 <wa-icon name="bell" animation="swing" label="Swinging Bell" style="font-size: 2em;"></wa-icon>
 <wa-icon name="key" animation="swing" label="Swinging Key" style="font-size: 2em;"></wa-icon>
 <!-- Use --swing-angle to control the peak rotation -->
 <wa-icon
-  name="bell"
+  name="tag"
   animation="swing"
-  label="Swinging Bell"
+  label="Swinging Tag"
   style="font-size: 2em; --animation-duration: 2s; --swing-angle: 45deg;"
 ></wa-icon>
 ```
@@ -729,7 +745,7 @@ Duotone icons render on two layers — a primary and a secondary — that you ca
 <style>
   .duotone-demo-preview {
     justify-content: center;
-    font-size: 4rem;
+    font-size: 3rem;
     min-height: 6rem;
     margin-block-end: 1.5rem;
   }
@@ -748,26 +764,46 @@ Duotone icons render on two layers — a primary and a secondary — that you ca
     const [primary, secondary] = demo.querySelectorAll('wa-color-picker');
     const [primaryOpacity, secondaryOpacity] = demo.querySelectorAll('wa-slider');
 
-    const apply = () => {
+    // Until the user picks a color, each layer stays on its default currentColor so it tracks
+    // the color scheme. Opacity changes must not pin a color, or the icons freeze on toggle.
+    let hasPrimaryColor = false;
+    let hasSecondaryColor = false;
+
+    const applyOpacity = () => {
       icons.forEach(icon => {
-        icon.style.setProperty('--primary-color', primary.value);
-        icon.style.setProperty('--secondary-color', secondary.value);
         icon.style.setProperty('--primary-opacity', primaryOpacity.value);
         icon.style.setProperty('--secondary-opacity', secondaryOpacity.value);
       });
     };
 
-    [primary, secondary, primaryOpacity, secondaryOpacity].forEach(control => control.addEventListener('input', apply));
-
-    // Default the color pickers to the page's text color, matching the icons' default duotone rendering (currentColor).
-    const probe = document.createElement('span');
-    demo.appendChild(probe);
-    const defaultColor = getComputedStyle(probe).color;
-    probe.remove();
-    customElements.whenDefined('wa-color-picker').then(() => {
-      primary.value = defaultColor;
-      secondary.value = defaultColor;
+    primary.addEventListener('input', () => {
+      hasPrimaryColor = true;
+      icons.forEach(icon => icon.style.setProperty('--primary-color', primary.value));
     });
+    secondary.addEventListener('input', () => {
+      hasSecondaryColor = true;
+      icons.forEach(icon => icon.style.setProperty('--secondary-color', secondary.value));
+    });
+    primaryOpacity.addEventListener('input', applyOpacity);
+    secondaryOpacity.addEventListener('input', applyOpacity);
+
+    // Keep the unedited color pickers showing the page's text color so their swatches match the
+    // icons' default currentColor — and re-probe when the scheme changes so they don't go stale.
+    const syncColorDefaults = () => {
+      const probe = document.createElement('span');
+      demo.appendChild(probe);
+      const textColor = getComputedStyle(probe).color;
+      probe.remove();
+      if (!hasPrimaryColor) primary.value = textColor;
+      if (!hasSecondaryColor) secondary.value = textColor;
+    };
+
+    customElements.whenDefined('wa-color-picker').then(syncColorDefaults);
+    document.addEventListener('color-scheme-settled', syncColorDefaults);
+    const preview = demo.closest('.code-example-preview');
+    if (preview) {
+      new MutationObserver(syncColorDefaults).observe(preview, { attributes: true, attributeFilter: ['class'] });
+    }
   })();
 </script>
 ```
@@ -796,7 +832,7 @@ For duotone icons, you can swap the primary and secondary opacity values using t
     <wa-icon family="duotone" name="user" swap-opacity></wa-icon>
     <wa-icon family="duotone" name="envelope" swap-opacity></wa-icon>
     <wa-icon family="duotone" name="calendar" swap-opacity></wa-icon>
-    <span style="font-size: 1rem;">Swapped opacity</span>
+    <span style="font-size: 1rem;">Swapped Opacity</span>
   </div>
 </div>
 ```

--- a/packages/webawesome/docs/docs/components/icon.md
+++ b/packages/webawesome/docs/docs/components/icon.md
@@ -486,7 +486,7 @@ Use the `flip` animation to rotate an icon in 3D space. By default, flip rotates
 
 ### Flip 360
 
-Use the `flip-360` animation to flip an icon all the way around in one smooth rotation — an extension of `flip` that gives it some extra oomph. It shares the same `--flip-x`, `--flip-y`, and `--flip-z` axis properties.
+Use the `flip-360` animation to flip an icon all the way around in one smooth rotation — an extension of `flip` that gives it some extra oomph. It shares the same `--flip-x`, `--flip-y`, and `--flip-z` axis properties, plus `--flip-angle`, `--flip-anticipation-scale`, and `--flip-overshoot`.
 
 ```html {.example}
 <wa-icon name="compact-disc" animation="flip-360" label="Flipping Compact Disc" style="font-size: 2em;"></wa-icon>

--- a/packages/webawesome/docs/docs/components/icon.md
+++ b/packages/webawesome/docs/docs/components/icon.md
@@ -16,15 +16,32 @@ use-cases:
 Web Awesome comes bundled with over 2,000 free icons courtesy of [Font Awesome](https://fontawesome.com/). These icons are part of the `default` icon library. Font Awesome Pro users can unlock additional [icon families](#families-and-variants). Or, if you prefer, you can register your own [custom icon library](#third-party-icon-libraries).
 
 ```html {.example}
-<div class="wa-cluster" style="font-size: 2em;">
-  <wa-icon name="star" label="Star"></wa-icon>
-  <wa-icon name="heart" label="Heart"></wa-icon>
-  <wa-icon name="bell" label="Bell"></wa-icon>
-  <wa-icon name="cloud" label="Cloud"></wa-icon>
-  <wa-icon name="camera" label="Camera"></wa-icon>
-  <wa-icon name="rocket" label="Rocket"></wa-icon>
-  <wa-icon name="face-smile" label="Smile"></wa-icon>
-  <wa-icon name="paw" label="Paw"></wa-icon>
+<!-- A few icon rebuses — can you read them? -->
+<div class="wa-cluster wa-gap-xl" style="font-size: 2em;">
+  <!-- Raining cats and dogs -->
+  <span class="wa-cluster wa-gap-0">
+    <wa-icon name="cloud-rain"></wa-icon>
+    <wa-icon name="cat"></wa-icon>
+    <wa-icon name="dog"></wa-icon>
+  </span>
+
+  <!-- Brainstorm -->
+  <span class="wa-cluster wa-gap-0">
+    <wa-icon name="brain"></wa-icon>
+    <wa-icon name="cloud-bolt"></wa-icon>
+  </span>
+
+  <!-- Bookworm -->
+  <span class="wa-cluster wa-gap-0">
+    <wa-icon name="book"></wa-icon>
+    <wa-icon name="worm"></wa-icon>
+  </span>
+
+  <!-- Moonwalk -->
+  <span class="wa-cluster wa-gap-0">
+    <wa-icon name="moon"></wa-icon>
+    <wa-icon name="person-walking"></wa-icon>
+  </span>
 </div>
 ```
 
@@ -110,11 +127,16 @@ A _family_ sets an icon's overall style; a _variant_ sets its weight. Set them w
   </thead>
   <tbody>
     <tr>
-      <td><code>classic</code></td>
-      <td><code>solid</code>, <code>regular</code>, <code>light</code>, <code>thin</code></td>
+      <td>
+        <span class="wa-cluster wa-flex-nowrap wa-gap-3xs">
+          <code>classic</code>
+          <wa-badge appearance="outlined" variant="neutral" pill style="font-size: var(--wa-font-size-2xs);">default</wa-badge>
+        </span>
+      </td>
+      <td><code>solid</code> <wa-badge appearance="outlined" variant="neutral" pill style="font-size: var(--wa-font-size-2xs);">default</wa-badge>, <code>regular</code>, <code>light</code>, <code>thin</code></td>
       <td>Free</td>
       <td>
-        <div class="wa-cluster icon-copy-row" style="font-size: 1.25em; gap: 0.75rem; align-items: center;">
+        <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.25em; align-items: center;">
           <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;gem&quot;></wa-icon>"><wa-icon variant="solid" name="gem"></wa-icon></wa-copy-button>
           <wa-copy-button copy-label="Copy code" value="<wa-icon variant=&quot;regular&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon variant="regular" name="gem"></wa-icon></wa-copy-button>
           <wa-copy-button copy-label="Copy code" value="<wa-icon variant=&quot;light&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon variant="light" name="gem"></wa-icon></wa-copy-button>
@@ -127,7 +149,7 @@ A _family_ sets an icon's overall style; a _variant_ sets its weight. Set them w
       <td>—</td>
       <td>Free</td>
       <td>
-        <div class="wa-cluster icon-copy-row" style="font-size: 1.25em; gap: 0.75rem; align-items: center;">
+        <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.25em; align-items: center;">
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;brands&quot; name=&quot;font-awesome&quot;></wa-icon>"><wa-icon family="brands" name="font-awesome"></wa-icon></wa-copy-button>
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;brands&quot; name=&quot;github&quot;></wa-icon>"><wa-icon family="brands" name="github"></wa-icon></wa-copy-button>
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;brands&quot; name=&quot;discord&quot;></wa-icon>"><wa-icon family="brands" name="discord"></wa-icon></wa-copy-button>
@@ -139,7 +161,7 @@ A _family_ sets an icon's overall style; a _variant_ sets its weight. Set them w
       <td><code>solid</code>, <code>regular</code>, <code>light</code>, <code>thin</code></td>
       <td>Pro</td>
       <td>
-        <div class="wa-cluster icon-copy-row" style="font-size: 1.25em; gap: 0.75rem; align-items: center;">
+        <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.25em; align-items: center;">
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;duotone&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="duotone" variant="solid" name="gem"></wa-icon></wa-copy-button>
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;duotone&quot; variant=&quot;regular&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="duotone" variant="regular" name="gem"></wa-icon></wa-copy-button>
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;duotone&quot; variant=&quot;light&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="duotone" variant="light" name="gem"></wa-icon></wa-copy-button>
@@ -152,7 +174,7 @@ A _family_ sets an icon's overall style; a _variant_ sets its weight. Set them w
       <td><code>solid</code>, <code>regular</code>, <code>light</code>, <code>thin</code></td>
       <td>Pro</td>
       <td>
-        <div class="wa-cluster icon-copy-row" style="font-size: 1.25em; gap: 0.75rem; align-items: center;">
+        <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.25em; align-items: center;">
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="sharp" variant="solid" name="gem"></wa-icon></wa-copy-button>
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp&quot; variant=&quot;regular&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="sharp" variant="regular" name="gem"></wa-icon></wa-copy-button>
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp&quot; variant=&quot;light&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="sharp" variant="light" name="gem"></wa-icon></wa-copy-button>
@@ -165,7 +187,7 @@ A _family_ sets an icon's overall style; a _variant_ sets its weight. Set them w
       <td><code>solid</code>, <code>regular</code>, <code>light</code>, <code>thin</code></td>
       <td>Pro</td>
       <td>
-        <div class="wa-cluster icon-copy-row" style="font-size: 1.25em; gap: 0.75rem; align-items: center;">
+        <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.25em; align-items: center;">
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp-duotone&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="sharp-duotone" variant="solid" name="gem"></wa-icon></wa-copy-button>
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp-duotone&quot; variant=&quot;regular&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="sharp-duotone" variant="regular" name="gem"></wa-icon></wa-copy-button>
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;sharp-duotone&quot; variant=&quot;light&quot; name=&quot;gem&quot;></wa-icon>"><wa-icon family="sharp-duotone" variant="light" name="gem"></wa-icon></wa-copy-button>
@@ -198,12 +220,17 @@ The _canvas_ is the box an icon sits in. Choose one of four mutually exclusive m
   </thead>
   <tbody>
     <tr>
-      <td><code>fixed</code></td>
+      <td>
+        <span class="wa-cluster wa-flex-nowrap wa-gap-3xs">
+          <code>fixed</code>
+          <wa-badge appearance="outlined" variant="neutral" pill style="font-size: var(--wa-font-size-2xs);">default</wa-badge>
+        </span>
+      </td>
       <td><code>1.25 × 1em</code></td>
       <td>Aligning icons in lists, menus, and toolbars</td>
       <td>
         <div class="wa-cluster icon-copy-row" style="font-size: 1.75em; align-items: center; justify-content: center;">
-          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;bookmark&quot;></wa-icon>"><wa-icon name="bookmark" style="background: var(--wa-color-brand-fill-quiet);"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;bookmark&quot;></wa-icon>"><wa-icon name="bookmark" style="background: var(--wa-color-brand-fill-quiet); border: var(--wa-border-width-s) dashed var(--wa-color-brand-border-loud);"></wa-icon></wa-copy-button>
         </div>
       </td>
     </tr>
@@ -213,7 +240,7 @@ The _canvas_ is the box an icon sits in. Choose one of four mutually exclusive m
       <td>Matching the icon's natural width</td>
       <td>
         <div class="wa-cluster icon-copy-row" style="font-size: 1.75em; align-items: center; justify-content: center;">
-          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;bookmark&quot; canvas=&quot;auto&quot;></wa-icon>"><wa-icon name="bookmark" canvas="auto" style="background: var(--wa-color-brand-fill-quiet);"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;bookmark&quot; canvas=&quot;auto&quot;></wa-icon>"><wa-icon name="bookmark" canvas="auto" style="background: var(--wa-color-brand-fill-quiet); border: var(--wa-border-width-s) dashed var(--wa-color-brand-border-loud);"></wa-icon></wa-copy-button>
         </div>
       </td>
     </tr>
@@ -223,7 +250,7 @@ The _canvas_ is the box an icon sits in. Choose one of four mutually exclusive m
       <td>Standalone icons on a square footprint</td>
       <td>
         <div class="wa-cluster icon-copy-row" style="font-size: 1.75em; align-items: center; justify-content: center;">
-          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;bookmark&quot; canvas=&quot;square&quot;></wa-icon>"><wa-icon name="bookmark" canvas="square" style="background: var(--wa-color-brand-fill-quiet);"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;bookmark&quot; canvas=&quot;square&quot;></wa-icon>"><wa-icon name="bookmark" canvas="square" style="background: var(--wa-color-brand-fill-quiet); border: var(--wa-border-width-s) dashed var(--wa-color-brand-border-loud);"></wa-icon></wa-copy-button>
         </div>
       </td>
     </tr>
@@ -233,7 +260,7 @@ The _canvas_ is the box an icon sits in. Choose one of four mutually exclusive m
       <td>Standalone icons that need more breathing room</td>
       <td>
         <div class="wa-cluster icon-copy-row" style="font-size: 1.75em; align-items: center; justify-content: center;">
-          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;bookmark&quot; canvas=&quot;roomy&quot;></wa-icon>"><wa-icon name="bookmark" canvas="roomy" style="background: var(--wa-color-brand-fill-quiet);"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;bookmark&quot; canvas=&quot;roomy&quot;></wa-icon>"><wa-icon name="bookmark" canvas="roomy" style="background: var(--wa-color-brand-fill-quiet); border: var(--wa-border-width-s) dashed var(--wa-color-brand-border-loud);"></wa-icon></wa-copy-button>
         </div>
       </td>
     </tr>
@@ -243,9 +270,18 @@ The _canvas_ is the box an icon sits in. Choose one of four mutually exclusive m
 ```html {.example}
 <div class="canvas-demo">
   <div class="canvas-demo-preview wa-cluster">
-    <wa-icon name="ruler-horizontal" style="background: var(--wa-color-brand-fill-quiet);"></wa-icon>
-    <wa-icon name="ruler-vertical" style="background: var(--wa-color-brand-fill-quiet);"></wa-icon>
-    <wa-icon name="face-smile" style="background: var(--wa-color-brand-fill-quiet);"></wa-icon>
+    <wa-icon
+      name="ruler-horizontal"
+      style="background: var(--wa-color-brand-fill-quiet); border: var(--wa-border-width-s) dashed var(--wa-color-brand-border-loud);"
+    ></wa-icon>
+    <wa-icon
+      name="ruler-vertical"
+      style="background: var(--wa-color-brand-fill-quiet); border: var(--wa-border-width-s) dashed var(--wa-color-brand-border-loud);"
+    ></wa-icon>
+    <wa-icon
+      name="face-smile"
+      style="background: var(--wa-color-brand-fill-quiet); border: var(--wa-border-width-s) dashed var(--wa-color-brand-border-loud);"
+    ></wa-icon>
   </div>
 
   <wa-divider></wa-divider>
@@ -312,7 +348,9 @@ Web Awesome supports [{{ site.siblings.fontAwesome.name }}'s rotation and flip u
       <td><code>rotate</code></td>
       <td><code>90</code></td>
       <td>
-        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+        <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.5em; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;paper-plane&quot; rotate=&quot;90&quot;></wa-icon>"><wa-icon name="paper-plane" rotate="90"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;location-arrow&quot; rotate=&quot;90&quot;></wa-icon>"><wa-icon name="location-arrow" rotate="90"></wa-icon></wa-copy-button>
           <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;hand-point-up&quot; rotate=&quot;90&quot;></wa-icon>"><wa-icon name="hand-point-up" rotate="90"></wa-icon></wa-copy-button>
         </div>
       </td>
@@ -321,7 +359,9 @@ Web Awesome supports [{{ site.siblings.fontAwesome.name }}'s rotation and flip u
       <td><code>rotate</code></td>
       <td><code>180</code></td>
       <td>
-        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+        <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.5em; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;paper-plane&quot; rotate=&quot;180&quot;></wa-icon>"><wa-icon name="paper-plane" rotate="180"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;location-arrow&quot; rotate=&quot;180&quot;></wa-icon>"><wa-icon name="location-arrow" rotate="180"></wa-icon></wa-copy-button>
           <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;hand-point-up&quot; rotate=&quot;180&quot;></wa-icon>"><wa-icon name="hand-point-up" rotate="180"></wa-icon></wa-copy-button>
         </div>
       </td>
@@ -330,7 +370,9 @@ Web Awesome supports [{{ site.siblings.fontAwesome.name }}'s rotation and flip u
       <td><code>rotate</code></td>
       <td><code>270</code></td>
       <td>
-        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+        <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.5em; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;paper-plane&quot; rotate=&quot;270&quot;></wa-icon>"><wa-icon name="paper-plane" rotate="270"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;location-arrow&quot; rotate=&quot;270&quot;></wa-icon>"><wa-icon name="location-arrow" rotate="270"></wa-icon></wa-copy-button>
           <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;hand-point-up&quot; rotate=&quot;270&quot;></wa-icon>"><wa-icon name="hand-point-up" rotate="270"></wa-icon></wa-copy-button>
         </div>
       </td>
@@ -339,7 +381,9 @@ Web Awesome supports [{{ site.siblings.fontAwesome.name }}'s rotation and flip u
       <td><code>flip</code></td>
       <td><code>x</code></td>
       <td>
-        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+        <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.5em; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;paper-plane&quot; flip=&quot;x&quot;></wa-icon>"><wa-icon name="paper-plane" flip="x"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;location-arrow&quot; flip=&quot;x&quot;></wa-icon>"><wa-icon name="location-arrow" flip="x"></wa-icon></wa-copy-button>
           <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;hand-point-up&quot; flip=&quot;x&quot;></wa-icon>"><wa-icon name="hand-point-up" flip="x"></wa-icon></wa-copy-button>
         </div>
       </td>
@@ -348,7 +392,9 @@ Web Awesome supports [{{ site.siblings.fontAwesome.name }}'s rotation and flip u
       <td><code>flip</code></td>
       <td><code>y</code></td>
       <td>
-        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+        <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.5em; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;paper-plane&quot; flip=&quot;y&quot;></wa-icon>"><wa-icon name="paper-plane" flip="y"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;location-arrow&quot; flip=&quot;y&quot;></wa-icon>"><wa-icon name="location-arrow" flip="y"></wa-icon></wa-copy-button>
           <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;hand-point-up&quot; flip=&quot;y&quot;></wa-icon>"><wa-icon name="hand-point-up" flip="y"></wa-icon></wa-copy-button>
         </div>
       </td>
@@ -357,7 +403,9 @@ Web Awesome supports [{{ site.siblings.fontAwesome.name }}'s rotation and flip u
       <td><code>flip</code></td>
       <td><code>both</code></td>
       <td>
-        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+        <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.5em; align-items: center;">
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;paper-plane&quot; flip=&quot;both&quot;></wa-icon>"><wa-icon name="paper-plane" flip="both"></wa-icon></wa-copy-button>
+          <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;location-arrow&quot; flip=&quot;both&quot;></wa-icon>"><wa-icon name="location-arrow" flip="both"></wa-icon></wa-copy-button>
           <wa-copy-button copy-label="Copy code" value="<wa-icon name=&quot;hand-point-up&quot; flip=&quot;both&quot;></wa-icon>"><wa-icon name="hand-point-up" flip="both"></wa-icon></wa-copy-button>
         </div>
       </td>
@@ -368,12 +416,12 @@ Web Awesome supports [{{ site.siblings.fontAwesome.name }}'s rotation and flip u
 Rotate by any angle — and combine `rotate` and `flip` on the same icon:
 
 ```html {.example}
-<wa-icon name="snowboarding" label="Snowboarding" style="font-size: 2em;"></wa-icon>
-<wa-icon name="snowboarding" rotate="45" label="Snowboarding" style="font-size: 2em;"></wa-icon>
-<wa-icon name="snowboarding" rotate="135" label="Snowboarding" style="font-size: 2em;"></wa-icon>
-<wa-icon name="snowboarding" rotate="270" label="Snowboarding" style="font-size: 2em;"></wa-icon>
-<wa-icon name="snowboarding" flip="both" label="Snowboarding" style="font-size: 2em;"></wa-icon>
-<wa-icon name="snowboarding" rotate="45" flip="x" label="Snowboarding" style="font-size: 2em;"></wa-icon>
+<wa-icon name="snowboarding" style="font-size: 2em;"></wa-icon>
+<wa-icon name="snowboarding" rotate="45" style="font-size: 2em;"></wa-icon>
+<wa-icon name="snowboarding" rotate="135" style="font-size: 2em;"></wa-icon>
+<wa-icon name="snowboarding" rotate="270" style="font-size: 2em;"></wa-icon>
+<wa-icon name="snowboarding" flip="both" style="font-size: 2em;"></wa-icon>
+<wa-icon name="snowboarding" rotate="45" flip="x" style="font-size: 2em;"></wa-icon>
 ```
 
 ## Animating
@@ -401,6 +449,7 @@ Use the `fade` animation to fade an icon in and out visually to grab attention i
 <wa-icon name="triangle-exclamation" animation="fade" label="Fading Warning" style="font-size: 2em;"></wa-icon>
 <wa-icon name="skull-crossbones" animation="fade" label="Fading Danger" style="font-size: 2em;"></wa-icon>
 <wa-icon name="cloud-arrow-down" animation="fade" label="Fading Download" style="font-size: 2em;"></wa-icon>
+<!-- Use --fade-opacity to set how faint it fades (and --animation-duration the pace) -->
 <wa-icon
   name="i-cursor"
   animation="fade"
@@ -416,12 +465,14 @@ Use the `beat-fade` animation to grab attention by visually scaling and pulsing 
 ```html {.example}
 <wa-icon name="person-digging" animation="beat-fade" label="Beat-Fading Construction" style="font-size: 2em;"></wa-icon>
 <wa-icon name="circle-exclamation" animation="beat-fade" label="Beat-Fading Alert" style="font-size: 2em;"></wa-icon>
+<!-- Stronger pulse: lower --beat-fade-opacity, higher --beat-fade-scale -->
 <wa-icon
   name="square-exclamation"
   animation="beat-fade"
   label="Beat-Fading Alert"
   style="font-size: 2em; --beat-fade-opacity: 0.1;--beat-fade-scale: 1.25"
 ></wa-icon>
+<!-- Subtler pulse -->
 <wa-icon
   name="circle-info"
   animation="beat-fade"
@@ -470,12 +521,14 @@ Use the `flip` animation to rotate an icon in 3D space. By default, flip rotates
 <wa-icon name="compact-disc" animation="flip" label="Flipping Compact Disc" style="font-size: 2em;"></wa-icon>
 <wa-icon name="camera-rotate" animation="flip" label="Flipping Camera Rotate" style="font-size: 2em;"></wa-icon>
 <wa-icon name="compact-disc" animation="flip" label="Flipping Disc" style="font-size: 2em;"></wa-icon>
+<!-- Set the flip axis with --flip-x / --flip-y -->
 <wa-icon
   name="scroll"
   animation="flip"
   label="Flipping Scroll"
   style="font-size: 2em; --flip-x: 1; --flip-y: 0"
 ></wa-icon>
+<!-- Slow it down with --animation-duration -->
 <wa-icon
   name="money-check-dollar"
   animation="flip"
@@ -491,12 +544,14 @@ Use the `flip-360` animation to flip an icon all the way around in one smooth ro
 ```html {.example}
 <wa-icon name="compact-disc" animation="flip-360" label="Flipping Compact Disc" style="font-size: 2em;"></wa-icon>
 <wa-icon name="camera-rotate" animation="flip-360" label="Flipping Camera Rotate" style="font-size: 2em;"></wa-icon>
+<!-- Set the flip axis with --flip-x / --flip-y -->
 <wa-icon
   name="scroll"
   animation="flip-360"
   label="Flipping Scroll"
   style="font-size: 2em; --flip-x: 1; --flip-y: 0;"
 ></wa-icon>
+<!-- Slow it down with --animation-duration -->
 <wa-icon
   name="compact-disc"
   animation="flip-360"
@@ -550,6 +605,7 @@ Use `spin-snap` to rotate in distinct steps with a pause on each, like a clock's
 <wa-icon name="gear" animation="spin-snap" label="Snapping Gear" style="font-size: 2em;"></wa-icon>
 <wa-icon name="gear" animation="spin-snap-4" label="Snapping Gear, four stops" style="font-size: 2em;"></wa-icon>
 <wa-icon name="gear" animation="spin-snap-8" label="Snapping Gear, eight stops" style="font-size: 2em;"></wa-icon>
+<!-- Add --animation-direction: reverse to run counter-clockwise -->
 <wa-icon
   name="gear"
   animation="spin-snap"
@@ -565,6 +621,7 @@ Use the `buzz` animation for a fast, tight vibration with rapid decay — quick 
 ```html {.example}
 <wa-icon name="bell" animation="buzz" label="Buzzing Bell" style="font-size: 2em;"></wa-icon>
 <wa-icon name="mobile" animation="buzz" label="Buzzing Phone" style="font-size: 2em;"></wa-icon>
+<!-- Use --buzz-distance to control how far it travels -->
 <wa-icon
   name="triangle-exclamation"
   animation="buzz"
@@ -580,6 +637,7 @@ Use the `float` animation for a slow, drifting motion — great for empty states
 ```html {.example}
 <wa-icon name="feather" animation="float" label="Floating Feather" style="font-size: 2em;"></wa-icon>
 <wa-icon name="ghost" animation="float" label="Floating Ghost" style="font-size: 2em;"></wa-icon>
+<!-- Use --float-height to control the rise (and --animation-duration the pace) -->
 <wa-icon
   name="feather"
   animation="float"
@@ -595,6 +653,7 @@ Use the `jello` animation for a playful jiggle — great for calling attention t
 ```html {.example}
 <wa-icon name="cube" animation="jello" label="Jiggling Cube" style="font-size: 2em;"></wa-icon>
 <wa-icon name="droplet" animation="jello" label="Jiggling Droplet" style="font-size: 2em;"></wa-icon>
+<!-- Use --jello-scale-x to control how far it stretches -->
 <wa-icon
   name="star"
   animation="jello"
@@ -610,6 +669,7 @@ Use the `swing` animation for a subtle dangle with a slow decay — great for th
 ```html {.example}
 <wa-icon name="bell" animation="swing" label="Swinging Bell" style="font-size: 2em;"></wa-icon>
 <wa-icon name="key" animation="swing" label="Swinging Key" style="font-size: 2em;"></wa-icon>
+<!-- Use --swing-angle to control the peak rotation -->
 <wa-icon
   name="bell"
   animation="swing"
@@ -625,6 +685,7 @@ Use the `wag` animation, a cousin of `swing`, for a bottom-anchored wag — the 
 ```html {.example}
 <wa-icon name="hand-pointer" animation="wag" label="Wagging Pointer" style="font-size: 2em;"></wa-icon>
 <wa-icon name="hand-point-up" animation="wag" label="Wagging Finger" style="font-size: 2em;"></wa-icon>
+<!-- Use --wag-angle to control the peak rotation -->
 <wa-icon
   name="hand-point-right"
   animation="wag"
@@ -648,43 +709,18 @@ Duotone icons render on two layers — a primary and a secondary — that you ca
 ```html {.example}
 <div class="duotone-demo">
   <div class="duotone-demo-preview wa-cluster">
-    <wa-icon
-      family="duotone"
-      name="palette"
-      label="Palette"
-      style="--primary-color: #3b82f6; --secondary-color: #3b82f6;"
-    ></wa-icon>
-    <wa-icon
-      family="duotone"
-      name="crow"
-      label="Crow"
-      style="--primary-color: #3b82f6; --secondary-color: #3b82f6;"
-    ></wa-icon>
-    <wa-icon
-      family="duotone"
-      name="campfire"
-      label="Campfire"
-      style="--primary-color: #3b82f6; --secondary-color: #3b82f6;"
-    ></wa-icon>
-    <wa-icon
-      family="duotone"
-      name="cloud-sun"
-      label="Cloud and sun"
-      style="--primary-color: #3b82f6; --secondary-color: #3b82f6;"
-    ></wa-icon>
-    <wa-icon
-      family="duotone"
-      name="bell"
-      label="Bell"
-      style="--primary-color: #3b82f6; --secondary-color: #3b82f6;"
-    ></wa-icon>
+    <wa-icon family="duotone" name="palette" label="Palette"></wa-icon>
+    <wa-icon family="duotone" name="crow" label="Crow"></wa-icon>
+    <wa-icon family="duotone" name="campfire" label="Campfire"></wa-icon>
+    <wa-icon family="duotone" name="cloud-sun" label="Cloud and sun"></wa-icon>
+    <wa-icon family="duotone" name="bell" label="Bell"></wa-icon>
   </div>
 
   <wa-divider></wa-divider>
 
   <div class="wa-cluster wa-gap-xl duotone-demo-controls">
-    <wa-color-picker label="Primary color" value="#3b82f6"></wa-color-picker>
-    <wa-color-picker label="Secondary color" value="#3b82f6"></wa-color-picker>
+    <wa-color-picker label="Primary color"></wa-color-picker>
+    <wa-color-picker label="Secondary color"></wa-color-picker>
     <wa-slider label="Primary opacity" min="0" max="1" step="0.1" value="1"></wa-slider>
     <wa-slider label="Secondary opacity" min="0" max="1" step="0.1" value="0.4"></wa-slider>
   </div>
@@ -722,6 +758,16 @@ Duotone icons render on two layers — a primary and a secondary — that you ca
     };
 
     [primary, secondary, primaryOpacity, secondaryOpacity].forEach(control => control.addEventListener('input', apply));
+
+    // Default the color pickers to the page's text color, matching the icons' default duotone rendering (currentColor).
+    const probe = document.createElement('span');
+    demo.appendChild(probe);
+    const defaultColor = getComputedStyle(probe).color;
+    probe.remove();
+    customElements.whenDefined('wa-color-picker').then(() => {
+      primary.value = defaultColor;
+      secondary.value = defaultColor;
+    });
   })();
 </script>
 ```
@@ -774,7 +820,7 @@ If you're a [Font Awesome Pro+ customer](https://fontawesome.com/), you have acc
       <td><code>chisel</code></td>
       <td><code>regular</code></td>
       <td>
-        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+        <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.5em; align-items: center;">
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;chisel&quot; variant=&quot;regular&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="chisel" variant="regular" name="house"></wa-icon></wa-copy-button>
         </div>
       </td>
@@ -784,7 +830,7 @@ If you're a [Font Awesome Pro+ customer](https://fontawesome.com/), you have acc
       <td><code>etch</code></td>
       <td><code>solid</code></td>
       <td>
-        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+        <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.5em; align-items: center;">
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;etch&quot; variant=&quot;solid&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="etch" variant="solid" name="house"></wa-icon></wa-copy-button>
         </div>
       </td>
@@ -794,7 +840,7 @@ If you're a [Font Awesome Pro+ customer](https://fontawesome.com/), you have acc
       <td><code>graphite</code></td>
       <td><code>thin</code></td>
       <td>
-        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+        <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.5em; align-items: center;">
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;graphite&quot; variant=&quot;thin&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="graphite" variant="thin" name="house"></wa-icon></wa-copy-button>
         </div>
       </td>
@@ -804,7 +850,7 @@ If you're a [Font Awesome Pro+ customer](https://fontawesome.com/), you have acc
       <td><code>jelly</code>, <code>jelly-duo</code>, <code>jelly-fill</code></td>
       <td><code>regular</code></td>
       <td>
-        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+        <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.5em; align-items: center;">
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;jelly&quot; variant=&quot;regular&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="jelly" variant="regular" name="house"></wa-icon></wa-copy-button>
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;jelly-duo&quot; variant=&quot;regular&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="jelly-duo" variant="regular" name="house" style="--secondary-color: skyblue; --secondary-opacity: 0.8;"></wa-icon></wa-copy-button>
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;jelly-fill&quot; variant=&quot;regular&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="jelly-fill" variant="regular" name="house"></wa-icon></wa-copy-button>
@@ -816,7 +862,7 @@ If you're a [Font Awesome Pro+ customer](https://fontawesome.com/), you have acc
       <td><code>mosaic</code></td>
       <td><code>solid</code></td>
       <td>
-        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+        <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.5em; align-items: center;">
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;mosaic&quot; variant=&quot;solid&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="mosaic" variant="solid" name="house"></wa-icon></wa-copy-button>
         </div>
       </td>
@@ -826,7 +872,7 @@ If you're a [Font Awesome Pro+ customer](https://fontawesome.com/), you have acc
       <td><code>notdog</code>, <code>notdog-duo</code></td>
       <td><code>solid</code></td>
       <td>
-        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+        <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.5em; align-items: center;">
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;notdog&quot; variant=&quot;solid&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="notdog" variant="solid" name="house"></wa-icon></wa-copy-button>
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;notdog-duo&quot; variant=&quot;solid&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="notdog-duo" variant="solid" name="house" style="--secondary-color: skyblue; --secondary-opacity: 0.8;"></wa-icon></wa-copy-button>
         </div>
@@ -837,7 +883,7 @@ If you're a [Font Awesome Pro+ customer](https://fontawesome.com/), you have acc
       <td><code>pixel</code></td>
       <td><code>regular</code></td>
       <td>
-        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+        <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.5em; align-items: center;">
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;pixel&quot; variant=&quot;regular&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="pixel" variant="regular" name="house"></wa-icon></wa-copy-button>
         </div>
       </td>
@@ -847,7 +893,7 @@ If you're a [Font Awesome Pro+ customer](https://fontawesome.com/), you have acc
       <td><code>slab</code>, <code>slab-press</code>, <code>slab-duo</code>, <code>slab-press-duo</code></td>
       <td><code>regular</code></td>
       <td>
-        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+        <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.5em; align-items: center;">
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;slab&quot; variant=&quot;regular&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="slab" variant="regular" name="house"></wa-icon></wa-copy-button>
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;slab-press&quot; variant=&quot;regular&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="slab-press" variant="regular" name="house"></wa-icon></wa-copy-button>
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;slab-duo&quot; variant=&quot;regular&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="slab-duo" variant="regular" name="house" style="--secondary-color: skyblue; --secondary-opacity: 0.8;"></wa-icon></wa-copy-button>
@@ -860,7 +906,7 @@ If you're a [Font Awesome Pro+ customer](https://fontawesome.com/), you have acc
       <td><code>thumbprint</code></td>
       <td><code>light</code></td>
       <td>
-        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+        <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.5em; align-items: center;">
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;thumbprint&quot; variant=&quot;light&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="thumbprint" variant="light" name="house" style="--secondary-color: skyblue; --secondary-opacity: 0.8;"></wa-icon></wa-copy-button>
         </div>
       </td>
@@ -870,7 +916,7 @@ If you're a [Font Awesome Pro+ customer](https://fontawesome.com/), you have acc
       <td><code>utility</code>, <code>utility-duo</code>, <code>utility-fill</code></td>
       <td><code>semibold</code></td>
       <td>
-        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+        <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.5em; align-items: center;">
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;utility&quot; variant=&quot;semibold&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="utility" variant="semibold" name="house"></wa-icon></wa-copy-button>
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;utility-duo&quot; variant=&quot;semibold&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="utility-duo" variant="semibold" name="house" style="--secondary-color: skyblue; --secondary-opacity: 0.8;"></wa-icon></wa-copy-button>
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;utility-fill&quot; variant=&quot;semibold&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="utility-fill" variant="semibold" name="house"></wa-icon></wa-copy-button>
@@ -882,7 +928,7 @@ If you're a [Font Awesome Pro+ customer](https://fontawesome.com/), you have acc
       <td><code>vellum</code></td>
       <td><code>solid</code></td>
       <td>
-        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+        <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.5em; align-items: center;">
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;vellum&quot; variant=&quot;solid&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="vellum" variant="solid" name="house"></wa-icon></wa-copy-button>
         </div>
       </td>
@@ -892,7 +938,7 @@ If you're a [Font Awesome Pro+ customer](https://fontawesome.com/), you have acc
       <td><code>whiteboard</code></td>
       <td><code>semibold</code></td>
       <td>
-        <div class="wa-cluster icon-copy-row" style="font-size: 1.5em; gap: 0.75rem; align-items: center;">
+        <div class="wa-cluster icon-copy-row wa-gap-s" style="font-size: 1.5em; align-items: center;">
           <wa-copy-button copy-label="Copy code" value="<wa-icon family=&quot;whiteboard&quot; variant=&quot;semibold&quot; name=&quot;house&quot;></wa-icon>"><wa-icon family="whiteboard" variant="semibold" name="house"></wa-icon></wa-copy-button>
         </div>
       </td>

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -34,10 +34,14 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 :::added
 
 - Added the experimental `<wa-random-content>` component, which randomly shows one or more of its children — handy for rotating testimonials, tips, or featured content
+- Added the Mosaic, Pixel, Vellum, Slab Duo, and Slab Press Duo Pro+ icon families to `<wa-icon>` [pr:2562]
+- Added the `buzz`, `flip-360`, `float`, `jello`, `spin-snap`, `spin-snap-4`, `spin-snap-8`, `swing`, and `wag` animations to `<wa-icon>` [pr:2562]
+- Added the `canvas` attribute to `<wa-icon>` for choosing the icon canvas — `fixed` (default), `auto`, `square`, or `roomy` [pr:2562]
 
 :::
 
 :::fixed
+
 - Fixed a bug in `wa-video` that was causing the `z-index` to leak out of the context of the component [issue:2542]
 - Fixed a bug in `<wa-chart>` and its variants that threw a `DataCloneError` when the Chart.js config contained functions, such as tooltip or scale callbacks
 - Fixed a bug in `<wa-date-input>` and `<wa-time-input>` where an empty `start`/`end` slot added a phantom gap causing it to be misaligned with other form controls [issue:2527]
@@ -61,6 +65,14 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
   - The current (keyboard-highlighted) state now uses `--wa-form-control-activated-color` for its background and a new `--current-text-color` custom property for its text, so options track form control theming alongside `<wa-checkbox>`, `<wa-radio>`, `<wa-switch>`, and `<wa-slider>`
   - Hover and current state changes now animate, matching `<wa-dropdown-item>`
 - Reordered component reference pages in the `webawesome` Agent Skill to put the import instructions and API tables before the examples
+- Updated `<wa-icon>` to use [Font Awesome 7.3.0](https://fontawesome.com/changelog#v7-3-0) [pr:2562]
+- Aligned `<wa-icon>` animation defaults with Font Awesome 7.3.0 — `flip`, `shake`, `fade`, and `beat-fade` use updated timing, duration, and keyframes [pr:2562]
+
+:::
+
+:::deprecated
+
+- Deprecated the `auto-width` attribute on `<wa-icon>` in favor of `canvas="auto"` [pr:2562]
 
 :::
 

--- a/packages/webawesome/src/components/icon/icon.styles.ts
+++ b/packages/webawesome/src/components/icon/icon.styles.ts
@@ -15,19 +15,41 @@ export default css`
     vertical-align: -0.125em;
   }
 
-  /* Standard */
-  :host(:not([auto-width])) {
+  /* #region Canvas — the box the icon is centered within (mirrors Font Awesome's icon canvas). Orthogonal to font-size. */
+
+  /* Fixed width (default): 1.25em × 1em (20 × 16px) */
+  :host(:not([canvas])),
+  :host([canvas='fixed']) {
     width: 1.25em;
     height: 1em;
     min-width: 1.25em; /* <-- this is what Safari respects for intrinsic */
     min-height: 1em;
   }
 
-  /* Auto-width */
-  :host([auto-width]) {
+  /* Auto: hug the icon's width. \`auto-width\` is the deprecated alias for canvas="auto". */
+  :host([canvas='auto']),
+  :host([auto-width]:not([canvas])) {
     width: auto;
     height: 1em;
   }
+
+  /* Square: 1.25em × 1.25em (20 × 20px) */
+  :host([canvas='square']) {
+    width: 1.25em;
+    height: 1.25em;
+    min-width: 1.25em;
+    min-height: 1.25em;
+  }
+
+  /* Roomy: 1.5em × 1.5em (24 × 24px) */
+  :host([canvas='roomy']) {
+    width: 1.5em;
+    height: 1.5em;
+    min-width: 1.5em;
+    min-height: 1.5em;
+  }
+
+  /* #endregion */
 
   svg {
     fill: currentColor;
@@ -74,7 +96,8 @@ export default css`
     transform: rotate(var(--rotate-angle, 0deg)) scale(-1, -1);
   }
 
-  /* Animations */
+  /* #region Animations — ported from Font Awesome 7.3 (--fa-* props mapped to wa-icon's --* names) */
+
   :host([animation='beat']) {
     animation-name: beat;
     animation-delay: var(--animation-delay, 0s);
@@ -82,24 +105,6 @@ export default css`
     animation-duration: var(--animation-duration, 1s);
     animation-iteration-count: var(--animation-iteration-count, infinite);
     animation-timing-function: var(--animation-timing, ease-in-out);
-  }
-
-  :host([animation='fade']) {
-    animation-name: fade;
-    animation-delay: var(--animation-delay, 0s);
-    animation-direction: var(--animation-direction, normal);
-    animation-duration: var(--animation-duration, 1s);
-    animation-iteration-count: var(--animation-iteration-count, infinite);
-    animation-timing-function: var(--animation-timing, cubic-bezier(0.4, 0, 0.6, 1));
-  }
-
-  :host([animation='beat-fade']) {
-    animation-name: beat-fade;
-    animation-delay: var(--animation-delay, 0s);
-    animation-direction: var(--animation-direction, normal);
-    animation-duration: var(--animation-duration, 1s);
-    animation-iteration-count: var(--animation-iteration-count, infinite);
-    animation-timing-function: var(--animation-timing, cubic-bezier(0.4, 0, 0.6, 1));
   }
 
   :host([animation='bounce']) {
@@ -111,8 +116,35 @@ export default css`
     animation-timing-function: var(--animation-timing, cubic-bezier(0.28, 0.84, 0.42, 1));
   }
 
+  :host([animation='fade']) {
+    animation-name: fade;
+    animation-delay: var(--animation-delay, 0s);
+    animation-direction: var(--animation-direction, normal);
+    animation-duration: var(--animation-duration, 1s);
+    animation-iteration-count: var(--animation-iteration-count, infinite);
+    animation-timing-function: var(--animation-timing, ease-in-out);
+  }
+
+  :host([animation='beat-fade']) {
+    animation-name: beat-fade;
+    animation-delay: var(--animation-delay, 0s);
+    animation-direction: var(--animation-direction, normal);
+    animation-duration: var(--animation-duration, 1s);
+    animation-iteration-count: var(--animation-iteration-count, infinite);
+    animation-timing-function: var(--animation-timing, ease-in-out);
+  }
+
   :host([animation='flip']) {
     animation-name: flip;
+    animation-delay: var(--animation-delay, 0s);
+    animation-direction: var(--animation-direction, normal);
+    animation-duration: var(--animation-duration, 1.5s);
+    animation-iteration-count: var(--animation-iteration-count, infinite);
+    animation-timing-function: var(--animation-timing, ease-in-out);
+  }
+
+  :host([animation='flip-360']) {
+    animation-name: flip-360;
     animation-delay: var(--animation-delay, 0s);
     animation-direction: var(--animation-direction, normal);
     animation-duration: var(--animation-duration, 1s);
@@ -124,9 +156,9 @@ export default css`
     animation-name: shake;
     animation-delay: var(--animation-delay, 0s);
     animation-direction: var(--animation-direction, normal);
-    animation-duration: var(--animation-duration, 1s);
+    animation-duration: var(--animation-duration, 0.75s);
     animation-iteration-count: var(--animation-iteration-count, infinite);
-    animation-timing-function: var(--animation-timing, linear);
+    animation-timing-function: var(--animation-timing, ease-in-out);
   }
 
   :host([animation='spin']) {
@@ -139,13 +171,14 @@ export default css`
   }
 
   :host([animation='spin-pulse']) {
-    animation-name: spin-pulse;
+    animation-name: spin;
     animation-direction: var(--animation-direction, normal);
     animation-duration: var(--animation-duration, 1s);
     animation-iteration-count: var(--animation-iteration-count, infinite);
     animation-timing-function: var(--animation-timing, steps(8));
   }
 
+  /* spin-reverse is FA's reverse modifier expressed as a standalone value; reverse any spin via --animation-direction: reverse */
   :host([animation='spin-reverse']) {
     animation-name: spin;
     animation-delay: var(--animation-delay, 0s);
@@ -155,108 +188,303 @@ export default css`
     animation-timing-function: var(--animation-timing, linear);
   }
 
-  /* Keyframes */
+  :host([animation='spin-snap']) {
+    animation-name: spin-snap;
+    animation-delay: var(--animation-delay, 0s);
+    animation-direction: var(--animation-direction, normal);
+    animation-duration: var(--animation-duration, 3s);
+    animation-iteration-count: var(--animation-iteration-count, infinite);
+    animation-timing-function: var(--animation-timing, linear);
+  }
+
+  :host([animation='spin-snap-4']) {
+    animation-name: spin-snap-4;
+    animation-delay: var(--animation-delay, 0s);
+    animation-direction: var(--animation-direction, normal);
+    animation-duration: var(--animation-duration, 2.4s);
+    animation-iteration-count: var(--animation-iteration-count, infinite);
+    animation-timing-function: var(--animation-timing, linear);
+  }
+
+  :host([animation='spin-snap-8']) {
+    animation-name: spin-snap-8;
+    animation-delay: var(--animation-delay, 0s);
+    animation-direction: var(--animation-direction, normal);
+    animation-duration: var(--animation-duration, 4s);
+    animation-iteration-count: var(--animation-iteration-count, infinite);
+    animation-timing-function: var(--animation-timing, linear);
+  }
+
+  :host([animation='buzz']) {
+    animation-name: buzz;
+    animation-delay: var(--animation-delay, 0s);
+    animation-direction: var(--animation-direction, normal);
+    animation-duration: var(--animation-duration, 0.6s);
+    animation-iteration-count: var(--animation-iteration-count, infinite);
+    animation-timing-function: var(--animation-timing, linear);
+  }
+
+  :host([animation='wag']) {
+    animation-name: wag;
+    animation-delay: var(--animation-delay, 0s);
+    animation-direction: var(--animation-direction, normal);
+    animation-duration: var(--animation-duration, 0.9s);
+    animation-iteration-count: var(--animation-iteration-count, infinite);
+    animation-timing-function: var(--animation-timing, ease-out);
+    transform-origin: bottom center;
+  }
+
+  :host([animation='float']) {
+    animation-name: float;
+    animation-delay: var(--animation-delay, 0s);
+    animation-direction: var(--animation-direction, normal);
+    animation-duration: var(--animation-duration, 3s);
+    animation-iteration-count: var(--animation-iteration-count, infinite);
+    animation-timing-function: var(--animation-timing, ease-in-out);
+    will-change: transform;
+  }
+
+  :host([animation='swing']) {
+    animation-name: swing;
+    animation-delay: var(--animation-delay, 0s);
+    animation-direction: var(--animation-direction, normal);
+    animation-duration: var(--animation-duration, 1.2s);
+    animation-iteration-count: var(--animation-iteration-count, infinite);
+    animation-timing-function: var(--animation-timing, ease-out);
+    transform-origin: top center;
+  }
+
+  :host([animation='jello']) {
+    animation-name: jello;
+    animation-delay: var(--animation-delay, 0s);
+    animation-direction: var(--animation-direction, normal);
+    animation-duration: var(--animation-duration, 0.9s);
+    animation-iteration-count: var(--animation-iteration-count, infinite);
+    animation-timing-function: var(--animation-timing, ease-out);
+  }
+
   @media (prefers-reduced-motion: reduce) {
     :host([animation='beat']),
     :host([animation='bounce']),
     :host([animation='fade']),
     :host([animation='beat-fade']),
     :host([animation='flip']),
+    :host([animation='flip-360']),
     :host([animation='shake']),
     :host([animation='spin']),
     :host([animation='spin-pulse']),
-    :host([animation='spin-reverse']) {
+    :host([animation='spin-reverse']),
+    :host([animation='spin-snap']),
+    :host([animation='spin-snap-4']),
+    :host([animation='spin-snap-8']),
+    :host([animation='buzz']),
+    :host([animation='wag']),
+    :host([animation='float']),
+    :host([animation='swing']),
+    :host([animation='jello']) {
       animation: none !important;
       transition: none !important;
     }
   }
+
+  /* #endregion */
+
+  /* #region Keyframes — ported verbatim from Font Awesome 7.3 */
+
   @keyframes beat {
-    0%,
-    90% {
+    0% {
       transform: scale(1);
+    }
+    25% {
+      transform: scale(calc(1.25 * var(--beat-scale, 1.25)));
     }
     45% {
-      transform: scale(var(--beat-scale, 1.25));
+      transform: scale(calc(1.22 * var(--beat-scale, 1.22)));
     }
-  }
-
-  @keyframes fade {
-    50% {
-      opacity: var(--fade-opacity, 0.4);
+    65% {
+      transform: scale(calc(1.25 * var(--beat-scale, 1.25)));
     }
-  }
-
-  @keyframes beat-fade {
-    0%,
-    100% {
-      opacity: var(--beat-fade-opacity, 0.4);
+    90% {
       transform: scale(1);
-    }
-    50% {
-      opacity: 1;
-      transform: scale(var(--beat-fade-scale, 1.125));
     }
   }
 
   @keyframes bounce {
     0% {
       transform: scale(1, 1) translateY(0);
+      animation-timing-function: var(--animation-timing);
     }
-    10% {
-      transform: scale(var(--bounce-start-scale-x, 1.1), var(--bounce-start-scale-y, 0.9)) translateY(0);
+    14% {
+      transform: scale(var(--bounce-start-scale-x, 1.06), var(--bounce-start-scale-y, 0.94))
+        translateY(var(--bounce-anticipation, 3px));
+      animation-timing-function: cubic-bezier(0.33, 0, 0.66, 0.33);
     }
-    30% {
-      transform: scale(var(--bounce-jump-scale-x, 0.9), var(--bounce-jump-scale-y, 1.1))
-        translateY(var(--bounce-height, -0.5em));
+    32% {
+      transform: scale(var(--bounce-jump-scale-x, 0.94), var(--bounce-jump-scale-y, 1.12))
+        translateY(calc(-1 * var(--bounce-height, 0.5em)));
+      animation-timing-function: cubic-bezier(0.33, 0.66, 0.66, 1);
     }
-    50% {
-      transform: scale(var(--bounce-land-scale-x, 1.05), var(--bounce-land-scale-y, 0.95)) translateY(0);
+    52% {
+      transform: scale(1, 1) translateY(calc(-1 * var(--bounce-height, 0.5em) * 1.1));
+      animation-timing-function: cubic-bezier(0.5, 0, 1, 0.5);
     }
-    57% {
-      transform: scale(1, 1) translateY(var(--bounce-rebound, -0.125em));
+    70% {
+      transform: scale(var(--bounce-land-scale-x, 1.06), var(--bounce-land-scale-y, 0.92)) translateY(0);
+      animation-timing-function: cubic-bezier(0.33, 0.33, 0.66, 1);
     }
-    64% {
-      transform: scale(1, 1) translateY(0);
+    85% {
+      transform: scale(0.98, 1.04) translateY(calc(-2px * var(--bounce-rebound, 1)));
+      animation-timing-function: cubic-bezier(0.33, 0, 0.66, 1);
     }
     100% {
       transform: scale(1, 1) translateY(0);
     }
   }
 
+  @keyframes fade {
+    0% {
+      opacity: 1;
+      transform: scale(1);
+      animation-timing-function: cubic-bezier(0.2, 0, 0.4, 1);
+    }
+    40% {
+      opacity: var(--fade-opacity, 0.4);
+      transform: scale(0.98);
+      animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
+    }
+    100% {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+
+  @keyframes beat-fade {
+    0% {
+      opacity: var(--beat-fade-opacity, 0.4);
+      transform: scale(1);
+      animation-timing-function: cubic-bezier(0.2, 0, 0.4, 1);
+    }
+    25% {
+      opacity: calc(var(--beat-fade-opacity, 0.4) + 0.4);
+      transform: scale(var(--beat-fade-scale, 1.28));
+      animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
+    }
+    45% {
+      opacity: 1;
+      transform: scale(var(--beat-fade-scale, 1.25));
+      animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    }
+    65% {
+      opacity: calc(var(--beat-fade-opacity, 0.4) + 0.4);
+      transform: scale(var(--beat-fade-scale, 1.28));
+      animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
+    }
+    100% {
+      opacity: var(--beat-fade-opacity, 0.4);
+      transform: scale(1);
+    }
+  }
+
   @keyframes flip {
+    0% {
+      transform: perspective(2em) scale(1) rotate3d(var(--flip-x, 0), var(--flip-y, 1), var(--flip-z, 0), 0deg);
+      animation-timing-function: cubic-bezier(0.2, 0, 0.4, 1);
+    }
+    8% {
+      transform: perspective(2em) scale(var(--flip-anticipation-scale, 0.95))
+        rotate3d(var(--flip-x, 0), var(--flip-y, 1), var(--flip-z, 0), 0deg);
+      animation-timing-function: cubic-bezier(0.33, 0, 0.66, 0.33);
+    }
+    35% {
+      transform: perspective(2em) scale(1)
+        rotate3d(var(--flip-x, 0), var(--flip-y, 1), var(--flip-z, 0), calc(var(--flip-angle, -360deg) * 0.6));
+      animation-timing-function: linear;
+    }
+    65% {
+      transform: perspective(2em) scale(1)
+        rotate3d(var(--flip-x, 0), var(--flip-y, 1), var(--flip-z, 0), calc(var(--flip-angle, -360deg) * 0.5));
+      animation-timing-function: cubic-bezier(0.33, 0.66, 0.66, 1);
+    }
+    92% {
+      transform: perspective(2em) scale(1)
+        rotate3d(
+          var(--flip-x, 0),
+          var(--flip-y, 1),
+          var(--flip-z, 0),
+          calc(var(--flip-angle, -360deg) * var(--flip-overshoot, 1.04))
+        );
+      animation-timing-function: cubic-bezier(0.33, 0, 0.66, 1);
+    }
+    100% {
+      transform: perspective(2em) scale(1)
+        rotate3d(var(--flip-x, 0), var(--flip-y, 1), var(--flip-z, 0), var(--flip-angle, -360deg));
+    }
+  }
+
+  @keyframes flip-360 {
+    0% {
+      transform: perspective(2em) scale(1) rotate3d(var(--flip-x, 0), var(--flip-y, 1), var(--flip-z, 0), 0deg);
+      animation-timing-function: cubic-bezier(0.2, 0, 0.4, 1);
+    }
+    8% {
+      transform: perspective(2em) scale(var(--flip-anticipation-scale, 0.95))
+        rotate3d(var(--flip-x, 0), var(--flip-y, 1), var(--flip-z, 0), 0deg);
+      animation-timing-function: cubic-bezier(0.33, 0, 0.66, 0.33);
+    }
     50% {
-      transform: rotate3d(var(--flip-x, 0), var(--flip-y, 1), var(--flip-z, 0), var(--flip-angle, -180deg));
+      transform: perspective(2em) scale(1)
+        rotate3d(var(--flip-x, 0), var(--flip-y, 1), var(--flip-z, 0), calc(var(--flip-angle, -360deg) * 0.6));
+      animation-timing-function: cubic-bezier(0.33, 0.66, 0.66, 1);
+    }
+    80% {
+      transform: perspective(2em) scale(1)
+        rotate3d(
+          var(--flip-x, 0),
+          var(--flip-y, 1),
+          var(--flip-z, 0),
+          calc(var(--flip-angle, -360deg) * var(--flip-overshoot, 1.04))
+        );
+      animation-timing-function: cubic-bezier(0.33, 0, 0.66, 1);
+    }
+    100% {
+      transform: perspective(2em) scale(1)
+        rotate3d(var(--flip-x, 0), var(--flip-y, 1), var(--flip-z, 0), var(--flip-angle, -360deg));
     }
   }
 
   @keyframes shake {
     0% {
-      transform: rotate(-15deg);
+      transform: rotate(0deg);
+      animation-timing-function: cubic-bezier(0.2, 0, 0.8, 1);
     }
-    4% {
-      transform: rotate(15deg);
-    }
-    8%,
-    24% {
-      transform: rotate(-18deg);
-    }
-    12%,
-    28% {
-      transform: rotate(18deg);
-    }
-    16% {
-      transform: rotate(-22deg);
+    8% {
+      transform: rotate(35deg) translateX(1px);
+      animation-timing-function: cubic-bezier(0.3, 0, 0.7, 1);
     }
     20% {
-      transform: rotate(22deg);
+      transform: rotate(-22deg) translateX(-1px);
+      animation-timing-function: cubic-bezier(0.3, 0, 0.7, 1);
     }
-    32% {
-      transform: rotate(-12deg);
+    35% {
+      transform: rotate(15deg) translateX(1px);
+      animation-timing-function: cubic-bezier(0.3, 0, 0.7, 1);
     }
-    36% {
-      transform: rotate(12deg);
+    50% {
+      transform: rotate(-9deg);
+      animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
     }
-    40%,
+    65% {
+      transform: rotate(5deg);
+      animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
+    }
+    78% {
+      transform: rotate(-3deg);
+      animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
+    }
+    90% {
+      transform: rotate(1deg);
+      animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    }
     100% {
       transform: rotate(0deg);
     }
@@ -271,12 +499,347 @@ export default css`
     }
   }
 
-  @keyframes spin-pulse {
+  @keyframes spin-snap {
     0% {
       transform: rotate(0deg);
+      animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    }
+    12% {
+      transform: rotate(60deg);
+      animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+    }
+    16.67% {
+      transform: rotate(60deg);
+      animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    }
+    28.67% {
+      transform: rotate(120deg);
+      animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+    }
+    33.33% {
+      transform: rotate(120deg);
+      animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    }
+    45.33% {
+      transform: rotate(180deg);
+      animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+    }
+    50% {
+      transform: rotate(180deg);
+      animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    }
+    62% {
+      transform: rotate(240deg);
+      animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+    }
+    66.67% {
+      transform: rotate(240deg);
+      animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    }
+    78.67% {
+      transform: rotate(300deg);
+      animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+    }
+    83.33% {
+      transform: rotate(300deg);
+      animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    }
+    95.33% {
+      transform: rotate(360deg);
+      animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
     }
     100% {
       transform: rotate(360deg);
     }
   }
+
+  @keyframes spin-snap-4 {
+    0% {
+      transform: rotate(0deg);
+      animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    }
+    15% {
+      transform: rotate(90deg);
+      animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+    }
+    25% {
+      transform: rotate(90deg);
+      animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    }
+    40% {
+      transform: rotate(180deg);
+      animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+    }
+    50% {
+      transform: rotate(180deg);
+      animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    }
+    65% {
+      transform: rotate(270deg);
+      animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+    }
+    75% {
+      transform: rotate(270deg);
+      animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    }
+    90% {
+      transform: rotate(360deg);
+      animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+
+  @keyframes spin-snap-8 {
+    0% {
+      transform: rotate(0deg);
+      animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    }
+    9% {
+      transform: rotate(45deg);
+      animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+    }
+    12.5% {
+      transform: rotate(45deg);
+      animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    }
+    21.5% {
+      transform: rotate(90deg);
+      animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+    }
+    25% {
+      transform: rotate(90deg);
+      animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    }
+    34% {
+      transform: rotate(135deg);
+      animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+    }
+    37.5% {
+      transform: rotate(135deg);
+      animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    }
+    46.5% {
+      transform: rotate(180deg);
+      animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+    }
+    50% {
+      transform: rotate(180deg);
+      animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    }
+    59% {
+      transform: rotate(225deg);
+      animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+    }
+    62.5% {
+      transform: rotate(225deg);
+      animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    }
+    71.5% {
+      transform: rotate(270deg);
+      animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+    }
+    75% {
+      transform: rotate(270deg);
+      animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    }
+    84% {
+      transform: rotate(315deg);
+      animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+    }
+    87.5% {
+      transform: rotate(315deg);
+      animation-timing-function: cubic-bezier(0, 0, 0.2, 1);
+    }
+    96.5% {
+      transform: rotate(360deg);
+      animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+
+  @keyframes buzz {
+    0% {
+      transform: translateX(0) rotate(0deg);
+      animation-timing-function: cubic-bezier(0.1, 0, 0.9, 1);
+    }
+    5% {
+      transform: translateX(var(--buzz-distance, 4px)) rotate(0.5deg);
+    }
+    10% {
+      transform: translateX(calc(-1 * var(--buzz-distance, 4px))) rotate(-0.5deg);
+    }
+    15% {
+      transform: translateX(var(--buzz-distance, 4px)) rotate(0.3deg);
+    }
+    20% {
+      transform: translateX(calc(-1 * var(--buzz-distance, 4px))) rotate(-0.3deg);
+    }
+    25% {
+      transform: translateX(calc(var(--buzz-distance, 4px) * 0.7)) rotate(0.2deg);
+    }
+    30% {
+      transform: translateX(calc(-1 * var(--buzz-distance, 4px) * 0.7)) rotate(-0.2deg);
+    }
+    35% {
+      transform: translateX(calc(var(--buzz-distance, 4px) * 0.4)) rotate(0.1deg);
+    }
+    40% {
+      transform: translateX(0) rotate(0deg);
+    }
+    100% {
+      transform: translateX(0) rotate(0deg);
+    }
+  }
+
+  @keyframes wag {
+    0% {
+      transform: rotate(0deg);
+      animation-timing-function: cubic-bezier(0.2, 0, 0.6, 1);
+    }
+    12% {
+      transform: rotate(var(--wag-angle, 12deg));
+      animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    }
+    24% {
+      transform: rotate(2deg);
+      animation-timing-function: cubic-bezier(0.2, 0, 0.6, 1);
+    }
+    36% {
+      transform: rotate(calc(var(--wag-angle, 12deg) * 0.85));
+      animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    }
+    48% {
+      transform: rotate(1deg);
+      animation-timing-function: cubic-bezier(0.2, 0, 0.6, 1);
+    }
+    58% {
+      transform: rotate(calc(var(--wag-angle, 12deg) * 0.6));
+      animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    }
+    68% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(0deg);
+    }
+  }
+
+  @keyframes float {
+    0% {
+      transform: translateY(0) translateX(0) rotate(0deg)
+        scale(var(--float-squash-x, 1.02), var(--float-squash-y, 0.98));
+      animation-timing-function: cubic-bezier(0.33, 0, 0.66, 0.33);
+    }
+    15% {
+      transform: translateY(calc(-0.4 * var(--float-height, 6px))) translateX(var(--float-drift, 1px))
+        rotate(var(--float-tilt, 1deg)) scale(1, 1);
+      animation-timing-function: cubic-bezier(0.33, 0.66, 0.66, 1);
+    }
+    35% {
+      transform: translateY(calc(-1 * var(--float-height, 6px))) translateX(0) rotate(0deg)
+        scale(var(--float-stretch-x, 0.98), var(--float-stretch-y, 1.03));
+      animation-timing-function: cubic-bezier(0.5, 0, 0.5, 0);
+    }
+    50% {
+      transform: translateY(calc(-0.92 * var(--float-height, 6px))) translateX(calc(-0.5 * var(--float-drift, 1px)))
+        rotate(calc(-0.5 * var(--float-tilt, 1deg))) scale(0.995, 1.01);
+      animation-timing-function: cubic-bezier(0.33, 0, 0.66, 0.33);
+    }
+    70% {
+      transform: translateY(calc(-0.3 * var(--float-height, 6px))) translateX(calc(-1 * var(--float-drift, 1px)))
+        rotate(calc(-1 * var(--float-tilt, 1deg))) scale(1, 1);
+      animation-timing-function: cubic-bezier(0.33, 0.66, 0.66, 1);
+    }
+    90% {
+      transform: translateY(calc(0.05 * var(--float-height, 6px))) translateX(0) rotate(0deg)
+        scale(var(--float-squash-x, 1.02), var(--float-squash-y, 0.98));
+      animation-timing-function: cubic-bezier(0.33, 0, 0.66, 1);
+    }
+    100% {
+      transform: translateY(0) translateX(0) rotate(0deg)
+        scale(var(--float-squash-x, 1.02), var(--float-squash-y, 0.98));
+    }
+  }
+
+  @keyframes swing {
+    0% {
+      transform: rotate(0deg);
+      animation-timing-function: cubic-bezier(0.2, 0, 0.8, 1);
+    }
+    8% {
+      transform: rotate(var(--swing-angle, 22deg));
+      animation-timing-function: cubic-bezier(0.3, 0, 0.7, 1);
+    }
+    18% {
+      transform: rotate(calc(-1 * var(--swing-angle, 22deg) * 0.85));
+      animation-timing-function: cubic-bezier(0.3, 0, 0.7, 1);
+    }
+    28% {
+      transform: rotate(calc(var(--swing-angle, 22deg) * 0.65));
+      animation-timing-function: cubic-bezier(0.35, 0, 0.65, 1);
+    }
+    38% {
+      transform: rotate(calc(-1 * var(--swing-angle, 22deg) * 0.45));
+      animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
+    }
+    48% {
+      transform: rotate(calc(var(--swing-angle, 22deg) * 0.25));
+      animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
+    }
+    56% {
+      transform: rotate(calc(-1 * var(--swing-angle, 22deg) * 0.1));
+      animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
+    }
+    64% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(0deg);
+    }
+  }
+
+  @keyframes jello {
+    0% {
+      transform: scale(1, 1);
+      animation-timing-function: cubic-bezier(0.2, 0, 0.8, 1);
+    }
+    12% {
+      transform: scale(var(--jello-scale-x, 1.15), calc(2 - var(--jello-scale-x, 1.15)));
+      animation-timing-function: cubic-bezier(0.3, 0, 0.7, 1);
+    }
+    24% {
+      transform: scale(calc(2 - var(--jello-scale-y, 1.12)), var(--jello-scale-y, 1.12));
+      animation-timing-function: cubic-bezier(0.3, 0, 0.7, 1);
+    }
+    36% {
+      transform: scale(
+        calc(1 + (var(--jello-scale-x, 1.15) - 1) * 0.5),
+        calc(2 - (1 + (var(--jello-scale-x, 1.15) - 1) * 0.5))
+      );
+      animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
+    }
+    48% {
+      transform: scale(
+        calc(2 - (1 + (var(--jello-scale-y, 1.12) - 1) * 0.3)),
+        calc(1 + (var(--jello-scale-y, 1.12) - 1) * 0.3)
+      );
+      animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
+    }
+    58% {
+      transform: scale(1.02, 0.98);
+      animation-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    }
+    68% {
+      transform: scale(1, 1);
+    }
+    100% {
+      transform: scale(1, 1);
+    }
+  }
+
+  /* #endregion */
 `;

--- a/packages/webawesome/src/components/icon/icon.styles.ts
+++ b/packages/webawesome/src/components/icon/icon.styles.ts
@@ -312,6 +312,8 @@ export default css`
   @keyframes bounce {
     0% {
       transform: scale(1, 1) translateY(0);
+      /* No fallback by design (ported from FA 7.3): the first segment uses the user's --animation-timing or the CSS
+         initial ease, while the explicit cubic-beziers on later stops drive the bounce physics. */
       animation-timing-function: var(--animation-timing);
     }
     14% {

--- a/packages/webawesome/src/components/icon/icon.styles.ts
+++ b/packages/webawesome/src/components/icon/icon.styles.ts
@@ -172,6 +172,7 @@ export default css`
 
   :host([animation='spin-pulse']) {
     animation-name: spin;
+    animation-delay: var(--animation-delay, 0s);
     animation-direction: var(--animation-direction, normal);
     animation-duration: var(--animation-duration, 1s);
     animation-iteration-count: var(--animation-iteration-count, infinite);

--- a/packages/webawesome/src/components/icon/icon.test.ts
+++ b/packages/webawesome/src/components/icon/icon.test.ts
@@ -387,6 +387,12 @@ describe('<wa-icon>', () => {
             '16px',
           ],
           [
+            'fixed (explicit)',
+            html`<wa-icon library="system" name="check" canvas="fixed" style="font-size:16px"></wa-icon>`,
+            '20px',
+            '16px',
+          ],
+          [
             'square',
             html`<wa-icon library="system" name="check" canvas="square" style="font-size:16px"></wa-icon>`,
             '20px',
@@ -409,6 +415,18 @@ describe('<wa-icon>', () => {
             expect(style.width).to.equal(width);
             expect(style.height).to.equal(height);
           });
+        });
+
+        it('should hug the icon for canvas="auto" without a fixed-width box', async () => {
+          const el = await fixture<WaIcon>(
+            html`<wa-icon library="system" name="check" canvas="auto" style="font-size:16px"></wa-icon>`,
+          );
+          await elementUpdated(el);
+          await el.updateComplete;
+          const style = getComputedStyle(el);
+          // auto keeps the 1em height but drops the fixed 1.25em (20px) min-width that `fixed` enforces
+          expect(style.height).to.equal('16px');
+          expect(style.minWidth).to.equal('0px');
         });
 
         it('should reflect the canvas property to an attribute', async () => {

--- a/packages/webawesome/src/components/icon/icon.test.ts
+++ b/packages/webawesome/src/components/icon/icon.test.ts
@@ -1,4 +1,5 @@
 import { aTimeout, elementUpdated, expect, oneEvent, waitUntil } from '@open-wc/testing';
+import { emulateMedia } from '@web/test-runner-commands';
 import { html } from 'lit';
 import { expectEvent } from '../../internal/test/expect-event.js';
 import { fixtures } from '../../internal/test/fixture.js';
@@ -7,6 +8,10 @@ import { fixtures } from '../../internal/test/fixture.js';
 import { registerIconLibrary } from '../../../dist-cdn/webawesome.js';
 import type WaIcon from './icon.js';
 import type { IconAnimation } from './icon.js';
+import { getIconFolder } from './library.default.js';
+
+// Captures the autoWidth argument passed to a resolver so we can assert the canvas="auto" coupling.
+let probeAutoWidth: boolean | undefined;
 
 const testLibraryIcons = {
   'test-icon1': `
@@ -37,6 +42,56 @@ describe('<wa-icon>', () => {
         return '';
       },
       mutator: (svg: SVGElement) => svg.setAttribute('fill', 'currentColor'),
+    });
+
+    registerIconLibrary('autowidth-probe', {
+      resolver: (_name: string, _family?: string, _variant?: string, autoWidth?: boolean) => {
+        probeAutoWidth = autoWidth;
+        return `data:image/svg+xml,${encodeURIComponent(testLibraryIcons['test-icon1'])}`;
+      },
+    });
+  });
+
+  describe('getIconFolder() default-library mapping', () => {
+    const cases: Array<[family: string, variant: string, folder: string]> = [
+      // Classic
+      ['classic', 'thin', 'thin'],
+      ['classic', 'light', 'light'],
+      ['classic', 'regular', 'regular'],
+      ['classic', 'solid', 'solid'],
+      // Brands
+      ['brands', 'solid', 'brands'],
+      // Duotone + Sharp
+      ['duotone', 'solid', 'duotone'],
+      ['duotone', 'regular', 'duotone-regular'],
+      ['sharp', 'solid', 'sharp-solid'],
+      ['sharp-duotone', 'thin', 'sharp-duotone-thin'],
+      // Existing Pro+ packs
+      ['chisel', 'regular', 'chisel-regular'],
+      ['whiteboard', 'semibold', 'whiteboard-semibold'],
+      ['utility', 'semibold', 'utility-semibold'],
+      ['utility-fill', 'semibold', 'utility-fill-semibold'],
+      ['jelly', 'regular', 'jelly-regular'],
+      ['jelly-duo', 'regular', 'jelly-duo-regular'],
+      ['notdog', 'solid', 'notdog-solid'],
+      ['slab', 'regular', 'slab-regular'],
+      ['slab-press', 'regular', 'slab-press-regular'],
+      // New in 7.3
+      ['mosaic', 'solid', 'mosaic-solid'],
+      ['pixel', 'regular', 'pixel-regular'],
+      ['vellum', 'solid', 'vellum-solid'],
+      ['slab-duo', 'regular', 'slab-duo-regular'],
+      ['slab-press-duo', 'regular', 'slab-press-duo-regular'],
+    ];
+
+    cases.forEach(([family, variant, folder]) => {
+      it(`maps family="${family}" variant="${variant}" to "${folder}"`, () => {
+        expect(getIconFolder('icon-name', family, variant)).to.equal(folder);
+      });
+    });
+
+    it('falls back to "solid" for an unknown family', () => {
+      expect(getIconFolder('icon-name', 'not-a-real-family', 'solid')).to.equal('solid');
     });
   });
 
@@ -246,25 +301,36 @@ describe('<wa-icon>', () => {
       });
 
       describe('animations', () => {
-        const animations: IconAnimation[] = [
-          'beat',
-          'beat-fade',
-          'bounce',
-          'fade',
-          'flip',
-          'shake',
-          'spin',
-          'spin-pulse',
+        // [animation value, expected @keyframes name] — spin-pulse and spin-reverse reuse the `spin` keyframes
+        const animations: Array<[IconAnimation, string]> = [
+          ['beat', 'beat'],
+          ['fade', 'fade'],
+          ['beat-fade', 'beat-fade'],
+          ['bounce', 'bounce'],
+          ['flip', 'flip'],
+          ['flip-360', 'flip-360'],
+          ['shake', 'shake'],
+          ['spin', 'spin'],
+          ['spin-pulse', 'spin'],
+          ['spin-reverse', 'spin'],
+          ['spin-snap', 'spin-snap'],
+          ['spin-snap-4', 'spin-snap-4'],
+          ['spin-snap-8', 'spin-snap-8'],
+          ['buzz', 'buzz'],
+          ['wag', 'wag'],
+          ['float', 'float'],
+          ['swing', 'swing'],
+          ['jello', 'jello'],
         ];
 
-        animations.forEach(animation => {
+        animations.forEach(([animation, keyframe]) => {
           it(`should apply the "${animation}" animation`, async () => {
             const el = await fixture<WaIcon>(html`
               <wa-icon library="system" name="check" animation=${animation}></wa-icon>
             `);
             await elementUpdated(el);
             await el.updateComplete;
-            expect(getComputedStyle(el).animationName).to.equal(animation);
+            expect(getComputedStyle(el).animationName).to.equal(keyframe);
           });
         });
 
@@ -277,6 +343,100 @@ describe('<wa-icon>', () => {
           const computedStyle = getComputedStyle(el);
           expect(computedStyle.animationName).to.equal('spin');
           expect(computedStyle.animationDirection).to.equal('reverse');
+        });
+
+        // Defaults aligned with Font Awesome 7.3
+        const revisedDefaults: Array<[IconAnimation, 'animationDuration' | 'animationTimingFunction', string]> = [
+          ['flip', 'animationDuration', '1.5s'],
+          ['shake', 'animationDuration', '0.75s'],
+          ['shake', 'animationTimingFunction', 'ease-in-out'],
+          ['fade', 'animationTimingFunction', 'ease-in-out'],
+          ['beat-fade', 'animationTimingFunction', 'ease-in-out'],
+        ];
+
+        revisedDefaults.forEach(([animation, prop, value]) => {
+          it(`should default ${animation} ${prop} to ${value} (FA 7.3)`, async () => {
+            const el = await fixture<WaIcon>(html`
+              <wa-icon library="system" name="check" animation=${animation}></wa-icon>
+            `);
+            await elementUpdated(el);
+            await el.updateComplete;
+            expect(getComputedStyle(el)[prop]).to.equal(value);
+          });
+        });
+
+        it('should disable animation under prefers-reduced-motion', async () => {
+          const el = await fixture<WaIcon>(html` <wa-icon library="system" name="check" animation="spin"></wa-icon> `);
+          await elementUpdated(el);
+          try {
+            await emulateMedia({ reducedMotion: 'reduce' });
+            expect(getComputedStyle(el).animationName).to.equal('none');
+          } finally {
+            await emulateMedia({ reducedMotion: 'no-preference' });
+          }
+        });
+      });
+
+      describe('canvas sizing', () => {
+        // Fix the em base so 1.25em = 20px and 1.5em = 24px deterministically
+        const sizes: Array<[label: string, markup: ReturnType<typeof html>, width: string, height: string]> = [
+          [
+            'fixed (default)',
+            html`<wa-icon library="system" name="check" style="font-size:16px"></wa-icon>`,
+            '20px',
+            '16px',
+          ],
+          [
+            'square',
+            html`<wa-icon library="system" name="check" canvas="square" style="font-size:16px"></wa-icon>`,
+            '20px',
+            '20px',
+          ],
+          [
+            'roomy',
+            html`<wa-icon library="system" name="check" canvas="roomy" style="font-size:16px"></wa-icon>`,
+            '24px',
+            '24px',
+          ],
+        ];
+
+        sizes.forEach(([label, markup, width, height]) => {
+          it(`should size the ${label} canvas to ${width} × ${height}`, async () => {
+            const el = await fixture<WaIcon>(markup);
+            await elementUpdated(el);
+            await el.updateComplete;
+            const style = getComputedStyle(el);
+            expect(style.width).to.equal(width);
+            expect(style.height).to.equal(height);
+          });
+        });
+
+        it('should reflect the canvas property to an attribute', async () => {
+          const el = await fixture<WaIcon>(html`<wa-icon library="system" name="check"></wa-icon>`);
+          el.canvas = 'roomy';
+          await elementUpdated(el);
+          expect(el.getAttribute('canvas')).to.equal('roomy');
+        });
+
+        it('should pass autoWidth=true to the resolver for canvas="auto"', async () => {
+          probeAutoWidth = undefined;
+          const el = await fixture<WaIcon>(html`<wa-icon library="autowidth-probe" name="x" canvas="auto"></wa-icon>`);
+          await oneEvent(el, 'wa-load');
+          expect(probeAutoWidth).to.be.true;
+        });
+
+        it('should pass autoWidth=true to the resolver for the deprecated auto-width attribute', async () => {
+          probeAutoWidth = undefined;
+          const el = await fixture<WaIcon>(html`<wa-icon library="autowidth-probe" name="x" auto-width></wa-icon>`);
+          await oneEvent(el, 'wa-load');
+          expect(probeAutoWidth).to.be.true;
+        });
+
+        it('should pass autoWidth=false to the resolver by default', async () => {
+          probeAutoWidth = undefined;
+          const el = await fixture<WaIcon>(html`<wa-icon library="autowidth-probe" name="x"></wa-icon>`);
+          await oneEvent(el, 'wa-load');
+          expect(probeAutoWidth).to.be.false;
         });
       });
 

--- a/packages/webawesome/src/components/icon/icon.ts
+++ b/packages/webawesome/src/components/icon/icon.ts
@@ -75,9 +75,9 @@ export type IconCanvas = 'fixed' | 'auto' | 'square' | 'roomy';
  * @cssproperty [--bounce-start-scale-y] Set the icon’s vertical distortion (“squish”) when starting to bounce.
  * @cssproperty [--fade-opacity] Set lowest opacity value an icon with `fade` animation will fade to and from.
  * @cssproperty [--flip-angle] Set rotation angle of flip for an icon with `flip` or `flip-360` animation. A positive angle denotes a clockwise rotation, a negative angle a counter-clockwise one.
- * @cssproperty [--flip-x] Set x-coordinate of the vector denoting the axis of rotation (between 0 and 1) for an icon with `flip` animation.
- * @cssproperty [--flip-y] Set y-coordinate of the vector denoting the axis of rotation (between 0 and 1) for an icon with `flip` animation.
- * @cssproperty [--flip-z] Set z-coordinate of the vector denoting the axis of rotation (between 0 and 1) for an icon with `flip` animation.
+ * @cssproperty [--flip-x] Set x-coordinate of the vector denoting the axis of rotation (between 0 and 1) for an icon with `flip` or `flip-360` animation.
+ * @cssproperty [--flip-y] Set y-coordinate of the vector denoting the axis of rotation (between 0 and 1) for an icon with `flip` or `flip-360` animation.
+ * @cssproperty [--flip-z] Set z-coordinate of the vector denoting the axis of rotation (between 0 and 1) for an icon with `flip` or `flip-360` animation.
  * @cssproperty [--flip-anticipation-scale] Set the scale of the wind-up before an icon with `flip` or `flip-360` animation rotates.
  * @cssproperty [--flip-overshoot] Set how far past the final angle an icon with `flip` or `flip-360` animation rotates before settling.
  * @cssproperty [--bounce-anticipation] Set the downward squash distance before an icon with `bounce` animation jumps.

--- a/packages/webawesome/src/components/icon/icon.ts
+++ b/packages/webawesome/src/components/icon/icon.ts
@@ -64,7 +64,7 @@ export type IconCanvas = 'fixed' | 'auto' | 'square' | 'roomy';
  * @cssproperty [--animation-timing] Describes how the animation will progress over one cycle of its duration.
  * @cssproperty [--beat-fade-opacity] Set lowest opacity value an icon with `beat-fade` animation will fade to and from.
  * @cssproperty [--beat-fade-scale] Set max value that an icon with `beat-fade` animation will scale.
- * @cssproperty [--beat-scale] Set max value that an icon with `beat` animation will scale.
+ * @cssproperty [--beat-scale] Set the scale multiplier for an icon with `beat` animation. This multiplies the animation's 1.25× base pulse, so the default `1.25` peaks at ~1.56× and `2` roughly doubles the pulse.
  * @cssproperty [--bounce-height] Set the max height an icon with `bounce` animation will jump to when bouncing.
  * @cssproperty [--bounce-jump-scale-x] Set the icon’s horizontal distortion (“squish”) at the top of the jump.
  * @cssproperty [--bounce-jump-scale-y] Set the icon’s vertical distortion (“squish”) at the top of the jump.
@@ -74,7 +74,7 @@ export type IconCanvas = 'fixed' | 'auto' | 'square' | 'roomy';
  * @cssproperty [--bounce-start-scale-x] Set the icon’s horizontal distortion (“squish”) when starting to bounce.
  * @cssproperty [--bounce-start-scale-y] Set the icon’s vertical distortion (“squish”) when starting to bounce.
  * @cssproperty [--fade-opacity] Set lowest opacity value an icon with `fade` animation will fade to and from.
- * @cssproperty [--flip-angle] Set rotation angle of flip for an icon with `flip` animation. A positive angle denotes a clockwise rotation, a negative angle a counter-clockwise one.
+ * @cssproperty [--flip-angle] Set rotation angle of flip for an icon with `flip` or `flip-360` animation. A positive angle denotes a clockwise rotation, a negative angle a counter-clockwise one.
  * @cssproperty [--flip-x] Set x-coordinate of the vector denoting the axis of rotation (between 0 and 1) for an icon with `flip` animation.
  * @cssproperty [--flip-y] Set y-coordinate of the vector denoting the axis of rotation (between 0 and 1) for an icon with `flip` animation.
  * @cssproperty [--flip-z] Set z-coordinate of the vector denoting the axis of rotation (between 0 and 1) for an icon with `flip` animation.

--- a/packages/webawesome/src/components/icon/icon.ts
+++ b/packages/webawesome/src/components/icon/icon.ts
@@ -28,10 +28,21 @@ export type IconAnimation =
   | 'beat-fade'
   | 'bounce'
   | 'flip'
+  | 'flip-360'
   | 'shake'
   | 'spin'
   | 'spin-pulse'
-  | 'spin-reverse';
+  | 'spin-reverse'
+  | 'spin-snap'
+  | 'spin-snap-4'
+  | 'spin-snap-8'
+  | 'buzz'
+  | 'wag'
+  | 'float'
+  | 'swing'
+  | 'jello';
+
+export type IconCanvas = 'fixed' | 'auto' | 'square' | 'roomy';
 
 /**
  * @summary Icons are scalable vector symbols that represent actions, content, or status throughout your application.
@@ -67,6 +78,21 @@ export type IconAnimation =
  * @cssproperty [--flip-x] Set x-coordinate of the vector denoting the axis of rotation (between 0 and 1) for an icon with `flip` animation.
  * @cssproperty [--flip-y] Set y-coordinate of the vector denoting the axis of rotation (between 0 and 1) for an icon with `flip` animation.
  * @cssproperty [--flip-z] Set z-coordinate of the vector denoting the axis of rotation (between 0 and 1) for an icon with `flip` animation.
+ * @cssproperty [--flip-anticipation-scale] Set the scale of the wind-up before an icon with `flip` or `flip-360` animation rotates.
+ * @cssproperty [--flip-overshoot] Set how far past the final angle an icon with `flip` or `flip-360` animation rotates before settling.
+ * @cssproperty [--bounce-anticipation] Set the downward squash distance before an icon with `bounce` animation jumps.
+ * @cssproperty [--buzz-distance] Set the horizontal travel of an icon with `buzz` animation.
+ * @cssproperty [--wag-angle] Set the peak rotation of an icon with `wag` animation.
+ * @cssproperty [--swing-angle] Set the peak rotation of an icon with `swing` animation.
+ * @cssproperty [--jello-scale-x] Set the horizontal stretch of an icon with `jello` animation.
+ * @cssproperty [--jello-scale-y] Set the vertical stretch of an icon with `jello` animation.
+ * @cssproperty [--float-height] Set the rise height of an icon with `float` animation.
+ * @cssproperty [--float-drift] Set the horizontal drift of an icon with `float` animation.
+ * @cssproperty [--float-tilt] Set the rotation of an icon with `float` animation.
+ * @cssproperty [--float-squash-x] Set the horizontal squash of an icon with `float` animation at rest.
+ * @cssproperty [--float-squash-y] Set the vertical squash of an icon with `float` animation at rest.
+ * @cssproperty [--float-stretch-x] Set the horizontal stretch of an icon with `float` animation at its peak.
+ * @cssproperty [--float-stretch-y] Set the vertical stretch of an icon with `float` animation at its peak.
  * @cssproperty [--primary-color=currentColor] - Sets a duotone icon's primary color.
  * @cssproperty [--primary-opacity=1] - Sets a duotone icon's primary opacity.
  * @cssproperty [--secondary-color=currentColor] - Sets a duotone icon's secondary color.
@@ -96,7 +122,18 @@ export default class WaIcon extends WebAwesomeElement {
    */
   @property({ reflect: true }) variant: string;
 
-  /** Sets the width of the icon to match the cropped SVG viewBox. This operates like the Font `fa-width-auto` class. */
+  /**
+   * Sets the icon canvas — the box the icon is centered within. Unset renders as `fixed` (1.25em × 1em); `auto` hugs the
+   * icon's width; `square` is 1.25em × 1.25em; `roomy` is 1.5em × 1.5em. Mirrors Font Awesome's `fa-fixed-width`,
+   * `fa-width-auto`, `fa-canvas-square`, and `fa-canvas-roomy`. Scales with `font-size`.
+   */
+  @property({ reflect: true }) canvas?: IconCanvas;
+
+  /**
+   * Sets the width of the icon to match the cropped SVG viewBox. This operates like the Font `fa-width-auto` class.
+   *
+   * @deprecated Use `canvas="auto"` instead.
+   */
   @property({ attribute: 'auto-width', type: Boolean, reflect: true }) autoWidth = false;
 
   /** Swaps the opacity of duotone icons. */
@@ -151,9 +188,11 @@ export default class WaIcon extends WebAwesomeElement {
     const family = this.family || getDefaultIconFamily();
 
     if (this.name && library) {
+      // canvas="auto" is the modern equivalent of the deprecated auto-width attribute
+      const autoWidth = this.canvas === 'auto' || this.autoWidth;
       let url: string | undefined;
       try {
-        url = await library.resolver(this.name, family, this.variant, this.autoWidth);
+        url = await library.resolver(this.name, family, this.variant, autoWidth);
       } catch {
         url = undefined;
       }
@@ -236,7 +275,9 @@ export default class WaIcon extends WebAwesomeElement {
     }
   }
 
-  @watch(['family', 'name', 'library', 'variant', 'src', 'autoWidth', 'swapOpacity'], { waitUntilFirstUpdate: true })
+  @watch(['family', 'name', 'library', 'variant', 'src', 'autoWidth', 'canvas', 'swapOpacity'], {
+    waitUntilFirstUpdate: true,
+  })
   async setIcon() {
     const { url, fromLibrary } = await this.getIconSource();
     const library = fromLibrary ? getIconLibrary(this.library) : undefined;

--- a/packages/webawesome/src/components/icon/library.default.ts
+++ b/packages/webawesome/src/components/icon/library.default.ts
@@ -88,17 +88,14 @@ export function getIconFolder(_name: string, family: string, variant: string) {
     folder = 'whiteboard-semibold';
   }
 
-  // Mosaic (Pro+, new in 7.3)
+  // Mosaic, Pixel, and Vellum (Pro+, new in 7.3) ship a single style each, so `variant` is ignored.
+  // If Font Awesome adds weights to these packs, branch on `variant` here like the families above.
   if (family === 'mosaic') {
     folder = 'mosaic-solid';
   }
-
-  // Pixel (Pro+, new in 7.3)
   if (family === 'pixel') {
     folder = 'pixel-regular';
   }
-
-  // Vellum (Pro+, new in 7.3)
   if (family === 'vellum') {
     folder = 'vellum-solid';
   }

--- a/packages/webawesome/src/components/icon/library.default.ts
+++ b/packages/webawesome/src/components/icon/library.default.ts
@@ -1,7 +1,7 @@
 import { getIconPath, getKitCode } from '../../utilities/base-path.js';
 import type { IconLibrary } from './library.js';
 
-const FA_VERSION = '7.2.0';
+const FA_VERSION = '7.3.0';
 
 /** Returns the folder name used by Font Awesome for a given icon family and variant combination. */
 export function getIconFolder(_name: string, family: string, variant: string) {
@@ -50,7 +50,7 @@ export function getIconFolder(_name: string, family: string, variant: string) {
   }
 
   // Slab (Pro+)
-  // Correct usage: family="slab" or family="slab-press", variant="regular"
+  // Correct usage: family="slab", family="slab-press", family="slab-duo", or family="slab-press-duo", variant="regular"
   if (family === 'slab') {
     // NOTE: variant="press-regular" is deprecated, use family="slab-press" variant="regular" instead
     if (variant === 'solid' || variant === 'regular') folder = 'slab-regular';
@@ -58,6 +58,12 @@ export function getIconFolder(_name: string, family: string, variant: string) {
   }
   if (family === 'slab-press') {
     folder = 'slab-press-regular';
+  }
+  if (family === 'slab-duo') {
+    folder = 'slab-duo-regular';
+  }
+  if (family === 'slab-press-duo') {
+    folder = 'slab-press-duo-regular';
   }
 
   // Thumbprint (Pro+)
@@ -80,6 +86,21 @@ export function getIconFolder(_name: string, family: string, variant: string) {
   // Whiteboard (Pro+)
   if (family === 'whiteboard') {
     folder = 'whiteboard-semibold';
+  }
+
+  // Mosaic (Pro+, new in 7.3)
+  if (family === 'mosaic') {
+    folder = 'mosaic-solid';
+  }
+
+  // Pixel (Pro+, new in 7.3)
+  if (family === 'pixel') {
+    folder = 'pixel-regular';
+  }
+
+  // Vellum (Pro+, new in 7.3)
+  if (family === 'vellum') {
+    folder = 'vellum-solid';
   }
 
   // Classic
@@ -163,6 +184,9 @@ const library: IconLibrary = {
         (family === 'jelly' && variant === 'duo-regular') ||
         // Utility duo (correct usage: family="utility-duo")
         family === 'utility-duo' ||
+        // Slab duo (new in 7.3)
+        family === 'slab-duo' ||
+        family === 'slab-press-duo' ||
         // Thumbprint
         family === 'thumbprint'
       ) {


### PR DESCRIPTION
Brings `<wa-icon>` up to date with [Font Awesome 7.3.0](https://fontawesome.com/changelog) — three new Pro+ icon families, the new animations, and the Icon Canvas sizing feature — and gives the icon documentation page a full overhaul to match our docs conventions.

### Live Preview

Docs and features can be seen at:
**https://webawesome-git-talbs-i-con-see-clearly-now-e396e0-font-awesome.vercel.app/docs/components/icon**.

### Icon families

Bumps the default library from `7.2.0` to `7.3.0` (verified the free CDN serves `v7.3.0`) and adds the new Pro+ packs to `getIconFolder()`: `mosaic`, `pixel`, and `vellum`. Also adds the two duo variants 7.3 brought to Slab — `slab-duo` and `slab-press-duo` — and wires them into the duotone mutator. The new-icon additions to existing free families (`classic`, `brands`) come along for free with the version bump.

### Animations

Adds the nine new 7.3 animations — `buzz`, `flip-360`, `float`, `jello`, `spin-snap`, `spin-snap-4`, `spin-snap-8`, `swing`, and `wag` — to the `IconAnimation` union, with `@keyframes` and defaults ported verbatim from Font Awesome's published 7.3 CSS. 

Also rewrote the keyframe geometry and timing of several existing animations (`flip`, `shake`, `fade`, `beat-fade`, `bounce`, `beat`), so those were brought back in line with FA. All new animations are included in the `prefers-reduced-motion` block. Reverse stays a `--animation-direction` modifier rather than a combinatorial set of enum values.

### Canvas

Adds a `canvas` attribute (`fixed` | `auto` | `square` | `roomy`) mirroring Font Awesome's mutually-exclusive icon-canvas modes, scaling with `font-size` and independent of sizing. 

Because Font Awesome's four modes are mutually exclusive — and `auto-width` is one of them — `canvas` is a single enum rather than stacked booleans. 

`auto-width` is soft-deprecated in favor of `canvas="auto"`: it keeps working, is folded into icon resolution (it feeds the resolver's `autoWidth` argument, not just CSS), and is marked `@deprecated`.

### Tests

Adds resolver-mapping coverage for `getIconFolder()` (every family/variant, including the new packs), the revised animation defaults, reduced-motion, the canvas enum, `auto-width` back-compat, and the Free-user-on-a-Pro-pack error path.

### Documentation

Overhauls `docs/components/icon.md`...
-  interactive Sizing, Canvas, and Duotone demos (sliders with notches and named values, color pickers)
- compact reference tables for Families, Canvas, Pro+ packs, and Rotating & Flipping, each with click-to-copy preview icons
- per-animation sections matched to Font Awesome's own wording
- a Duotone props table and customization playground
- a new `## Accessibility Considerations` section that consolidates icon labeling guidance and reduced-motion behavior. 
- Internal anchors and the Font Awesome / Pro callouts were cleaned up along the way.

### Notes

- The Pro+ pack folder slugs (`mosaic-solid`, `pixel-regular`, `vellum-solid`, `slab-duo-regular`, `slab-press-duo-regular`) were taken from Font Awesome's published Styles reference. Worth a final confirm against a live Pro+ kit, since those CDN paths can't be reached without a kit token.