### PR TITLE
Fix webawesome-design skill description tags

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -42,6 +42,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 :::fixed
 
+- Fixed the `webawesome-design` Agent Skill description so it can be uploaded to Claude.ai without XML tag validation errors [issue:2558]
 - Fixed a bug in `wa-video` that was causing the `z-index` to leak out of the context of the component [issue:2542]
 - Fixed a bug in `<wa-chart>` and its variants that threw a `DataCloneError` when the Chart.js config contained functions, such as tooltip or scale callbacks
 - Fixed a bug in `<wa-date-input>` and `<wa-time-input>` where an empty `start`/`end` slot added a phantom gap causing it to be misaligned with other form controls [issue:2527]

--- a/packages/webawesome/scripts/design-skill/SKILL.md
+++ b/packages/webawesome/scripts/design-skill/SKILL.md
@@ -4,9 +4,9 @@ description: >
   Design and lay out user interfaces with Web Awesome. Use this when building or styling a PAGE,
   LAYOUT, or SECTION; choosing or customizing a THEME; applying brand COLORS or design tokens; or
   composing a polished, good-looking UI with Web Awesome components and utilities. Triggers on requests
-  like "build a landing page", "make an app layout", "set up <wa-page>", "add a sidebar", "apply a
+  like "build a landing page", "make an app layout", "set up wa-page", "add a sidebar", "apply a
   theme", "match our brand color", "style this to look designed", "build a settings page", or "lay out
-  a dashboard". Teaches layout (when and how to use <wa-page>), theming (--wa-* tokens), and visual
+  a dashboard". Teaches layout (when and how to use wa-page), theming (--wa-* tokens), and visual
   composition. Pair with the `webawesome` skill, which documents individual component APIs.
 license: MIT / Commercial (for Web Awesome Pro)
 metadata:


### PR DESCRIPTION
## Summary
- remove angle-bracket custom element references from the `webawesome-design` skill frontmatter description
- add an Unreleased changelog entry for the Claude.ai skill upload fix

Closes #2558

## Testing
- `node - <<'NODE' ...` confirmed the frontmatter description has no XML-like tags
- `npm run prettier`
- `npm run build`