### PR TITLE
Capitalize doc headings

### DIFF
--- a/packages/webawesome/docs/_layouts/component.njk
+++ b/packages/webawesome/docs/_layouts/component.njk
@@ -205,7 +205,7 @@
 
 {# Custom Properties #}
 {% if component.cssProperties.length %}
-<h2>CSS custom properties</h2>
+<h2>CSS Custom Properties</h2>
 <p>Learn more about <a href="/docs/usage/#custom-properties">CSS custom properties</a>.</p>
 
 <wa-scroller>
@@ -269,7 +269,7 @@
 
 {# CSS Parts #}
 {% if component.cssParts.length %}
-<h2>CSS parts</h2>
+<h2>CSS Parts</h2>
 <p>Learn more about <a href="/docs/usage/#css-parts">CSS parts</a>.</p>
 
 <wa-scroller>

--- a/packages/webawesome/docs/docs/ai/agent-skills.md
+++ b/packages/webawesome/docs/docs/ai/agent-skills.md
@@ -13,7 +13,7 @@ Web Awesome publishes **two complementary Agent Skills** that are designed to wo
 | `webawesome`        | "What does this component do?"                   | Working with a specific component's properties, slots, events, or framework setup |
 | `webawesome-design` | "How do I build a good-looking page with these?" | Laying out a page (`<wa-page>`), theming on-brand, or composing a polished UI     |
 
-### Which skill do I need?
+### Which Skill Do I Need?
 
 The simplest way to decide:
 
@@ -34,7 +34,7 @@ When working with AI coding assistants like Claude Code, Cursor, or other tools 
 
 Unlike a single file, Agent Skills use progressive disclosure. The AI loads only the documentation it needs for the current task, so a large reference doesn't bloat the context window. Each skill also triggers on its own kind of request, so the right one loads when you ask for it.
 
-### Skill quality
+### Skill Quality
 
 Both skills are kept in sync with the library by tooling. The `webawesome` skill is generated from the Custom Elements Manifest on every release, so it matches the current component API exactly. The `webawesome-design` skill is hand-authored but verified — every component tag, attribute, slot, and CSS custom property it cites is cross-checked against the library on every build, so it can't claim something the components don't actually do.
 
@@ -84,7 +84,7 @@ node_modules/@awesome.me/webawesome/dist/skills/webawesome-design/
 
 Add both as separate doc sources if you want both skills available. Cursor will index the markdown and surface it via @-mention or as relevant context.
 
-### Other AI tools
+### Other AI Tools
 
 The skills follow the [Agent Skills specification](https://agentskills.io/), so any tool that supports the spec should be able to use them. We've tested in Claude Code and Cursor. If your tool can load a directory of markdown references on demand, point it at the same `node_modules/@awesome.me/webawesome/dist/skills/` directories shown above.
 

--- a/packages/webawesome/docs/docs/ai/index.md
+++ b/packages/webawesome/docs/docs/ai/index.md
@@ -7,7 +7,7 @@ hasBreadcrumbs: false
 
 Web Awesome publishes machine-readable documentation so AI coding assistants can understand its components and help you write better code. Whether you're using Claude, ChatGPT, Copilot, Cursor, or another tool, you can give it context about Web Awesome's APIs, properties, events, slots, and more.
 
-## AI-ready Documentation
+## AI-Ready Documentation
 
 We provide two formats for giving AI tools context about Web Awesome. Both formats are generated automatically with every Web Awesome build and are available in your `node_modules` directory after installing via npm.
 
@@ -37,7 +37,7 @@ We're a small team, and like most people building things these days, we use AI t
 
 But Web Awesome is an open-source library that a lot of people rely on, so we want to be clear about how we use AI.
 
-<h3 data-no-anchor>Human-led, AI-assisted</h3>
+<h3 data-no-anchor>Human-Led, AI-Assisted</h3>
 
 Everything in Web Awesome is built and owned by humans. AI is a capable assistant, but it never gets the final say. The humans on our team are always responsible for:
 

--- a/packages/webawesome/docs/docs/components/accordion.md
+++ b/packages/webawesome/docs/docs/components/accordion.md
@@ -265,7 +265,7 @@ To place HTML in an accordion item's header, use the `label` slot instead of the
 </wa-accordion>
 ```
 
-### Expand and Collapse All
+### Expand & Collapse All
 
 Use the `expandAll()` and `collapseAll()` methods to programmatically control all items at once. Note that `expandAll()` is a no-op when `mode` is `single` or `single-collapsible`.
 

--- a/packages/webawesome/docs/docs/components/animated-image.md
+++ b/packages/webawesome/docs/docs/components/animated-image.md
@@ -36,7 +36,7 @@ Both GIF and WEBP images are supported.
 ></wa-animated-image>
 ```
 
-### Setting a Width and Height
+### Setting a Width & Height
 
 To set a custom size, apply a width and/or height to the host element.
 

--- a/packages/webawesome/docs/docs/components/carousel.md
+++ b/packages/webawesome/docs/docs/components/carousel.md
@@ -265,7 +265,7 @@ This example is best demonstrated using a mouse. Try clicking and dragging the s
 </script>
 ```
 
-### Multiple Slides Per View
+### Multiple Slides per View
 
 The `slides-per-page` attribute makes it possible to display multiple slides at a time. You can also use the `slides-per-move` attribute to advance more than once slide at a time, if desired.
 

--- a/packages/webawesome/docs/docs/components/carousel.md
+++ b/packages/webawesome/docs/docs/components/carousel.md
@@ -280,7 +280,7 @@ The `slides-per-page` attribute makes it possible to display multiple slides at 
 </wa-carousel>
 ```
 
-### Adding and Removing Slides
+### Adding & Removing Slides
 
 The content of the carousel can be changed by adding or removing carousel items. The carousel will update itself automatically.
 

--- a/packages/webawesome/docs/docs/components/copy-button.md
+++ b/packages/webawesome/docs/docs/components/copy-button.md
@@ -69,7 +69,7 @@ You can also use a native button as the trigger.
 Custom triggers automatically receive the same tooltip and copy feedback as the default trigger — no extra wiring required. The icon swap is the only piece that's specific to the default trigger. Use `without-tooltip` to opt out of the tooltip, and use the `wa-copy` and `wa-error` events or the `:state(success)` and `:state(error)` CSS custom states for additional feedback.
 :::
 
-### Copying Values From Other Elements
+### Copying Values from Other Elements
 
 Normally, the data that gets copied will come from the component's `value` attribute, but you can copy data from any element within the same document by providing its `id` to the `from` attribute.
 

--- a/packages/webawesome/docs/docs/components/dialog.md
+++ b/packages/webawesome/docs/docs/components/dialog.md
@@ -34,7 +34,7 @@ use-cases:
 
 ## Examples
 
-### Dialog without Header
+### Dialog Without Header
 
 Headers are enabled by default. To render a dialog without a header, add the `without-header` attribute.
 

--- a/packages/webawesome/docs/docs/components/dialog.md
+++ b/packages/webawesome/docs/docs/components/dialog.md
@@ -74,7 +74,7 @@ Footers can be used to display titles and more. Use the `footer` slot to add a f
 </script>
 ```
 
-### Opening and Closing Dialogs Declaratively
+### Opening & Closing Dialogs Declaratively
 
 You can open and close dialogs with JavaScript by toggling the `open` attribute, but you can also do it declaratively. Add the `data-dialog="open id"` to any button on the page, where `id` is the ID of the dialog you want to open.
 

--- a/packages/webawesome/docs/docs/components/drawer.md
+++ b/packages/webawesome/docs/docs/components/drawer.md
@@ -74,7 +74,7 @@ Footers can be used to display titles and more. Use the `footer` slot to add a f
 </script>
 ```
 
-### Opening and Closing Drawers Declaratively
+### Opening & Closing Drawers Declaratively
 
 You can open and close drawers with JavaScript by toggling the `open` attribute, but you can also do it declaratively. Add the `data-drawer="open id"` to any button on the page, where `id` is the ID of the drawer you want to open.
 

--- a/packages/webawesome/docs/docs/components/drawer.md
+++ b/packages/webawesome/docs/docs/components/drawer.md
@@ -34,7 +34,7 @@ use-cases:
 
 ## Examples
 
-### Drawer without Header
+### Drawer Without Header
 
 Headers are enabled by default. To render a drawer without a header, add the `without-header` attribute.
 
@@ -98,7 +98,7 @@ Similarly, you can add `data-drawer="close"` to a button _inside_ of a drawer to
 <wa-button appearance="filled" data-drawer="open drawer-dismiss">Open Drawer</wa-button>
 ```
 
-### Slide in From Start
+### Slide in from Start
 
 By default, drawers slide in from the end. To make the drawer slide in from the start, set the `placement` attribute to `start`.
 
@@ -118,7 +118,7 @@ By default, drawers slide in from the end. To make the drawer slide in from the 
 </script>
 ```
 
-### Slide in From Top
+### Slide in from Top
 
 To make the drawer slide in from the top, set the `placement` attribute to `top`.
 
@@ -138,7 +138,7 @@ To make the drawer slide in from the top, set the `placement` attribute to `top`
 </script>
 ```
 
-### Slide in From Bottom
+### Slide in from Bottom
 
 To make the drawer slide in from the bottom, set the `placement` attribute to `bottom`.
 

--- a/packages/webawesome/docs/docs/components/icon.md
+++ b/packages/webawesome/docs/docs/components/icon.md
@@ -610,7 +610,7 @@ Custom icons can be loaded individually with the `src` attribute. Only SVGs on a
 <wa-icon src="https://shoelace.style/assets/images/shoe.svg" style="font-size: 4rem;"></wa-icon>
 ```
 
-### Self-hosting the Default Library
+### Self-Hosting the Default Library
 
 By default, icons are loaded from the {{ site.siblings.fontAwesome.name }} CDN. If you'd prefer to [download the icons](https://fontawesome.com/download) and serve them from your own server, you can use the `setIconPath()` function to point the default icon library at your self-hosted directory.
 
@@ -665,7 +665,7 @@ For example, this will change the default icon library to use [Bootstrap Icons](
 </script>
 ```
 
-#### Customize the default library to use SVG sprites
+#### Customize the Default Library to Use SVG Sprites
 
 To improve performance you can use a SVG sprites to avoid multiple trips for each SVG. The browser will load the sprite sheet once and then you reference the particular SVG within the sprite sheet using hash selector.
 
@@ -705,7 +705,7 @@ If you want to change the icons Web Awesome uses internally, you can register an
 </script>
 ```
 
-### Third-party Icon Libraries
+### Third-Party Icon Libraries
 
 You can register additional icons to use with the `<wa-icon>` component through icon libraries. Icon files can exist locally or on a CORS-enabled endpoint (e.g. a CDN). There is no limit to how many icon libraries you can register and there is no cost associated with registering them, as individual icons are only requested when they're used.
 

--- a/packages/webawesome/docs/docs/components/known-date.md
+++ b/packages/webawesome/docs/docs/components/known-date.md
@@ -103,7 +103,7 @@ The three fields render in the natural order for the inherited `lang` (or the ex
 <wa-known-date label="Japanese order" lang="ja-JP"></wa-known-date>
 ```
 
-### Min and Max
+### Min & Max
 
 Constrain the accepted range with `min` and `max`. Values outside the range are reported as invalid.
 
@@ -123,7 +123,7 @@ Set `required` to make the date input required for form submission. Like other f
 </form>
 ```
 
-### Disabled and Readonly
+### Disabled & Readonly
 
 ```html {.example}
 <wa-known-date label="Disabled" value="2007-03-27" disabled></wa-known-date>

--- a/packages/webawesome/docs/docs/components/markdown.md
+++ b/packages/webawesome/docs/docs/components/markdown.md
@@ -44,7 +44,7 @@ Since content is rendered client-side, it won't be visible to search engine craw
 
 ## Examples
 
-### Providing content
+### Providing Content
 
 Markdown must go inside a `<script type="text/markdown">` element, which must be a direct child of the markdown component. (The script is required to prevent the browser from parsing the content.) The rendered output is placed in the light DOM where it inherits your page's styles.
 
@@ -58,7 +58,7 @@ Markdown must go inside a `<script type="text/markdown">` element, which must be
 
 The [Marked](https://marked.js.org/) library is used under the hood to render markdown. Marked supports [GitHub Flavored Markdown](https://github.github.com/gfm/) (GFM) and the [CommonMark](https://commonmark.org/) specification. This includes headings, bold, italic, links, images, lists, blockquotes, code blocks, tables, task lists, strike-through, and auto-links. For a full breakdown of supported syntax, see the [Marked documentation](https://marked.js.org/#specifications).
 
-### Whitespace normalization
+### Whitespace Normalization
 
 Indentation inside the script is automatically normalized before the markdown parser sees it. This lets you indent your content to match the surrounding HTML without it being treated as a code block. The normalization process:
 
@@ -93,7 +93,7 @@ For tab-indented source files, adjust the tab stop width with the `tab-size` att
 </wa-markdown>
 ```
 
-### Formatting features
+### Formatting Features
 
 All standard markdown formatting supported by Marked is available, including headings, lists, blockquotes, code blocks, links, and images.
 
@@ -151,7 +151,7 @@ All `<wa-markdown>` instances share a single [Marked](https://marked.js.org/usin
 The Marked instance is shared across all `<wa-markdown>` elements. If you want every instance on the page to pick up the new configuration, call `WaMarkdown.updateAll()` instead of `renderMarkdown()` on a single element.
 :::
 
-### Writing a custom Marked plugin
+### Writing a Custom Marked Plugin
 
 Custom [Marked extensions](https://marked.js.org/using_advanced#extensions) can be applied through any element's `marked` property. The example below adds support for `==highlight==` syntax, wrapping matched text in `<mark>` tags.
 
@@ -196,7 +196,7 @@ Custom [Marked extensions](https://marked.js.org/using_advanced#extensions) can 
 </script>
 ```
 
-### Updating content dynamically
+### Updating Content Dynamically
 
 The component parses and renders automatically when the script element is first slotted in. It does not watch for subsequent changes to the script's content. To re-render after modifying the source, update the script's `textContent` and call `renderMarkdown()`.
 

--- a/packages/webawesome/docs/docs/components/number-input.md
+++ b/packages/webawesome/docs/docs/components/number-input.md
@@ -51,7 +51,7 @@ Use the `placeholder` attribute to add a placeholder.
 <wa-number-input placeholder="Enter a number" style="max-width: 260px;"></wa-number-input>
 ```
 
-### Setting Min, Max, and Step
+### Setting Min, Max, & Step
 
 Use the `min` and `max` attributes to set a minimum and maximum value. Use the `step` attribute to change the granularity the value must adhere to when using the stepper buttons or arrow keys.
 

--- a/packages/webawesome/docs/docs/components/page.md
+++ b/packages/webawesome/docs/docs/components/page.md
@@ -134,7 +134,7 @@ This is often desirable, but you can change this behavior using the `disable-sti
 <wa-page disable-sticky="header aside"> ... </wa-page>
 ```
 
-### Skip To Content
+### Skip to Content
 
 The layout provides a "skip to content" link that's visually hidden until the user tabs into it. You don't have to do anything to configure this, unless you want to change the text displayed in the link. In that case, you can slot in your own text using the `skip-to-content` slot.
 
@@ -250,7 +250,7 @@ You can override the default spacing for each slot with your own CSS. In this ex
 }
 ```
 
-## Utility classes
+## Utility Classes
 
 [Native styles](/docs/utilities/native/) define a few useful defaults for `<wa-page>`, as well as two utility classes you can use for common responsive design tasks:
 

--- a/packages/webawesome/docs/docs/components/popover.md
+++ b/packages/webawesome/docs/docs/components/popover.md
@@ -48,7 +48,7 @@ Use `<wa-button>` or `<button>` elements as popover anchors. Connect the popover
 Make sure the anchor element exists in the DOM before the popover connects. If it doesn't exist, the popover won't attach and you'll see a console warning.
 :::
 
-### Opening and Closing
+### Opening & Closing
 
 Popovers show when you click their anchor element. You can also control them programmatically by setting the `open` property to `true` or `false`.
 

--- a/packages/webawesome/docs/docs/components/popup.md
+++ b/packages/webawesome/docs/docs/components/popup.md
@@ -497,7 +497,7 @@ By default, the arrow will be aligned as close to the center of the _anchor_ as 
 </div>
 ```
 
-### Adding a border
+### Adding a Border
 
 Borders can also be added to the popup element by targeting the contents of the `wa-popup` element. This styling can also be extended to the arrow itself by targeting `.arrow` class in the popup.
 
@@ -821,7 +821,7 @@ Toggle the switch to see the difference.
 </script>
 ```
 
-### Auto-size
+### Auto-Size
 
 Use the `auto-size` attribute to tell the popup to resize when necessary to prevent it from overflowing.
 Possible values are `horizontal`, `vertical`, and `both`. You can use `autoSizeBoundary` and `auto-size-padding` to customize the behavior of this option. Auto-size works well with `flip`, but if you're using `auto-size-padding` make sure `flip-padding` is the same value.

--- a/packages/webawesome/docs/docs/components/progress-ring.md
+++ b/packages/webawesome/docs/docs/components/progress-ring.md
@@ -26,7 +26,7 @@ Use the `--size` custom property to set the diameter of the progress ring.
 <wa-progress-ring value="50" style="--size: 200px;"></wa-progress-ring>
 ```
 
-### Track and Indicator Width
+### Track & Indicator Width
 
 Use the `--track-width` and `--indicator-width` custom properties to set the width of the progress ring's track and indicator.
 

--- a/packages/webawesome/docs/docs/components/rating.md
+++ b/packages/webawesome/docs/docs/components/rating.md
@@ -143,7 +143,7 @@ You can provide custom icons by passing a function to the `getSymbol` property.
 </script>
 ```
 
-### Value-based Icons
+### Value-Based Icons
 
 You can also use the `getSymbol` property to render different icons based on value and/or whether the icon is currently selected.
 

--- a/packages/webawesome/docs/docs/components/select.md
+++ b/packages/webawesome/docs/docs/components/select.md
@@ -346,11 +346,11 @@ Be sure you trust the content you are outputting! Passing unsanitized user input
 When using custom tags with `with-remove`, you must include the `data-value` attribute set to the option's value. This allows the select to identify which option to deselect when the tag's remove button is clicked.
 :::
 
-### Lazy loading options
+### Lazy Loading Options
 
 Lazy loading options works similarly to native `<select>` elements. The select component handles various scenarios intelligently:
 
-#### Basic lazy loading scenarios:
+#### Basic Lazy Loading Scenarios
 
 - **Empty select with value**: If a `<wa-select>` is created without any options but given a `value` attribute, its value will be `""` initially. When options are added later, if any option has a value matching the select's value attribute, the select's value will update to match.
 

--- a/packages/webawesome/docs/docs/components/slider.md
+++ b/packages/webawesome/docs/docs/components/slider.md
@@ -52,7 +52,7 @@ Add descriptive hint to a slider with the `hint` attribute. For hints that conta
 <wa-slider label="Volume" hint="Controls the volume of the current song." min="0" max="100" value="50"></wa-slider>
 ```
 
-### Showing tooltips
+### Showing Tooltips
 
 Use the `with-tooltip` attribute to display a tooltip with the current value when the slider is focused or being dragged.
 
@@ -60,7 +60,7 @@ Use the `with-tooltip` attribute to display a tooltip with the current value whe
 <wa-slider label="Quality" name="quality" min="0" max="100" value="50" with-tooltip></wa-slider>
 ```
 
-### Setting min, max, and step
+### Setting Min, Max, and Step
 
 Use the `min` and `max` attributes to define the slider's range, and the `step` attribute to control the increment between values.
 
@@ -68,7 +68,7 @@ Use the `min` and `max` attributes to define the slider's range, and the `step` 
 <wa-slider label="Between zero and one" min="0" max="1" step="0.1" value="0.5" with-tooltip></wa-slider>
 ```
 
-### Showing markers
+### Showing Markers
 
 Use the `with-markers` attribute to display visual indicators at each step increment. This works best with sliders that have a smaller range of values.
 
@@ -76,7 +76,7 @@ Use the `with-markers` attribute to display visual indicators at each step incre
 <wa-slider label="Size" name="size" min="0" max="8" value="4" with-markers></wa-slider>
 ```
 
-### Adding references
+### Adding References
 
 Use the `reference` slot to add contextual labels below the slider. References are automatically spaced using `space-between`, making them easy to align with the start, center, and end positions.
 
@@ -100,7 +100,7 @@ Use the `reference` slot to add contextual labels below the slider. References a
 If you want to show a reference next to a specific marker, you can add `position: absolute` to it and set the `left`, `right`, `top`, or `bottom` property to a percentage that corresponds to the marker's position.
 :::
 
-### Formatting the value
+### Formatting the Value
 
 Customize how values are displayed in tooltips and announced to screen readers using the `valueFormatter` property. Set it to a function that accepts a number and returns a formatted string. The [`Intl.NumberFormat API`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat) is particularly useful for this.
 
@@ -158,7 +158,7 @@ Customize how values are displayed in tooltips and announced to screen readers u
 </script>
 ```
 
-### Range selection
+### Range Selection
 
 Use the `range` attribute to enable dual-thumb selection for choosing a range of values. Set the initial thumb positions with the `min-value` and `max-value` attributes.
 

--- a/packages/webawesome/docs/docs/components/slider.md
+++ b/packages/webawesome/docs/docs/components/slider.md
@@ -60,7 +60,7 @@ Use the `with-tooltip` attribute to display a tooltip with the current value whe
 <wa-slider label="Quality" name="quality" min="0" max="100" value="50" with-tooltip></wa-slider>
 ```
 
-### Setting Min, Max, and Step
+### Setting Min, Max, & Step
 
 Use the `min` and `max` attributes to define the slider's range, and the `step` attribute to control the increment between values.
 

--- a/packages/webawesome/docs/docs/components/textarea.md
+++ b/packages/webawesome/docs/docs/components/textarea.md
@@ -113,7 +113,7 @@ Textareas will automatically resize to expand to fit their content when `resize`
 <wa-textarea resize="auto"></wa-textarea>
 ```
 
-### Resize horizontal
+### Resize Horizontal
 
 Textareas can be made to resize horizontally when `resize` is set to `"horizontal"`
 
@@ -121,7 +121,7 @@ Textareas can be made to resize horizontally when `resize` is set to `"horizonta
 <wa-textarea resize="horizontal"></wa-textarea>
 ```
 
-### Resize both
+### Resize Both
 
 Textareas can be made to resize both vertically and horizontally when `resize` is set to `"both"`
 

--- a/packages/webawesome/docs/docs/components/time-input.md
+++ b/packages/webawesome/docs/docs/components/time-input.md
@@ -129,7 +129,7 @@ Combine `required` with `with-clear` to enforce a value while still letting user
 </form>
 ```
 
-### Min and Max
+### Min & Max
 
 Constrain the selectable range. The picker delegates reversed-range (overnight) semantics to the native `<input type="time">`, so `min="22:00" max="06:00"` represents an overnight range.
 

--- a/packages/webawesome/docs/docs/components/time-input.md
+++ b/packages/webawesome/docs/docs/components/time-input.md
@@ -219,7 +219,7 @@ Use the `disabled` attribute to disable the time input entirely. Disabled time i
 <wa-time-input label="Disabled" value="09:00" disabled></wa-time-input>
 ```
 
-### Read-only
+### Read-Only
 
 Use the `readonly` attribute to make the time input non-editable while still allowing it to be focused and to submit its value with the form. The popup still opens for browsing.
 

--- a/packages/webawesome/docs/docs/components/tree.md
+++ b/packages/webawesome/docs/docs/components/tree.md
@@ -232,7 +232,7 @@ If you want to disable this behavior after the first load, simply remove the `la
 </script>
 ```
 
-### Customizing the Expand and Collapse Icons
+### Customizing the Expand & Collapse Icons
 
 Use the `expand-icon` and `collapse-icon` slots to change the expand and collapse icons, respectively. To disable the animation, override the `rotate` property on the `expand-button` part as shown below.
 

--- a/packages/webawesome/docs/docs/components/zoomable-frame.md
+++ b/packages/webawesome/docs/docs/components/zoomable-frame.md
@@ -18,7 +18,7 @@ use-cases:
 
 ## Examples
 
-### Loading external content
+### Loading External Content
 
 Use the `src` attribute to embed external websites or resources. The URL must be accessible, and cross-origin restrictions may apply due to the Same-Origin Policy, potentially limiting access to the iframe's content.
 
@@ -43,7 +43,7 @@ Use the `srcdoc` attribute or property to display custom HTML content directly w
 When both `src` and `srcdoc` are specified, `srcdoc` takes precedence.
 :::
 
-### Controlling zoom behavior
+### Controlling Zoom Behavior
 
 Set the `zoom` attribute to control the frame's zoom level. Use `1` for 100%, `2` for 200%, `0.5` for 50%, and so on.
 
@@ -53,7 +53,7 @@ Define specific zoom increments with the `zoom-levels` attribute using space-sep
 <wa-zoomable-frame src="/examples/themes/showcase" zoom="0.5" zoom-levels="50% 0.75 100%"> </wa-zoomable-frame>
 ```
 
-### Hiding zoom controls
+### Hiding Zoom Controls
 
 Add the `without-controls` attribute to hide the zoom control interface from the frame.
 
@@ -61,7 +61,7 @@ Add the `without-controls` attribute to hide the zoom control interface from the
 <wa-zoomable-frame src="/examples/themes/showcase" without-controls zoom="0.5"> </wa-zoomable-frame>
 ```
 
-### Preventing user interaction
+### Preventing User Interaction
 
 Apply the `without-interaction` attribute to make the frame non-interactive. Note that this prevents keyboard navigation into the frame, which may impact accessibility for some users.
 
@@ -69,7 +69,7 @@ Apply the `without-interaction` attribute to make the frame non-interactive. Not
 <wa-zoomable-frame src="/examples/themes/showcase" zoom="0.5" without-interaction> </wa-zoomable-frame>
 ```
 
-### Enabling theme sync
+### Enabling Theme Sync
 
 By default, the frame does not sync theme classes into the iframe. Add the `with-theme-sync` attribute to mirror the host page's light/dark mode and [theme selector classes](/docs/theming-overview) (such as `wa-theme-*`, `wa-brand-*`, and `wa-palette-*`) into the iframe document. This is useful when the iframe renders Web Awesome styles that should match the host page's theme.
 

--- a/packages/webawesome/docs/docs/customizing.md
+++ b/packages/webawesome/docs/docs/customizing.md
@@ -111,7 +111,7 @@ The Theme Builder is a visual editor for **Pro workspace projects** that lets yo
 
 You can launch the Theme Builder from your project's <wa-tag class="tag-ui" appearance="outlined"><wa-icon name="gear" variant="regular"></wa-icon> Settings</wa-tag> by pressing <wa-tag class="tag-ui" appearance="outlined"><wa-icon name="paintbrush" variant="regular"></wa-icon> Edit Your Theme</wa-tag>.
 
-### Light and Dark Mode
+### Light & Dark Mode
 
 Every theme is designed to adapt to light and dark mode. Light mode styles are applied by default, but you can apply a specific color scheme to an entire page or just a section with `class="wa-light"` or `class="wa-dark"`.
 

--- a/packages/webawesome/docs/docs/frameworks/angular.md
+++ b/packages/webawesome/docs/docs/frameworks/angular.md
@@ -14,7 +14,7 @@ Angular [plays nice](https://custom-elements-everywhere.com/#angular) with custo
 
 ## Installation
 
-### Download the npm package
+### Download the npm Package
 
 To add Web Awesome to your Angular app, install the package from npm.
 
@@ -64,7 +64,7 @@ import { AppComponent } from './app.component';
 export class AppModule {}
 ```
 
-## Reference Web Awesome components in your Angular component code
+## Reference Web Awesome Components in Your Angular Component Code
 
 ```js
 // need to have both or Angular will tree shake the component out.

--- a/packages/webawesome/docs/docs/frameworks/react.md
+++ b/packages/webawesome/docs/docs/frameworks/react.md
@@ -173,7 +173,7 @@ These instructions are for apps created via Create React App. If you're using Je
 
 For more details, refer to Jest's [`transformIgnorePatterns` customization](https://jestjs.io/docs/tutorial-react-native#transformignorepatterns-customization) documentation.
 
-## Legacy React Wrappers (React 18 and Below)
+## Legacy React Wrappers (React 18 & Below)
 
 React 18 and below have [poor support](https://custom-elements-everywhere.com/#react) for custom elements. For these versions, Web Awesome provides React wrappers for every component.
 

--- a/packages/webawesome/docs/docs/frameworks/react.md
+++ b/packages/webawesome/docs/docs/frameworks/react.md
@@ -191,7 +191,7 @@ export default MyComponent;
 
 You can find a copy + paste import for each component by selecting the _React_ tab in the _Importing_ section of each component's documentation.
 
-#### Notes about tree shaking
+#### Notes About Tree Shaking
 
 Previously, it was recommended to import from a single entrypoint like so:
 

--- a/packages/webawesome/docs/docs/frameworks/svelte.md
+++ b/packages/webawesome/docs/docs/frameworks/svelte.md
@@ -44,7 +44,7 @@ Next, import the Web Awesome stylesheet, import the components you need, and the
 </wa-callout>
 ```
 
-### Two-way Binding
+### Two-Way Binding
 
 One caveat is there's currently Svelte only supports `bind:value` directive in `<input>`, `<textarea>` and `<select>`, but you can still achieve two-way binding manually.
 

--- a/packages/webawesome/docs/docs/frameworks/vue-2.md
+++ b/packages/webawesome/docs/docs/frameworks/vue-2.md
@@ -61,7 +61,7 @@ When binding complex data such as objects and arrays, use the `.prop` modifier t
 <wa-color-picker :swatches.prop="mySwatches" />
 ```
 
-### Two-way Binding
+### Two-Way Binding
 
 One caveat is there's currently [no support for v-model on custom elements](https://github.com/vuejs/vue/issues/7830), but you can still achieve two-way binding manually.
 

--- a/packages/webawesome/docs/docs/frameworks/vue.md
+++ b/packages/webawesome/docs/docs/frameworks/vue.md
@@ -52,7 +52,7 @@ Once you have configured your application for custom elements, you should be abl
 
 ## Usage
 
-### QR code generator example
+### QR Code Generator Example
 
 ```html
 <template>
@@ -89,7 +89,7 @@ When binding complex data such as objects and arrays, use the `.prop` modifier t
 <wa-color-picker :swatches.prop="mySwatches" />
 ```
 
-### Two-way Binding
+### Two-Way Binding
 
 One caveat is there's currently [varying levels of support for v-model on custom elements](https://github.com/vuejs/vue/issues/7830), but you can still achieve two-way binding manually.
 

--- a/packages/webawesome/docs/docs/index.md
+++ b/packages/webawesome/docs/docs/index.md
@@ -140,7 +140,7 @@ Most of the magic behind assets is handled internally by Web Awesome, but if you
 </script>
 ```
 
-### Using Font Awesome Pro and Pro+
+### Using Font Awesome Pro & Pro+
 
 {{ site.siblings.fontAwesome.name }} users can provide their kit code to unlock Pro and Pro+ icon packs. You can do so by adding the `data-fa-kit-code` attribute to any element on the page, or by calling the `setKitCode()` method.
 

--- a/packages/webawesome/docs/docs/localization.md
+++ b/packages/webawesome/docs/docs/localization.md
@@ -72,7 +72,7 @@ If you have any questions, please start a [discussion]({{ site.github.discussion
 Web Awesome provides a localization mechanism for component internals. This is not designed to be used as localization tool for your entire application. You should use a more appropriate tool such as [i18next](https://www.i18next.com/) if you need to localize content in your app.
 :::
 
-## Multiple Locales Per Page
+## Multiple Locales per Page
 
 You can use a different locale for an individual component by setting its `lang` and/or `dir` attributes. Here's a contrived example to demonstrate.
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -585,7 +585,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 :::
 
-## Pre-release Versions
+## Pre-Release Versions
 
 Betas, release candidates, and snapshots from before each major release.
 

--- a/packages/webawesome/docs/docs/resources/contributing.md
+++ b/packages/webawesome/docs/docs/resources/contributing.md
@@ -85,7 +85,7 @@ The docs are powered by [Eleventy](https://www.11ty.dev/). Check out `docs/compo
 
 If you need help with documentation, feel free to reach out on the [community chat]({{ site.urls.discord }}).
 
-### Web Awesome-flavoured Markdown
+### Web Awesome-Flavored Markdown
 
 The Web Awesome documentation uses an extended version of [markdown-it](https://github.com/markdown-it/markdown-it). Generally speaking, it follows the [Commonmark spec](https://spec.commonmark.org/) while sprinkling in some additional features.
 
@@ -310,13 +310,13 @@ export default class WaExample {
 
 When an item within a keyboard navigable set is disabled (e.g. tabs, trees, menu items, etc.), the disabled item _should not_ receive focus via keyboard, click, or tap. It should be skipped just like in operating system menus and in native HTML form controls. There is no exception to this. If a particular item requires focus for assistive devices to provide a good user experience, the item should not be disabled and, upon activation, it should inform the user why the respective action cannot be completed.
 
-### When to use a property vs. a CSS custom property
+### When to Use a Property vs. a CSS Custom Property
 
 When designing a component's API, standard properties are generally used to change the _behavior_ of a component, whereas CSS custom properties ("CSS variables") are used to change the _appearance_ of a component. Remember that properties can't respond to media queries, but CSS variables can.
 
 There are some exceptions to this (e.g. when it significantly improves developer experience), but a good rule of thumbs is "will this need to change based on screen size?" If so, you probably want to use a CSS variable.
 
-### When to use a CSS custom property vs. a CSS part
+### When to Use a CSS Custom Property vs. a CSS Part
 
 There are two ways to enable customizations for components. One way is with CSS custom properties ("CSS variables"), the other is with CSS parts ("parts").
 
@@ -440,7 +440,7 @@ Avoid inlining SVG icons inside of templates. If a component requires an icon, m
 
 This will render the icons instantly whereas the default library will fetch them from a remote source. If an icon isn't available in the system library, you will need to add it to `library.system.ts`. Using the system library ensures that all icons load instantly and are customizable by users who wish to provide a custom resolver for the system library.
 
-### Writing tests
+### Writing Tests
 
 What to test for a given component:
 
@@ -463,7 +463,7 @@ Guidelines for writing tests:
 - Try to aim testing the user facing features of the component instead of the internal workings of the component.
 - Group multiple tests for one feature into describe blocks.
 
-### Running tests
+### Running Tests
 
 Right now, tests run both "hydrated" (SSR → client hydrated) and "client only". If you're debugging only one specific kind you can set an environment variable. For example, to run only the client tests, you can do:
 
@@ -477,7 +477,7 @@ or for hydrated rendering only:
 SSR_ONLY="true" npm run test
 ```
 
-## Built On
+## Built on
 
 Web Awesome stands on the shoulders of some excellent open source projects. Special thanks to:
 

--- a/packages/webawesome/docs/docs/resources/contributing.md
+++ b/packages/webawesome/docs/docs/resources/contributing.md
@@ -236,7 +236,7 @@ When a component relies on the presence of slotted content to do something, don'
 
 See the source of card, dialog, or drawer for examples.
 
-### Dynamic Slot Names and Expand/Collapse Icons
+### Dynamic Slot Names & Expand/Collapse Icons
 
 A pattern has been established in `<wa-details>` and `<wa-tree-item>` for expand/collapse icons that animate on open/close. In short, create two slots called `expand-icon` and `collapse-icon` and render them both in the DOM, using CSS to show/hide only one based on the current open state. Avoid conditionally rendering them. Also avoid using dynamic slot names, such as `<slot name=${open ? 'open' : 'closed'}>`, because Firefox will not animate them.
 
@@ -410,7 +410,7 @@ connectedCallback() {
 }
 ```
 
-#### Slot Detection and `with-*` Attributes
+#### Slot Detection & `with-*` Attributes
 
 Some components use `HasSlotController` to conditionally render parts of their template (e.g. a footer that only appears when a `footer` slot is present). During SSR, slot detection doesn't work because the DOM isn't available, so these parts would be missing from the initial server-rendered markup.
 

--- a/packages/webawesome/docs/docs/resources/migrating-from-shoelace.md
+++ b/packages/webawesome/docs/docs/resources/migrating-from-shoelace.md
@@ -694,7 +694,7 @@ Cancel `wa-invalid` with `event.preventDefault()` to suppress the browser's defa
 
 The `customError` attribute is a declarative version of `setCustomValidity()` that you can set from your template.
 
-### Step 6: Things to Watch For
+### Step 6: Things to Watch for
 
 Most of what follows is silent breakage: code that won't throw but will misbehave. Check each item against your codebase.
 

--- a/packages/webawesome/docs/docs/resources/migrating-from-shoelace.md
+++ b/packages/webawesome/docs/docs/resources/migrating-from-shoelace.md
@@ -664,7 +664,7 @@ You also gain a few systems that didn't exist in Shoelace:
 The `wa-theme-shoelace` theme and `wa-palette-shoelace` color palette defines tokens that approximate Shoelace's defaults, so most of your existing custom CSS will keep working. Apply it with `<html class="wa-theme-shoelace wa-palette-shoelace">` for a one-line escape hatch during migration.
 :::
 
-### Step 5: Forms and Validation
+### Step 5: Forms & Validation
 
 Web Awesome form controls are real form-associated custom elements (FACE) using `ElementInternals`. This means:
 

--- a/packages/webawesome/docs/docs/resources/migration-checklist.njk
+++ b/packages/webawesome/docs/docs/resources/migration-checklist.njk
@@ -192,7 +192,7 @@ layout: page
   <wa-checkbox data-checklist-item="callout-toast-migration">Migrated <code>.toast()</code> calls to Web Awesome Pro
     <code>&lt;wa-toast&gt;</code> (or built your own)</wa-checkbox>
 
-  <h3>Dialog and Drawer</h3>
+  <h3>Dialog & Drawer</h3>
 
   <wa-checkbox data-checklist-item="dialog-show-hide-events">Updated
     <code>sl-show</code>/<code>sl-hide</code>/<code>sl-after-show</code>/<code>sl-after-hide</code> to <code>wa-</code>
@@ -204,7 +204,7 @@ layout: page
   <wa-checkbox data-checklist-item="dialog-noheader">Renamed <code>noHeader</code> attribute to
     <code>without-header</code></wa-checkbox>
 
-  <h3>Dropdown and Menu</h3>
+  <h3>Dropdown & Menu</h3>
 
   <wa-checkbox data-checklist-item="dropdown-combined">Combined <code>&lt;sl-dropdown&gt;</code> +
     <code>&lt;sl-menu&gt;</code> into <code>&lt;wa-dropdown&gt;</code> (menu is gone)</wa-checkbox>
@@ -305,7 +305,7 @@ layout: page
 </section>
 
 <section data-checklist-section="forms">
-  <h2>5. Forms and Validation</h2>
+  <h2>5. Forms & Validation</h2>
 
   <wa-checkbox data-checklist-item="forms-removed-formdata-listeners">Removed <code>formdata</code> event listeners that
     extracted Shoelace control values</wa-checkbox>

--- a/packages/webawesome/docs/docs/theming-overview.md
+++ b/packages/webawesome/docs/docs/theming-overview.md
@@ -145,7 +145,7 @@ Variants assign palette hues to five semantic roles — `brand`, `neutral`, `suc
   <wa-icon slot="end" name="arrow-right"></wa-icon>
 </wa-button>
 
-### Light and Dark Mode
+### Light & Dark Mode
 
 <span class="wa-cluster">`.wa-light` `.wa-dark`</span>
 

--- a/packages/webawesome/docs/docs/usage.md
+++ b/packages/webawesome/docs/docs/usage.md
@@ -147,7 +147,7 @@ await allDefined({
 
 </wa-details>
 
-## Component Rendering and Updating
+## Component Rendering & Updating
 
 Web Awesome components are built with [Lit](https://lit.dev/), a tiny library that makes authoring custom elements easier, more maintainable, and a lot of fun! As a Web Awesome user, here is some helpful information about rendering and updating you should probably be aware of.
 

--- a/packages/webawesome/docs/docs/utilities/native.md
+++ b/packages/webawesome/docs/docs/utilities/native.md
@@ -16,7 +16,7 @@ use-cases:
 
 Native styles use design tokens to spruce up native HTML elements so that they match the look and feel of your theme. While these native styles are completely optional, they're a great starting point for a cohesive design and a huge help when using a combination of native elements and Web Awesome components in your project.
 
-## Using native styles
+## Using Native Styles
 
 <wa-tab-group>
   <wa-tab panel="cdn"><wa-icon name="rocket-launch" variant="regular"></wa-icon> CDN</wa-tab>
@@ -70,7 +70,7 @@ Or, if you only want styles for native elements, include a theme and native styl
 
 You can additionally include any pre-made [theme](/docs/themes/) or [color palette](/docs/color-palettes/) to change the look of native elements.
 
-## Opting out of native styles
+## Opting out of Native Styles
 
 If you want to keep Web Awesome's components, tokens, and utilities but let a native element fall back to browser defaults, reset that element in your own stylesheet.
 
@@ -101,7 +101,7 @@ To opt out for an entire section, apply the same reset within a wrapper and targ
 
 If your app has separate page-level entry points, the simplest page-level opt-out is to not load `native.css` on pages that should keep browser defaults. You can still load your theme, components, and any [utilities](/docs/utilities/) you want on those pages.
 
-## Content flow
+## Content Flow
 
 Native styles set default space between many block-level HTML elements using the `--wa-content-spacing` token from your theme. This helps ensure that your content is readable.
 
@@ -253,7 +253,7 @@ Use `<dl>` to create lists of terms (`<dt>`) and definitions (`<dd>`).
 </dl>
 ```
 
-### Code blocks
+### Code Blocks
 
 Create code blocks or other preformatted text with `<pre>`. Preformatted text uses your theme's monospace font family and a subtle background color.
 
@@ -266,7 +266,7 @@ export function thing() {
 </pre>
 ```
 
-### Inline text
+### Inline Text
 
 Use any inline text element like `<strong>`, `<em>`, `<a>`, `<kbd>`, and others to stylize or emphasize text.
 
@@ -293,7 +293,7 @@ Use any inline text element like `<strong>`, `<em>`, `<a>`, `<kbd>`, and others 
 </div>
 ```
 
-## Widgets & media
+## Widgets & Media
 
 ### Media
 
@@ -517,7 +517,7 @@ When using `<wa-icon>` within a button, wrap adjacent label text in `<span>` or 
 </button>
 ```
 
-### Form controls
+### Form Controls
 
 Create a variety of form controls with `<input type="">`, `<select>`, and `<textarea>`. Each control closely matches the appearance of the corresponding Web Awesome component.
 
@@ -630,7 +630,7 @@ Group form controls together with `<fieldset>` and `<legend>`.
 </fieldset>
 ```
 
-### Form layouts
+### Form Layouts
 
 Wrap form controls in a flex container to arrange them horizontally or vertically with even spacing. Layout utility classes like [`wa-cluster`](/docs/utilities/cluster) and [`wa-stack`](/docs/utilities/stack) can be added directly to a `<fieldset>` or `<form>` to make this especially easy.
 

--- a/packages/webawesome/docs/docs/utilities/prose.md
+++ b/packages/webawesome/docs/docs/utilities/prose.md
@@ -36,7 +36,7 @@ By default, content is constrained to a comfortable reading column of `65ch`. Ov
 
 ## Examples
 
-### Headings and Paragraphs
+### Headings & Paragraphs
 
 Each heading level gets generous space above and tight space below, so the eye reads it as part of the section it introduces — not the one it follows. When two headings sit back-to-back, the second tightens up so it reads as subordinate to the first.
 

--- a/packages/webawesome/docs/docs/utilities/prose.md
+++ b/packages/webawesome/docs/docs/utilities/prose.md
@@ -21,7 +21,7 @@ Wrap a block of content in `wa-prose` to apply a hierarchical, asymmetric typogr
 
 Reach for it on documentation, blog posts, articles, or marketing copy. Element styling (color, font, borders) still comes from [native styles](/docs/utilities/native/); `wa-prose` only adjusts rhythm, type scale, and the reading column.
 
-## Using prose
+## Using Prose
 
 Wrap your long-form content in any block element with the `wa-prose` class.
 
@@ -36,7 +36,7 @@ By default, content is constrained to a comfortable reading column of `65ch`. Ov
 
 ## Examples
 
-### Headings and paragraphs
+### Headings and Paragraphs
 
 Each heading level gets generous space above and tight space below, so the eye reads it as part of the section it introduces — not the one it follows. When two headings sit back-to-back, the second tightens up so it reads as subordinate to the first.
 
@@ -94,7 +94,7 @@ Lists get a small breath between multi-line items. Quiet markers and bold `<dt>`
 </article>
 ```
 
-### Inline elements
+### Inline Elements
 
 Inline elements you'd reach for in long-form writing — `<kbd>`, `<mark>`, `<sub>`/`<sup>`, `<abbr>` — work as expected inside a prose container, styled by [native styles](/docs/utilities/native/).
 
@@ -108,7 +108,7 @@ Inline elements you'd reach for in long-form writing — `<kbd>`, `<mark>`, `<su
 </article>
 ```
 
-### Major blocks
+### Major Blocks
 
 Code samples, tables, callouts, and collapsible `<details>` get more breathing room than running prose, so they read as distinct chunks of content rather than another sentence.
 
@@ -159,7 +159,7 @@ develop in HC-110, dilution B</code></pre>
 </article>
 ```
 
-### Section breaks
+### Section Breaks
 
 `<hr>` marks a topic shift. Its own margin defines the gap; the heading or paragraph that follows hugs up to it so the divider stays visually anchored to what comes next.
 
@@ -180,7 +180,7 @@ develop in HC-110, dilution B</code></pre>
 </article>
 ```
 
-## Typographic details
+## Typographic Details
 
 A few quieter refinements come along with the rhythm:
 
@@ -188,7 +188,7 @@ A few quieter refinements come along with the rhythm:
 - **Hanging punctuation** pulls opening quotes, em-dashes, and trailing stops into the margin (Safari today; progressive enhancement elsewhere).
 - **Long-word breaks** on `<code>` and `<pre>` so URLs and identifiers can't overflow the column.
 
-## Composing with font-size utilities
+## Composing with Font Size Utilities
 
 Apply any [`wa-font-size-*`](/docs/utilities/text/#font-size) utility to a `wa-prose` container and text, headings, and rhythm scale together. No size variants required.
 
@@ -214,7 +214,7 @@ Apply any [`wa-font-size-*`](/docs/utilities/text/#font-size) utility to a `wa-p
 </div>
 ```
 
-## Adjusting rhythm
+## Adjusting Rhythm
 
 Set `--wa-prose-rhythm-scale` on the prose container to multiply every margin in the system. Values below `1` tighten the rhythm; values above loosen it. Type sizes are unaffected.
 
@@ -234,7 +234,7 @@ Set `--wa-prose-rhythm-scale` on the prose container to multiply every margin in
 </div>
 ```
 
-## Composing with other utilities
+## Composing with Other Utilities
 
 The `wa-prose` class and its element rules sit at `0,0,0` specificity, so any utility class you apply alongside — `wa-heading-m`, `wa-cluster`, `wa-text-center`, and so on — wins automatically. The same goes for plain element rules in your own stylesheet, no `!important` or specificity tricks required.
 
@@ -255,7 +255,7 @@ Color flows from your theme's [color tokens](/docs/tokens/color/), so prose foll
 }
 ```
 
-## Opting out of prose
+## Opting out of Prose
 
 Apply `wa-not-prose` to any element inside a `wa-prose` container to disable prose rhythm for that element and its descendants. Other utilities — `wa-cluster`, `wa-stack`, `wa-font-size-*` — keep working in the opt-out subtree.
 

--- a/packages/webawesome/docs/docs/utilities/visually-hidden.md
+++ b/packages/webawesome/docs/docs/utilities/visually-hidden.md
@@ -40,7 +40,7 @@ In this example, the link will open a new window. Screen readers will announce "
 </a>
 ```
 
-### Content Conveyed By Context
+### Content Conveyed by Context
 
 Adding a label may seem redundant at times, but they're very helpful for unsighted users. Rather than omit them, you can provide context to unsighted users with visually hidden content that will be announced by assistive devices such as screen readers.
 


### PR DESCRIPTION
Consistently uses title case for headings throughout the docs.
Additionally replaces "and" with "&" in headings for consistency and brevity.

See also: https://github.com/shoelace-style/webawesome-pro/pull/249