### PR TITLE
Improve Forms Components Documentation

### DIFF
--- a/packages/webawesome/docs/docs/components/checkbox-group.md
+++ b/packages/webawesome/docs/docs/components/checkbox-group.md
@@ -69,33 +69,31 @@ Checkbox groups stack vertically by default. Set the `orientation` attribute to 
 The size of grouped checkboxes and switches is determined by the checkbox group's `size` attribute. Any `size` set on individual items will be overridden.
 
 ```html {.example}
-<div>
-  <wa-checkbox-group id="checkbox-group-size" label="Options" hint="Use the select below to change the size." size="m">
+<div class="wa-stack">
+  <wa-checkbox-group label="Extra small" size="xs">
     <wa-checkbox>Option 1</wa-checkbox>
     <wa-checkbox>Option 2</wa-checkbox>
-    <wa-checkbox>Option 3</wa-checkbox>
   </wa-checkbox-group>
-
-  <wa-divider></wa-divider>
-
-  <wa-select label="Size" value="m" style="max-width: 200px;">
-    <wa-option value="xs">Extra small</wa-option>
-    <wa-option value="s">Small</wa-option>
-    <wa-option value="m">Medium</wa-option>
-    <wa-option value="l">Large</wa-option>
-    <wa-option value="xl">Extra large</wa-option>
-  </wa-select>
+  <wa-checkbox-group label="Small" size="s">
+    <wa-checkbox>Option 1</wa-checkbox>
+    <wa-checkbox>Option 2</wa-checkbox>
+  </wa-checkbox-group>
+  <wa-checkbox-group label="Medium" size="m">
+    <wa-checkbox>Option 1</wa-checkbox>
+    <wa-checkbox>Option 2</wa-checkbox>
+  </wa-checkbox-group>
+  <wa-checkbox-group label="Large" size="l">
+    <wa-checkbox>Option 1</wa-checkbox>
+    <wa-checkbox>Option 2</wa-checkbox>
+  </wa-checkbox-group>
+  <wa-checkbox-group label="Extra large" size="xl">
+    <wa-checkbox>Option 1</wa-checkbox>
+    <wa-checkbox>Option 2</wa-checkbox>
+  </wa-checkbox-group>
 </div>
-
-<script>
-  const checkboxGroup = document.getElementById('checkbox-group-size');
-  const sizeSelect = checkboxGroup.parentElement.querySelector('wa-select');
-
-  sizeSelect.addEventListener('change', () => (checkboxGroup.size = sizeSelect.value));
-</script>
 ```
 
-### Disabling
+### Disabled
 
 A checkbox group itself can't be disabled. Add the `disabled` attribute to individual checkboxes to disable them.
 

--- a/packages/webawesome/docs/docs/components/checkbox-group.md
+++ b/packages/webawesome/docs/docs/components/checkbox-group.md
@@ -25,7 +25,7 @@ Checkboxes in a group remain independent form controls with their own `name`, `v
 
 ## Examples
 
-### Labels
+### Label
 
 Use the `label` attribute to give the group an accessible label. For labels that contain HTML, use the `label` slot instead.
 
@@ -64,7 +64,7 @@ Checkbox groups stack vertically by default. Set the `orientation` attribute to 
 </wa-checkbox-group>
 ```
 
-### Sizes
+### Size
 
 The size of grouped checkboxes and switches is determined by the checkbox group's `size` attribute. Any `size` set on individual items will be overridden.
 

--- a/packages/webawesome/docs/docs/components/checkbox.md
+++ b/packages/webawesome/docs/docs/components/checkbox.md
@@ -14,33 +14,42 @@ use-cases:
 ---
 
 ```html {.example}
-<wa-checkbox>Checkbox</wa-checkbox>
+<wa-checkbox>I agree to the terms and conditions</wa-checkbox>
 ```
 
 :::info
-This component works with standard `<form>` elements. Please refer to the section on [form controls](/docs/form-controls) to learn more about form submission and client-side validation.
+This component works with standard `<form>` elements. See [form controls](/docs/form-controls) for form submission and client-side validation.
 :::
 
 ## Examples
 
-### Checked
+### Setting Initial Values
 
 Use the `checked` attribute to activate the checkbox.
 
 ```html {.example}
-<wa-checkbox checked>Checked</wa-checkbox>
+<wa-checkbox checked>Remember me</wa-checkbox>
 ```
 
 :::info
-The `checked` attribute is the initial value and does not reflect changes, consistent with native checkboxes. To toggle the checked state with JavaScript, use the `checked` property instead. To target checked checkboxes with CSS, use the `:state(checked)` selector.
+<strong>`checked` sets the initial value, not the current state.</strong><br />
+Consistent with native checkboxes, it doesn't reflect later changes. To toggle the checked state with JavaScript, use the `checked` property instead. To target checked checkboxes with CSS, use the `:state(checked)` selector.
 :::
+
+### Hint
+
+Add a descriptive hint with the `hint` attribute. For hints that contain HTML, use the `hint` slot instead.
+
+```html {.example}
+<wa-checkbox hint="You can turn this off later in settings.">Subscribe to the newsletter</wa-checkbox>
+```
 
 ### Indeterminate
 
-Use the `indeterminate` attribute to make the checkbox indeterminate.
+Use the `indeterminate` attribute to make the checkbox indeterminate. This is typically used for a "select all" control when its associated checkboxes have a mix of checked and unchecked states.
 
 ```html {.example}
-<wa-checkbox indeterminate>Indeterminate</wa-checkbox>
+<wa-checkbox indeterminate>Select all</wa-checkbox>
 ```
 
 ### Disabled
@@ -48,7 +57,7 @@ Use the `indeterminate` attribute to make the checkbox indeterminate.
 Use the `disabled` attribute to disable the checkbox.
 
 ```html {.example}
-<wa-checkbox disabled>Disabled</wa-checkbox>
+<wa-checkbox disabled>I accept marketing emails</wa-checkbox>
 ```
 
 ### Sizes
@@ -56,23 +65,13 @@ Use the `disabled` attribute to disable the checkbox.
 Use the `size` attribute to change a checkbox's size.
 
 ```html {.example}
-<wa-checkbox size="xs">Extra Small</wa-checkbox>
-<br />
-<wa-checkbox size="s">Small</wa-checkbox>
-<br />
-<wa-checkbox size="m">Medium</wa-checkbox>
-<br />
-<wa-checkbox size="l">Large</wa-checkbox>
-<br />
-<wa-checkbox size="xl">Extra Large</wa-checkbox>
-```
-
-### Hint
-
-Add descriptive hint to a switch with the `hint` attribute. For hints that contain HTML, use the `hint` slot instead.
-
-```html {.example}
-<wa-checkbox hint="What should the user know about the checkbox?">Label</wa-checkbox>
+<div class="wa-stack">
+  <wa-checkbox size="xs">Extra Small</wa-checkbox>
+  <wa-checkbox size="s">Small</wa-checkbox>
+  <wa-checkbox size="m">Medium</wa-checkbox>
+  <wa-checkbox size="l">Large</wa-checkbox>
+  <wa-checkbox size="xl">Extra Large</wa-checkbox>
+</div>
 ```
 
 ### Custom Validity

