### PR TITLE
add transform-types hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7716,6 +7716,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/get-uri": {
       "version": "6.0.4",
       "dev": true,
@@ -10228,6 +10241,20 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/mylas": {
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/mylas/-/mylas-2.1.14.tgz",
+      "integrity": "sha512-BzQguy9W9NJgoVn2mRWzbFrFWWztGCcng2QI9+41frfk+Athwgx3qhqhvStz7ExeUUu7Kzw427sNzHpEZNINog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/raouldeheer"
+      }
+    },
     "node_modules/nanocolors": {
       "version": "0.2.13",
       "dev": true,
@@ -11157,6 +11184,19 @@
         "semver-compare": "^1.0.0"
       }
     },
+    "node_modules/plimit-lit": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.6.1.tgz",
+      "integrity": "sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "queue-lit": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/plop": {
       "version": "4.0.1",
       "dev": true,
@@ -11486,6 +11526,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/queue-lit": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/queue-lit/-/queue-lit-1.5.2.tgz",
+      "integrity": "sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "dev": true,
@@ -11782,6 +11832,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/resp-modifier": {
@@ -12997,6 +13057,69 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/tsc-alias": {
+      "version": "1.8.17",
+      "resolved": "https://registry.npmjs.org/tsc-alias/-/tsc-alias-1.8.17.tgz",
+      "integrity": "sha512-EIduCZHqbNwPm8BZYfq1aD7BQ697A4h6uSGMOFQfYGoQwfrYFTKwYfy9Bv42YxHkduVBcn9Zx0DkX111DKskyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.3",
+        "commander": "^9.0.0",
+        "get-tsconfig": "^4.10.0",
+        "globby": "^11.0.4",
+        "mylas": "^2.1.9",
+        "normalize-path": "^3.0.0",
+        "plimit-lit": "^1.2.6"
+      },
+      "bin": {
+        "tsc-alias": "dist/bin/index.js"
+      },
+      "engines": {
+        "node": ">=16.20.2"
+      }
+    },
+    "node_modules/tsc-alias/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/tsc-alias/node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tsc-alias/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "dev": true,
@@ -13761,6 +13884,7 @@
         "npm-check-updates": "^19.1.2",
         "open": "^11.0.0",
         "rollup-plugin-typescript-paths": "^1.5.0",
+        "tsc-alias": "^1.8.17",
         "turndown": "^7.2.2"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3203,9 +3203,40 @@
       "license": "MIT"
     },
     "node_modules/@wc-toolkit/jsx-types": {
-      "version": "1.3.0",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@wc-toolkit/jsx-types/-/jsx-types-1.6.0.tgz",
+      "integrity": "sha512-xx1g8yYw9ZYX5sG47eEVhVcSm3nWfDqrcix0heN9Vu36Fuhmu1baSYCqZIUU+J9n29bfuu4vhSgrGKpLa0f2Fg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "@prettier/sync": "^0.6.1"
+      }
+    },
+    "node_modules/@wc-toolkit/jsx-types/node_modules/@prettier/sync": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@prettier/sync/-/sync-0.6.1.tgz",
+      "integrity": "sha512-yF9G8vK/LYUTF3Cijd7VC9La3b20F20/J/fgoR4H0B8JGOWnZVZX6+I6+vODPosjmMcpdlUV+gUqJQZp3kLOcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "make-synchronized": "^0.8.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier-synchronized?sponsor=1"
+      },
+      "peerDependencies": {
+        "prettier": "*"
+      }
+    },
+    "node_modules/@wc-toolkit/jsx-types/node_modules/make-synchronized": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/make-synchronized/-/make-synchronized-0.8.0.tgz",
+      "integrity": "sha512-DZu4lwc0ffoFz581BSQa/BJl+1ZqIkoRQ+VejMlH0VrP4E86StAODnZujZ4sepumQj8rcP7wUnUBGM8Gu+zKUA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/fisker/make-synchronized?sponsor=1"
+      }
     },
     "node_modules/@wc-toolkit/type-parser": {
       "version": "1.2.0",
@@ -13840,7 +13871,7 @@
       },
       "devDependencies": {
         "@wc-toolkit/cem-validator": "^1.0.3",
-        "@wc-toolkit/jsx-types": "^1.3.0",
+        "@wc-toolkit/jsx-types": "^1.6.0",
         "cookie-parser": "^1.4.7",
         "eleventy-plugin-git-commit-date": "^0.1.3",
         "esbuild": "^0.25.11",

--- a/packages/webawesome/custom-elements-manifest.js
+++ b/packages/webawesome/custom-elements-manifest.js
@@ -215,8 +215,10 @@ export default {
       outdir,
       defaultExport: true,
       includeDefaultDOMEvents: true,
-      componentTypePath: (_name, _tag, modulePath) => {
-        return `./${modulePath}`;
+      componentTypePath: (name, tag, modulePath) => {
+        if (!tag) { return `./${modulePath}` }
+        const unprefixedTag = tag.replace("wa-", "")
+        return `./components/${unprefixedTag}/${unprefixedTag}.js`;
       },
     }),
 

--- a/packages/webawesome/custom-elements-manifest.js
+++ b/packages/webawesome/custom-elements-manifest.js
@@ -216,8 +216,10 @@ export default {
       defaultExport: true,
       includeDefaultDOMEvents: true,
       componentTypePath: (name, tag, modulePath) => {
-        if (!tag) { return `./${modulePath}` }
-        const unprefixedTag = tag.replace("wa-", "")
+        if (!tag) {
+          return `./${modulePath}`;
+        }
+        const unprefixedTag = tag.replace('wa-', '');
         return `./components/${unprefixedTag}/${unprefixedTag}.js`;
       },
     }),

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -29,6 +29,15 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 {% include "changelog-email-signup.njk" %}
 
