### PR TITLE
fix `name` property typing on `wa-checkbox`

### DIFF
--- a/packages/webawesome/src/components/checkbox/checkbox.ts
+++ b/packages/webawesome/src/components/checkbox/checkbox.ts
@@ -75,9 +75,6 @@ export default class WaCheckbox extends WebAwesomeFormAssociatedElement {
 
   @property() title = ''; // make reactive to pass through
 
-  /** The name of the checkbox, submitted as a name/value pair with form data. */
-  @property({ reflect: true }) name = null;
-
   private _value: string | null = this.getAttribute('value') ?? null;
 
   /** The value of the checkbox, submitted as a name/value pair with form data. */


### PR DESCRIPTION
The `name` property on `wa-checkbox` should accept strings. Currently, the property is only accepting `null`, as seen in the [generated typedefs](https://app.unpkg.com/@awesome.me/webawesome@3.9.0/files/dist/components/checkbox/checkbox.d.ts#L51-52).

```
    /** The name of the checkbox, submitted as a name/value pair with form data. */
    name: null;
```