### PR TITLE
Improve Actions Components Documentation

### DIFF
--- a/packages/webawesome/docs/docs/components/button-group.md
+++ b/packages/webawesome/docs/docs/components/button-group.md
@@ -21,92 +21,60 @@ use-cases:
 </wa-button-group>
 ```
 
+:::warning
+<strong>Give every button group a `label`.</strong><br />
+It isn't shown on screen, but assistive devices announce it so people know what the grouped buttons control.
+:::
+
 ## Examples
 
-### Vertical Button Groups
+### Orientation
 
-Set the `orientation` attribute to `vertical` to make a vertical button group.
+Set the `orientation` attribute to `vertical` to stack the buttons instead of placing them side by side.
 
 ```html {.example}
 <wa-button-group orientation="vertical" label="Options">
-  <wa-button appearance="filled">Button</wa-button>
-  <wa-dropdown>
-    <wa-button appearance="filled" slot="trigger" with-caret>Dropdown</wa-button>
-    <wa-dropdown-item>Item 1</wa-dropdown-item>
-    <wa-dropdown-item>Item 2</wa-dropdown-item>
-    <wa-dropdown-item>Item 3</wa-dropdown-item>
-  </wa-dropdown>
-  <wa-button appearance="filled">Button</wa-button>
+  <wa-button appearance="filled">Top</wa-button>
+  <wa-button appearance="filled">Middle</wa-button>
+  <wa-button appearance="filled">Bottom</wa-button>
 </wa-button-group>
 ```
 
-### Pill Buttons
+### Pill
 
-Pill buttons are supported through the button's `pill` attribute.
+Add the `pill` attribute to each button to round the group's outer edges.
 
 ```html {.example}
-<wa-button-group label="Alignment">
-  <wa-button appearance="filled" size="xs" pill>Left</wa-button>
-  <wa-button appearance="filled" size="xs" pill>Center</wa-button>
-  <wa-button appearance="filled" size="xs" pill>Right</wa-button>
-</wa-button-group>
-
-<br /><br />
-
-<wa-button-group label="Alignment">
-  <wa-button appearance="filled" size="s" pill>Left</wa-button>
-  <wa-button appearance="filled" size="s" pill>Center</wa-button>
-  <wa-button appearance="filled" size="s" pill>Right</wa-button>
-</wa-button-group>
-
-<br /><br />
-
 <wa-button-group label="Alignment">
   <wa-button appearance="filled" size="m" pill>Left</wa-button>
   <wa-button appearance="filled" size="m" pill>Center</wa-button>
   <wa-button appearance="filled" size="m" pill>Right</wa-button>
 </wa-button-group>
-
-<br /><br />
-
-<wa-button-group label="Alignment">
-  <wa-button appearance="filled" size="l" pill>Left</wa-button>
-  <wa-button appearance="filled" size="l" pill>Center</wa-button>
-  <wa-button appearance="filled" size="l" pill>Right</wa-button>
-</wa-button-group>
-
-<br /><br />
-
-<wa-button-group label="Alignment">
-  <wa-button appearance="filled" size="xl" pill>Left</wa-button>
-  <wa-button appearance="filled" size="xl" pill>Center</wa-button>
-  <wa-button appearance="filled" size="xl" pill>Right</wa-button>
-</wa-button-group>
 ```
 
-### Dropdowns in Button Groups
+### Dropdowns
 
-Dropdowns can be placed into button groups.
+Place a [dropdown](/docs/components/dropdown) anywhere in the group to attach a menu of related actions.
 
 ```html {.example}
-<wa-button-group label="Example Button Group">
-  <wa-button appearance="filled">Button</wa-button>
+<wa-button-group label="Options">
+  <wa-button appearance="filled">Edit</wa-button>
   <wa-dropdown>
-    <wa-button appearance="filled" slot="trigger" with-caret>Dropdown</wa-button>
-    <wa-dropdown-item>Item 1</wa-dropdown-item>
-    <wa-dropdown-item>Item 2</wa-dropdown-item>
-    <wa-dropdown-item>Item 3</wa-dropdown-item>
+    <wa-button appearance="filled" slot="trigger" with-caret>More</wa-button>
+    <wa-dropdown-item>Cut</wa-dropdown-item>
+    <wa-dropdown-item>Copy</wa-dropdown-item>
+    <wa-dropdown-item>Paste</wa-dropdown-item>
   </wa-dropdown>
-  <wa-button appearance="filled">Button</wa-button>
+  <wa-button appearance="filled">Delete</wa-button>
 </wa-button-group>
 ```
 
 ### Split Buttons
 
-Create a split button using a button and a dropdown. Use a [visually hidden](/docs/utilities/visually-hidden) label to ensure the dropdown is accessible to users with assistive devices.
+Pair a primary button with a dropdown to make a split button. Give the dropdown trigger an accessible label so people using assistive devices know what it opens.
 
 ```html {.example}
-<wa-button-group label="Example Button Group">
+<wa-button-group label="Save">
   <wa-button appearance="filled" variant="brand">Save</wa-button>
   <wa-dropdown placement="bottom-end">
     <wa-button appearance="filled" slot="trigger" variant="brand">