--- a/packages/webawesome/docs/docs/components/checkbox.md
+++ b/packages/webawesome/docs/docs/components/checkbox.md
@@ -23,7 +23,7 @@ This component works with standard `<form>` elements. See [form controls](/docs/
 
 ## Examples
 
-### Setting Initial Values
+### Initial Value
 
 Use the `checked` attribute to activate the checkbox.
 
@@ -60,7 +60,7 @@ Use the `disabled` attribute to disable the checkbox.
 <wa-checkbox disabled>I accept marketing emails</wa-checkbox>
 ```
 
-### Sizes
+### Size
 
 Use the `size` attribute to change a checkbox's size.
 

--- a/packages/webawesome/docs/docs/components/color-picker.md
+++ b/packages/webawesome/docs/docs/components/color-picker.md
@@ -19,32 +19,40 @@ use-cases:
 ```
 
 :::info
-This component works with standard `<form>` elements. Please refer to the section on [form controls](/docs/form-controls) to learn more about form submission and client-side validation.
+This component works with standard `<form>` elements. See [form controls](/docs/form-controls) for form submission and client-side validation.
 :::
 
 ## Examples
 
-### Initial Value
+### Labels
 
-Use the `value` attribute to set an initial value for the color picker.
+Use the `label` attribute to give the color picker an accessible label. For labels that contain HTML, use the `label` slot instead.
+
+```html {.example}
+<wa-color-picker label="Brand color"></wa-color-picker>
+```
+
+### Hint
+
+Add a descriptive hint with the `hint` attribute. For hints that contain HTML, use the `hint` slot instead.
+
+```html {.example}
+<wa-color-picker label="Accent" hint="Pick something with enough contrast to read against white."></wa-color-picker>
+```
+
+### Setting an Initial Value
+
+Use the `value` attribute to set a starting color. The value's format follows the `format` attribute, but any parsable color (including CSS color names) is accepted as input.
 
 ```html {.example}
 <wa-color-picker value="#4a90e2" label="Select a color"></wa-color-picker>
 ```
 
-### Opacity
-
-Use the `opacity` attribute to enable the opacity slider. When this is enabled, the value will be displayed as HEXA, RGBA, HSLA, or HSVA based on `format`.
-
-```html {.example}
-<wa-color-picker value="#f5a623ff" opacity label="Select a color"></wa-color-picker>
-```
-
 ### Formats
 
-Set the color picker's format with the `format` attribute. Valid options include `hex`, `rgb`, `hsl`, and `hsv`. Note that the color picker's input will accept any parsable format (including CSS color names) regardless of this option.
+Set the color picker's format with the `format` attribute. Valid options are `hex`, `rgb`, `hsl`, and `hsv`. The input still accepts any parsable format regardless of this setting.
 
-To prevent users from toggling the format themselves, add the `without-format-toggle` attribute.
+To stop people from cycling through formats themselves, add the `without-format-toggle` attribute.
 
 ```html {.example}
 <div class="wa-grid" style="--min-column-size: 12ch;">
@@ -55,9 +63,25 @@ To prevent users from toggling the format themselves, add the `without-format-to
 </div>
 ```
 
+### Opacity
+
+Use the `opacity` attribute to add an opacity slider. With opacity enabled, the value is shown as HEXA, RGBA, HSLA, or HSVA to match the `format`.
+
+```html {.example}
+<wa-color-picker value="#f5a623ff" opacity label="Select a color"></wa-color-picker>
+```
+
+### Uppercase Values
+
+By default, values are lowercase. Add the `uppercase` attribute to display them in uppercase instead.
+
+```html {.example}
+<wa-color-picker value="#4a90e2" uppercase label="Select a color"></wa-color-picker>
+```
+
 ### Swatches
 
-Use the `swatches` attribute to add convenient presets to the color picker. Any format the color picker can parse is acceptable (including [CSS color names](https://www.w3schools.com/colors/colors_names.asp)), but each value must be separated by a semicolon (`;`). Alternatively, you can pass an array of color values to this property using JavaScript.
+Use the `swatches` attribute to offer preset colors. Any format the picker can parse works (including [CSS color names](https://www.w3schools.com/colors/colors_names.asp)), and each value must be separated by a semicolon (`;`).
 
 ```html {.example}
 <wa-color-picker
@@ -69,34 +93,16 @@ Use the `swatches` attribute to add convenient presets to the color picker. Any 
 ></wa-color-picker>
 ```
 
-You can also pass an array of objects with `color` and `label` properties using JavaScript. When labels are provided, they will be used as the accessible name for each swatch instead of the raw color value.
-
-```html {.example}
-<wa-color-picker id="labeled-swatches" label="Select a color"></wa-color-picker>
-
-<script>
-  const colorPicker = document.getElementById('labeled-swatches');
-  await customElements.whenDefined("wa-color-picker")
-  await colorPicker.updateComplete
-  colorPicker.swatches = [
-    { color: '#d0021b', label: 'Red' },
-    { color: '#f5a623', label: 'Orange' },
-    { color: '#f8e71c', label: 'Yellow' },
-    { color: '#7ed321', label: 'Green' },
-    { color: '#4a90e2', label: 'Blue' },
-    { color: '#bd10e0', label: 'Purple' },
-    { color: '#000', label: 'Black' },
-    { color: '#fff', label: 'White' },
-  ];
-</script>
-```
+:::info
+To give swatches accessible names, set the `swatches` property in JavaScript to an array of `{ color, label }` objects — each `label` becomes that swatch's accessible name instead of the raw color value.
+:::
 
 ### Placement
 
-The preferred placement of the dropdown can be set with the `placement` attribute. Note that the actual position may vary to ensure the panel remains in the viewport.
+Set the `placement` attribute to control where the dropdown opens. The actual position may shift to keep the panel inside the viewport.
 
 ```html {.example}
-<div class="wa-gap-m wa-align-items-baseline">
+<div class="wa-cluster wa-align-items-baseline">
   <wa-color-picker placement="top-start" label="Select a color"></wa-color-picker>
   <wa-color-picker placement="bottom-end" label="Select a color"></wa-color-picker>
   <wa-color-picker placement="right" label="Select a color"></wa-color-picker>
@@ -109,27 +115,76 @@ The preferred placement of the dropdown can be set with the `placement` attribut
 Use the `size` attribute to change the color picker's trigger size.
 
 ```html {.example}
-<div class="wa-gap-m wa-align-items-baseline">
-  <wa-color-picker size="xs" label="Select a color"></wa-color-picker>
-  <wa-color-picker size="s" label="Select a color"></wa-color-picker>
-  <wa-color-picker size="m" label="Select a color"></wa-color-picker>
-  <wa-color-picker size="l" label="Select a color"></wa-color-picker>
-  <wa-color-picker size="xl" label="Select a color"></wa-color-picker>
+<div class="wa-cluster wa-align-items-baseline">
+  <wa-color-picker size="xs" label="Extra small"></wa-color-picker>
+  <wa-color-picker size="s" label="Small"></wa-color-picker>
+  <wa-color-picker size="m" label="Medium"></wa-color-picker>
+  <wa-color-picker size="l" label="Large"></wa-color-picker>
+  <wa-color-picker size="xl" label="Extra large"></wa-color-picker>
 </div>
 ```
 
 ### Disabled
 
-The color picker can be rendered as disabled.
+Use the `disabled` attribute to disable a color picker.
 
 ```html {.example}
 <wa-color-picker disabled label="Select a color"></wa-color-picker>
 ```
 
-### Hint
+### Applying the Selected Color
 
-Add descriptive hint to a color picker with the `hint` attribute. For hints that contain HTML, use the `hint` slot instead.
+The color picker emits an `input` event as the user picks, so you can apply the chosen color to your UI in real time. Here, changing the color themes a preview card.
 
 ```html {.example}
-<wa-color-picker label="Select a color" hint="Choose a color with appropriate contrast!"></wa-color-picker>
+<div class="color-apply-demo">
+  <div class="color-apply-preview">
+    <wa-icon name="palette"></wa-icon>
+    <div>
+      <strong>Brand preview</strong>
+      <p>Pick a color to theme this card in real time.</p>
+    </div>
+  </div>
+
+  <wa-divider></wa-divider>
+
+  <wa-color-picker label="Accent color" value="#6e40c9"></wa-color-picker>
+</div>
+
+<script>
+  const demo = document.querySelector('.color-apply-demo');
+  const picker = demo.querySelector('wa-color-picker');
+  const preview = demo.querySelector('.color-apply-preview');
+
+  picker.addEventListener('input', () => {
+    preview.style.setProperty('--accent', picker.value);
+  });
+</script>
+
+<style>
+  .color-apply-demo .color-apply-preview {
+    --accent: #6e40c9;
+    display: flex;
+    align-items: center;
+    gap: var(--wa-space-m);
+    margin-block-end: 1rem;
+    padding: var(--wa-space-l);
+    border-radius: var(--wa-border-radius-l);
+    border-inline-start: 4px solid var(--accent);
+    background-color: color-mix(in srgb, var(--accent) 12%, transparent);
+  }
+
+  .color-apply-demo .color-apply-preview wa-icon {
+    color: var(--accent);
+    font-size: 1.5rem;
+  }
+
+  .color-apply-demo .color-apply-preview strong {
+    color: var(--accent);
+  }
+
+  .color-apply-demo .color-apply-preview p {
+    margin: 0.25rem 0 0;
+  }
+</style>
 ```

--- a/packages/webawesome/docs/docs/components/color-picker.md
+++ b/packages/webawesome/docs/docs/components/color-picker.md
@@ -94,8 +94,18 @@ Use the `swatches` attribute to offer preset colors. Any format the picker can p
 ```
 
 :::info
-To give swatches accessible names, set the `swatches` property in JavaScript to an array of `{ color, label }` objects — each `label` becomes that swatch's accessible name instead of the raw color value.
+To give swatches accessible names, set the `swatches` property in JavaScript to an array of `{ color, label }` objects — each `label` becomes that swatch's accessible name instead of the raw color value. (Their appearance is identical, so this isn't a live example.)
 :::
+
+```js
+const picker = document.querySelector('wa-color-picker');
+picker.swatches = [
+  { color: '#d0021b', label: 'Red' },
+  { color: '#f5a623', label: 'Orange' },
+  { color: '#417505', label: 'Green' },
+  { color: '#4a90e2', label: 'Blue' },
+];
+```
 
 ### Placement
 

--- a/packages/webawesome/docs/docs/components/color-picker.md
+++ b/packages/webawesome/docs/docs/components/color-picker.md
@@ -24,7 +24,7 @@ This component works with standard `<form>` elements. See [form controls](/docs/
 
 ## Examples
 
-### Labels
+### Label
 
 Use the `label` attribute to give the color picker an accessible label. For labels that contain HTML, use the `label` slot instead.
 
@@ -48,7 +48,7 @@ Use the `value` attribute to set a starting color. The value's format follows th
 <wa-color-picker value="#4a90e2" label="Select a color"></wa-color-picker>
 ```
 
-### Formats
+### Format
 
 Set the color picker's format with the `format` attribute. Valid options are `hex`, `rgb`, `hsl`, and `hsv`. The input still accepts any parsable format regardless of this setting.
 
@@ -120,7 +120,7 @@ Set the `placement` attribute to control where the dropdown opens. The actual po
 </div>
 ```
 
-### Sizes
+### Size
 
 Use the `size` attribute to change the color picker's trigger size.
 

--- a/packages/webawesome/docs/docs/components/input.md
+++ b/packages/webawesome/docs/docs/components/input.md
@@ -16,11 +16,11 @@ use-cases:
 ---
 
 ```html {.example}
-<wa-input></wa-input>
+<wa-input label="Name"></wa-input>
 ```
 
 :::info
-This component works with standard `<form>` elements. Please refer to the section on [form controls](/docs/form-controls) to learn more about form submission and client-side validation.
+This component works with standard `<form>` elements. See [form controls](/docs/form-controls) for form submission and client-side validation.
 :::
 
 ## Examples
@@ -46,7 +46,7 @@ Add descriptive hint to an input with the `hint` attribute. For hints that conta
 Use the `placeholder` attribute to add a placeholder.
 
 ```html {.example}
-<wa-input placeholder="Type something"></wa-input>
+<wa-input label="Search" placeholder="Search the docs"></wa-input>
 ```
 
 ### Clearable
@@ -70,9 +70,11 @@ Add the `password-toggle` attribute to add a toggle button that will show the pa
 Use the `appearance` attribute to change the input's visual appearance.
 
 ```html {.example}
-<wa-input placeholder="Type something" appearance="filled"></wa-input><br />
-<wa-input placeholder="Type something" appearance="filled-outlined"></wa-input><br />
-<wa-input placeholder="Type something" appearance="outlined"></wa-input>
+<div class="wa-stack">
+  <wa-input appearance="outlined" placeholder="outlined"></wa-input>
+  <wa-input appearance="filled" placeholder="filled"></wa-input>
+  <wa-input appearance="filled-outlined" placeholder="filled-outlined"></wa-input>
+</div>
 ```
 
 ### Disabled
@@ -83,20 +85,26 @@ Use the `disabled` attribute to disable an input.
 <wa-input placeholder="Disabled" disabled></wa-input>
 ```
 
+### Readonly
+
+Use the `readonly` attribute to keep a value visible but uneditable. Unlike `disabled`, a readonly input stays focusable and its value is still submitted with the form.
+
+```html {.example}
+<wa-input label="Account ID" value="WA-2049" readonly></wa-input>
+```
+
 ### Sizes
 
 Use the `size` attribute to change an input's size.
 
 ```html {.example}
-<wa-input placeholder="Extra Small" size="xs"></wa-input>
-<br />
-<wa-input placeholder="Small" size="s"></wa-input>
-<br />
-<wa-input placeholder="Medium" size="m"></wa-input>
-<br />
-<wa-input placeholder="Large" size="l"></wa-input>
-<br />
-<wa-input placeholder="Extra Large" size="xl"></wa-input>
+<div class="wa-stack">
+  <wa-input size="xs" placeholder="Extra small"></wa-input>
+  <wa-input size="s" placeholder="Small"></wa-input>
+  <wa-input size="m" placeholder="Medium"></wa-input>
+  <wa-input size="l" placeholder="Large"></wa-input>
+  <wa-input size="xl" placeholder="Extra large"></wa-input>
+</div>
 ```
 
 ### Pill
@@ -104,15 +112,7 @@ Use the `size` attribute to change an input's size.
 Use the `pill` attribute to give inputs rounded edges.
 
 ```html {.example}
-<wa-input placeholder="Extra Small" size="xs" pill></wa-input>
-<br />
-<wa-input placeholder="Small" size="s" pill></wa-input>
-<br />
-<wa-input placeholder="Medium" size="m" pill></wa-input>
-<br />
-<wa-input placeholder="Large" size="l" pill></wa-input>
-<br />
-<wa-input placeholder="Extra Large" size="xl" pill></wa-input>
+<wa-input placeholder="Search" pill></wa-input>
 ```
 
 ### Input Types
@@ -120,11 +120,11 @@ Use the `pill` attribute to give inputs rounded edges.
 The `type` attribute controls the type of input the browser renders.
 
 ```html {.example}
-<wa-input type="email" placeholder="Email"></wa-input>
-<br />
-<wa-input type="number" placeholder="Number"></wa-input>
-<br />
-<wa-input type="date" placeholder="Date"></wa-input>
+<div class="wa-stack">
+  <wa-input type="email" placeholder="Email"></wa-input>
+  <wa-input type="number" placeholder="Number"></wa-input>
+  <wa-input type="date" placeholder="Date"></wa-input>
+</div>
 ```
 
 ### Start & End Decorations
@@ -132,20 +132,15 @@ The `type` attribute controls the type of input the browser renders.
 Use the `start` and `end` slots to add presentational elements like `<wa-icon>` within the input.
 
 ```html {.example}
-<wa-input placeholder="Small" size="s">
-  <wa-icon name="house" slot="start"></wa-icon>
-  <wa-icon name="comment" slot="end"></wa-icon>
-</wa-input>
-<br />
-<wa-input placeholder="Medium" size="m">
-  <wa-icon name="house" slot="start"></wa-icon>
-  <wa-icon name="comment" slot="end"></wa-icon>
-</wa-input>
-<br />
-<wa-input placeholder="Large" size="l">
-  <wa-icon name="house" slot="start"></wa-icon>
-  <wa-icon name="comment" slot="end"></wa-icon>
-</wa-input>
+<div class="wa-stack">
+  <wa-input label="Search" placeholder="Search the docs">
+    <wa-icon name="magnifying-glass" slot="start"></wa-icon>
+  </wa-input>
+  <wa-input label="Website" placeholder="example.com">
+    <wa-icon name="globe" slot="start"></wa-icon>
+    <wa-icon name="circle-info" slot="end"></wa-icon>
+  </wa-input>
+</div>
 ```
 
 ### Customizing Label Position

--- a/packages/webawesome/docs/docs/components/input.md
+++ b/packages/webawesome/docs/docs/components/input.md
@@ -25,7 +25,7 @@ This component works with standard `<form>` elements. See [form controls](/docs/
 
 ## Examples
 
-### Labels
+### Label
 
 Use the `label` attribute to give the input an accessible label. For labels that contain HTML, use the `label` slot instead.
 
@@ -41,7 +41,7 @@ Add descriptive hint to an input with the `hint` attribute. For hints that conta
 <wa-input label="Nickname" hint="What would you like people to call you?"></wa-input>
 ```
 
-### Placeholders
+### Placeholder
 
 Use the `placeholder` attribute to add a placeholder.
 
@@ -93,7 +93,7 @@ Use the `readonly` attribute to keep a value visible but uneditable. Unlike `dis
 <wa-input label="Account ID" value="WA-2049" readonly></wa-input>
 ```
 
-### Sizes
+### Size
 
 Use the `size` attribute to change an input's size.
 

--- a/packages/webawesome/docs/docs/components/known-date.md
+++ b/packages/webawesome/docs/docs/components/known-date.md
@@ -24,16 +24,19 @@ Known Date collects a date the user already knows — a birthday, a passport iss
 ```
 
 :::info
-For dates the user needs help finding (scheduling, ranges, browsing), use [`<wa-date-input>`](/docs/components/date-input) instead. Known Date is intentionally simple: no popup calendar, no auto-advance between fields, and no clever parsing.
+<strong>Need a calendar, ranges, or browsing?</strong><br />
+Use [`<wa-date-input>`](/docs/components/date-input) instead. Known Date is intentionally simple: no popup calendar, no auto-advance between fields, and no clever parsing.
 :::
 
 ## Form Submission
 
 The hidden form value is canonical ISO 8601 (`YYYY-MM-DD`), regardless of the locale used to render the fields:
 
-- A complete, real calendar date is submitted as `YYYY-MM-DD`.
-- A partial entry (one or two fields filled) submits no value — the form data omits the entry entirely.
-- An invalid combination such as 30 February submits no value.
+| Entry | Form value |
+| --- | --- |
+| Complete, valid date | `YYYY-MM-DD` (e.g. `2007-03-27`) |
+| Partial (one or two fields) | _(empty)_ — omitted from form data |
+| Invalid date (e.g. 30 February) | _(empty)_ |
 
 ```html {.example}
 <form id="kd-form-demo">
@@ -96,11 +99,11 @@ Use the `hint` attribute (or slot) to show an example value. The hint is associa
 The three fields render in the natural order for the inherited `lang` (or the explicit `locale` attribute). The labels stay the same; only the position changes.
 
 ```html {.example}
-<wa-known-date label="UK order" lang="en-GB"></wa-known-date>
-<br />
-<wa-known-date label="US order" lang="en-US"></wa-known-date>
-<br />
-<wa-known-date label="Japanese order" lang="ja-JP"></wa-known-date>
+<div class="wa-stack">
+  <wa-known-date label="UK order" lang="en-GB"></wa-known-date>
+  <wa-known-date label="US order" lang="en-US"></wa-known-date>
+  <wa-known-date label="Japanese order" lang="ja-JP"></wa-known-date>
+</div>
 ```
 
 ### Min & Max
@@ -123,12 +126,20 @@ Set `required` to make the date input required for form submission. Like other f
 </form>
 ```
 
-### Disabled & Readonly
+### Disabled
+
+Use the `disabled` attribute to disable a date field.
 
 ```html {.example}
-<wa-known-date label="Disabled" value="2007-03-27" disabled></wa-known-date>
-<br />
-<wa-known-date label="Readonly" value="2007-03-27" readonly></wa-known-date>
+<wa-known-date label="Birthday" value="2007-03-27" disabled></wa-known-date>
+```
+
+### Readonly
+
+Use the `readonly` attribute to keep a value visible but uneditable. Unlike `disabled`, a readonly date field stays focusable and its value is still submitted with the form.
+
+```html {.example}
+<wa-known-date label="Member since" value="2007-03-27" readonly></wa-known-date>
 ```
 
 ### Autocomplete
@@ -142,25 +153,23 @@ Set `autocomplete="bday"` to enable browser autofill for birthdays. The host exp
 ### Sizes
 
 ```html {.example}
-<wa-known-date label="Extra small" size="xs"></wa-known-date>
-<br />
-<wa-known-date label="Small" size="s"></wa-known-date>
-<br />
-<wa-known-date label="Medium (default)" size="m"></wa-known-date>
-<br />
-<wa-known-date label="Large" size="l"></wa-known-date>
-<br />
-<wa-known-date label="Extra large" size="xl"></wa-known-date>
+<div class="wa-stack">
+  <wa-known-date label="Extra small" size="xs"></wa-known-date>
+  <wa-known-date label="Small" size="s"></wa-known-date>
+  <wa-known-date label="Medium (default)" size="m"></wa-known-date>
+  <wa-known-date label="Large" size="l"></wa-known-date>
+  <wa-known-date label="Extra large" size="xl"></wa-known-date>
+</div>
 ```
 
-### Appearances
+### Appearance
 
 ```html {.example}
-<wa-known-date label="Outlined (default)" appearance="outlined"></wa-known-date>
-<br />
-<wa-known-date label="Filled" appearance="filled"></wa-known-date>
-<br />
-<wa-known-date label="Filled outlined" appearance="filled-outlined"></wa-known-date>
+<div class="wa-stack">
+  <wa-known-date label="Outlined (default)" appearance="outlined"></wa-known-date>
+  <wa-known-date label="Filled" appearance="filled"></wa-known-date>
+  <wa-known-date label="Filled outlined" appearance="filled-outlined"></wa-known-date>
+</div>
 ```
 
 ### Pill

--- a/packages/webawesome/docs/docs/components/known-date.md
+++ b/packages/webawesome/docs/docs/components/known-date.md
@@ -150,7 +150,7 @@ Set `autocomplete="bday"` to enable browser autofill for birthdays. The host exp
 <wa-known-date label="Date of birth" autocomplete="bday"></wa-known-date>
 ```
 
-### Sizes
+### Size
 
 ```html {.example}
 <div class="wa-stack">

--- a/packages/webawesome/docs/docs/components/number-input.md
+++ b/packages/webawesome/docs/docs/components/number-input.md
@@ -18,7 +18,7 @@ use-cases:
 ```
 
 :::info
-This component works with standard `<form>` elements. Please refer to the section on [form controls](/docs/form-controls) to learn more about form submission and client-side validation.
+This component works with standard `<form>` elements. See [form controls](/docs/form-controls) for form submission and client-side validation.
 :::
 
 ## Examples
@@ -51,7 +51,62 @@ Use the `placeholder` attribute to add a placeholder.
 <wa-number-input placeholder="Enter a number" style="max-width: 260px;"></wa-number-input>
 ```
 
-### Setting Min, Max, & Step
+### Appearance
+
+Use the `appearance` attribute to change the input's visual appearance.
+
+```html {.example}
+<div class="wa-stack">
+  <wa-number-input label="Outlined" appearance="outlined" value="42" style="max-width: 260px;"></wa-number-input>
+  <wa-number-input label="Filled" appearance="filled" value="42" style="max-width: 260px;"></wa-number-input>
+  <wa-number-input
+    label="Filled Outlined"
+    appearance="filled-outlined"
+    value="42"
+    style="max-width: 260px;"
+  ></wa-number-input>
+</div>
+```
+
+### Disabled
+
+Use the `disabled` attribute to disable an input.
+
+```html {.example}
+<wa-number-input label="Disabled" value="100" disabled style="max-width: 260px;"></wa-number-input>
+```
+
+### Readonly
+
+Use the `readonly` attribute to keep a value visible but uneditable. Unlike `disabled`, a readonly input stays focusable and its value is still submitted with the form.
+
+```html {.example}
+<wa-number-input label="Readonly" value="42" readonly style="max-width: 260px;"></wa-number-input>
+```
+
+### Sizes
+
+Use the `size` attribute to change an input's size.
+
+```html {.example}
+<div class="wa-stack">
+  <wa-number-input label="Extra Small" size="xs" value="5" style="max-width: 260px;"></wa-number-input>
+  <wa-number-input label="Small" size="s" value="10" style="max-width: 260px;"></wa-number-input>
+  <wa-number-input label="Medium" size="m" value="20" style="max-width: 260px;"></wa-number-input>
+  <wa-number-input label="Large" size="l" value="30" style="max-width: 260px;"></wa-number-input>
+  <wa-number-input label="Extra Large" size="xl" value="40" style="max-width: 260px;"></wa-number-input>
+</div>
+```
+
+### Pill
+
+Use the `pill` attribute to give inputs rounded edges.
+
+```html {.example}
+<wa-number-input label="Quantity" pill value="5" style="max-width: 260px;"></wa-number-input>
+```
+
+### Setting Min, Max & Step
 
 Use the `min` and `max` attributes to set a minimum and maximum value. Use the `step` attribute to change the granularity the value must adhere to when using the stepper buttons or arrow keys.
 
@@ -67,108 +122,43 @@ Use the `min` and `max` attributes to set a minimum and maximum value. Use the `
 ></wa-number-input>
 ```
 
-### Appearance
+### Hiding the Steppers
 
-Use the `appearance` attribute to change the input's visual appearance.
-
-```html {.example}
-<wa-number-input label="Outlined" appearance="outlined" value="42" style="max-width: 260px;"></wa-number-input>
-<br />
-<wa-number-input label="Filled" appearance="filled" value="42" style="max-width: 260px;"></wa-number-input>
-<br />
-<wa-number-input
-  label="Filled Outlined"
-  appearance="filled-outlined"
-  value="42"
-  style="max-width: 260px;"
-></wa-number-input>
-```
-
-### Disabled
-
-Use the `disabled` attribute to disable an input.
-
-```html {.example}
-<wa-number-input label="Disabled" value="100" disabled style="max-width: 260px;"></wa-number-input>
-```
-
-### Readonly
-
-Use the `readonly` attribute to make the input readonly. The value can still be selected and copied, but it cannot be changed.
-
-```html {.example}
-<wa-number-input label="Readonly" value="42" readonly style="max-width: 260px;"></wa-number-input>
-```
-
-### Sizes
-
-Use the `size` attribute to change an input's size.
-
-```html {.example}
-<wa-number-input label="Extra Small" size="xs" value="5" style="max-width: 260px;"></wa-number-input>
-<br />
-<wa-number-input label="Small" size="s" value="10" style="max-width: 260px;"></wa-number-input>
-<br />
-<wa-number-input label="Medium" size="m" value="20" style="max-width: 260px;"></wa-number-input>
-<br />
-<wa-number-input label="Large" size="l" value="30" style="max-width: 260px;"></wa-number-input>
-<br />
-<wa-number-input label="Extra Large" size="xl" value="40" style="max-width: 260px;"></wa-number-input>
-```
-
-### Pill
-
-Use the `pill` attribute to give inputs rounded edges.
-
-```html {.example}
-<wa-number-input label="Extra Small Pill" size="xs" pill value="5" style="max-width: 260px;"></wa-number-input>
-<br />
-<wa-number-input label="Small Pill" size="s" pill value="10" style="max-width: 260px;"></wa-number-input>
-<br />
-<wa-number-input label="Medium Pill" size="m" pill value="20" style="max-width: 260px;"></wa-number-input>
-<br />
-<wa-number-input label="Large Pill" size="l" pill value="30" style="max-width: 260px;"></wa-number-input>
-<br />
-<wa-number-input label="Extra Large Pill" size="xl" pill value="40" style="max-width: 260px;"></wa-number-input>
-```
-
-### Without Steppers
-
-Add the `without-steppers` attribute to remove the increment/decrement buttons. Users can still modify the value using the keyboard.
+Add the `without-steppers` attribute to remove the increment and decrement buttons.
 
 ```html {.example}
 <wa-number-input label="No steppers" value="50" without-steppers style="max-width: 260px;"></wa-number-input>
 ```
 
 :::info
-When steppers are hidden, users can still use the arrow keys to increment and decrement the value.
+<strong>The keyboard still works.</strong><br />
+With the steppers hidden, the arrow keys can still increment and decrement the value.
 :::
+
+### Custom Stepper Icons
+
+Use the `increment-icon` and `decrement-icon` slots to replace the default stepper button icons.
+
+```html {.example}
+<wa-number-input label="Custom icons" value="5" style="max-width: 260px;">
+  <wa-icon slot="increment-icon" name="plus"></wa-icon>
+  <wa-icon slot="decrement-icon" name="minus"></wa-icon>
+</wa-number-input>
+```
 
 ### Start & End Decorations
 
 Use the `start` and `end` slots to add presentational elements like `<wa-icon>` within the input.
 
 ```html {.example}
-<wa-number-input label="Price" value="100" style="max-width: 260px;">
-  <wa-icon slot="start" name="dollar-sign" family="utility" variant="semibold"></wa-icon>
-</wa-number-input>
-
-<br />
-
-<wa-number-input label="Weight (kg)" value="75" style="max-width: 260px;">
-  <wa-icon slot="end" name="bag-shopping" family="utility" variant="semibold"></wa-icon>
-</wa-number-input>
-```
-
-### Custom Stepper Icons
-
-Use the `increment-icon` and `decrement-icon` slots to customize the stepper button icons.
-
-```html {.example}
-<wa-number-input label="Custom icons" value="5" style="max-width: 260px;">
-  <wa-icon slot="increment-icon" name="plus" family="notdog-duo" variant="solid"></wa-icon>
-  <wa-icon slot="decrement-icon" name="minus" family="notdog-duo" variant="solid"></wa-icon>
-</wa-number-input>
+<div class="wa-stack">
+  <wa-number-input label="Price" value="100" style="max-width: 260px;">
+    <wa-icon slot="start" name="dollar-sign"></wa-icon>
+  </wa-number-input>
+  <wa-number-input label="Quantity" value="3" style="max-width: 260px;">
+    <wa-icon slot="end" name="cart-shopping"></wa-icon>
+  </wa-number-input>
+</div>
 ```
 
 ### Customizing Label Position

--- a/packages/webawesome/docs/docs/components/number-input.md
+++ b/packages/webawesome/docs/docs/components/number-input.md
@@ -23,7 +23,7 @@ This component works with standard `<form>` elements. See [form controls](/docs/
 
 ## Examples
 
-### Labels
+### Label
 
 Use the `label` attribute to give the input an accessible label. For labels that contain HTML, use the `label` slot instead.
 
@@ -43,7 +43,7 @@ Add descriptive hint to an input with the `hint` attribute. For hints that conta
 ></wa-number-input>
 ```
 
-### Placeholders
+### Placeholder
 
 Use the `placeholder` attribute to add a placeholder.
 
@@ -84,7 +84,7 @@ Use the `readonly` attribute to keep a value visible but uneditable. Unlike `dis
 <wa-number-input label="Readonly" value="42" readonly style="max-width: 260px;"></wa-number-input>
 ```
 
-### Sizes
+### Size
 
 Use the `size` attribute to change an input's size.
 
@@ -106,7 +106,7 @@ Use the `pill` attribute to give inputs rounded edges.
 <wa-number-input label="Quantity" pill value="5" style="max-width: 260px;"></wa-number-input>
 ```
 
-### Setting Min, Max & Step
+### Min, Max & Step
 
 Use the `min` and `max` attributes to set a minimum and maximum value. Use the `step` attribute to change the granularity the value must adhere to when using the stepper buttons or arrow keys.
 
@@ -198,7 +198,7 @@ Use [CSS parts](#css-parts) to customize the way form controls are drawn. This e
 </style>
 ```
 
-### Form Validation
+### Validation
 
 Use the `required` attribute to make the field required. Combine with `min` and `max` for range validation.
 

--- a/packages/webawesome/docs/docs/components/radio-group.md
+++ b/packages/webawesome/docs/docs/components/radio-group.md
@@ -12,24 +12,24 @@ use-cases:
 ---
 
 ```html {.example}
-<wa-radio-group label="Select an option" name="a" value="1">
-  <wa-radio value="1">Option 1</wa-radio>
-  <wa-radio value="2">Option 2</wa-radio>
-  <wa-radio value="3">Option 3</wa-radio>
+<wa-radio-group label="Coffee roast" name="roast" value="medium">
+  <wa-radio value="light">Light roast</wa-radio>
+  <wa-radio value="medium">Medium roast</wa-radio>
+  <wa-radio value="dark">Dark roast</wa-radio>
 </wa-radio-group>
 ```
 
 ## Examples
 
-### Checked
+### Setting Initial Values
 
-Use the `value` attribute on the radio group to set the checked radio.
+Use the `value` attribute on the radio group to set the initially selected radio. Match it to the `value` of the radio that should start checked, just like native HTML.
 
 ```html {.example}
-<wa-radio-group label="Select an option" name="a" value="2">
-  <wa-radio value="1">Option 1</wa-radio>
-  <wa-radio value="2">Option 2</wa-radio>
-  <wa-radio value="3">Option 3</wa-radio>
+<wa-radio-group label="Coffee roast" name="roast" value="dark">
+  <wa-radio value="light">Light roast</wa-radio>
+  <wa-radio value="medium">Medium roast</wa-radio>
+  <wa-radio value="dark">Dark roast</wa-radio>
 </wa-radio-group>
 ```
 
@@ -42,10 +42,10 @@ To target checked radios with CSS, use the `:state(checked)` selector.
 Add descriptive hint to a radio group with the `hint` attribute. For hints that contain HTML, use the `hint` slot instead.
 
 ```html {.example}
-<wa-radio-group label="Select an option" hint="Choose the most appropriate option." name="a" value="1">
-  <wa-radio value="1">Option 1</wa-radio>
-  <wa-radio value="2">Option 2</wa-radio>
-  <wa-radio value="3">Option 3</wa-radio>
+<wa-radio-group label="Coffee roast" hint="Pick the roast we'll grind for your order." name="roast" value="medium">
+  <wa-radio value="light">Light roast</wa-radio>
+  <wa-radio value="medium">Medium roast</wa-radio>
+  <wa-radio value="dark">Dark roast</wa-radio>
 </wa-radio-group>
 ```
 
@@ -54,132 +54,130 @@ Add descriptive hint to a radio group with the `hint` attribute. For hints that 
 Set the `appearance` attribute to `button` on all radios to render a radio button group.
 
 ```html {.example}
-<wa-radio-group
-  label="Horizontal options"
-  hint="Select an option that makes you proud."
-  orientation="horizontal"
-  name="a"
-  value="1"
->
-  <wa-radio appearance="button" value="1">Option 1</wa-radio>
-  <wa-radio appearance="button" value="2">Option 2</wa-radio>
-  <wa-radio appearance="button" value="3">Option 3</wa-radio>
-</wa-radio-group>
+<div class="wa-stack">
+  <wa-radio-group
+    label="Color scheme"
+    hint="Choose how the interface should appear."
+    orientation="horizontal"
+    name="scheme"
+    value="auto"
+  >
+    <wa-radio appearance="button" value="light">Light</wa-radio>
+    <wa-radio appearance="button" value="dark">Dark</wa-radio>
+    <wa-radio appearance="button" value="auto">Auto</wa-radio>
+  </wa-radio-group>
 
-<br />
-
-<wa-radio-group
-  label="Vertical options"
-  hint="Select an option that makes you proud."
-  orientation="vertical"
-  name="a"
-  value="1"
-  style="max-width: 300px;"
->
-  <wa-radio appearance="button" value="1">Option 1</wa-radio>
-  <wa-radio appearance="button" value="2">Option 2</wa-radio>
-  <wa-radio appearance="button" value="3">Option 3</wa-radio>
-</wa-radio-group>
+  <wa-radio-group
+    label="Color scheme"
+    hint="Choose how the interface should appear."
+    orientation="vertical"
+    name="scheme"
+    value="auto"
+    style="max-width: 300px;"
+  >
+    <wa-radio appearance="button" value="light">Light</wa-radio>
+    <wa-radio appearance="button" value="dark">Dark</wa-radio>
+    <wa-radio appearance="button" value="auto">Auto</wa-radio>
+  </wa-radio-group>
+</div>
 ```
 
-### Disabling
+### Disabled
 
 To disable the entire radio group, add the `disabled` attribute to the radio group.
 
 ```html {.example}
-<wa-radio-group label="Select an option" disabled>
-  <wa-radio value="1">Option 1</wa-radio>
-  <wa-radio value="2" disabled>Option 2</wa-radio>
-  <wa-radio value="3">Option 3</wa-radio>
+<wa-radio-group label="Shipping speed" disabled>
+  <wa-radio value="standard">Standard</wa-radio>
+  <wa-radio value="express">Express</wa-radio>
+  <wa-radio value="overnight">Overnight</wa-radio>
 </wa-radio-group>
 ```
 
 To disable individual options, add the `disabled` attribute to the respective options.
 
 ```html {.example}
-<wa-radio-group label="Select an option">
-  <wa-radio value="1">Option 1</wa-radio>
-  <wa-radio value="2" disabled>Option 2</wa-radio>
-  <wa-radio value="3">Option 3</wa-radio>
+<wa-radio-group label="Shipping speed">
+  <wa-radio value="standard">Standard</wa-radio>
+  <wa-radio value="express">Express</wa-radio>
+  <wa-radio value="overnight" disabled>Overnight</wa-radio>
 </wa-radio-group>
 ```
 
 ### Orientation
 
-The default orientation for radio items is `vertical`. Set the `orientation` to `horizontal` to items on the same row.
+The default orientation for radio items is `vertical`. Set the `orientation` to `horizontal` to lay items out on the same row.
 
 ```html {.example}
 <wa-radio-group
-  label="Select an option"
-  hint="Choose the most appropriate option."
+  label="Shipping speed"
+  hint="Choose how fast you'd like your order."
   orientation="horizontal"
-  name="a"
-  value="1"
+  name="shipping"
+  value="standard"
 >
-  <wa-radio value="1">Option 1</wa-radio>
-  <wa-radio value="2">Option 2</wa-radio>
-  <wa-radio value="3">Option 3</wa-radio>
+  <wa-radio value="standard">Standard</wa-radio>
+  <wa-radio value="express">Express</wa-radio>
+  <wa-radio value="overnight">Overnight</wa-radio>
 </wa-radio-group>
 ```
 
-### Sizing Options
+### Sizes
 
 The size of radios will be determined by the Radio Group's `size` attribute.
 
 ```html {.example}
-<wa-radio-group label="Extra small options" size="xs" value="1">
-  <wa-radio value="1">Option 1</wa-radio>
-  <wa-radio value="2">Option 2</wa-radio>
-  <wa-radio value="3">Option 3</wa-radio>
-</wa-radio-group>
-<br />
-<wa-radio-group label="Small options" size="s" value="1">
-  <wa-radio value="1">Option 1</wa-radio>
-  <wa-radio value="2">Option 2</wa-radio>
-  <wa-radio value="3">Option 3</wa-radio>
-</wa-radio-group>
-<br />
-<wa-radio-group label="Medium options" size="m" value="2">
-  <wa-radio value="1">Option 1</wa-radio>
-  <wa-radio value="2">Option 2</wa-radio>
-  <wa-radio value="3">Option 3</wa-radio>
-</wa-radio-group>
-<br />
-<wa-radio-group label="Large options" size="l" value="3">
-  <wa-radio value="1">Option 1</wa-radio>
-  <wa-radio value="2">Option 2</wa-radio>
-  <wa-radio value="3">Option 3</wa-radio>
-</wa-radio-group>
-<br />
-<wa-radio-group label="Extra large options" size="xl" value="3">
-  <wa-radio value="1">Option 1</wa-radio>
-  <wa-radio value="2">Option 2</wa-radio>
-  <wa-radio value="3">Option 3</wa-radio>
-</wa-radio-group>
+<div class="wa-stack">
+  <wa-radio-group label="Extra small" size="xs" value="medium">
+    <wa-radio value="light">Light roast</wa-radio>
+    <wa-radio value="medium">Medium roast</wa-radio>
+    <wa-radio value="dark">Dark roast</wa-radio>
+  </wa-radio-group>
+  <wa-radio-group label="Small" size="s" value="medium">
+    <wa-radio value="light">Light roast</wa-radio>
+    <wa-radio value="medium">Medium roast</wa-radio>
+    <wa-radio value="dark">Dark roast</wa-radio>
+  </wa-radio-group>
+  <wa-radio-group label="Medium" size="m" value="medium">
+    <wa-radio value="light">Light roast</wa-radio>
+    <wa-radio value="medium">Medium roast</wa-radio>
+    <wa-radio value="dark">Dark roast</wa-radio>
+  </wa-radio-group>
+  <wa-radio-group label="Large" size="l" value="dark">
+    <wa-radio value="light">Light roast</wa-radio>
+    <wa-radio value="medium">Medium roast</wa-radio>
+    <wa-radio value="dark">Dark roast</wa-radio>
+  </wa-radio-group>
+  <wa-radio-group label="Extra large" size="xl" value="dark">
+    <wa-radio value="light">Light roast</wa-radio>
+    <wa-radio value="medium">Medium roast</wa-radio>
+    <wa-radio value="dark">Dark roast</wa-radio>
+  </wa-radio-group>
+</div>
 ```
 
 If you need to have radios of varying sizes, place the `size` attribute on individual radio items instead.
 
 ```html {.example}
-<wa-radio-group label="Mixed options" value="medium">
-  <wa-radio value="1" size="xs">Extra Small</wa-radio>
-  <wa-radio value="2" size="s">Small</wa-radio>
-  <wa-radio value="3" size="m">Medium</wa-radio>
-  <wa-radio value="4" size="l">Large</wa-radio>
-  <wa-radio value="5" size="xl">Extra Large</wa-radio>
+<wa-radio-group label="Mixed sizes" value="m">
+  <wa-radio value="xs" size="xs">Extra Small</wa-radio>
+  <wa-radio value="s" size="s">Small</wa-radio>
+  <wa-radio value="m" size="m">Medium</wa-radio>
+  <wa-radio value="l" size="l">Large</wa-radio>
+  <wa-radio value="xl" size="xl">Extra Large</wa-radio>
 </wa-radio-group>
 ```
 
 ### Validation
 
-Setting the `required` attribute to make selecting an option mandatory. If a value has not been selected, it will prevent the form from submitting and display an error message.
+Set the `required` attribute to make selecting an option mandatory. If a value has not been selected, it will prevent the form from submitting and display an error message.
 
 ```html {.example}
 <form class="validation">
-  <wa-radio-group label="Select an option" name="a" required>
-    <wa-radio value="1">Option 1</wa-radio>
-    <wa-radio value="2">Option 2</wa-radio>
-    <wa-radio value="3">Option 3</wa-radio>
+  <wa-radio-group label="Coffee roast" name="roast" required>
+    <wa-radio value="light">Light roast</wa-radio>
+    <wa-radio value="medium">Medium roast</wa-radio>
+    <wa-radio value="dark">Dark roast</wa-radio>
   </wa-radio-group>
   <br />
   <wa-button appearance="filled" type="submit" variant="neutral">Submit</wa-button>
@@ -202,10 +200,10 @@ Use the `setCustomValidity()` method to set a custom validation message. This wi
 
 ```html {.example}
 <form class="custom-validity">
-  <wa-radio-group label="Select an option" name="a" value="1">
-    <wa-radio value="1">Not me</wa-radio>
-    <wa-radio value="2">Me neither</wa-radio>
-    <wa-radio value="3">Choose me</wa-radio>
+  <wa-radio-group label="Coffee roast" name="roast" value="light">
+    <wa-radio value="light">Light roast</wa-radio>
+    <wa-radio value="medium">Medium roast</wa-radio>
+    <wa-radio value="dark">Dark roast</wa-radio>
   </wa-radio-group>
   <br />
   <wa-button appearance="filled" type="submit" variant="neutral">Submit</wa-button>
@@ -214,7 +212,7 @@ Use the `setCustomValidity()` method to set a custom validation message. This wi
 <script>
   const form = document.querySelector('.custom-validity');
   const radioGroup = form.querySelector('wa-radio-group');
-  const errorMessage = 'You must choose the last option';
+  const errorMessage = 'Sorry, we only have dark roast today';
 
   // Set initial validity as soon as the element is defined
   customElements.whenDefined('wa-radio-group').then(() => {
@@ -223,7 +221,7 @@ Use the `setCustomValidity()` method to set a custom validation message. This wi
 
   // Update validity when a selection is made
   form.addEventListener('change', () => {
-    const isValid = radioGroup.value === '3';
+    const isValid = radioGroup.value === 'dark';
     radioGroup.setCustomValidity(isValid ? '' : errorMessage);
   });
 

--- a/packages/webawesome/docs/docs/components/radio-group.md
+++ b/packages/webawesome/docs/docs/components/radio-group.md
@@ -21,7 +21,7 @@ use-cases:
 
 ## Examples
 
-### Setting Initial Values
+### Initial Value
 
 Use the `value` attribute on the radio group to set the initially selected radio. Match it to the `value` of the radio that should start checked, just like native HTML.
 
@@ -122,7 +122,7 @@ The default orientation for radio items is `vertical`. Set the `orientation` to 
 </wa-radio-group>
 ```
 
-### Sizes
+### Size
 
 The size of radios will be determined by the Radio Group's `size` attribute.
 

--- a/packages/webawesome/docs/docs/components/rating.md
+++ b/packages/webawesome/docs/docs/components/rating.md
@@ -18,59 +18,17 @@ use-cases:
 ```
 
 :::info
-This component works with standard `<form>` elements. Please refer to the section on [form controls](/docs/form-controls) to learn more about form submission and client-side validation.
+This component works with standard `<form>` elements. See [form controls](/docs/form-controls) for form submission and client-side validation.
 :::
 
 ## Examples
 
 ### Labels
 
-Ratings are commonly identified contextually, so labels aren't displayed. However, you should always provide one for assistive devices using the `label` attribute.
+Ratings are usually identified by context, so the label isn't displayed. Always provide one with the `label` attribute so assistive devices can announce the control.
 
 ```html {.example}
 <wa-rating label="Rate this component"></wa-rating>
-```
-
-### Maximum Value
-
-Ratings are 0-5 by default. To change the maximum possible value, use the `max` attribute.
-
-```html {.example}
-<wa-rating label="Rating" max="3"></wa-rating>
-```
-
-### Precision
-
-Use the `precision` attribute to let users select fractional ratings.
-
-```html {.example}
-<wa-rating label="Rating" precision="0.5" value="2.5"></wa-rating>
-```
-
-### Sizing
-
-Use the `size` attribute to adjust the size of the rating.
-
-```html {.example}
-<wa-rating label="Rating" size="xs"></wa-rating><br />
-<wa-rating label="Rating" size="s"></wa-rating><br />
-<wa-rating label="Rating" size="m"></wa-rating><br />
-<wa-rating label="Rating" size="l"></wa-rating><br />
-<wa-rating label="Rating" size="xl"></wa-rating>
-```
-
-For more granular sizing, you can use the `font-size` property.
-
-```html {.example}
-<wa-rating label="Rating" style="font-size: 2rem;"></wa-rating>
-```
-
-### Readonly
-
-Use the `readonly` attribute to display a rating that users can't change.
-
-```html {.example}
-<wa-rating label="Rating" readonly value="3"></wa-rating>
 ```
 
 ### Disabled
@@ -81,11 +39,92 @@ Use the `disabled` attribute to disable the rating.
 <wa-rating label="Rating" disabled value="3"></wa-rating>
 ```
 
+### Readonly
+
+Use the `readonly` attribute to display a rating that users can't change. Unlike `disabled`, a readonly rating still submits its value with the form.
+
+```html {.example}
+<wa-rating label="Rating" readonly value="3"></wa-rating>
+```
+
+### Sizes
+
+Use the `size` attribute to change the rating's size.
+
+```html {.example}
+<div class="wa-stack">
+  <wa-rating label="Extra small" size="xs"></wa-rating>
+  <wa-rating label="Small" size="s"></wa-rating>
+  <wa-rating label="Medium" size="m"></wa-rating>
+  <wa-rating label="Large" size="l"></wa-rating>
+  <wa-rating label="Extra large" size="xl"></wa-rating>
+</div>
+```
+
+For finer control, set the `font-size` property directly.
+
+```html {.example}
+<wa-rating label="Rating" style="font-size: 3rem;"></wa-rating>
+```
+
+### Max Value
+
+Ratings go from 0 to 5 by default. Use the `max` attribute to change the highest possible value.
+
+```html {.example}
+<wa-rating label="Rating" max="3"></wa-rating>
+```
+
+### Precision
+
+Use the `precision` attribute to let users select fractional ratings, such as half stars.
+
+```html {.example}
+<wa-rating label="Rating" precision="0.5" value="2.5"></wa-rating>
+```
+
+### Custom Icons
+
+Pass a function to the `getSymbol` property to render a custom symbol in place of the default star.
+
+```html {.example}
+<wa-rating label="Rating" class="rating-hearts" style="--symbol-color-active: #ff4136;"></wa-rating>
+
+<script type="module">
+  const rating = document.querySelector('.rating-hearts');
+
+  await customElements.whenDefined('wa-rating');
+  await rating.updateComplete;
+
+  rating.getSymbol = () => '<wa-icon name="heart" variant="solid"></wa-icon>';
+</script>
+```
+
+### Value-Based Icons
+
+The `getSymbol` function receives the symbol's value and whether it's currently selected, so you can render different icons across the scale.
+
+```html {.example}
+<wa-rating label="Rating" class="rating-emojis"></wa-rating>
+
+<script type="module">
+  const rating = document.querySelector('.rating-emojis');
+
+  await customElements.whenDefined('wa-rating');
+  await rating.updateComplete;
+
+  rating.getSymbol = (value, isSelected) => {
+    const icons = ['face-angry', 'face-frown', 'face-meh', 'face-smile', 'face-laugh'];
+    return `<wa-icon name="${icons[value - 1]}"></wa-icon>`;
+  };
+</script>
+```
+
 ### Detecting Hover
 
-Use the `wa-hover` event to detect when the user hovers over (or touch and drag) the rating. This lets you hook into values as the user interacts with the rating, but before they select a value.
+Use the `wa-hover` event to react as the user hovers over (or touches and drags across) the rating, before they commit to a value.
 
-The event has a payload with `phase` and `value` properties. The `phase` property tells when hovering starts, moves to a new value, and ends. The `value` property tells what the rating's value would be if the user were to commit to the hovered value.
+The event's `detail` carries `phase` and `value`. The `phase` property reports when hovering starts, moves to a new value, and ends. The `value` property is what the rating would become if the user committed to the hovered symbol.
 
 ```html {.example}
 <div class="detect-hover">
@@ -126,46 +165,9 @@ The event has a payload with `phase` and `value` properties. The `phase` propert
 </style>
 ```
 
-### Custom Icons
-
-You can provide custom icons by passing a function to the `getSymbol` property.
-
-```html {.example}
-<wa-rating label="Rating" class="rating-hearts" style="--symbol-color-active: #ff4136;"></wa-rating>
-
-<script type="module">
-  const rating = document.querySelector('.rating-hearts');
-
-  await customElements.whenDefined('wa-rating');
-  await rating.updateComplete;
-
-  rating.getSymbol = () => '<wa-icon name="heart" variant="solid"></wa-icon>';
-</script>
-```
-
-### Value-Based Icons
-
-You can also use the `getSymbol` property to render different icons based on value and/or whether the icon is currently selected.
-
-```html {.example}
-<wa-rating label="Rating" class="rating-emojis"></wa-rating>
-
-<script type="module">
-  const rating = document.querySelector('.rating-emojis');
-
-  await customElements.whenDefined('wa-rating');
-  await rating.updateComplete;
-
-  rating.getSymbol = (value, isSelected) => {
-    const icons = ['face-angry', 'face-frown', 'face-meh', 'face-smile', 'face-laugh'];
-    return `<wa-icon name="${icons[value - 1]}"></wa-icon>`;
-  };
-</script>
-```
-
 ### Required
 
-Use the `required` attribute to make the rating mandatory. The form will not submit if the user hasn't selected a value.
+Use the `required` attribute to make the rating mandatory. The form won't submit until the user selects a value.
 
 ```html {.example}
 <form class="rating-required">
@@ -188,7 +190,7 @@ Use the `required` attribute to make the rating mandatory. The form will not sub
 
 ### Custom Validity
 
-Use the `setCustomValidity()` method to set a custom validation message. This will prevent the form from submitting and make the browser display the error message you provide. To clear the error, call this function with an empty string.
+Use the `setCustomValidity()` method to set a custom validation message. This prevents the form from submitting and makes the browser display your message. Pass an empty string to clear the error.
 
 ```html {.example}
 <form class="rating-custom-validity">
@@ -222,12 +224,11 @@ Use the `setCustomValidity()` method to set a custom validation message. This wi
 
 ### Form Submission
 
-Ratings can be used in forms just like native form controls. The rating's `name` and `value` will be included in the form data when submitted.
+Ratings work in forms just like native form controls. The rating's `name` and `value` are included in the form data on submit.
 
 ```html {.example}
 <form class="rating-form-submission" action="about:blank" method="get" target="_blank">
-  <label style="display: block; margin-bottom: 0.5rem;">How would you rate your experience?</label>
-  <wa-rating name="rating" label="Rating" required></wa-rating>
+  <wa-rating name="rating" label="How would you rate your experience?" required></wa-rating>
   <br /><br />
   <wa-button type="submit">Submit</wa-button>
   <wa-button appearance="filled" type="reset" variant="neutral">Reset</wa-button>

--- a/packages/webawesome/docs/docs/components/rating.md
+++ b/packages/webawesome/docs/docs/components/rating.md
@@ -23,7 +23,7 @@ This component works with standard `<form>` elements. See [form controls](/docs/
 
 ## Examples
 
-### Labels
+### Label
 
 Ratings are usually identified by context, so the label isn't displayed. Always provide one with the `label` attribute so assistive devices can announce the control.
 
@@ -47,7 +47,7 @@ Use the `readonly` attribute to display a rating that users can't change. Unlike
 <wa-rating label="Rating" readonly value="3"></wa-rating>
 ```
 
-### Sizes
+### Size
 
 Use the `size` attribute to change the rating's size.
 

--- a/packages/webawesome/docs/docs/components/select.md
+++ b/packages/webawesome/docs/docs/components/select.md
@@ -16,18 +16,17 @@ use-cases:
 ---
 
 ```html {.example}
-<wa-select>
-  <wa-option value="">Option 1</wa-option>
-  <wa-option value="option-2">Option 2</wa-option>
-  <wa-option value="option-3">Option 3</wa-option>
-  <wa-option value="option-4">Option 4</wa-option>
-  <wa-option value="option-5">Option 5</wa-option>
-  <wa-option value="option-6">Option 6</wa-option>
+<wa-select label="Coffee order" placeholder="How do you take it?">
+  <wa-option value="espresso">Espresso</wa-option>
+  <wa-option value="latte">Latte</wa-option>
+  <wa-option value="cappuccino">Cappuccino</wa-option>
+  <wa-option value="cold-brew">Cold brew</wa-option>
+  <wa-option value="drip">Drip</wa-option>
 </wa-select>
 ```
 
 :::info
-This component works with standard `<form>` elements. Please refer to the section on [form controls](/docs/form-controls) to learn more about form submission and client-side validation.
+This component works with standard `<form>` elements. See [form controls](/docs/form-controls) for form submission and client-side validation.
 :::
 
 ## Examples
@@ -37,19 +36,19 @@ This component works with standard `<form>` elements. Please refer to the sectio
 Use the `label` attribute to give the select an accessible label. For labels that contain HTML, use the `label` slot instead.
 
 ```html {.example}
-<wa-select label="Select one">
-  <wa-option value="option-1">Option 1</wa-option>
-  <wa-option value="option-2">Option 2</wa-option>
-  <wa-option value="option-3">Option 3</wa-option>
+<wa-select label="Country">
+  <wa-option value="us">United States</wa-option>
+  <wa-option value="ca">Canada</wa-option>
+  <wa-option value="mx">Mexico</wa-option>
 </wa-select>
 ```
 
 ### Hint
 
-Add descriptive hint to a select with the `hint` attribute. For hints that contain HTML, use the `hint` slot instead.
+Add a descriptive hint with the `hint` attribute. For hints that contain HTML, use the `hint` slot instead.
 
 ```html {.example}
-<wa-select label="Experience" hint="Please tell us your skill level.">
+<wa-select label="Experience" hint="Tell us how comfortable you are with the command line.">
   <wa-option value="1">Novice</wa-option>
   <wa-option value="2">Intermediate</wa-option>
   <wa-option value="3">Advanced</wa-option>
@@ -58,7 +57,7 @@ Add descriptive hint to a select with the `hint` attribute. For hints that conta
 
 ### Placeholders
 
-Use the `placeholder` attribute to add a placeholder.
+Use the `placeholder` attribute to show prompt text before a selection is made.
 
 ```html {.example}
 <wa-select placeholder="Select one">
@@ -68,52 +67,63 @@ Use the `placeholder` attribute to add a placeholder.
 </wa-select>
 ```
 
-### Clearable
-
-Use the `with-clear` attribute to make the control clearable. The clear button only appears when an option is selected.
-
-```html {.example}
-<wa-select with-clear value="option-1">
-  <wa-option value="option-1">Option 1</wa-option>
-  <wa-option value="option-2">Option 2</wa-option>
-  <wa-option value="option-3">Option 3</wa-option>
-</wa-select>
-```
-
 ### Appearance
 
-Use the `appearance` attribute to change the select's visual appearance.
+Use the `appearance` attribute to change the select's visual style.
 
 ```html {.example}
-<wa-select appearance="filled">
-  <wa-option value="option-1">Option 1</wa-option>
-  <wa-option value="option-2">Option 2</wa-option>
-  <wa-option value="option-3">Option 3</wa-option>
-</wa-select>
-<br />
-<wa-select appearance="filled-outlined">
-  <wa-option value="option-1">Option 1</wa-option>
-  <wa-option value="option-2">Option 2</wa-option>
-  <wa-option value="option-3">Option 3</wa-option>
-</wa-select>
-<br />
-<wa-select appearance="outlined">
-  <wa-option value="option-1">Option 1</wa-option>
-  <wa-option value="option-2">Option 2</wa-option>
-  <wa-option value="option-3">Option 3</wa-option>
-</wa-select>
+<div class="wa-stack">
+  <wa-select appearance="outlined" value="outlined">
+    <wa-option value="outlined">outlined</wa-option>
+  </wa-select>
+  <wa-select appearance="filled" value="filled">
+    <wa-option value="filled">filled</wa-option>
+  </wa-select>
+  <wa-select appearance="filled-outlined" value="filled-outlined">
+    <wa-option value="filled-outlined">filled-outlined</wa-option>
+  </wa-select>
+</div>
 ```
 
 ### Pill
 
-Use the `pill` attribute to give selects rounded edges.
+Use the `pill` attribute to give the select rounded edges.
 
 ```html {.example}
-<wa-select pill>
+<wa-select pill placeholder="Select one">
   <wa-option value="option-1">Option 1</wa-option>
   <wa-option value="option-2">Option 2</wa-option>
   <wa-option value="option-3">Option 3</wa-option>
 </wa-select>
+```
+
+### Sizes
+
+Use the `size` attribute to change a select's size.
+
+```html {.example}
+<div class="wa-stack">
+  <wa-select size="xs" placeholder="Extra small">
+    <wa-option value="option-1">Option 1</wa-option>
+    <wa-option value="option-2">Option 2</wa-option>
+  </wa-select>
+  <wa-select size="s" placeholder="Small">
+    <wa-option value="option-1">Option 1</wa-option>
+    <wa-option value="option-2">Option 2</wa-option>
+  </wa-select>
+  <wa-select size="m" placeholder="Medium">
+    <wa-option value="option-1">Option 1</wa-option>
+    <wa-option value="option-2">Option 2</wa-option>
+  </wa-select>
+  <wa-select size="l" placeholder="Large">
+    <wa-option value="option-1">Option 1</wa-option>
+    <wa-option value="option-2">Option 2</wa-option>
+  </wa-select>
+  <wa-select size="xl" placeholder="Extra large">
+    <wa-option value="option-1">Option 1</wa-option>
+    <wa-option value="option-2">Option 2</wa-option>
+  </wa-select>
+</div>
 ```
 
 ### Disabled
@@ -128,46 +138,46 @@ Use the `disabled` attribute to disable a select.
 </wa-select>
 ```
 
-### Multiple
+### Clearable
 
-To allow multiple options to be selected, use the `multiple` attribute. It's a good practice to use `with-clear` when this option is enabled. You can select multiple options by adding the `selected` attribute to individual options.
+Use the `with-clear` attribute to let people reset their choice. The clear button only appears once an option is selected.
 
 ```html {.example}
-<wa-select label="Select a Few" multiple with-clear>
-  <wa-option value="option-1" selected>Option 1</wa-option>
-  <wa-option value="option-2" selected>Option 2</wa-option>
-  <wa-option value="option-3" selected>Option 3</wa-option>
-  <wa-option value="option-4">Option 4</wa-option>
-  <wa-option value="option-5">Option 5</wa-option>
-  <wa-option value="option-6">Option 6</wa-option>
+<wa-select with-clear value="option-1">
+  <wa-option value="option-1">Option 1</wa-option>
+  <wa-option value="option-2">Option 2</wa-option>
+  <wa-option value="option-3">Option 3</wa-option>
+</wa-select>
+```
+
+### Multiple
+
+To let people choose more than one option, add the `multiple` attribute. Pair it with `with-clear` so a long selection is easy to reset. Mark the initial selection with the `selected` attribute on individual options.
+
+```html {.example}
+<wa-select label="Notify me about" multiple with-clear>
+  <wa-option value="mentions" selected>Mentions</wa-option>
+  <wa-option value="replies" selected>Replies</wa-option>
+  <wa-option value="reactions">Reactions</wa-option>
+  <wa-option value="follows">New followers</wa-option>
+  <wa-option value="releases">Releases</wa-option>
 </wa-select>
 ```
 
 :::info
-Selecting multiple options may result in wrapping, causing the control to expand vertically. You can use the `max-options-visible` attribute to control the maximum number of selected options to show at once.
+<strong>Multiple selections can grow the control vertically.</strong><br />
+Use the `max-options-visible` attribute to cap how many tags show at once before the rest collapse into a count.
 :::
 
 ### Setting Initial Values
 
-Use the `selected` attribute on individual options to set the initial selection, similar to native HTML.
+Use the `selected` attribute on individual options to set the initial selection, just like native HTML. For a multiple select, mark every option that should start selected.
 
 ```html {.example}
-<wa-select>
-  <wa-option value="option-1" selected>Option 1</wa-option>
-  <wa-option value="option-2">Option 2</wa-option>
-  <wa-option value="option-3">Option 3</wa-option>
-  <wa-option value="option-4">Option 4</wa-option>
-</wa-select>
-```
-
-For multiple selections, apply it to all selected options.
-
-```html {.example}
-<wa-select multiple with-clear>
-  <wa-option value="option-1" selected>Option 1</wa-option>
-  <wa-option value="option-2" selected>Option 2</wa-option>
-  <wa-option value="option-3">Option 3</wa-option>
-  <wa-option value="option-4">Option 4</wa-option>
+<wa-select label="Default branch">
+  <wa-option value="main" selected>main</wa-option>
+  <wa-option value="develop">develop</wa-option>
+  <wa-option value="staging">staging</wa-option>
 </wa-select>
 ```
 
@@ -177,72 +187,27 @@ Framework users can bind directly to the `value` property for reactive data bind
 
 ### Grouping Options
 
-Use `<wa-divider>` to group listbox items visually. You can also use `<small>` to provide labels, but they won't be announced by most assistive devices.
+Use `<wa-divider>` to separate groups of options visually. You can also add `<small>` labels, but note that most assistive technologies won't announce them.
 
 ```html {.example}
-<wa-select>
-  <small>Section 1</small>
-  <wa-option value="option-1">Option 1</wa-option>
-  <wa-option value="option-2">Option 2</wa-option>
-  <wa-option value="option-3">Option 3</wa-option>
+<wa-select label="Add a language" placeholder="Select one">
+  <small>Frontend</small>
+  <wa-option value="ts">TypeScript</wa-option>
+  <wa-option value="css">CSS</wa-option>
   <wa-divider></wa-divider>
-  <small>Section 2</small>
-  <wa-option value="option-4">Option 4</wa-option>
-  <wa-option value="option-5">Option 5</wa-option>
-  <wa-option value="option-6">Option 6</wa-option>
-</wa-select>
-```
-
-### Sizes
-
-Use the `size` attribute to change a select's size.
-
-```html {.example}
-<wa-select placeholder="Extra Small" size="xs">
-  <wa-option value="option-1">Option 1</wa-option>
-  <wa-option value="option-2">Option 2</wa-option>
-  <wa-option value="option-3">Option 3</wa-option>
-</wa-select>
-
-<br />
-
-<wa-select placeholder="Small" size="s">
-  <wa-option value="option-1">Option 1</wa-option>
-  <wa-option value="option-2">Option 2</wa-option>
-  <wa-option value="option-3">Option 3</wa-option>
-</wa-select>
-
-<br />
-
-<wa-select placeholder="Medium" size="m">
-  <wa-option value="option-1">Option 1</wa-option>
-  <wa-option value="option-2">Option 2</wa-option>
-  <wa-option value="option-3">Option 3</wa-option>
-</wa-select>
-
-<br />
-
-<wa-select placeholder="Large" size="l">
-  <wa-option value="option-1">Option 1</wa-option>
-  <wa-option value="option-2">Option 2</wa-option>
-  <wa-option value="option-3">Option 3</wa-option>
-</wa-select>
-
-<br />
-
-<wa-select placeholder="Extra Large" size="xl">
-  <wa-option value="option-1">Option 1</wa-option>
-  <wa-option value="option-2">Option 2</wa-option>
-  <wa-option value="option-3">Option 3</wa-option>
+  <small>Backend</small>
+  <wa-option value="go">Go</wa-option>
+  <wa-option value="rust">Rust</wa-option>
+  <wa-option value="python">Python</wa-option>
 </wa-select>
 ```
 
 ### Placement
 
-The preferred placement of the select's listbox can be set with the `placement` attribute. Note that the actual position may vary to ensure the panel remains in the viewport. Valid placements are `top` and `bottom`.
+Set the `placement` attribute to control where the listbox opens. Valid placements are `bottom` (default) and `top`; the actual position may flip to keep the panel in the viewport.
 
 ```html {.example}
-<wa-select placement="top">
+<wa-select placement="top" placeholder="Opens upward">
   <wa-option value="option-1">Option 1</wa-option>
   <wa-option value="option-2">Option 2</wa-option>
   <wa-option value="option-3">Option 3</wa-option>
@@ -251,55 +216,22 @@ The preferred placement of the select's listbox can be set with the `placement` 
 
 ### Start & End Decorations
 
-Use the `start` and `end` slots to add presentational elements like `<wa-icon>` within the combobox.
+Use the `start` and `end` slots to add presentational elements such as `<wa-icon>` inside the combobox.
 
 ```html {.example}
-<wa-select placeholder="Extra Small" size="xs" with-clear>
-  <wa-icon slot="start" name="house" variant="solid"></wa-icon>
-  <wa-icon slot="end" name="flag-checkered"></wa-icon>
-  <wa-option value="option-1">Option 1</wa-option>
-  <wa-option value="option-2">Option 2</wa-option>
-  <wa-option value="option-3">Option 3</wa-option>
-</wa-select>
-<br />
-<wa-select placeholder="Small" size="s" with-clear>
-  <wa-icon slot="start" name="house" variant="solid"></wa-icon>
-  <wa-icon slot="end" name="flag-checkered"></wa-icon>
-  <wa-option value="option-1">Option 1</wa-option>
-  <wa-option value="option-2">Option 2</wa-option>
-  <wa-option value="option-3">Option 3</wa-option>
-</wa-select>
-<br />
-<wa-select placeholder="Medium" size="m" with-clear>
-  <wa-icon slot="start" name="house" variant="solid"></wa-icon>
-  <wa-icon slot="end" name="flag-checkered"></wa-icon>
-  <wa-option value="option-1">Option 1</wa-option>
-  <wa-option value="option-2">Option 2</wa-option>
-  <wa-option value="option-3">Option 3</wa-option>
-</wa-select>
-<br />
-<wa-select placeholder="Large" size="l" with-clear>
-  <wa-icon slot="start" name="house" variant="solid"></wa-icon>
-  <wa-icon slot="end" name="flag-checkered"></wa-icon>
-  <wa-option value="option-1">Option 1</wa-option>
-  <wa-option value="option-2">Option 2</wa-option>
-  <wa-option value="option-3">Option 3</wa-option>
-</wa-select>
-<br />
-<wa-select placeholder="Extra Large" size="xl" with-clear>
-  <wa-icon slot="start" name="house" variant="solid"></wa-icon>
-  <wa-icon slot="end" name="flag-checkered"></wa-icon>
-  <wa-option value="option-1">Option 1</wa-option>
-  <wa-option value="option-2">Option 2</wa-option>
-  <wa-option value="option-3">Option 3</wa-option>
+<wa-select label="Destination" placeholder="Where to?" with-clear>
+  <wa-icon slot="start" name="plane-departure" variant="solid"></wa-icon>
+  <wa-option value="lax">Los Angeles</wa-option>
+  <wa-option value="jfk">New York</wa-option>
+  <wa-option value="nrt">Tokyo</wa-option>
 </wa-select>
 ```
 
 ### Custom Tags
 
-When multiple options can be selected, you can provide custom tags by passing a function to the `getTag` property. Your function can return a string of HTML, a [Lit Template](https://lit.dev/docs/templates/overview/), or an [`HTMLElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement). The `getTag()` function will be called for each option. The first argument is an `<wa-option>` element and the second argument is the tag's index (its position in the tag list).
+When multiple options can be selected, supply custom tags by passing a function to the `getTag` property. The function runs for each selected option and can return a string of HTML, a [Lit template](https://lit.dev/docs/templates/overview/), or an [`HTMLElement`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement). Its first argument is the `<wa-option>` element and its second is the tag's index.
 
-Remember that custom tags are rendered in a shadow root. To style them, you can use the `style` attribute in your template or you can add your own [parts](/docs/usage/#css-parts) and target them with the [`::part()`](https://developer.mozilla.org/en-US/docs/Web/CSS/::part) selector.
+Because custom tags render in a shadow root, style them with the `style` attribute in your template, or add your own [parts](/docs/usage/#css-parts) and target them with [`::part()`](https://developer.mozilla.org/en-US/docs/Web/CSS/::part).
 
 ```html {.example}
 <wa-select placeholder="Select one" multiple with-clear class="custom-tag">
@@ -323,11 +255,11 @@ Remember that custom tags are rendered in a shadow root. To style them, you can 
   await select.updateComplete;
 
   select.getTag = (option, index) => {
-    // Use the same icon used in wa-option
+    // Reuse the icon from the matching wa-option
     const name = option.querySelector('wa-icon[slot="start"]').name;
 
-    // You can return a string, a Lit Template, or an HTMLElement here
-    // Important: include data-value so the tag can be removed properly!
+    // Return a string, a Lit Template, or an HTMLElement.
+    // Include data-value so the tag can be removed properly.
     return `
       <wa-tag with-remove data-value="${option.value}">
         <wa-icon name="${name}"></wa-icon>
@@ -339,24 +271,20 @@ Remember that custom tags are rendered in a shadow root. To style them, you can 
 ```
 
 :::warning
-Be sure you trust the content you are outputting! Passing unsanitized user input to `getTag()` can result in XSS vulnerabilities.
+<strong>Only pass content you trust to `getTag()`.</strong><br />
+Unsanitized user input rendered into a tag can result in XSS vulnerabilities.
 :::
 
 :::info
-When using custom tags with `with-remove`, you must include the `data-value` attribute set to the option's value. This allows the select to identify which option to deselect when the tag's remove button is clicked.
+When using custom tags with `with-remove`, include the `data-value` attribute set to the option's value so the select knows which option to deselect when the tag's remove button is clicked.
 :::
 
 ### Lazy Loading Options
 
-Lazy loading options works similarly to native `<select>` elements. The select component handles various scenarios intelligently:
+The select handles options that arrive after the initial render, similar to a native `<select>`:
 
-#### Basic Lazy Loading Scenarios
-
-- **Empty select with value**: If a `<wa-select>` is created without any options but given a `value` attribute, its value will be `""` initially. When options are added later, if any option has a value matching the select's value attribute, the select's value will update to match.
-
-- **Multiple select with partial options**: If a `<wa-select multiple>` has an initial value with multiple options, but only some options are present in the DOM, it will respect only the available options. When additional selected options are loaded later (and the user hasn't changed the selection), those options will be automatically added to the selection.
-
-Here's a comprehensive example showing different lazy loading scenarios:
+- **Empty select with a value:** a `<wa-select>` created without options but given a `value` starts with an empty value. When an option whose value matches is added later, the select updates to match.
+- **Multiple select with partial options:** a `<wa-select multiple>` with an initial value respects only the options present in the DOM. When the remaining selected options load later — and the user hasn't changed the selection — they're added automatically.
 
 ```html {.example}
 <form id="lazy-options-example">
@@ -384,7 +312,7 @@ Here's a comprehensive example showing different lazy loading scenarios:
   <br />
 
   <div>
-    <wa-select name="select-3" multiple label="Multiple Select (with existing selected options)">
+    <wa-select name="select-3" multiple label="Multiple select (with existing selected options)">
       <wa-option value="bar" selected>Bar</wa-option>
       <wa-option value="baz" selected>Baz</wa-option>
     </wa-select>
@@ -397,7 +325,7 @@ Here's a comprehensive example showing different lazy loading scenarios:
   <br />
 
   <div>
-    <wa-select name="select-4" value="foo" multiple label="Multiple Select (with no existing options)"> </wa-select>
+    <wa-select name="select-4" value="foo" multiple label="Multiple select (with no existing options)"> </wa-select>
 
     <wa-divider></wa-divider>
 
@@ -468,6 +396,4 @@ Here's a comprehensive example showing different lazy loading scenarios:
 </script>
 ```
 
-:::info
-The key principle is that the select component prioritizes user interactions and explicit selections over programmatic changes, ensuring a predictable user experience even with dynamically loaded content.
-:::
+Throughout, the select prioritizes user interactions and explicit selections over programmatic changes, keeping behavior predictable even with dynamically loaded content.

--- a/packages/webawesome/docs/docs/components/select.md
+++ b/packages/webawesome/docs/docs/components/select.md
@@ -171,7 +171,7 @@ Use the `max-options-visible` attribute to cap how many tags show at once before
 
 ### Setting Initial Values
 
-Use the `selected` attribute on individual options to set the initial selection, just like native HTML. For a multiple select, mark every option that should start selected.
+Use the `selected` attribute on individual options to set the initial selection, just like native HTML.
 
 ```html {.example}
 <wa-select label="Default branch">

--- a/packages/webawesome/docs/docs/components/select.md
+++ b/packages/webawesome/docs/docs/components/select.md
@@ -31,7 +31,7 @@ This component works with standard `<form>` elements. See [form controls](/docs/
 
 ## Examples
 
-### Labels
+### Label
 
 Use the `label` attribute to give the select an accessible label. For labels that contain HTML, use the `label` slot instead.
 
@@ -55,7 +55,7 @@ Add a descriptive hint with the `hint` attribute. For hints that contain HTML, u
 </wa-select>
 ```
 
-### Placeholders
+### Placeholder
 
 Use the `placeholder` attribute to show prompt text before a selection is made.
 
@@ -97,7 +97,7 @@ Use the `pill` attribute to give the select rounded edges.
 </wa-select>
 ```
 
-### Sizes
+### Size
 
 Use the `size` attribute to change a select's size.
 
@@ -169,7 +169,7 @@ To let people choose more than one option, add the `multiple` attribute. Pair it
 Use the `max-options-visible` attribute to cap how many tags show at once before the rest collapse into a count.
 :::
 
-### Setting Initial Values
+### Initial Value
 
 Use the `selected` attribute on individual options to set the initial selection, just like native HTML.
 

--- a/packages/webawesome/docs/docs/components/slider.md
+++ b/packages/webawesome/docs/docs/components/slider.md
@@ -31,7 +31,7 @@ use-cases:
 ```
 
 :::info
-This component works with standard `<form>` elements. Please refer to the section on [form controls](/docs/form-controls) to learn more about form submission and client-side validation.
+This component works with standard `<form>` elements. See [form controls](/docs/form-controls) for form submission and client-side validation.
 :::
 
 ## Examples
@@ -60,7 +60,7 @@ Use the `with-tooltip` attribute to display a tooltip with the current value whe
 <wa-slider label="Quality" name="quality" min="0" max="100" value="50" with-tooltip></wa-slider>
 ```
 
-### Setting Min, Max, & Step
+### Setting Min, Max & Step
 
 Use the `min` and `max` attributes to define the slider's range, and the `step` attribute to control the increment between values.
 
@@ -97,7 +97,8 @@ Use the `reference` slot to add contextual labels below the slider. References a
 ```
 
 :::info
-If you want to show a reference next to a specific marker, you can add `position: absolute` to it and set the `left`, `right`, `top`, or `bottom` property to a percentage that corresponds to the marker's position.
+<strong>Show a reference next to a specific marker.</strong><br />
+Add `position: absolute` to the reference and set `left`, `right`, `top`, or `bottom` to a percentage that matches the marker's position.
 :::
 
 ### Formatting the Value
@@ -250,16 +251,18 @@ Range sliders can also be vertical.
 </script>
 ```
 
-### Size
+### Sizes
 
-Control the slider's size using the `size` attribute. Valid options include `xs`, `s`, `m`, `l`, and `xl`.
+Control the slider's size with the `size` attribute. Valid options are `xs`, `s`, `m`, `l`, and `xl`.
 
 ```html {.example}
-<wa-slider size="xs" value="50" label="Extra Small"></wa-slider><br />
-<wa-slider size="s" value="50" label="Small"></wa-slider><br />
-<wa-slider size="m" value="50" label="Medium"></wa-slider><br />
-<wa-slider size="l" value="50" label="Large"></wa-slider><br />
-<wa-slider size="xl" value="50" label="Extra Large"></wa-slider>
+<div class="wa-stack">
+  <wa-slider size="xs" value="50" label="Extra small"></wa-slider>
+  <wa-slider size="s" value="50" label="Small"></wa-slider>
+  <wa-slider size="m" value="50" label="Medium"></wa-slider>
+  <wa-slider size="l" value="50" label="Large"></wa-slider>
+  <wa-slider size="xl" value="50" label="Extra large"></wa-slider>
+</div>
 ```
 
 ### Indicator Offset
@@ -290,4 +293,102 @@ Use the `disabled` attribute to disable a slider.
 
 ```html {.example}
 <wa-slider label="Disabled" value="50" disabled></wa-slider>
+```
+
+### Readonly
+
+Use the `readonly` attribute to show a value that users can't change by dragging. Unlike `disabled`, a readonly slider stays focusable and its value is still submitted with the form.
+
+```html {.example}
+<wa-slider label="Server load" value="72" min="0" max="100" with-tooltip readonly></wa-slider>
+```
+
+### Reacting to Input
+
+The slider emits an `input` event as the user drags, so you can drive live UI from its value in real time. Here, moving the slider resizes the preview text.
+
+```html {.example}
+<div class="text-size-demo">
+  <p class="text-size-preview">The quick brown fox jumps over the lazy dog.</p>
+
+  <wa-divider></wa-divider>
+
+  <wa-slider label="Text size" min="12" max="48" value="18" with-tooltip></wa-slider>
+</div>
+
+<script>
+  const demo = document.querySelector('.text-size-demo');
+  const slider = demo.querySelector('wa-slider');
+  const preview = demo.querySelector('.text-size-preview');
+
+  slider.addEventListener('input', () => {
+    preview.style.fontSize = `${slider.value}px`;
+  });
+</script>
+
+<style>
+  .text-size-demo .text-size-preview {
+    margin: 0 0 1rem;
+    font-size: 18px;
+    transition: font-size 75ms ease;
+  }
+</style>
+```
+
+### Filtering with a Range
+
+A range slider's two thumbs make it a natural filter control. Here, dragging the thumbs hides list items whose price falls outside the selected range.
+
+```html {.example}
+<div class="price-filter-demo">
+  <ul class="price-filter-list">
+    <li data-price="15">Sticker pack — $15</li>
+    <li data-price="30">T-shirt — $30</li>
+    <li data-price="55">Hoodie — $55</li>
+    <li data-price="80">Backpack — $80</li>
+    <li data-price="120">Jacket — $120</li>
+  </ul>
+
+  <wa-divider></wa-divider>
+
+  <wa-slider id="price-filter" label="Price range" range min="0" max="150" min-value="0" max-value="150" with-tooltip></wa-slider>
+</div>
+
+<script>
+  const demo = document.querySelector('.price-filter-demo');
+  const slider = demo.querySelector('wa-slider');
+  const items = demo.querySelectorAll('.price-filter-list li');
+  const currency = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 });
+
+  function filter() {
+    items.forEach(item => {
+      const price = Number(item.dataset.price);
+      item.hidden = price < slider.minValue || price > slider.maxValue;
+    });
+  }
+
+  customElements.whenDefined('wa-slider').then(() => {
+    slider.valueFormatter = value => currency.format(value);
+    slider.addEventListener('input', filter);
+    filter();
+  });
+</script>
+
+<style>
+  .price-filter-demo .price-filter-list {
+    list-style: none;
+    margin: 0 0 1rem;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    min-height: 13rem;
+  }
+
+  .price-filter-demo .price-filter-list li {
+    padding: 0.5rem 0.75rem;
+    border-radius: var(--wa-border-radius-m);
+    background-color: color-mix(in srgb, var(--wa-color-brand-fill-loud) 10%, transparent);
+  }
+</style>
 ```

--- a/packages/webawesome/docs/docs/components/slider.md
+++ b/packages/webawesome/docs/docs/components/slider.md
@@ -36,7 +36,7 @@ This component works with standard `<form>` elements. See [form controls](/docs/
 
 ## Examples
 
-### Labels
+### Label
 
 Use the `label` attribute to give the slider an accessible label. For labels that contain HTML, use the `label` slot instead.
 
@@ -52,20 +52,20 @@ Add descriptive hint to a slider with the `hint` attribute. For hints that conta
 <wa-slider label="Volume" hint="Controls the volume of the current song." min="0" max="100" value="50"></wa-slider>
 ```
 
-### Showing Tooltips
-
-Use the `with-tooltip` attribute to display a tooltip with the current value when the slider is focused or being dragged.
-
-```html {.example}
-<wa-slider label="Quality" name="quality" min="0" max="100" value="50" with-tooltip></wa-slider>
-```
-
-### Setting Min, Max & Step
+### Min, Max & Step
 
 Use the `min` and `max` attributes to define the slider's range, and the `step` attribute to control the increment between values.
 
 ```html {.example}
 <wa-slider label="Between zero and one" min="0" max="1" step="0.1" value="0.5" with-tooltip></wa-slider>
+```
+
+### Showing a Tooltip
+
+Use the `with-tooltip` attribute to display a tooltip with the current value when the slider is focused or being dragged.
+
+```html {.example}
+<wa-slider label="Quality" name="quality" min="0" max="100" value="50" with-tooltip></wa-slider>
 ```
 
 ### Showing Markers
@@ -100,64 +100,6 @@ Use the `reference` slot to add contextual labels below the slider. References a
 <strong>Show a reference next to a specific marker.</strong><br />
 Add `position: absolute` to the reference and set `left`, `right`, `top`, or `bottom` to a percentage that matches the marker's position.
 :::
-
-### Formatting the Value
-
-Customize how values are displayed in tooltips and announced to screen readers using the `valueFormatter` property. Set it to a function that accepts a number and returns a formatted string. The [`Intl.NumberFormat API`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat) is particularly useful for this.
-
-```html {.example}
-<!-- Percent -->
-<wa-slider
-  id="slider__percent"
-  label="Percentage"
-  name="percentage"
-  value="0.5"
-  min="0"
-  max="1"
-  step=".01"
-  with-tooltip
-></wa-slider
-><br />
-
-<script>
-  const slider = document.getElementById('slider__percent');
-  const formatter = new Intl.NumberFormat('en-US', { style: 'percent' });
-
-  customElements.whenDefined('wa-slider').then(() => {
-    slider.valueFormatter = value => formatter.format(value);
-  });
-</script>
-
-<!-- Duration -->
-<wa-slider id="slider__duration" label="Duration" name="duration" value="12" min="0" max="24" with-tooltip></wa-slider
-><br />
-
-<script>
-  const slider = document.getElementById('slider__duration');
-  const formatter = new Intl.NumberFormat('en-US', { style: 'unit', unit: 'hour', unitDisplay: 'long' });
-
-  customElements.whenDefined('wa-slider').then(() => {
-    slider.valueFormatter = value => formatter.format(value);
-  });
-</script>
-
-<!-- Currency -->
-<wa-slider id="slider__currency" label="Currency" name="currency" min="0" max="100" value="50" with-tooltip></wa-slider>
-
-<script>
-  const slider = document.getElementById('slider__currency');
-  const formatter = new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    currencyDisplay: 'symbol',
-    maximumFractionDigits: 0,
-  });
-
-  customElements.whenDefined('wa-slider').then(() => {
-    slider.valueFormatter = value => formatter.format(value);
-  });
-</script>
-```
 
 ### Range Selection
 
@@ -251,7 +193,7 @@ Range sliders can also be vertical.
 </script>
 ```
 
-### Sizes
+### Size
 
 Control the slider's size with the `size` attribute. Valid options are `xs`, `s`, `m`, `l`, and `xl`.
 
@@ -301,6 +243,64 @@ Use the `readonly` attribute to show a value that users can't change by dragging
 
 ```html {.example}
 <wa-slider label="Server load" value="72" min="0" max="100" with-tooltip readonly></wa-slider>
+```
+
+### Formatting the Value
+
+Customize how values are displayed in tooltips and announced to screen readers using the `valueFormatter` property. Set it to a function that accepts a number and returns a formatted string. The [`Intl.NumberFormat API`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat) is particularly useful for this.
+
+```html {.example}
+<!-- Percent -->
+<wa-slider
+  id="slider__percent"
+  label="Percentage"
+  name="percentage"
+  value="0.5"
+  min="0"
+  max="1"
+  step=".01"
+  with-tooltip
+></wa-slider
+><br />
+
+<script>
+  const slider = document.getElementById('slider__percent');
+  const formatter = new Intl.NumberFormat('en-US', { style: 'percent' });
+
+  customElements.whenDefined('wa-slider').then(() => {
+    slider.valueFormatter = value => formatter.format(value);
+  });
+</script>
+
+<!-- Duration -->
+<wa-slider id="slider__duration" label="Duration" name="duration" value="12" min="0" max="24" with-tooltip></wa-slider
+><br />
+
+<script>
+  const slider = document.getElementById('slider__duration');
+  const formatter = new Intl.NumberFormat('en-US', { style: 'unit', unit: 'hour', unitDisplay: 'long' });
+
+  customElements.whenDefined('wa-slider').then(() => {
+    slider.valueFormatter = value => formatter.format(value);
+  });
+</script>
+
+<!-- Currency -->
+<wa-slider id="slider__currency" label="Currency" name="currency" min="0" max="100" value="50" with-tooltip></wa-slider>
+
+<script>
+  const slider = document.getElementById('slider__currency');
+  const formatter = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    currencyDisplay: 'symbol',
+    maximumFractionDigits: 0,
+  });
+
+  customElements.whenDefined('wa-slider').then(() => {
+    slider.valueFormatter = value => formatter.format(value);
+  });
+</script>
 ```
 
 ### Reacting to Input

--- a/packages/webawesome/docs/docs/components/switch.md
+++ b/packages/webawesome/docs/docs/components/switch.md
@@ -13,49 +13,21 @@ use-cases:
 ---
 
 ```html {.example}
-<wa-switch>Switch</wa-switch>
+<wa-switch>Enable notifications</wa-switch>
 ```
 
 :::info
-This component works with standard `<form>` elements. Please refer to the section on [form controls](/docs/form-controls) to learn more about form submission and client-side validation.
+This component works with standard `<form>` elements. See [form controls](/docs/form-controls) for form submission and client-side validation.
 :::
 
 ## Examples
 
-### Checked
+### Labels
 
-Use the `checked` attribute to activate the switch.
-
-```html {.example}
-<wa-switch checked>Checked</wa-switch>
-```
-
-:::info
-The `checked` attribute is the initial value and does not reflect changes, consistent with native checkboxes. To toggle the checked state with JavaScript, use the `checked` property instead. To target checked switches with CSS, use the `:state(checked)` selector.
-:::
-
-### Disabled
-
-Use the `disabled` attribute to disable the switch.
+Add label text as the switch's default content. For labels that contain HTML, slot the markup in directly.
 
 ```html {.example}
-<wa-switch disabled>Disabled</wa-switch>
-```
-
-### Sizes
-
-Use the `size` attribute to change a switch's size.
-
-```html {.example}
-<wa-switch size="xs">Extra Small</wa-switch>
-<br />
-<wa-switch size="s">Small</wa-switch>
-<br />
-<wa-switch size="m">Medium</wa-switch>
-<br />
-<wa-switch size="l">Large</wa-switch>
-<br />
-<wa-switch size="xl">Extra Large</wa-switch>
+<wa-switch>Subscribe to the newsletter</wa-switch>
 ```
 
 ### Hint
@@ -63,10 +35,45 @@ Use the `size` attribute to change a switch's size.
 Add descriptive hint to a switch with the `hint` attribute. For hints that contain HTML, use the `hint` slot instead.
 
 ```html {.example}
-<wa-switch hint="What should the user know about the switch?">Label</wa-switch>
+<wa-switch hint="You can change this at any time in settings.">Email me about new releases</wa-switch>
 ```
 
-### Custom Styles
+### Setting Initial Values
+
+Use the `checked` attribute to activate the switch.
+
+```html {.example}
+<wa-switch checked>Remember this device</wa-switch>
+```
+
+:::info
+<strong>`checked` sets the initial value, not the current state.</strong><br />
+Consistent with native checkboxes, it doesn't reflect later changes. To toggle the checked state with JavaScript, use the `checked` property instead. To target checked switches with CSS, use the `:state(checked)` selector.
+:::
+
+### Disabled
+
+Use the `disabled` attribute to disable the switch.
+
+```html {.example}
+<wa-switch disabled>Sync over cellular</wa-switch>
+```
+
+### Sizes
+
+Use the `size` attribute to change a switch's size.
+
+```html {.example}
+<div class="wa-stack">
+  <wa-switch size="xs">Extra Small</wa-switch>
+  <wa-switch size="s">Small</wa-switch>
+  <wa-switch size="m">Medium</wa-switch>
+  <wa-switch size="l">Large</wa-switch>
+  <wa-switch size="xl">Extra Large</wa-switch>
+</div>
+```
+
+### Custom Properties
 
 Use the available custom properties to change how the switch is styled.
 

--- a/packages/webawesome/docs/docs/components/switch.md
+++ b/packages/webawesome/docs/docs/components/switch.md
@@ -22,7 +22,7 @@ This component works with standard `<form>` elements. See [form controls](/docs/
 
 ## Examples
 
-### Labels
+### Label
 
 Add label text as the switch's default content. For labels that contain HTML, slot the markup in directly.
 
@@ -38,7 +38,7 @@ Add descriptive hint to a switch with the `hint` attribute. For hints that conta
 <wa-switch hint="You can change this at any time in settings.">Email me about new releases</wa-switch>
 ```
 
-### Setting Initial Values
+### Initial Value
 
 Use the `checked` attribute to activate the switch.
 
@@ -59,7 +59,7 @@ Use the `disabled` attribute to disable the switch.
 <wa-switch disabled>Sync over cellular</wa-switch>
 ```
 
-### Sizes
+### Size
 
 Use the `size` attribute to change a switch's size.
 

--- a/packages/webawesome/docs/docs/components/textarea.md
+++ b/packages/webawesome/docs/docs/components/textarea.md
@@ -14,11 +14,11 @@ use-cases:
 ---
 
 ```html {.example}
-<wa-textarea label="Type somethin', will ya"></wa-textarea>
+<wa-textarea label="Feedback"></wa-textarea>
 ```
 
 :::info
-This component works with standard `<form>` elements. Please refer to the section on [form controls](/docs/form-controls) to learn more about form submission and client-side validation.
+This component works with standard `<form>` elements. See [form controls](/docs/form-controls) for form submission and client-side validation.
 :::
 
 ## Examples
@@ -33,18 +33,10 @@ Use the `label` attribute to give the textarea an accessible label. For labels t
 
 ### Hint
 
-Add descriptive hint to a textarea with the `hint` attribute. For hints that contain HTML, use the `hint` slot instead.
+Add a descriptive hint to a textarea with the `hint` attribute. For hints that contain HTML, use the `hint` slot instead.
 
 ```html {.example}
-<wa-textarea label="Feedback" hint="Please tell us what you think."> </wa-textarea>
-```
-
-### Rows
-
-Use the `rows` attribute to change the number of text rows that get shown.
-
-```html {.example}
-<wa-textarea rows="2"></wa-textarea>
+<wa-textarea label="Feedback" hint="Please tell us what you think."></wa-textarea>
 ```
 
 ### Placeholders
@@ -52,7 +44,7 @@ Use the `rows` attribute to change the number of text rows that get shown.
 Use the `placeholder` attribute to add a placeholder.
 
 ```html {.example}
-<wa-textarea placeholder="Type something"></wa-textarea>
+<wa-textarea label="Comments" placeholder="Share your thoughts"></wa-textarea>
 ```
 
 ### Appearance
@@ -60,9 +52,11 @@ Use the `placeholder` attribute to add a placeholder.
 Use the `appearance` attribute to change the textarea's visual appearance.
 
 ```html {.example}
-<wa-textarea placeholder="Type something" appearance="filled"></wa-textarea><br />
-<wa-textarea placeholder="Type something" appearance="filled-outlined"></wa-textarea><br />
-<wa-textarea placeholder="Type something" appearance="outlined"></wa-textarea>
+<div class="wa-stack">
+  <wa-textarea appearance="outlined" placeholder="outlined"></wa-textarea>
+  <wa-textarea appearance="filled" placeholder="filled"></wa-textarea>
+  <wa-textarea appearance="filled-outlined" placeholder="filled-outlined"></wa-textarea>
+</div>
 ```
 
 ### Disabled
@@ -70,15 +64,15 @@ Use the `appearance` attribute to change the textarea's visual appearance.
 Use the `disabled` attribute to disable a textarea.
 
 ```html {.example}
-<wa-textarea placeholder="Textarea" disabled></wa-textarea>
+<wa-textarea placeholder="Disabled" disabled></wa-textarea>
 ```
 
-### Value
+### Readonly
 
-Use the `value` attribute to set an initial value.
+Use the `readonly` attribute to keep a value visible but uneditable. Unlike `disabled`, a readonly textarea stays focusable and its value is still submitted with the form.
 
 ```html {.example}
-<wa-textarea value="Write something awesome!"></wa-textarea>
+<wa-textarea label="Release notes" value="Fixed a handful of bugs and polished the edges." readonly></wa-textarea>
 ```
 
 ### Sizes
@@ -86,55 +80,61 @@ Use the `value` attribute to set an initial value.
 Use the `size` attribute to change a textarea's size.
 
 ```html {.example}
-<wa-textarea placeholder="Extra Small" size="xs"></wa-textarea>
-<br />
-<wa-textarea placeholder="Small" size="s"></wa-textarea>
-<br />
-<wa-textarea placeholder="Medium" size="m"></wa-textarea>
-<br />
-<wa-textarea placeholder="Large" size="l"></wa-textarea>
-<br />
-<wa-textarea placeholder="Extra Large" size="xl"></wa-textarea>
+<div class="wa-stack">
+  <wa-textarea size="xs" placeholder="Extra small"></wa-textarea>
+  <wa-textarea size="s" placeholder="Small"></wa-textarea>
+  <wa-textarea size="m" placeholder="Medium"></wa-textarea>
+  <wa-textarea size="l" placeholder="Large"></wa-textarea>
+  <wa-textarea size="xl" placeholder="Extra large"></wa-textarea>
+</div>
 ```
 
-### Prevent Resizing
+### Rows
 
-By default, textareas can be resized vertically by the user. To prevent resizing, set the `resize` attribute to `none`.
+Use the `rows` attribute to change the number of text rows that show by default.
 
 ```html {.example}
-<wa-textarea resize="none"></wa-textarea>
+<wa-textarea rows="2"></wa-textarea>
 ```
 
-### Expand with Content
+### Resize
 
-Textareas will automatically resize to expand to fit their content when `resize` is set to `auto`.
+Use the `resize` attribute to control how the user can resize the textarea.
 
-```html {.example}
-<wa-textarea resize="auto"></wa-textarea>
-```
+| Mode                 | Behavior                                       | Best for                              |
+| -------------------- | ---------------------------------------------- | ------------------------------------- |
+| `vertical` (default) | Drag the bottom edge to change the height      | Most multi-line fields                |
+| `none`               | Resizing is disabled                           | Fixed layouts where height must hold  |
+| `horizontal`         | Drag the side edge to change the width         | Adjusting line length                 |
+| `both`               | Drag the corner to change width and height     | Free-form editing                     |
+| `auto`               | Grows to fit its content as the user types     | Inputs whose length varies a lot      |
 
-### Resize Horizontal
-
-Textareas can be made to resize horizontally when `resize` is set to `"horizontal"`
-
-```html {.example}
-<wa-textarea resize="horizontal"></wa-textarea>
-```
-
-### Resize Both
-
-Textareas can be made to resize both vertically and horizontally when `resize` is set to `"both"`
+Set `resize` to `auto` and the textarea grows to fit its content as the user types.
 
 ```html {.example}
-<wa-textarea resize="both"></wa-textarea>
+<wa-textarea label="Comments" resize="auto"></wa-textarea>
 ```
 
 ### Character Count
 
-Add the `with-count` attribute to show a character count below the textarea. When combined with `maxlength`, the count shows remaining characters instead. The count is exposed to assistive technologies using a live region so screen readers can announce updates as the user types.
+Add the `with-count` attribute to show a character count below the textarea. When combined with `maxlength`, the count shows remaining characters instead.
 
 ```html {.example}
-<wa-textarea label="Comments" hint="Share your thoughts with us" with-count></wa-textarea>
-<br />
-<wa-textarea label="Bio" hint="Tell us a little about yourself" with-count maxlength="100"></wa-textarea>
+<div class="wa-stack">
+  <wa-textarea label="Comments" hint="Share your thoughts with us" with-count></wa-textarea>
+  <wa-textarea label="Bio" hint="Tell us a little about yourself" with-count maxlength="100"></wa-textarea>
+</div>
+```
+
+:::info
+<strong>The character count is announced to screen readers.</strong><br />
+It's exposed through a live region so assistive technologies announce updates as the user types.
+:::
+
+### Setting Initial Values
+
+Use the `value` attribute to set an initial value.
+
+```html {.example}
+<wa-textarea value="Write something awesome!"></wa-textarea>
 ```

--- a/packages/webawesome/docs/docs/components/textarea.md
+++ b/packages/webawesome/docs/docs/components/textarea.md
@@ -101,13 +101,19 @@ Use the `rows` attribute to change the number of text rows that show by default.
 
 Use the `resize` attribute to control how the user can resize the textarea.
 
-| Mode                 | Behavior                                       | Best for                              |
-| -------------------- | ---------------------------------------------- | ------------------------------------- |
-| `vertical` (default) | Drag the bottom edge to change the height      | Most multi-line fields                |
-| `none`               | Resizing is disabled                           | Fixed layouts where height must hold  |
-| `horizontal`         | Drag the side edge to change the width         | Adjusting line length                 |
-| `both`               | Drag the corner to change width and height     | Free-form editing                     |
-| `auto`               | Grows to fit its content as the user types     | Inputs whose length varies a lot      |
+| Mode                 | Behavior                                   | Best for                             |
+| -------------------- | ------------------------------------------ | ------------------------------------ |
+| `vertical` (default) | Drag the bottom edge to change the height  | Most multi-line fields               |
+| `none`               | Resizing is disabled                       | Fixed layouts where height must hold |
+| `horizontal`         | Drag the side edge to change the width     | Adjusting line length                |
+| `both`               | Drag the corner to change width and height | Free-form editing                    |
+| `auto`               | Grows to fit its content as the user types | Inputs whose length varies a lot     |
+
+The default, `vertical`, lets the user drag the bottom edge to resize the field.
+
+```html {.example}
+<wa-textarea label="Feedback" resize="vertical"></wa-textarea>
+```
 
 Set `resize` to `auto` and the textarea grows to fit its content as the user types.
 

--- a/packages/webawesome/docs/docs/components/textarea.md
+++ b/packages/webawesome/docs/docs/components/textarea.md
@@ -23,7 +23,7 @@ This component works with standard `<form>` elements. See [form controls](/docs/
 
 ## Examples
 
-### Labels
+### Label
 
 Use the `label` attribute to give the textarea an accessible label. For labels that contain HTML, use the `label` slot instead.
 
@@ -39,7 +39,7 @@ Add a descriptive hint to a textarea with the `hint` attribute. For hints that c
 <wa-textarea label="Feedback" hint="Please tell us what you think."></wa-textarea>
 ```
 
-### Placeholders
+### Placeholder
 
 Use the `placeholder` attribute to add a placeholder.
 
@@ -75,7 +75,7 @@ Use the `readonly` attribute to keep a value visible but uneditable. Unlike `dis
 <wa-textarea label="Release notes" value="Fixed a handful of bugs and polished the edges." readonly></wa-textarea>
 ```
 
-### Sizes
+### Size
 
 Use the `size` attribute to change a textarea's size.
 
@@ -137,7 +137,7 @@ Add the `with-count` attribute to show a character count below the textarea. Whe
 It's exposed through a live region so assistive technologies announce updates as the user types.
 :::
 
-### Setting Initial Values
+### Initial Value
 
 Use the `value` attribute to set an initial value.
 

--- a/packages/webawesome/docs/docs/components/time-input.md
+++ b/packages/webawesome/docs/docs/components/time-input.md
@@ -26,17 +26,20 @@ Type digits to fill the focused segment (focus auto-advances when a segment can 
 ```
 
 :::info
-The submitted form value matches HTML `<input type="time">`: `HH:mm` for whole-minute steps, `HH:mm:ss` when seconds are shown (`step` < 60). The wire value is always 24-hour even when the UI is 12-hour. The displayed text follows the user's locale, inherited from the `lang` attribute on the host or an ancestor.
+<strong>The submitted value is always canonical 24-hour.</strong><br />
+It matches HTML `<input type="time">`: `HH:mm` for whole-minute steps, `HH:mm:ss` when seconds are shown (`step` < 60), even when the UI is 12-hour. The displayed text follows the user's locale, inherited from the `lang` attribute on the host or an ancestor.
 :::
 
 ## Form Submission
 
 The hidden form value is canonical 24-hour time, regardless of the user's locale or `hour-format`:
 
-- **Whole-minute steps** (default `step="60"` or any multiple of 60): `HH:mm` (e.g., `14:30`).
-- **Sub-minute steps** (`step` < 60, seconds segment shown): `HH:mm:ss` (e.g., `14:30:15`).
-- **12-hour UI**: still submits 24-hour on the wire, i.e. `2:30 PM` becomes `14:30`.
-- **Partial input**: the form value is empty until every required segment is filled.
+| Input | Form value | Notes |
+| --- | --- | --- |
+| Whole-minute steps (default) | `HH:mm` | `step="60"` or any multiple; e.g. `14:30` |
+| Sub-minute steps | `HH:mm:ss` | When `step` < 60 and the seconds segment shows; e.g. `14:30:15` |
+| 12-hour UI | 24-hour | `2:30 PM` submits as `14:30` |
+| Partial input | _(empty)_ | Until every required segment is filled |
 
 The example below renders a working form. Submit it (or change the time) and watch the console. The time input submits its value just like a native `<input type="time">`, regardless of how the user typed or what locale they used.
 
@@ -108,13 +111,14 @@ Add descriptive hint to a time input with the `hint` attribute. For hints that c
 Use the `start` and `end` slots to add presentational elements like `<wa-icon>` inside the input.
 
 ```html {.example}
-<wa-time-input label="Start">
-  <wa-icon name="hourglass-start" slot="start"></wa-icon>
-</wa-time-input>
-<br />
-<wa-time-input label="End">
-  <wa-icon name="hourglass-end" slot="end"></wa-icon>
-</wa-time-input>
+<div class="wa-stack">
+  <wa-time-input label="Start">
+    <wa-icon name="hourglass-start" slot="start"></wa-icon>
+  </wa-time-input>
+  <wa-time-input label="End">
+    <wa-icon name="hourglass-end" slot="end"></wa-icon>
+  </wa-time-input>
+</div>
 ```
 
 ### Required + Clear Button
@@ -142,9 +146,10 @@ Constrain the selectable range. The picker delegates reversed-range (overnight) 
 The `step` attribute is in **seconds**, matching the HTML spec. The default is `60` (one minute). Set `step` below `60` to expose a seconds segment; set it to a multiple of `60` to populate the minute column at that stride.
 
 ```html {.example}
-<wa-time-input label="Every 5 minutes" step="300"></wa-time-input>
-<br />
-<wa-time-input label="With seconds" step="1"></wa-time-input>
+<div class="wa-stack">
+  <wa-time-input label="Every 5 minutes" step="300"></wa-time-input>
+  <wa-time-input label="With seconds" step="1"></wa-time-input>
+</div>
 ```
 
 ### 12-Hour vs 24-Hour
@@ -152,9 +157,10 @@ The `step` attribute is in **seconds**, matching the HTML spec. The default is `
 By default, `hour-format="auto"` follows the resolved locale. Pass `hour-format="12"` or `hour-format="24"` to override.
 
 ```html {.example}
-<wa-time-input label="12-hour" hour-format="12" value="09:00"></wa-time-input>
-<br />
-<wa-time-input label="24-hour" hour-format="24" value="09:00"></wa-time-input>
+<div class="wa-stack">
+  <wa-time-input label="12-hour" hour-format="12" value="09:00"></wa-time-input>
+  <wa-time-input label="24-hour" hour-format="24" value="09:00"></wa-time-input>
+</div>
 ```
 
 ### Localized
@@ -162,11 +168,11 @@ By default, `hour-format="auto"` follows the resolved locale. Pass `hour-format=
 The segment order, separators, and AM/PM strings all derive from the page's locale. Set the `lang` attribute on the host (or an ancestor) to change locales.
 
 ```html {.example}
-<wa-time-input lang="en-US" label="English (US)" value="14:30"></wa-time-input>
-<br />
-<wa-time-input lang="en-GB" label="English (UK)" value="14:30"></wa-time-input>
-<br />
-<wa-time-input lang="de-DE" label="German" value="14:30"></wa-time-input>
+<div class="wa-stack">
+  <wa-time-input lang="en-US" label="English (US)" value="14:30"></wa-time-input>
+  <wa-time-input lang="en-GB" label="English (UK)" value="14:30"></wa-time-input>
+  <wa-time-input lang="de-DE" label="German" value="14:30"></wa-time-input>
+</div>
 ```
 
 ### "Now" Button
@@ -182,25 +188,25 @@ Add a quick-pick "Now" button in the popup footer with `with-now`.
 Use the `size` attribute to match the time input to surrounding form controls.
 
 ```html {.example}
-<wa-time-input size="xs" label="Extra small"></wa-time-input>
-<br />
-<wa-time-input size="s" label="Small"></wa-time-input>
-<br />
-<wa-time-input size="m" label="Medium"></wa-time-input>
-<br />
-<wa-time-input size="l" label="Large"></wa-time-input>
-<br />
-<wa-time-input size="xl" label="Extra large"></wa-time-input>
+<div class="wa-stack">
+  <wa-time-input size="xs" label="Extra small"></wa-time-input>
+  <wa-time-input size="s" label="Small"></wa-time-input>
+  <wa-time-input size="m" label="Medium"></wa-time-input>
+  <wa-time-input size="l" label="Large"></wa-time-input>
+  <wa-time-input size="xl" label="Extra large"></wa-time-input>
+</div>
 ```
 
-### Filled Appearance
+### Appearance
 
 Use the `appearance` attribute to switch between the default outlined input, a filled background, or a filled input with an outlined border.
 
 ```html {.example}
-<wa-time-input appearance="filled" label="Filled"></wa-time-input>
-<br />
-<wa-time-input appearance="filled-outlined" label="Filled outlined"></wa-time-input>
+<div class="wa-stack">
+  <wa-time-input appearance="outlined" label="Outlined"></wa-time-input>
+  <wa-time-input appearance="filled" label="Filled"></wa-time-input>
+  <wa-time-input appearance="filled-outlined" label="Filled outlined"></wa-time-input>
+</div>
 ```
 
 ### Pill
@@ -219,7 +225,7 @@ Use the `disabled` attribute to disable the time input entirely. Disabled time i
 <wa-time-input label="Disabled" value="09:00" disabled></wa-time-input>
 ```
 
-### Read-Only
+### Readonly
 
 Use the `readonly` attribute to make the time input non-editable while still allowing it to be focused and to submit its value with the form. The popup still opens for browsing.
 

--- a/packages/webawesome/docs/docs/components/time-input.md
+++ b/packages/webawesome/docs/docs/components/time-input.md
@@ -25,11 +25,6 @@ Type digits to fill the focused segment (focus auto-advances when a segment can 
 <wa-time-input label="Pick a time"></wa-time-input>
 ```
 
-:::info
-<strong>The submitted value is always canonical 24-hour.</strong><br />
-It matches HTML `<input type="time">`: `HH:mm` for whole-minute steps, `HH:mm:ss` when seconds are shown (`step` < 60), even when the UI is 12-hour. The displayed text follows the user's locale, inherited from the `lang` attribute on the host or an ancestor.
-:::
-
 ## Form Submission
 
 The hidden form value is canonical 24-hour time, regardless of the user's locale or `hour-format`:
@@ -90,7 +85,7 @@ Set the `value` attribute to a time string to pre-populate the input.
 <wa-time-input label="Meeting time" value="14:30"></wa-time-input>
 ```
 
-### Labels
+### Label
 
 Use the `label` attribute to give the time input an accessible label. For labels that contain HTML, use the `label` slot instead.
 
@@ -121,16 +116,12 @@ Use the `start` and `end` slots to add presentational elements like `<wa-icon>` 
 </div>
 ```
 
-### Required + Clear Button
+### Clearable
 
-Combine `required` with `with-clear` to enforce a value while still letting users wipe their selection in a single click.
+Add the `with-clear` attribute to let users wipe their selection in a single click. The clear button only appears once a value is set.
 
 ```html {.example}
-<form>
-  <wa-time-input name="alarm" label="Alarm" required with-clear></wa-time-input>
-  <br />
-  <wa-button type="submit" appearance="filled" variant="neutral">Submit</wa-button>
-</form>
+<wa-time-input label="Alarm" with-clear value="07:00"></wa-time-input>
 ```
 
 ### Min & Max
@@ -183,7 +174,7 @@ Add a quick-pick "Now" button in the popup footer with `with-now`.
 <wa-time-input label="When?" with-now></wa-time-input>
 ```
 
-### Sizes
+### Size
 
 Use the `size` attribute to match the time input to surrounding form controls.
 

--- a/packages/webawesome/src/components/slider/slider.ts
+++ b/packages/webawesome/src/components/slider/slider.ts
@@ -23,7 +23,7 @@ import styles from './slider.styles.js';
  * <wa-slider>
  *
  * @summary Sliders let users choose a numeric value within a defined range by dragging a thumb along a track.
- * @documentation https://webawesome.com/docs/components/range
+ * @documentation https://webawesome.com/docs/components/slider
  * @status stable
  * @since 2.0
  *


### PR DESCRIPTION
This work audits and improves the examples across all 13 free Forms component docs, bringing them in line with our [`.house-rules`](https://github.com/shoelace-style/webawesome-app/blob/main/.house-rules/HOUSE-RULES.md) docs conventions.

### Auditing Examples
Every page's examples were reworked for:
- clarity and consistency
- task-named sections
- enumerated attributes (`size`, `variant`, `appearance`) labeled by the value they show
- to order sections from simple → complex — plain attribute examples up top, event- and script-driven demos last. 
- Multi-part callouts now lead with the point in bold

### Adding Interactive Demos
A few interactive demos were added to show off the capabilities or common needs of specific components.

**`slider`**
- resizes preview text as you drag (`Reacting to Input`)
- filters a list by price range (`Filtering with a Range`) 

**`color-picker`**
- themes a preview card in real time (`Applying the Selected Color`)

### Bug Fix
- `slider.ts` — `@documentation` link now points at `/slider` (was `/range`)
