### PR TITLE
Use `@scope` in `prose.css`

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -61,7 +61,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
   - The current (keyboard-highlighted) state now uses `--wa-form-control-activated-color` for its background and a new `--current-text-color` custom property for its text, so options track form control theming alongside `<wa-checkbox>`, `<wa-radio>`, `<wa-switch>`, and `<wa-slider>`
   - Hover and current state changes now animate, matching `<wa-dropdown-item>`
 - Reordered component reference pages in the `webawesome` Agent Skill to put the import instructions and API tables before the examples
-- Changed the CSS layer for `prose.css` from `wa-utilities` to new `wa-prose` so that reverting properties with the `wa-not-prose` class doesn't also revert the properties specified in other utilities. [pr:2564]
+- Rewrote `prose.css` rules with `@scope` so that `wa-prose` and `wa-not-prose` classes are proximity aware. This ensures that nested instances of either class work as expected, no matter the nesting depth. [pr:2564]
 
 :::
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -61,6 +61,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
   - The current (keyboard-highlighted) state now uses `--wa-form-control-activated-color` for its background and a new `--current-text-color` custom property for its text, so options track form control theming alongside `<wa-checkbox>`, `<wa-radio>`, `<wa-switch>`, and `<wa-slider>`
   - Hover and current state changes now animate, matching `<wa-dropdown-item>`
 - Reordered component reference pages in the `webawesome` Agent Skill to put the import instructions and API tables before the examples
+- Changed the CSS layer for `prose.css` from `wa-utilities` to new `wa-prose` so that reverting properties with the `wa-not-prose` class doesn't also revert the properties specified in other utilities. [pr:2564]
 
 :::
 

--- a/packages/webawesome/docs/docs/utilities/prose.md
+++ b/packages/webawesome/docs/docs/utilities/prose.md
@@ -260,21 +260,26 @@ Color flows from your theme's [color tokens](/docs/tokens/color/), so prose foll
 Apply `wa-not-prose` to any element inside a `wa-prose` container to disable prose rhythm for that element and its descendants. Other utilities — `wa-cluster`, `wa-stack`, `wa-font-size-*` — keep working in the opt-out subtree.
 
 ```html {.example}
-<article class="wa-prose">
+<article class="wa-prose wa-font-size-s">
   <h3>Ready when you are</h3>
   <p>
-    The paragraphs around this section follow prose rhythm. The callout below is given
-    <code>wa-not-prose</code>, so its font sizing and spacing revert to the component defaults.
+    The content in this section follows prose rhythm and adopt a smaller font size. The callout below is given
+    <code>wa-not-prose</code>, so its spacing and font sizing revert to element defaults.
   </p>
 
   <wa-callout class="wa-not-prose" variant="warning">
     <wa-icon slot="icon" name="highlighter"></wa-icon>
-    <div class="wa-stack">
+    <div class="wa-stack wa-gap-s">
       <h4>Leave it to the prose</h4>
-      <p>The elements in this callout are exempt from <code>wa-prose</code> rules, thanks to <code>wa-not-prose</code>.</p>
+      <p>This callout and its child elements are exempt from <code>wa-prose</code> rules, thanks to <code>wa-not-prose</code>.</p>
     </div>
   </wa-callout>
 
-  <p>And the paragraph after picks the rhythm back up where it left off.</p>
+  <p>And the content after picks the rhythm back up where it left off.</p>
+  <ul>
+    <li>Asymmetric spacing</li>
+    <li>Relative font sizing</li>
+    <li>Comfortable line length</li>
+  </ul>
 </article>
 ```

--- a/packages/webawesome/docs/docs/utilities/prose.md
+++ b/packages/webawesome/docs/docs/utilities/prose.md
@@ -263,16 +263,17 @@ Apply `wa-not-prose` to any element inside a `wa-prose` container to disable pro
 <article class="wa-prose">
   <h3>Ready when you are</h3>
   <p>
-    The paragraphs around this section follow prose rhythm. The button row below sits inside a
-    <code>wa-not-prose</code> wrapper, so its spacing reverts to the component defaults.
+    The paragraphs around this section follow prose rhythm. The callout below is given
+    <code>wa-not-prose</code>, so its font sizing and spacing revert to the component defaults.
   </p>
 