@@ -119,9 +87,9 @@ Create a split button using a button and a dropdown. Use a [visually hidden](/do
 </wa-button-group>
 ```
 
-### Tooltips in Button Groups
+### Tooltips
 
-Buttons can be wrapped in tooltips to provide more detail when the user interacts with them.
+Pair each button with a [tooltip](/docs/components/tooltip) to explain what it does on hover and focus.
 
 ```html {.example}
 <wa-button-group label="Alignment">
@@ -130,38 +98,48 @@ Buttons can be wrapped in tooltips to provide more detail when the user interact
   <wa-button appearance="filled" id="button-right">Right</wa-button>
 </wa-button-group>
 
-<wa-tooltip for="button-left">I'm on the left</wa-tooltip>
-<wa-tooltip for="button-center">I'm in the middle</wa-tooltip>
-<wa-tooltip for="button-right">I'm on the right</wa-tooltip>
+<wa-tooltip for="button-left">Align left</wa-tooltip>
+<wa-tooltip for="button-center">Align center</wa-tooltip>
+<wa-tooltip for="button-right">Align right</wa-tooltip>
 ```
 
-### Toolbar Example
+### Toolbars
 
-Create interactive toolbars with button groups.
+Combine several button groups into a toolbar of related action sets. Use icon-only buttons with `label` for compact controls, and tooltips to name each one.
 
 ```html {.example}
-<div class="button-group-toolbar">
+<div class="button-group-toolbar wa-cluster">
   <wa-button-group label="History">
-    <wa-button appearance="filled" id="undo-button"><wa-icon name="undo" variant="solid" label="Undo"></wa-icon></wa-button>
-    <wa-button appearance="filled" id="redo-button"><wa-icon name="redo" variant="solid" label="Redo"></wa-icon></wa-button>
+    <wa-button appearance="filled" id="undo-button"
+      ><wa-icon name="undo" variant="solid" label="Undo"></wa-icon
+    ></wa-button>
+    <wa-button appearance="filled" id="redo-button"
+      ><wa-icon name="redo" variant="solid" label="Redo"></wa-icon
+    ></wa-button>
   </wa-button-group>
 
   <wa-button-group label="Formatting">
-    <wa-button appearance="filled" id="button-bold"><wa-icon name="bold" variant="solid" label="Bold"></wa-icon></wa-button>
-    <wa-button appearance="filled" id="button-italic"><wa-icon name="italic" variant="solid" label="Italic"></wa-icon></wa-button>
-    <wa-button appearance="filled" id="button-underline"><wa-icon name="underline" variant="solid" label="Underline"></wa-icon></wa-button>
+    <wa-button appearance="filled" id="button-bold"
+      ><wa-icon name="bold" variant="solid" label="Bold"></wa-icon
+    ></wa-button>
+    <wa-button appearance="filled" id="button-italic"
+      ><wa-icon name="italic" variant="solid" label="Italic"></wa-icon
+    ></wa-button>
+    <wa-button appearance="filled" id="button-underline"
+      ><wa-icon name="underline" variant="solid" label="Underline"></wa-icon
+    ></wa-button>
   </wa-button-group>
 
   <wa-button-group label="Alignment">
-    <wa-button appearance="filled" id="button-align-left">
-      <wa-icon name="align-left" variant="solid" label="Align Left"></wa-icon>
-    </wa-button>
-    <wa-button appearance="filled" id="button-align-center">
-      <wa-icon name="align-center" variant="solid" label="Align Center"></wa-icon>
-    </wa-button>
-    <wa-button appearance="filled" id="button-align-right">
-      <wa-icon name="align-right" variant="solid" label="Align Right"></wa-icon>
-    </wa-button>
+    <wa-button appearance="filled" id="button-align-left"
+      ><wa-icon name="align-left" variant="solid" label="Align left"></wa-icon
+    ></wa-button>
+    <wa-button appearance="filled" id="button-align-center"
+      ><wa-icon name="align-center" variant="solid" label="Align center"></wa-icon
+    ></wa-button>
+    <wa-button appearance="filled" id="button-align-right"
+      ><wa-icon name="align-right" variant="solid" label="Align right"></wa-icon
+    ></wa-button>
   </wa-button-group>
 </div>
 
@@ -170,16 +148,9 @@ Create interactive toolbars with button groups.
 <wa-tooltip for="button-bold">Bold</wa-tooltip>
 <wa-tooltip for="button-italic">Italic</wa-tooltip>
 <wa-tooltip for="button-underline">Underline</wa-tooltip>
-
-<wa-tooltip for="button-align-left">Align Left</wa-tooltip>
-<wa-tooltip for="button-align-center">Align Center</wa-tooltip>
-<wa-tooltip for="button-align-right">Align Right</wa-tooltip>
-
-<style>
-  .button-group-toolbar wa-button-group:not(:last-of-type) {
-    margin-right: var(--wa-space-xs);
-  }
-</style>
+<wa-tooltip for="button-align-left">Align left</wa-tooltip>
+<wa-tooltip for="button-align-center">Align center</wa-tooltip>
+<wa-tooltip for="button-align-right">Align right</wa-tooltip>
 ```
 
 ### Native Buttons

--- a/packages/webawesome/docs/docs/components/button.md
+++ b/packages/webawesome/docs/docs/components/button.md
@@ -15,12 +15,12 @@ use-cases:
 ---
 
 ```html {.example}
-<wa-button>Button</wa-button>
+<wa-button>Save</wa-button>
 ```
 
 ## Examples
 
-### Variants
+### Variant
 
 Use the `variant` attribute to set the button's [semantic variant](/docs/theming-overview#variants).
 
@@ -36,7 +36,7 @@ Use the `variant` attribute to set the button's [semantic variant](/docs/theming
 
 ### Appearance
 
-Use the `appearance` attribute to change the button's visual appearance.
+Use the `appearance` attribute to change the button's visual appearance. Pair it with any `variant` for the full matrix.
 
 ```html {.example}
 <div class="wa-stack">
@@ -78,7 +78,7 @@ Use the `appearance` attribute to change the button's visual appearance.
 </div>
 ```
 
-### Sizes
+### Size
 
 Use the `size` attribute to change a button's size.
 
@@ -92,23 +92,17 @@ Use the `size` attribute to change a button's size.
 </div>
 ```
 
-### Pill Buttons
+### Pill
 
 Use the `pill` attribute to give buttons rounded edges.
 
 ```html {.example}
-<div class="wa-cluster wa-gap-2xs">
-  <wa-button size="xs" pill>Extra Small</wa-button>
-  <wa-button size="s" pill>Small</wa-button>
-  <wa-button size="m" pill>Medium</wa-button>
-  <wa-button size="l" pill>Large</wa-button>
-  <wa-button size="xl" pill>Extra Large</wa-button>
-</div>
+<wa-button pill>Pill Button</wa-button>
 ```
 
-### Link Buttons
+### Link Button
 
-It's often helpful to have a button that works like a link. This is possible by setting the `href` attribute, which will make the component render an `<a>` under the hood. This gives you all the default link behavior the browser provides (e.g. [[CMD/CTRL/SHIFT]] + [[CLICK]]) and exposes the `rel`, `target`, and `download` attributes.
+Set the `href` attribute to render the button as an `<a>` under the hood. Provides all the browser's native link behavior (e.g. [[CMD/CTRL/SHIFT]] + [[CLICK]]) plus the `rel`, `target`, and `download` attributes.
 
 ```html {.example}
 <div class="wa-cluster wa-gap-2xs">
@@ -118,9 +112,9 @@ It's often helpful to have a button that works like a link. This is possible by 
 </div>
 ```
 
-### Icon Buttons
+### Icon Button
 
-When only an [icon](/docs/components/icon) is slotted into the `label` slot, the button becomes an icon button. In this case, it's important to give the icon a label for users with assistive devices. Icon buttons can use any appearance or variant.
+When an [icon](/docs/components/icon) is the only thing slotted into the label, the button becomes an icon button. Icon buttons work with any appearance or variant.
 
 ```html {.example}
 <div class="wa-cluster wa-gap-2xs">
@@ -131,99 +125,46 @@ When only an [icon](/docs/components/icon) is slotted into the `label` slot, the
 </div>
 ```
 
-### Setting a Custom Width
-
-As expected, buttons can be given a custom width by setting the `width` CSS property. This is useful for making buttons span the full width of their container on smaller screens.
-
-```html {.example}
-<div class="wa-stack">
-  <wa-button size="xs" style="width: 100%;">Extra Small</wa-button>
-  <wa-button size="s" style="width: 100%;">Small</wa-button>
-  <wa-button size="m" style="width: 100%;">Medium</wa-button>
-  <wa-button size="l" style="width: 100%;">Large</wa-button>
-  <wa-button size="xl" style="width: 100%;">Extra Large</wa-button>
-</div>
-```
+:::warning
+<strong>Give icon-only buttons a label.</strong><br />
+With no text to announce, a screen reader has nothing to read. Add `label` to the icon (`<wa-icon name="house" label="Home">`) so the button has an accessible name.
+:::
 
 ### Start & End Decorations
 
-Use the `start` and `end` slots to add presentational elements like `<wa-icon>` next to the button label.
+Use the `start` and `end` slots to add presentational elements like `<wa-icon>` beside the button label.
 
 ```html {.example}
-<div class="wa-stack">
-  <div class="wa-cluster wa-gap-2xs">
-    <wa-button size="s">
-      <wa-icon slot="start" name="gear"></wa-icon>
-      Settings
-    </wa-button>
+<div class="wa-cluster wa-gap-2xs">
+  <wa-button>
+    <wa-icon slot="start" name="gear"></wa-icon>
+    Settings
+  </wa-button>
 
-    <wa-button size="s">
-      <wa-icon slot="end" name="undo"></wa-icon>
-      Refresh
-    </wa-button>
+  <wa-button>
+    <wa-icon slot="end" name="undo"></wa-icon>
+    Refresh
+  </wa-button>
 
-    <wa-button size="s">
-      <wa-icon slot="start" name="link"></wa-icon>
-      <wa-icon slot="end" name="arrow-up-right-from-square"></wa-icon>
-      Open
-    </wa-button>
-  </div>
-
-  <div class="wa-cluster wa-gap-2xs">
-    <wa-button>
-      <wa-icon slot="start" name="gear"></wa-icon>
-      Settings
-    </wa-button>
-
-    <wa-button>
-      <wa-icon slot="end" name="undo"></wa-icon>
-      Refresh
-    </wa-button>
-
-    <wa-button>
-      <wa-icon slot="start" name="link"></wa-icon>
-      <wa-icon slot="end" name="arrow-up-right-from-square"></wa-icon>
-      Open
-    </wa-button>
-  </div>
-
-  <div class="wa-cluster wa-gap-2xs">
-    <wa-button size="l">
-      <wa-icon slot="start" name="gear"></wa-icon>
-      Settings
-    </wa-button>
-
-    <wa-button size="l">
-      <wa-icon slot="end" name="undo"></wa-icon>
-      Refresh
-    </wa-button>
-
-    <wa-button size="l">
-      <wa-icon slot="start" name="link"></wa-icon>
-      <wa-icon slot="end" name="arrow-up-right-from-square"></wa-icon>
-      Open
-    </wa-button>
-  </div>
+  <wa-button>
+    <wa-icon slot="start" name="link"></wa-icon>
+    <wa-icon slot="end" name="arrow-up-right-from-square"></wa-icon>
+    Open
+  </wa-button>
 </div>
 ```
 
 ### Caret
 
-Use the `with-caret` attribute to add a dropdown indicator when a button will trigger a dropdown, menu, or popover.
+Use the `with-caret` attribute to add a dropdown indicator when a button triggers a dropdown, menu, or popover.
 
 ```html {.example}
-<div class="wa-cluster wa-gap-2xs">
-  <wa-button size="xs" with-caret>Extra Small</wa-button>
-  <wa-button size="s" with-caret>Small</wa-button>
-  <wa-button size="m" with-caret>Medium</wa-button>
-  <wa-button size="l" with-caret>Large</wa-button>
-  <wa-button size="xl" with-caret>Extra Large</wa-button>
-</div>
+<wa-button with-caret>Options</wa-button>
 ```
 
 ### Loading
 
-Use the `loading` attribute to make a button busy. The width will remain the same as before, preventing adjacent elements from moving around.
+Use the `loading` attribute to put a button in a busy state. Its width stays the same, so adjacent elements don't shift.
 
 ```html {.example}
 <div class="wa-cluster wa-gap-2xs">
@@ -237,25 +178,37 @@ Use the `loading` attribute to make a button busy. The width will remain the sam
 
 ### Disabled
 
-Use the `disabled` attribute to disable a button.
+Use the `disabled` attribute to disable a button. It works on link buttons too.
 
 ```html {.example}
-<wa-button variant="brand" disabled>Brand</wa-button>
-<wa-button variant="success" disabled>Success</wa-button>
-<wa-button variant="neutral" disabled>Neutral</wa-button>
-<wa-button variant="warning" disabled>Warning</wa-button>
-<wa-button variant="danger" disabled>Danger</wa-button>
+<div class="wa-stack">
+  <div class="wa-cluster wa-gap-2xs">
+    <wa-button variant="brand" disabled>Brand</wa-button>
+    <wa-button variant="success" disabled>Success</wa-button>
+    <wa-button variant="neutral" disabled>Neutral</wa-button>
+    <wa-button variant="warning" disabled>Warning</wa-button>
+    <wa-button variant="danger" disabled>Danger</wa-button>
+  </div>
 
-<br /><br />
-
-<wa-button href="https://example.com/" disabled>Link</wa-button>
-<wa-button href="https://example.com/" target="_blank" disabled>New Window</wa-button>
-<wa-button href="/assets/images/logo.svg" download="shoelace.svg" disabled>Download</wa-button>
+  <div class="wa-cluster wa-gap-2xs">
+    <wa-button href="https://example.com/" disabled>Link</wa-button>
+    <wa-button href="https://example.com/" target="_blank" disabled>New Window</wa-button>
+    <wa-button href="/assets/images/logo.svg" download="shoelace.svg" disabled>Download</wa-button>
+  </div>
+</div>
 ```
 
-### Styling Buttons
+### Custom Width
 
-This example demonstrates how to style buttons using a custom class. This is the recommended approach if you need to add additional variations. To customize an existing variation, modify the selector to target the button's `variant` attribute instead of a class (e.g. `wa-button[variant="brand"]`).
+Give a button a custom `width` to size it independently of its content — useful for making buttons span their container on smaller screens.
+
+```html {.example}
+<wa-button style="width: 100%;">Save</wa-button>
+```
+
+### Customizing
+
+Target the `base` part to restyle a button from the outside. Use a custom class when you're adding a new variation; to retheme an existing one, target its `variant` attribute instead (e.g. `wa-button[variant="brand"]`).
 
 ```html {.example}
 <wa-button class="pink">Pink Button</wa-button>

--- a/packages/webawesome/docs/docs/components/copy-button.md
+++ b/packages/webawesome/docs/docs/components/copy-button.md
@@ -13,18 +13,53 @@ use-cases:
 ---
 
 ```html {.example}
-<wa-copy-button value="Web Awesome rocks!"></wa-copy-button>
+<wa-copy-button value="https://webawesome.com"></wa-copy-button>
 ```
 
 :::info
+<strong>Copying requires a secure context.</strong><br />
 Copy buttons use the browser's [`clipboard.writeText()`](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText) method, which requires a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) (HTTPS) in most browsers.
 :::
 
 ## Examples
 
+### Copying from Other Elements
+
+Set the `value` attribute to copy a literal string, or point the `from` attribute at another element's `id` to copy live content. When both are present, `from` wins.
+
+By default `from` copies the target's [`textContent`](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent). Add a modifier to copy an attribute or property instead:
+
+| Syntax            | Copies                      | Example                 |
+| ----------------- | --------------------------- | ----------------------- |
+| `from="id"`       | The element's `textContent` | `from="my-phone"`       |
+| `from="id[attr]"` | The named attribute         | `from="my-link[href]"`  |
+| `from="id.prop"`  | The named property          | `from="my-input.value"` |
+
+```html {.example}
+<div class="wa-stack">
+  <!-- Copies the span's textContent -->
+  <div class="wa-cluster wa-align-items-center wa-gap-2xs">
+    <span id="my-phone">+1 (234) 456-7890</span>
+    <wa-copy-button from="my-phone"></wa-copy-button>
+  </div>
+
+  <!-- Copies the input's "value" property -->
+  <div class="wa-cluster wa-align-items-center wa-gap-2xs">
+    <wa-input id="my-input" type="text" value="User input" style="max-width: 300px;"></wa-input>
+    <wa-copy-button from="my-input.value"></wa-copy-button>
+  </div>
+
+  <!-- Copies the link's "href" attribute -->
+  <div class="wa-cluster wa-align-items-center wa-gap-2xs">
+    <a id="my-link" href="https://webawesome.com/">Web Awesome Website</a>
+    <wa-copy-button from="my-link[href]"></wa-copy-button>
+  </div>
+</div>
+```
+
 ### Custom Labels
 
-The default copy button shows a tooltip on hover and focus, and the tooltip text changes briefly to confirm a successful or failed copy. You can customize these labels using the `copy-label`, `success-label`, and `error-label` attributes. The `copy-label` is also used as the button's accessible name.
+The copy button shows a tooltip on hover and focus, then briefly swaps it to confirm a copy. Set the `copy-label`, `success-label`, and `error-label` attributes to customize the text for each state. `copy-label` also serves as the button's accessible name.
 
 ```html {.example}
 <wa-copy-button
@@ -37,7 +72,7 @@ The default copy button shows a tooltip on hover and focus, and the tooltip text
 
 ### Custom Icons
 
-Use the `copy-icon`, `success-icon`, and `error-icon` slots to customize the icons that get displayed for each state. You can use [`<wa-icon>`](/docs/components/icon) or your own images.
+Use the `copy-icon`, `success-icon`, and `error-icon` slots to replace the icon shown in each state. [`<wa-icon>`](/docs/components/icon) works best, but any image will do.
 
 ```html {.example}
 <wa-copy-button value="Copied from a custom button">
@@ -49,142 +84,83 @@ Use the `copy-icon`, `success-icon`, and `error-icon` slots to customize the ico
 
 ### Custom Trigger
 
-By default, the copy button renders an icon-only button. You can slot in any element to use as a custom trigger instead. This works with Web Awesome buttons, native buttons, or any clickable element.
+By default the copy button renders an icon-only button. Slot in any clickable element to use as the trigger instead — a Web Awesome button, a native button, or anything else.
 
 ```html {.example}
-<wa-copy-button value="You can copy anything with a custom trigger!">
-  <wa-button appearance="filled">Copy to Clipboard</wa-button>
-</wa-copy-button>
-```
+<div class="wa-stack">
+  <wa-copy-button value="You can copy anything with a custom trigger!">
+    <wa-button appearance="filled">Copy to Clipboard</wa-button>
+  </wa-copy-button>
 
-You can also use a native button as the trigger.
-
-```html {.example}
-<wa-copy-button value="Native buttons work too!">
-  <button type="button" class="wa-filled">Copy to Clipboard</button>
-</wa-copy-button>
+  <wa-copy-button value="https://webawesome.com">
+    <button type="button" class="wa-filled">Copy to Clipboard</button>
+  </wa-copy-button>
+</div>
 ```
 
 :::info
-Custom triggers automatically receive the same tooltip and copy feedback as the default trigger — no extra wiring required. The icon swap is the only piece that's specific to the default trigger. Use `without-tooltip` to opt out of the tooltip, and use the `wa-copy` and `wa-error` events or the `:state(success)` and `:state(error)` CSS custom states for additional feedback.
+<strong>Custom triggers get the same feedback with no extra wiring.</strong><br />
+They receive the same tooltip and copy feedback as the default trigger; the icon swap is the one piece unique to it. Set `tooltip="none"` to opt out of the tooltip, and listen for the `wa-copy` and `wa-error` events or style the `:state(success)` and `:state(error)` custom states for your own feedback.
 :::
-
-### Copying Values from Other Elements
-
-Normally, the data that gets copied will come from the component's `value` attribute, but you can copy data from any element within the same document by providing its `id` to the `from` attribute.
-
-When using the `from` attribute, the element's [`textContent`](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) will be copied by default. Passing an attribute or property modifier will let you copy data from one of the element's attributes or properties instead.
-
-To copy data from an attribute, use `from="id[attr]"` where `id` is the id of the target element and `attr` is the name of the attribute you'd like to copy. To copy data from a property, use `from="id.prop"` where `id` is the id of the target element and `prop` is the name of the property you'd like to copy.
-
-```html {.example}
-<!-- Copies the span's textContent -->
-<div class="wa-cluster wa-align-items-center wa-gap-2xs">
-  <span id="my-phone">+1 (234) 456-7890</span>
-  <wa-copy-button from="my-phone"></wa-copy-button>
-</div>
-
-<br />
-
-<!-- Copies the input's "value" property -->
-<div class="wa-cluster wa-align-items-center wa-gap-2xs">
-  <wa-input id="my-input" type="text" value="User input" style="max-width: 300px;"></wa-input>
-  <wa-copy-button from="my-input.value"></wa-copy-button>
-</div>
-
-<br />
-
-<!-- Copies the link's "href" attribute -->
-<div class="wa-cluster wa-align-items-center wa-gap-2xs">
-  <a id="my-link" href="https://shoelace.style/">Web Awesome Website</a>
-  <wa-copy-button from="my-link[href]"></wa-copy-button>
-</div>
-```
-
-### Handling Errors
-
-A copy error will occur if the value is an empty string, if the `from` attribute points to an id that doesn't exist, or if the browser rejects the operation for any reason. When this happens, the `wa-error` event will be emitted.
-
-This example demonstrates what happens when a copy error occurs. You can customize the error label and icon using the `error-label` attribute and the `error-icon` slot, respectively.
-
-```html {.example}
-<wa-copy-button from="i-do-not-exist"></wa-copy-button>
-```
 
 ### Disabled
 
-Copy buttons can be disabled by adding the `disabled` attribute.
+Add the `disabled` attribute to turn off the copy button.
 
 ```html {.example}
 <wa-copy-button value="You can't copy me" disabled></wa-copy-button>
 ```
 
-### Changing Feedback Duration
+### Handling Errors
 
-After copying, the tooltip briefly displays a success or error label. Use the `feedback-duration` attribute to control how long it stays visible.
+A copy fails when `value` is empty, when `from` points to an id that doesn't exist, or when the browser rejects the operation. Either way, the button shows its error state and emits the `wa-error` event. Customize the message with `error-label` and the icon with the `error-icon` slot.
 
+```html {.example}
+<wa-copy-button from="i-do-not-exist"></wa-copy-button>
+```
+
+### Feedback Duration
+
+After a copy, the tooltip briefly shows the success or error label. Set the `feedback-duration` attribute (in milliseconds) to control how long it stays visible.
 
 ```html {.example}
 <wa-copy-button value="Web Awesome rocks!" feedback-duration="250"></wa-copy-button>
 ```
 
-### Tooltip Modes
+### Tooltip Mode
 
-The `tooltip` attribute controls when the built-in tooltip appears. It applies to both the default trigger and [custom triggers](#custom-trigger).
+The `tooltip` attribute controls when the built-in tooltip appears, on both the default and custom triggers.
 
-- `full` (default): the tooltip shows on hover and focus, and is reused to display copy feedback.
-- `copy`: the tooltip stays silent on hover and focus, and only appears briefly to confirm a successful or failed copy.
-- `none`: no tooltip is shown in any state.
-
-```html {.example}
-<wa-copy-button value="Full" tooltip="full"></wa-copy-button>
-<wa-copy-button value="Copy" tooltip="copy"></wa-copy-button>
-<wa-copy-button value="None" tooltip="none"></wa-copy-button>
-```
+| Value                                                                            | Behavior                                                        |
+| -------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `full` <wa-badge appearance="outlined" variant="neutral" pill>default</wa-badge> | Shows on hover and focus, and reused for copy feedback          |
+| `copy`                                                                           | Stays silent on hover and focus; appears only to confirm a copy |
+| `none`                                                                           | Never shown                                                     |
 
 ```html {.example}
-<wa-copy-button value="Full" tooltip="full">
-  <wa-button appearance="filled">Full</wa-button>
-</wa-copy-button>
-<wa-copy-button value="Copy" tooltip="copy">
-  <wa-button appearance="filled">Copy</wa-button>
-</wa-copy-button>
-<wa-copy-button value="None" tooltip="none">
-  <wa-button appearance="filled">None</wa-button>
-</wa-copy-button>
+<div class="wa-cluster">
+  <wa-copy-button value="npm install @awesome.me/webawesome" tooltip="full"></wa-copy-button>
+  <wa-copy-button value="npm install @awesome.me/webawesome" tooltip="copy"></wa-copy-button>
+  <wa-copy-button value="npm install @awesome.me/webawesome" tooltip="none"></wa-copy-button>
+</div>
 ```
 
-### Changing Tooltip Placement
+### Tooltip Placement
 
-The tooltip is shown above the trigger by default. Use the `tooltip-placement` attribute to position it on the `top`, `right`, `bottom`, or `left`.
+The tooltip sits above the trigger by default. Set the `tooltip-placement` attribute to `top`, `right`, `bottom`, or `left` to move it.
 
 ```html {.example}
-<wa-copy-button value="Above" tooltip-placement="top"></wa-copy-button>
-<wa-copy-button value="Right" tooltip-placement="right"></wa-copy-button>
-<wa-copy-button value="Below" tooltip-placement="bottom"></wa-copy-button>
-<wa-copy-button value="Left" tooltip-placement="left"></wa-copy-button>
+<div class="wa-cluster">
+  <wa-copy-button value="Above" tooltip-placement="top"></wa-copy-button>
+  <wa-copy-button value="Right" tooltip-placement="right"></wa-copy-button>
+  <wa-copy-button value="Below" tooltip-placement="bottom"></wa-copy-button>
+  <wa-copy-button value="Left" tooltip-placement="left"></wa-copy-button>
+</div>
 ```
 
-The same attribute applies to custom triggers.
+### Customizing
 
-```html {.example}
-<wa-copy-button value="Above" tooltip-placement="top">
-  <wa-button appearance="filled">Above</wa-button>
-</wa-copy-button>
-<wa-copy-button value="Right" tooltip-placement="right">
-  <wa-button appearance="filled">Right</wa-button>
-</wa-copy-button>
-<wa-copy-button value="Below" tooltip-placement="bottom">
-  <wa-button appearance="filled">Below</wa-button>
-</wa-copy-button>
-<wa-copy-button value="Left" tooltip-placement="left">
-  <wa-button appearance="filled">Left</wa-button>
-</wa-copy-button>
-```
-
-### Custom Styles
-
-You can customize the button to your liking with CSS.
+Style the button through its CSS parts — `button`, `copy-icon`, `success-icon`, and `error-icon` — to match your design.
 
 ```html {.example}
 <wa-copy-button value="I'm so stylish" class="custom-styles">

--- a/packages/webawesome/docs/docs/components/dropdown.md
+++ b/packages/webawesome/docs/docs/components/dropdown.md
@@ -14,77 +14,23 @@ use-cases:
   - right-click menu
 ---
 
-Dropdowns consist of a trigger and a panel. By default, activating the trigger will expose the panel and interacting outside of the panel will close it.
-
-Dropdowns are designed to work well with [dropdown items](/docs/components/dropdown-item) to provide a list of options the user can select from. However, dropdowns can also be used in lower-level applications. The API gives you complete control over showing, hiding, and positioning the panel.
-
 ```html {.example}
 <wa-dropdown>
-  <wa-button appearance="filled" slot="trigger" with-caret>Dropdown</wa-button>
+  <wa-button appearance="filled" slot="trigger" with-caret>Options</wa-button>
 
-  <wa-dropdown-item>
-    <wa-icon slot="icon" name="scissors"></wa-icon>
-    Cut
-  </wa-dropdown-item>
-  <wa-dropdown-item>
-    <wa-icon slot="icon" name="copy"></wa-icon>
-    Copy
-  </wa-dropdown-item>
-  <wa-dropdown-item>
-    <wa-icon slot="icon" name="paste"></wa-icon>
-    Paste
-  </wa-dropdown-item>
-  <wa-divider></wa-divider>
-  <wa-dropdown-item>
-    Show images
-    <wa-dropdown-item slot="submenu" value="show-all-images">Show All Images</wa-dropdown-item>
-    <wa-dropdown-item slot="submenu" value="show-thumbnails">Show Thumbnails</wa-dropdown-item>
-  </wa-dropdown-item>
-  <wa-divider></wa-divider>
-  <wa-dropdown-item type="checkbox" checked>Emoji Shortcuts</wa-dropdown-item>
-  <wa-dropdown-item type="checkbox" checked>Word Wrap</wa-dropdown-item>
-  <wa-divider></wa-divider>
-  <wa-dropdown-item variant="danger">
-    <wa-icon slot="icon" name="trash"></wa-icon>
-    Delete
-  </wa-dropdown-item>
+  <wa-dropdown-item value="edit">Edit</wa-dropdown-item>
+  <wa-dropdown-item value="duplicate">Duplicate</wa-dropdown-item>
+  <wa-dropdown-item value="delete">Delete</wa-dropdown-item>
 </wa-dropdown>
 ```
 
+A dropdown pairs a trigger with a panel: activating the trigger opens the panel, and interacting outside it closes the panel. Most dropdowns hold [dropdown items](/docs/components/dropdown-item), but the API also gives you direct control over showing, hiding, and positioning the panel for lower-level uses.
+
 ## Examples
-
-### Getting the Selected Item
-
-When an item is selected, the `wa-select` event will be emitted by the dropdown. You can inspect `event.detail.item` to get a reference to the selected item. If you've provided a value for each [dropdown item](/docs/components/dropdown-item), it will be available in `event.detail.item.value`.
-
-```html {.example}
-<div class="dropdown-selection">
-  <wa-dropdown>
-    <wa-button appearance="filled" slot="trigger" with-caret>View</wa-button>
-    <wa-dropdown-item value="full-screen">Enter full screen</wa-dropdown-item>
-    <wa-dropdown-item value="actual">Actual size</wa-dropdown-item>
-    <wa-dropdown-item value="zoom-in">Zoom in</wa-dropdown-item>
-    <wa-dropdown-item value="zoom-out">Zoom out</wa-dropdown-item>
-  </wa-dropdown>
-</div>
-
-<script>
-  const container = document.querySelector('.dropdown-selection');
-  const dropdown = container.querySelector('wa-dropdown');
-
-  dropdown.addEventListener('wa-select', event => {
-    console.log(event.detail.item.value);
-  });
-</script>
-```
-
-:::info
-To keep the dropdown open after selection, call `event.preventDefault()` in the `wa-select` event's callback.
-:::
 
 ### Showing Icons
 
-Use the `icon` slot to add icons to [dropdown items](/docs/components/dropdown-item). This works best with [icon](/docs/components/icon) elements.
+Use the `icon` slot to add an icon before a [dropdown item's](/docs/components/dropdown-item) label. This works best with [icon](/docs/components/icon) elements.
 
 ```html {.example}
 <wa-dropdown>
@@ -114,7 +60,7 @@ Use the `icon` slot to add icons to [dropdown items](/docs/components/dropdown-i
 
 ### Showing Labels & Dividers
 
-Use any heading, e.g. `<h1>`–`<h6>` to add labels and the [`<wa-divider>`](/docs/components/divider) element for separators.
+Use any heading (`<h1>`–`<h6>`) to label a group of items, and the [`<wa-divider>`](/docs/components/divider) element to separate them.
 
 ```html {.example}
 <wa-dropdown>
@@ -133,7 +79,7 @@ Use any heading, e.g. `<h1>`–`<h6>` to add labels and the [`<wa-divider>`](/do
 
 ### Showing Details
 
-Use the `details` slot to display details, such as keyboard shortcuts, inside [dropdown items](/docs/components/dropdown-item).
+Use the `details` slot to show secondary content after the label, such as a keyboard shortcut.
 
 ```html {.example}
 <wa-dropdown>
@@ -170,7 +116,7 @@ Use the `details` slot to display details, such as keyboard shortcuts, inside [d
 
 ### Checkable Items
 
-You can turn a [dropdown item](/docs/components/dropdown-item) into a checkable option by setting `type="checkbox"`. Add the `checked` attribute to make it checked initially. When clicked, the item's checked state will toggle and the dropdown will close. You can cancel the `wa-select` event if you want to keep it open instead.
+Set `type="checkbox"` to turn a [dropdown item](/docs/components/dropdown-item) into a toggle, and add `checked` to start it on. Selecting a checkable item flips its `checked` state and closes the dropdown; cancel the `wa-select` event to keep it open instead.
 
 ```html {.example}
 <div class="dropdown-checkboxes">
@@ -193,10 +139,8 @@ You can turn a [dropdown item](/docs/components/dropdown-item) into a checkable 
 
   dropdown.addEventListener('wa-select', event => {
     if (event.detail.item.type === 'checkbox') {
-      // Checkbox
       console.log(event.detail.item.value, event.detail.item.checked ? 'checked' : 'unchecked');
     } else {
-      // Not a checkbox
       console.log(event.detail.item.value);
     }
   });
@@ -204,12 +148,12 @@ You can turn a [dropdown item](/docs/components/dropdown-item) into a checkable 
 ```
 
 :::info
-When a checkable option exists anywhere in the dropdown, all items will receive additional padding so they align properly.
+When any item is checkable, every item in the dropdown gains matching padding so labels stay aligned.
 :::
 
 ### Destructive Items
 
-Add `variant="danger"` to any [dropdown item](/docs/components/dropdown-item) to highlight that it's a dangerous action.
+Set `variant="danger"` on a [dropdown item](/docs/components/dropdown-item) to flag a destructive action like deleting.
 
 ```html {.example}
 <wa-dropdown>
@@ -241,99 +185,27 @@ Add `variant="danger"` to any [dropdown item](/docs/components/dropdown-item) to
 </wa-dropdown>
 ```
 
-### Placement
-
-The preferred placement of the dropdown can be set with the `placement` attribute. Note that the actual position may vary to ensure the panel remains in the viewport.
-
-```html {.example}
-<wa-dropdown placement="right-start">
-  <wa-button appearance="filled" slot="trigger">
-    File formats
-    <wa-icon slot="end" name="chevron-right"></wa-icon>
-  </wa-button>
-
-  <wa-dropdown-item value="pdf">PDF Document</wa-dropdown-item>
-  <wa-dropdown-item value="docx">Word Document</wa-dropdown-item>
-  <wa-dropdown-item value="xlsx">Excel Spreadsheet</wa-dropdown-item>
-  <wa-dropdown-item value="pptx">PowerPoint Presentation</wa-dropdown-item>
-  <wa-dropdown-item value="txt">Plain Text</wa-dropdown-item>
-  <wa-dropdown-item value="json">JSON File</wa-dropdown-item>
-</wa-dropdown>
-```
-
-### Distance
-
-The distance from the panel to the trigger can be customized using the `distance` attribute. This value is specified in pixels.
-
-```html {.example}
-<wa-dropdown distance="30">
-  <wa-button appearance="filled" slot="trigger" with-caret>Edit</wa-button>
-
-  <wa-dropdown-item>Cut</wa-dropdown-item>
-  <wa-dropdown-item>Copy</wa-dropdown-item>
-  <wa-dropdown-item>Paste</wa-dropdown-item>
-
-  <wa-divider></wa-divider>
-
-  <wa-dropdown-item>Find</wa-dropdown-item>
-  <wa-dropdown-item>Replace</wa-dropdown-item>
-</wa-dropdown>
-```
-
-### Offset
-
-The offset of the panel along the trigger can be customized using the `skidding` attribute. This value is specified in pixels.
-
-```html {.example}
-<wa-dropdown skidding="30">
-  <wa-button appearance="filled" slot="trigger" with-caret>Edit</wa-button>
-
-  <wa-dropdown-item>Cut</wa-dropdown-item>
-  <wa-dropdown-item>Copy</wa-dropdown-item>
-  <wa-dropdown-item>Paste</wa-dropdown-item>
-
-  <wa-divider></wa-divider>
-
-  <wa-dropdown-item>Find</wa-dropdown-item>
-  <wa-dropdown-item>Replace</wa-dropdown-item>
-</wa-dropdown>
-```
-
 ### Submenus
 
-To create submenus, nest [dropdown items](/docs/components/dropdown-item) inside of a dropdown item and assign `slot="submenu"` to each one. You can also add [dividers](/docs/components/divider) as needed.
+To nest a menu, place [dropdown items](/docs/components/dropdown-item) inside another item with `slot="submenu"`. Add [dividers](/docs/components/divider) between groups as needed.
 
 ```html {.example}
 <div class="dropdown-submenus">
   <wa-dropdown>
-    <wa-button appearance="filled" slot="trigger" with-caret>Export</wa-button>
+    <wa-button appearance="filled" slot="trigger" with-caret>File</wa-button>
 
-    <wa-dropdown-item>
-      Documents
-      <wa-dropdown-item slot="submenu" value="pdf">PDF</wa-dropdown-item>
-      <wa-dropdown-item slot="submenu" value="docx">Word Document</wa-dropdown-item>
-    </wa-dropdown-item>
-
-    <wa-dropdown-item>
-      Spreadsheets
-      <wa-dropdown-item slot="submenu">
-        Excel Formats
-        <wa-dropdown-item slot="submenu" value="xlsx">Excel (.xlsx)</wa-dropdown-item>
-        <wa-dropdown-item slot="submenu" value="xls">Excel 97-2003 (.xls)</wa-dropdown-item>
-        <wa-dropdown-item slot="submenu" value="csv">CSV (.csv)</wa-dropdown-item>
-      </wa-dropdown-item>
-
-      <wa-dropdown-item slot="submenu">
-        Other Formats
-        <wa-dropdown-item slot="submenu" value="ods">OpenDocument (.ods)</wa-dropdown-item>
-        <wa-dropdown-item slot="submenu" value="tsv">Tab-separated (.tsv)</wa-dropdown-item>
-        <wa-dropdown-item slot="submenu" value="json">JSON (.json)</wa-dropdown-item>
-      </wa-dropdown-item>
-
-      <wa-dropdown-item slot="submenu" value="numbers">Apple Numbers</wa-dropdown-item>
-    </wa-dropdown-item>
+    <wa-dropdown-item value="new">New</wa-dropdown-item>
+    <wa-dropdown-item value="open">Open</wa-dropdown-item>
 
     <wa-divider></wa-divider>
+
+    <wa-dropdown-item>
+      Export
+      <wa-dropdown-item slot="submenu" value="pdf">PDF</wa-dropdown-item>
+      <wa-dropdown-item slot="submenu" value="docx">Word document</wa-dropdown-item>
+      <wa-dropdown-item slot="submenu" value="xlsx">Excel spreadsheet</wa-dropdown-item>
+      <wa-dropdown-item slot="submenu" value="csv">CSV</wa-dropdown-item>
+    </wa-dropdown-item>
 
     <wa-dropdown-item>
       Options
@@ -355,16 +227,17 @@ To create submenus, nest [dropdown items](/docs/components/dropdown-item) inside
 ```
 
 :::info
-Dropdown items that have a submenu will not dispatch the `wa-select` event. However, items inside the submenu will, unless they also have a submenu.
+An item that opens a submenu won't emit `wa-select` itself. Items inside the submenu do, unless they open a submenu of their own.
 :::
 
 :::warning
-As a UX best practice, avoid using more than one level of submenu when possible.
+<strong>Avoid nesting more than one level of submenu.</strong><br />
+Deeply nested menus are hard to navigate, especially with a pointer. Flatten the structure or move secondary choices into a separate view when you can.
 :::
 
-### Disabling Items
+### Disabled
 
-Add the `disabled` attribute to any [dropdown item](/docs/components/dropdown-item) to disable it.
+Add `disabled` to any [dropdown item](/docs/components/dropdown-item) to make it unselectable.
 
 ```html {.example}
 <wa-dropdown>
@@ -376,3 +249,145 @@ Add the `disabled` attribute to any [dropdown item](/docs/components/dropdown-it
   <wa-dropdown-item value="gift-card">Gift card</wa-dropdown-item>
 </wa-dropdown>
 ```
+
+### Placement
+
+Set the `placement` attribute to control where the panel opens relative to the trigger. The panel shifts to a more optimal spot when the preferred placement doesn't have room.
+
+| Placement                                                                                | Opens                                                  |
+| ---------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `bottom-start` <wa-badge appearance="outlined" variant="neutral" pill>default</wa-badge> | Below the trigger, aligned to its start edge           |
+| `bottom`, `bottom-end`                                                                   | Below the trigger, centered or aligned to the end edge |
+| `top`, `top-start`, `top-end`                                                            | Above the trigger                                      |
+| `right`, `right-start`, `right-end`                                                      | To the right of the trigger                            |
+| `left`, `left-start`, `left-end`                                                         | To the left of the trigger                             |
+
+```html {.example}
+<wa-dropdown placement="right-start">
+  <wa-button appearance="filled" slot="trigger">
+    File formats
+    <wa-icon slot="end" name="chevron-right"></wa-icon>
+  </wa-button>
+
+  <wa-dropdown-item value="pdf">PDF document</wa-dropdown-item>
+  <wa-dropdown-item value="docx">Word document</wa-dropdown-item>
+  <wa-dropdown-item value="xlsx">Excel spreadsheet</wa-dropdown-item>
+  <wa-dropdown-item value="pptx">PowerPoint presentation</wa-dropdown-item>
+  <wa-dropdown-item value="txt">Plain text</wa-dropdown-item>
+  <wa-dropdown-item value="json">JSON file</wa-dropdown-item>
+</wa-dropdown>
+```
+
+### Distance
+
+Set the `distance` attribute to change the gap between the panel and the trigger, in pixels.
+
+```html {.example}
+<wa-dropdown distance="30">
+  <wa-button appearance="filled" slot="trigger" with-caret>Edit</wa-button>
+
+  <wa-dropdown-item>Cut</wa-dropdown-item>
+  <wa-dropdown-item>Copy</wa-dropdown-item>
+  <wa-dropdown-item>Paste</wa-dropdown-item>
+
+  <wa-divider></wa-divider>
+
+  <wa-dropdown-item>Find</wa-dropdown-item>
+  <wa-dropdown-item>Replace</wa-dropdown-item>
+</wa-dropdown>
+```
+
+### Offset
+
+Set the `skidding` attribute to slide the panel along the trigger, in pixels.
+
+```html {.example}
+<wa-dropdown skidding="30">
+  <wa-button appearance="filled" slot="trigger" with-caret>Edit</wa-button>
+
+  <wa-dropdown-item>Cut</wa-dropdown-item>
+  <wa-dropdown-item>Copy</wa-dropdown-item>
+  <wa-dropdown-item>Paste</wa-dropdown-item>
+
+  <wa-divider></wa-divider>
+
+  <wa-dropdown-item>Find</wa-dropdown-item>
+  <wa-dropdown-item>Replace</wa-dropdown-item>
+</wa-dropdown>
+```
+
+### Reacting to Selections
+
+When an item is selected, the dropdown emits the `wa-select` event. Inspect `event.detail.item` for the selected [dropdown item](/docs/components/dropdown-item); if you set a `value` on each item, read it from `event.detail.item.value`.
+
+```html {.example}
+<div class="dropdown-zoom-demo">
+  <div class="dropdown-zoom-stage">
+    <div class="dropdown-zoom-content">
+      <wa-icon name="image"></wa-icon>
+      <span class="dropdown-zoom-level">100%</span>
+    </div>
+  </div>
+
+  <wa-dropdown>
+    <wa-button appearance="filled" slot="trigger" with-caret>View</wa-button>
+    <wa-dropdown-item value="zoom-in">Zoom in</wa-dropdown-item>
+    <wa-dropdown-item value="zoom-out">Zoom out</wa-dropdown-item>
+    <wa-divider></wa-divider>
+    <wa-dropdown-item value="actual">Actual size</wa-dropdown-item>
+  </wa-dropdown>
+</div>
+
+<script>
+  const demo = document.querySelector('.dropdown-zoom-demo');
+  const content = demo.querySelector('.dropdown-zoom-content');
+  const level = demo.querySelector('.dropdown-zoom-level');
+  const dropdown = demo.querySelector('wa-dropdown');
+  let zoom = 1;
+
+  dropdown.addEventListener('wa-select', event => {
+    const action = event.detail.item.value;
+
+    if (action === 'zoom-in') zoom = Math.min(zoom + 0.25, 2);
+    if (action === 'zoom-out') zoom = Math.max(zoom - 0.25, 0.5);
+    if (action === 'actual') zoom = 1;
+
+    content.style.transform = `scale(${zoom})`;
+    level.textContent = `${Math.round(zoom * 100)}%`;
+  });
+</script>
+
+<style>
+  .dropdown-zoom-demo .dropdown-zoom-stage {
+    display: grid;
+    place-items: center;
+    height: 12rem;
+    margin-block-end: 1rem;
+    overflow: hidden;
+    border-radius: var(--wa-border-radius-l);
+    background-color: color-mix(in srgb, var(--wa-color-brand-fill-loud) 8%, transparent);
+  }
+
+  .dropdown-zoom-demo .dropdown-zoom-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--wa-space-2xs);
+    transition: transform 150ms ease;
+  }
+
+  .dropdown-zoom-demo .dropdown-zoom-content wa-icon {
+    font-size: 3rem;
+    color: var(--wa-color-brand-fill-loud);
+  }
+
+  .dropdown-zoom-demo .dropdown-zoom-level {
+    font-size: var(--wa-font-size-s);
+    font-variant-numeric: tabular-nums;
+  }
+</style>
+```
+
+:::info
+To keep the dropdown open after a selection, call `event.preventDefault()` in the `wa-select` handler.
+:::


### PR DESCRIPTION
This work applies the `.house-rules/` docs conventions to the Actions category:  `button`, `button-group`, `copy-button`, and `dropdown`.

### Renamed Section Names
- Normalized headings to singular-by-default: `Variants`→`Variant`, `Sizes`→`Size`, `Tooltip Modes`→`Tooltip Mode`, `Disabling Items`→`Disabled`, and `Link Buttons`/`Icon Buttons`→`Link Button`/`Icon Button`. 
- Genuine composition sets stay plural (`button-group`'s `Split Buttons`, `Dropdowns`, `Tooltips`, `Toolbars`, `Native Buttons`; `dropdown`'s `Checkable Items`, `Destructive Items`, `Submenus`).

### Audited Examples
- Reworked each component's examples to show one thing clearly
- Labeled instances by the value they demonstrate
- Dropped redundant demos. 
- Added point-of-use accessibility callouts (`button`'s icon-only warning, `button-group`'s `label` warning)
- Converted option lists to tables where they pair a value with behavior.
- `dropdown`'s interactive `Reacting to Selections` demo is scoped to its own container.

### Copy Consistencies
Named API surfaces by their kind on first reference in `copy-button` (the `value` attribute, the `feedback-duration` attribute, …) to match `button`'s rigor.