+## Unreleased
+
+:::fixed
+
+- Fixed type resolution issues with `pro` components like `<wa-file-input>`, `<wa-combobox>`, etc. [pr:2577]
+
+:::
+
+
 ## 3.10.0
 
 <small><time datetime="2026-06-30">June 30th, 2026</time></small>

--- a/packages/webawesome/package.json
+++ b/packages/webawesome/package.json
@@ -109,7 +109,7 @@
   },
   "devDependencies": {
     "@wc-toolkit/cem-validator": "^1.0.3",
-    "@wc-toolkit/jsx-types": "^1.3.0",
+    "@wc-toolkit/jsx-types": "^1.6.0",
     "cookie-parser": "^1.4.7",
     "eleventy-plugin-git-commit-date": "^0.1.3",
     "esbuild": "^0.25.11",

--- a/packages/webawesome/scripts/build.js
+++ b/packages/webawesome/scripts/build.js
@@ -46,6 +46,7 @@ if (!process.env.NODE_ENV) {
  * @property {Array<string>} [watchedDocsDirectories]
  * @property {(eventName: "change" | "add" | "unlink", filePath: string) => unknown} [beforeWatchEvent]
  * @property {(eventName: "change" | "add" | "unlink", filePath: string) => unknown} [afterWatchEvent]
+ * @property {(dir: string) => void} [transformTypes]
  */
 
 /**
@@ -67,6 +68,8 @@ export async function build(options = {}) {
   if (!options.watchedDocsDirectories) {
     options.watchedDocsDirectories = [getDocsDir()];
   }
+
+  const transformTypes = options.transformTypes || ((_dir) => {})
 
   /**
    * Runs the full build.
@@ -235,7 +238,9 @@ export async function build(options = {}) {
       if (process.env.ROOT_DIR) {
         process.chdir(process.env.ROOT_DIR);
       }
+      const cdnDir = getCdnDir()
       execSync(`tsc --project ./tsconfig.prod.json --outdir "${getCdnDir()}"`, { stdio: 'inherit' });
+      transformTypes(cdnDir)
       process.chdir(cwd);
     } catch (error) {
       process.chdir(cwd);

--- a/packages/webawesome/scripts/build.js
+++ b/packages/webawesome/scripts/build.js
@@ -69,7 +69,7 @@ export async function build(options = {}) {
     options.watchedDocsDirectories = [getDocsDir()];
   }
 
-  const transformTypes = options.transformTypes || ((_dir) => {})
+  const transformTypes = options.transformTypes || (_dir => {});
 
   /**
    * Runs the full build.
@@ -238,9 +238,9 @@ export async function build(options = {}) {
       if (process.env.ROOT_DIR) {
         process.chdir(process.env.ROOT_DIR);
       }
-      const cdnDir = getCdnDir()
+      const cdnDir = getCdnDir();
       execSync(`tsc --project ./tsconfig.prod.json --outdir "${getCdnDir()}"`, { stdio: 'inherit' });
-      transformTypes(cdnDir)
+      transformTypes(cdnDir);
       process.chdir(cwd);
     } catch (error) {
       process.chdir(cwd);

--- a/packages/webawesome/src/internal/webawesome-element.ts
+++ b/packages/webawesome/src/internal/webawesome-element.ts
@@ -45,6 +45,9 @@ function buildStyleAttribute(options: { property?: string | null; value?: unknow
   return null;
 }
 
+/**
+ * @internal
+ */
 export default class WebAwesomeElement extends LitElement {
   // One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended.
   static css?: CSSResultGroup;


### PR DESCRIPTION
- Adds a `transformTypes` hook to be run in `webawesome-pro` and run `tsc-alias` to fix `$webawesome/` calls and resolve them to relative paths.

Pro PR: https://github.com/shoelace-style/webawesome-pro/pull/250/

Fixes: 
  - #2578 
  - #2557 
  - #2540