### PR TITLE
fix(color-picker): preserve alpha of initial HEXA value when opacity is enabled

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -59,6 +59,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 - Aligned the `start` and `end` slot region in `<wa-date-input>` and `<wa-time-input>` with `<wa-input>` and `<wa-select>`
   - The trailing calendar/clock and clear icons no longer sit a few pixels inward of where the other controls place them
   - The `start` and `end` slots now use the same spacing as the other controls instead of a tighter gap
+- Fixed a bug in `<wa-color-picker>` where an initial HEXA value lost its alpha (collapsing to a 6-digit hex) when `opacity` was enabled [issue:2550]
 
 :::
 

--- a/packages/webawesome/src/components/color-picker/color-picker.test.ts
+++ b/packages/webawesome/src/components/color-picker/color-picker.test.ts
@@ -24,6 +24,18 @@ describe('<wa-color-picker>', () => {
           expect(opacitySlider).to.exist;
         });
 
+        it('should preserve the alpha of an initial HEXA value when opacity is enabled', async () => {
+          // https://github.com/shoelace-style/webawesome/issues/2550
+          const el = await fixture<WaColorPicker>(
+            html` <wa-color-picker format="hex" opacity value="#4d64d54d"></wa-color-picker> `,
+          );
+          await el.updateComplete;
+
+          // The alpha (~30%) must survive loading: the value should stay HEXA, not collapse to 6-digit hex.
+          expect(el.value).to.equal('#4d64d54d');
+          expect(el.getFormattedValue('hexa')).to.equal('#4d64d54d');
+        });
+
         it('should render the correct swatches when passing a string of color values', async () => {
           const el = await fixture<WaColorPicker>(html`
             <wa-color-picker swatches="red; #008000; rgb(0,0,255);"></wa-color-picker>

--- a/packages/webawesome/src/components/color-picker/color-picker.ts
+++ b/packages/webawesome/src/components/color-picker/color-picker.ts
@@ -806,7 +806,7 @@ export default class WaColorPicker extends WebAwesomeFormAssociatedElement {
     this.syncValues();
   }
 
-  @watch('opacity')
+  @watch('opacity', { waitUntilFirstUpdate: true })
   handleOpacityChange() {
     this.alpha = 100;
   }
@@ -940,6 +940,15 @@ export default class WaColorPicker extends WebAwesomeFormAssociatedElement {
     super.firstUpdated(changedProperties);
 
     this.hasEyeDropper = 'EyeDropper' in window;
+
+    // The initial `value` is synced into the color state in the constructor, before the `opacity`
+    // property has been applied. With opacity off, `syncValues()` reduces an initial HEXA value to a
+    // 6-digit hex and stores that alpha-less string, so the alpha is lost. Now that opacity is in
+    // effect, re-apply the original value so an opacity picker keeps its alpha in both the slider
+    // state and the submitted value. See https://github.com/shoelace-style/webawesome/issues/2550
+    if (this.opacity && this.defaultValue) {
+      this.setColor(this.defaultValue);
+    }
   }
 
   private handleKeyDown = (event: KeyboardEvent) => {


### PR DESCRIPTION
## Problem

Closes #2550.

When a `<wa-color-picker opacity>` is given an initial **HEXA** value, the alpha is lost on load: the value collapses to a 6-digit hex and the opacity slider resets to 100% — even though typing the same value into the input later works fine.

```html
<wa-color-picker format="hex" opacity value="#4d64d54d"></wa-color-picker>
```

Expected: the alpha slider and the submitted value both reflect `#4d64d54d` (~30% alpha).
Actual (before): the value becomes `#4d64d5` and the alpha is `100%`.

## Root cause

Two things combine:

1. **Slider state** — `handleOpacityChange` is wired with `@watch('opacity')` (no `waitUntilFirstUpdate`), so the initial `opacity` upgrade (`false → true`) fires `this.alpha = 100`, clobbering the alpha just parsed from the value.
2. **Value string** — the initial `value` → color sync runs in the **constructor**, before `opacity` is applied. With `opacity` still `false`, `syncValues()` emits a 6-digit `hex` and stores that alpha-less string as `this.value`, and the `isSafeValue` guard then blocks a re-sync once `opacity` turns on.

## Fix

- Add `{ waitUntilFirstUpdate: true }` to the `@watch('opacity')` handler so the initial opacity upgrade no longer resets the parsed alpha (matching the existing `@watch('format', { waitUntilFirstUpdate: true })`).
- In `firstUpdated()` — now that `opacity` is in effect — re-apply the original `defaultValue` via `setColor()` when `opacity` is enabled, so an opacity picker keeps its alpha in both the slider state and the submitted value.

## Tests

Added a unit test asserting that an `opacity` color picker with an initial HEXA value keeps its alpha in both `value` and `getFormattedValue('hexa')`.

Verified locally with `web-test-runner` (chromium, client rendering): the new test **fails on `next` without the fix** (`expected '#4d64d5' to equal '#4d64d54d'`) and **passes with the fix**, with the rest of the color-picker suite still green (27/27).

Also added a changelog entry under 3.10.0.