-  <div class="wa-not-prose">
-    <div class="wa-cluster" style="gap: var(--wa-space-s);">
-      <wa-button variant="brand">Primary action</wa-button>
-      <wa-button appearance="outlined">Secondary action</wa-button>
+  <wa-callout class="wa-not-prose" variant="warning">
+    <wa-icon slot="icon" name="highlighter"></wa-icon>
+    <div class="wa-stack">
+      <h4>Leave it to the prose</h4>
+      <p>The elements in this callout are exempt from <code>wa-prose</code> rules, thanks to <code>wa-not-prose</code>.</p>
     </div>
-  </div>
+  </wa-callout>
 
   <p>And the paragraph after picks the rhythm back up where it left off.</p>
 </article>

--- a/packages/webawesome/src/styles/layers.css
+++ b/packages/webawesome/src/styles/layers.css
@@ -1,5 +1,5 @@
 /* Order of precedence for all cascade layers in Web Awesome */
-@layer wa-native, wa-base, wa-utilities, wa-color-palette, wa-color-variant, wa-theme, wa-theme-dimension, wa-theme-overrides;
+@layer wa-native, wa-base, wa-utilities, wa-utilities-prose, wa-color-palette, wa-color-variant, wa-theme, wa-theme-dimension, wa-theme-overrides;
 
 @layer wa-base {
   /**

--- a/packages/webawesome/src/styles/layers.css
+++ b/packages/webawesome/src/styles/layers.css
@@ -1,5 +1,5 @@
 /* Order of precedence for all cascade layers in Web Awesome */
-@layer wa-native, wa-prose, wa-base, wa-utilities, wa-color-palette, wa-color-variant, wa-theme, wa-theme-dimension, wa-theme-overrides;
+@layer wa-native, wa-base, wa-utilities, wa-color-palette, wa-color-variant, wa-theme, wa-theme-dimension, wa-theme-overrides;
 
 @layer wa-base {
   /**

--- a/packages/webawesome/src/styles/layers.css
+++ b/packages/webawesome/src/styles/layers.css
@@ -1,5 +1,5 @@
 /* Order of precedence for all cascade layers in Web Awesome */
-@layer wa-native, wa-base, wa-utilities, wa-utilities-prose, wa-color-palette, wa-color-variant, wa-theme, wa-theme-dimension, wa-theme-overrides;
+@layer wa-native, wa-prose, wa-base, wa-utilities, wa-color-palette, wa-color-variant, wa-theme, wa-theme-dimension, wa-theme-overrides;
 
 @layer wa-base {
   /**

--- a/packages/webawesome/src/styles/utilities/prose.css
+++ b/packages/webawesome/src/styles/utilities/prose.css
@@ -6,7 +6,7 @@
      sits at 0,0,0 specificity — any utility class or element rule the author
      applies inside the container takes precedence without weight tricks. */
   @scope (.wa-prose) to (.wa-not-prose) {
-    :scope {
+    :where(:scope) {
       /* #region Tokens ~~~~~~~~~~~~ */
 
       /* Em-based rhythm scale: each token resolves at the use site, so margins

--- a/packages/webawesome/src/styles/utilities/prose.css
+++ b/packages/webawesome/src/styles/utilities/prose.css
@@ -5,7 +5,7 @@
      The class and its element selectors are wrapped in `:where()` so every rule
      sits at 0,0,0 specificity — any utility class or element rule the author
      applies inside the container takes precedence without weight tricks. */
-     
+
   /* @scope is Newly Available in Baseline 2025. As such, it should be reserved for
      non-essential, progressive enhancement features until @scope is established
      as Widely Available. https://caniuse.com/css-cascade-scope */

--- a/packages/webawesome/src/styles/utilities/prose.css
+++ b/packages/webawesome/src/styles/utilities/prose.css
@@ -1,168 +1,157 @@
-@layer wa-prose {
+@layer wa-utilities {
   /* `wa-prose` applies hierarchical, asymmetric typographic rhythm to a block
      of long-form content. Builds on `wa-native`'s base block styles instead of
      duplicating them. Em-based spacing scales when composed with `wa-font-size-*`.
      The class and its element selectors are wrapped in `:where()` so every rule
      sits at 0,0,0 specificity — any utility class or element rule the author
      applies inside the container takes precedence without weight tricks. */
-  :where(.wa-prose) {
-    /* #region Tokens ~~~~~~~~~~~~ */
+  @scope (.wa-prose) to (.wa-not-prose) {
+    :scope {
+      /* #region Tokens ~~~~~~~~~~~~ */
 
-    /* Em-based rhythm scale: each token resolves at the use site, so margins
-       scale with the element's own font-size. `--wa-prose-rhythm-scale` is a
-       single knob to tighten or loosen everything at once. */
-    --wa-prose-rhythm-scale: 1;
-    --wa-prose-rhythm-2xs: calc(0.25em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
-    --wa-prose-rhythm-xs: calc(0.5em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
-    --wa-prose-rhythm-s: calc(0.75em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
-    --wa-prose-rhythm-m: calc(1em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
-    --wa-prose-rhythm-l: calc(1.5em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
-    --wa-prose-rhythm-xl: calc(2em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
-    --wa-prose-rhythm-2xl: calc(2.5em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
-    --wa-prose-rhythm-3xl: calc(3em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
+      /* Em-based rhythm scale: each token resolves at the use site, so margins
+        scale with the element's own font-size. `--wa-prose-rhythm-scale` is a
+        single knob to tighten or loosen everything at once. */
+      --wa-prose-rhythm-scale: 1;
+      --wa-prose-rhythm-2xs: calc(0.25em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
+      --wa-prose-rhythm-xs: calc(0.5em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
+      --wa-prose-rhythm-s: calc(0.75em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
+      --wa-prose-rhythm-m: calc(1em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
+      --wa-prose-rhythm-l: calc(1.5em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
+      --wa-prose-rhythm-xl: calc(2em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
+      --wa-prose-rhythm-2xl: calc(2.5em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
+      --wa-prose-rhythm-3xl: calc(3em * var(--wa-space-scale) * var(--wa-prose-rhythm-scale));
 
-    --wa-prose-line-length: 65ch;
+      --wa-prose-line-length: 65ch;
 
-    max-inline-size: var(--wa-prose-line-length);
+      max-inline-size: var(--wa-prose-line-length);
 
-    /* Oldstyle proportional figures for running text; tables reassert
-       `tabular-nums` below. Fonts without the OpenType feature fall back. */
-    font-variant-numeric: oldstyle-nums proportional-nums;
+      /* Oldstyle proportional figures for running text; tables reassert
+        `tabular-nums` below. Fonts without the OpenType feature fall back. */
+      font-variant-numeric: oldstyle-nums proportional-nums;
 
-    /* Inherits to descendants. Safari today; progressive enhancement elsewhere. */
-    hanging-punctuation: first last allow-end;
-    /* #endregion */
+      /* Inherits to descendants. Safari today; progressive enhancement elsewhere. */
+      hanging-punctuation: first last allow-end;
+      /* #endregion */
 
-    /* #region Headings ~~~~~~~~~~~~ */
+      /* #region Headings ~~~~~~~~~~~~ */
 
-    /* Em sizes inherit through the cascade — re-applying `--wa-font-size-scale`
-       here would double-scale. Authors overriding should stay em-based. */
-    & :where(h1) {
-      font-size: 2.5625em;
+      /* Em sizes inherit through the cascade — re-applying `--wa-font-size-scale`
+        here would double-scale. Authors overriding should stay em-based. */
+      & :where(h1) {
+        font-size: 2.5625em;
+      }
+      & :where(h2) {
+        font-size: 2em;
+      }
+      & :where(h3) {
+        font-size: 1.5625em;
+      }
+      & :where(h4) {
+        font-size: 1.25em;
+      }
+      & :where(h5) {
+        font-size: 1em;
+      }
+      & :where(h6) {
+        font-size: 0.75em;
+      }
+
+      /* Slight optical tracking; only the larger sizes need it. */
+      & :where(h1, h2) {
+        letter-spacing: -0.01em;
+      }
+
+      /* Headings hug what they introduce: generous above, tight below. */
+      & :where(h1):has(+ *) {
+        margin-block-end: var(--wa-prose-rhythm-s);
+      }
+
+      & * + :where(h2) {
+        margin-block-start: var(--wa-prose-rhythm-2xl);
+      }
+      & :where(h2):has(+ *) {
+        margin-block-end: var(--wa-prose-rhythm-s);
+      }
+
+      & * + :where(h3) {
+        margin-block-start: var(--wa-prose-rhythm-xl);
+      }
+      & :where(h3):has(+ *) {
+        margin-block-end: var(--wa-prose-rhythm-s);
+      }
+
+      & :where(h4, h5, h6):has(+ *) {
+        margin-block-end: var(--wa-prose-rhythm-xs);
+      }
+
+      /* Back-to-back headings tighten so the second reads as subordinate.
+        Enumerated explicitly — skipping more than two levels is rare enough
+        that the default rhythm reads better. */
+      & :where(h1 + h2, h1 + h3, h2 + h3, h2 + h4, h3 + h4, h4 + h5, h5 + h6) {
+        margin-block-start: var(--wa-prose-rhythm-m);
+      }
+      /* #endregion */
+
+      /* #region Body text & lists ~~~~~~~~~~~~ */
+
+      /* Replaces wa-native's rem-based `--wa-content-spacing` with em rhythm. */
+      & :where(p, ul, ol, dl):has(+ *) {
+        margin-block-end: var(--wa-prose-rhythm-l);
+      }
+
+      & :where(ul, ol) > :where(li):has(+ li) {
+        margin-block-end: var(--wa-prose-rhythm-2xs);
+      }
+
+      & :where(dd):has(+ *) {
+        margin-block-end: var(--wa-prose-rhythm-s);
+      }
+      /* #endregion */
+
+      /* #region Captions ~~~~~~~~~~~~ */
+
+      /* Em-based override keeps caption spacing in step with the prose
+        container; wa-native sets the visual style. */
+      & :where(figcaption) {
+        margin-block-start: var(--wa-prose-rhythm-xs);
+      }
+      /* #endregion */
+
+      /* #region Inline code & long-word breaks ~~~~~~~~~~~~ */
+
+      /* `anywhere` is the right trade-off in prose: long URLs and identifiers
+        break instead of overflowing the column. */
+      & :where(code, pre) {
+        overflow-wrap: anywhere;
+      }
+      /* #endregion */
+
+      /* #region Section breaks & major non-text blocks ~~~~~~~~~~~~ */
+
+      /* `<hr>`'s own margin defines the gap; the next heading shouldn't double-stack. */
+      & :where(hr) {
+        margin-block: var(--wa-prose-rhythm-3xl);
+      }
+      & :where(hr + :is(h1, h2, h3, h4, h5, h6)) {
+        margin-block-start: 0;
+      }
+
+      /* Major non-text blocks get more air than running prose, but headings
+        still hug — so the top-margin rule excludes the heading-to-block case
+        (handled separately below with a smaller gap). */
+      & :where(pre, figure, table, blockquote, wa-callout, details):has(+ *) {
+        margin-block-end: var(--wa-prose-rhythm-xl);
+      }
+
+      & :where(:not(h1, h2, h3, h4, h5, h6) + :is(pre, figure, table, blockquote, wa-callout, details)) {
+        margin-block-start: var(--wa-prose-rhythm-xl);
+      }
+
+      & :where(:is(h1, h2, h3, h4, h5, h6) + :is(pre, figure, table, blockquote, wa-callout, details)) {
+        margin-block-start: var(--wa-prose-rhythm-m);
+      }
+      /* #endregion */
     }
-    & :where(h2) {
-      font-size: 2em;
-    }
-    & :where(h3) {
-      font-size: 1.5625em;
-    }
-    & :where(h4) {
-      font-size: 1.25em;
-    }
-    & :where(h5) {
-      font-size: 1em;
-    }
-    & :where(h6) {
-      font-size: 0.75em;
-    }
-
-    /* Slight optical tracking; only the larger sizes need it. */
-    & :where(h1, h2) {
-      letter-spacing: -0.01em;
-    }
-
-    /* Headings hug what they introduce: generous above, tight below. */
-    & :where(h1):has(+ *) {
-      margin-block-end: var(--wa-prose-rhythm-s);
-    }
-
-    & * + :where(h2) {
-      margin-block-start: var(--wa-prose-rhythm-2xl);
-    }
-    & :where(h2):has(+ *) {
-      margin-block-end: var(--wa-prose-rhythm-s);
-    }
-
-    & * + :where(h3) {
-      margin-block-start: var(--wa-prose-rhythm-xl);
-    }
-    & :where(h3):has(+ *) {
-      margin-block-end: var(--wa-prose-rhythm-s);
-    }
-
-    & :where(h4, h5, h6):has(+ *) {
-      margin-block-end: var(--wa-prose-rhythm-xs);
-    }
-
-    /* Back-to-back headings tighten so the second reads as subordinate.
-       Enumerated explicitly — skipping more than two levels is rare enough
-       that the default rhythm reads better. */
-    & :where(h1 + h2, h1 + h3, h2 + h3, h2 + h4, h3 + h4, h4 + h5, h5 + h6) {
-      margin-block-start: var(--wa-prose-rhythm-m);
-    }
-    /* #endregion */
-
-    /* #region Body text & lists ~~~~~~~~~~~~ */
-
-    /* Replaces wa-native's rem-based `--wa-content-spacing` with em rhythm. */
-    & :where(p, ul, ol, dl):has(+ *) {
-      margin-block-end: var(--wa-prose-rhythm-l);
-    }
-
-    & :where(ul, ol) > :where(li):has(+ li) {
-      margin-block-end: var(--wa-prose-rhythm-2xs);
-    }
-
-    & :where(dd):has(+ *) {
-      margin-block-end: var(--wa-prose-rhythm-s);
-    }
-    /* #endregion */
-
-    /* #region Captions ~~~~~~~~~~~~ */
-
-    /* Em-based override keeps caption spacing in step with the prose
-       container; wa-native sets the visual style. */
-    & :where(figcaption) {
-      margin-block-start: var(--wa-prose-rhythm-xs);
-    }
-    /* #endregion */
-
-    /* #region Inline code & long-word breaks ~~~~~~~~~~~~ */
-
-    /* `anywhere` is the right trade-off in prose: long URLs and identifiers
-       break instead of overflowing the column. */
-    & :where(code, pre) {
-      overflow-wrap: anywhere;
-    }
-    /* #endregion */
-
-    /* #region Section breaks & major non-text blocks ~~~~~~~~~~~~ */
-
-    /* `<hr>`'s own margin defines the gap; the next heading shouldn't double-stack. */
-    & :where(hr) {
-      margin-block: var(--wa-prose-rhythm-3xl);
-    }
-    & :where(hr + :is(h1, h2, h3, h4, h5, h6)) {
-      margin-block-start: 0;
-    }
-
-    /* Major non-text blocks get more air than running prose, but headings
-       still hug — so the top-margin rule excludes the heading-to-block case
-       (handled separately below with a smaller gap). */
-    & :where(pre, figure, table, blockquote, wa-callout, details):has(+ *) {
-      margin-block-end: var(--wa-prose-rhythm-xl);
-    }
-
-    & :where(:not(h1, h2, h3, h4, h5, h6) + :is(pre, figure, table, blockquote, wa-callout, details)) {
-      margin-block-start: var(--wa-prose-rhythm-xl);
-    }
-
-    & :where(:is(h1, h2, h3, h4, h5, h6) + :is(pre, figure, table, blockquote, wa-callout, details)) {
-      margin-block-start: var(--wa-prose-rhythm-m);
-    }
-    /* #endregion */
-  }
-
-  /* Reverts the properties wa-prose touches so utilities like `wa-cluster`
-     or `wa-font-size-*` still work inside the opt-out subtree. `.wa-not-prose *`
-     at 0,1,0 wins over wa-prose's 0,0,0 element rules. */
-  .wa-not-prose,
-  .wa-not-prose * {
-    margin-block-start: revert-layer;
-    margin-block-end: revert-layer;
-    font-size: revert-layer;
-    letter-spacing: revert-layer;
-    font-variant-numeric: revert-layer;
-    hanging-punctuation: revert-layer;
   }
 }

--- a/packages/webawesome/src/styles/utilities/prose.css
+++ b/packages/webawesome/src/styles/utilities/prose.css
@@ -1,4 +1,4 @@
-@layer wa-utilities-prose {
+@layer wa-prose {
   /* `wa-prose` applies hierarchical, asymmetric typographic rhythm to a block
      of long-form content. Builds on `wa-native`'s base block styles instead of
      duplicating them. Em-based spacing scales when composed with `wa-font-size-*`.

--- a/packages/webawesome/src/styles/utilities/prose.css
+++ b/packages/webawesome/src/styles/utilities/prose.css
@@ -1,4 +1,4 @@
-@layer wa-utilities {
+@layer wa-utilities-prose {
   /* `wa-prose` applies hierarchical, asymmetric typographic rhythm to a block
      of long-form content. Builds on `wa-native`'s base block styles instead of
      duplicating them. Em-based spacing scales when composed with `wa-font-size-*`.

--- a/packages/webawesome/src/styles/utilities/prose.css
+++ b/packages/webawesome/src/styles/utilities/prose.css
@@ -5,6 +5,10 @@
      The class and its element selectors are wrapped in `:where()` so every rule
      sits at 0,0,0 specificity — any utility class or element rule the author
      applies inside the container takes precedence without weight tricks. */
+     
+  /* @scope is Newly Available in Baseline 2025. As such, it should be reserved for
+     non-essential, progressive enhancement features until @scope is established
+     as Widely Available. https://caniuse.com/css-cascade-scope */
   @scope (.wa-prose) to (.wa-not-prose) {
     :where(:scope) {
       /* #region Tokens ~~~~~~~~~~~~ */


### PR DESCRIPTION
### Summary
Wraps `prose.css` rules in `@scope (.wa-prose) to (.wa-not-prose)` so that the classes are proximity aware. That way, we don't need to fight specificity or precedence wars to opt-in or opt-out of these styles.

Prose styles reliably apply to `wa-prose` elements, even when nested in `wa-not-prose` containers, and the styles are reliably ignored for `wa-not-prose` elements, even when nested in `wa-prose` containers.

---

### The Problem

There are two issues at play with our current approach for opting in and out of `prose.css` styles:

1. **Layer precedence:** The `wa-not-prose` class in `prose.css` specifies `revert-layer` for the properties styled otherwise in with `wa-prose`. However, because these rules are scoped to `@layer wa-utilities`, `wa-not-prose` reverts the properties across the entire `wa-utilities` layer. This renders many essential styles for other utilities — like `font-size` for text utility classes and `margin-block` resets for layout utility classes — inapplicable.

2. **Specificity:** While using `wa-not-prose` within a `wa-prose` container ignores the prose styles as expected, using `wa-prose` within a `wa-not-prose` container doesn't yield the same results. `wa-prose` always loses the specificity battle with `wa-not-prose`, so we can't opt back in to `wa-prose` styling.

### Example

Each of our docs uses `wa-prose`, but each of our code examples uses `wa-not-prose`. Because of this, the two problems described above rear their heads in different contexts:

1. Code examples that use text or layout utility classes don't get the intended font sizes or spacing from those classes. In first example below, note how the classes `wa-stack` and `wa-heading-l` don't apply all intended styles in the _Before_ image.
2. Code examples that are meant to demonstrate `wa-prose` can't actually show the intended `wa-prose` styles. In the second example below, note how `wa-prose`'s bespoke spacing isn't applied in the _Before_ image.

| Before | After |
| - | - |
| <img width="732" height="570" alt="Screenshot 2026-06-26 at 4 45 53 PM" src="https://github.com/user-attachments/assets/f2f7048f-7bc1-4d9e-bf97-439c8ae20327" /> | <img width="732" height="516" alt="Screenshot 2026-06-26 at 4 45 45 PM" src="https://github.com/user-attachments/assets/614412d9-eaf3-4e4c-81cc-fa5dc1946f97" /> |
| <img width="761" height="592" alt="Screenshot 2026-06-26 at 6 07 57 PM" src="https://github.com/user-attachments/assets/ffed9a00-56c1-41f3-b0ac-9c3d6d8355d2" /> | <img width="761" height="605" alt="Screenshot 2026-06-26 at 6 07 51 PM" src="https://github.com/user-attachments/assets/4c899d42-3d84-43f9-966e-6ba6c480e350" /> |

---

### Browser Support

[`@scope` has longstanding support](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@scope#browser_compatibility) in Chrome, Edge, and Safari, though it was only enabled by default in Firefox less than a year ago.

Firefox is currently on version 152, and `@scope` support was enabled in version 146. That satisfies our "latest two major versions" requirement and feels comfortable for an opt-in, progressive enhancement–style feature like `prose.css`.