### PR TITLE
Fix #2571: keep color-picker swatches the same size when only a few are present

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -54,6 +54,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 - Fixed a bug in `<wa-known-date>` that showed validation errors while typing instead of on form submission like other form controls
 - Fixed a bug in `<wa-known-date>` where the validation tooltip always pointed to the first input regardless of which one was invalid
 - Fixed a bug in `<wa-toast-item>` where the documented `--padding` custom property was unused in component styles
+- Fixed a bug in `<wa-color-picker>` where swatches grew larger than normal when only a few were present [issue:2571]
 - Aligned the `start` and `end` slot region in `<wa-date-input>` and `<wa-time-input>` with `<wa-input>` and `<wa-select>`
   - The trailing calendar/clock and clear icons no longer sit a few pixels inward of where the other controls place them
   - The `start` and `end` slots now use the same spacing as the other controls instead of a tighter gap

--- a/packages/webawesome/src/components/color-picker/color-picker.styles.ts
+++ b/packages/webawesome/src/components/color-picker/color-picker.styles.ts
@@ -216,7 +216,7 @@ export default css`
 
   .swatches {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(min(1.5em, 100%), 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(min(1.5em, 100%), 1fr));
     grid-gap: 0.5em;
     justify-items: center;
     border-block-start: var(--wa-form-control-border-style) var(--wa-form-control-border-width)


### PR DESCRIPTION
## Summary

`<wa-color-picker>` drew its swatches much larger than normal when only a few were present.

Fixes #2571

## Cause

The `.swatches` grid uses:

```css
grid-template-columns: repeat(auto-fit, minmax(min(1.5em, 100%), 1fr));
```

`auto-fit` collapses the empty tracks and hands their space to the filled tracks (each able to grow to `1fr`), so with only a few swatches each one stretched to a large fraction of the container width.

## Fix

Switch `auto-fit` to `auto-fill`. `auto-fill` keeps the empty tracks, so filled swatches keep the same size whether the row is full or holds a single swatch — which is the expected behavior described in the issue. One-character CSS change, plus a changelog entry.

## Testing

- `npm run build` — passes
- `CI=true npx web-test-runner --group color-picker` — **51 passed** on both Chromium and Firefox
- Reproduced the issue case (`swatches="red; green; blue;"`): before the change, 3 swatches rendered ~3× larger than in a full row (75px vs 27px in a 240px container); after, they render at the same size as a full row.