### PR TITLE
Fix Anchor-Link Scrolling for Sticky Header/Subheader

### DIFF
--- a/packages/webawesome/docs/assets/scripts/scroll.js
+++ b/packages/webawesome/docs/assets/scripts/scroll.js
@@ -25,16 +25,12 @@ document.addEventListener('click', event => {
 
   // Only handle smooth scroll if there's a hash and the link points to the current page
   if (id && link.pathname === window.location.pathname) {
-    const target = document.getElementById(id);
-    const headerHeight = document.querySelector('wa-page > header').clientHeight;
+    const target = document.getElementById(decodeURIComponent(id));
 
     if (target) {
       event.preventDefault();
-      window.scroll({
-        top: target.offsetTop - headerHeight,
-        behavior: 'smooth',
-      });
-
+      // Offset comes from scroll-margin-top on wa-page descendants (library layers.css).
+      target.scrollIntoView({ behavior: 'smooth' });
       history.replaceState(history.state, '', `#${id}`);
     }
   }
@@ -49,14 +45,36 @@ window.addEventListener('scroll', updateScrollClass);
 window.addEventListener('turbo:render', updateScrollClass);
 updateScrollClass();
 
+// wa-page publishes its sticky-region heights via ResizeObserver, so scroll-margin-top reads
+// ~0 for the first frames. Wait for the offset to settle, else the target lands behind the header.
+function alignToHashTarget(target) {
+  let previousOffset = -1;
+  let steadyFrames = 0;
+  let attempts = 0;
+  const tick = () => {
+    const offset = parseFloat(getComputedStyle(target).scrollMarginTop) || 0;
+    steadyFrames = offset === previousOffset ? steadyFrames + 1 : 0;
+    previousOffset = offset;
+    if (steadyFrames >= 3 || ++attempts > 90) {
+      target.scrollIntoView();
+    } else {
+      requestAnimationFrame(tick);
+    }
+  };
+  requestAnimationFrame(tick);
+}
+
 // Restore scroll position after components are defined
 allDefined().then(() => {
   const navigationType = getNavigationType();
   const key = `wa-scroll-y-[${location.pathname}]`;
   const scrollY = sessionStorage.getItem(key);
+  const hashTarget = location.hash ? document.getElementById(decodeURIComponent(location.hash.slice(1))) : null;
 
-  // Only restore when reloading, otherwise clear it
-  if (navigationType === 'reload' && scrollY) {
+  if (hashTarget) {
+    // Re-align after hydration; the browser's initial hash jump landed at a stale position.
+    alignToHashTarget(hashTarget);
+  } else if (navigationType === 'reload' && scrollY) {
     window.scrollTo(0, scrollY);
   } else {
     sessionStorage.removeItem(key);

--- a/packages/webawesome/docs/assets/scripts/scroll.js
+++ b/packages/webawesome/docs/assets/scripts/scroll.js
@@ -29,8 +29,8 @@ document.addEventListener('click', event => {
 
     if (target) {
       event.preventDefault();
-      // Offset comes from scroll-margin-top on wa-page descendants (library layers.css).
-      target.scrollIntoView({ behavior: 'smooth' });
+      // Offset from the library's scroll-margin-top; smoothness from CSS scroll-behavior (honors reduced-motion).
+      target.scrollIntoView();
       history.replaceState(history.state, '', `#${id}`);
     }
   }
@@ -56,7 +56,8 @@ function alignToHashTarget(target) {
     steadyFrames = offset === previousOffset ? steadyFrames + 1 : 0;
     previousOffset = offset;
     if (steadyFrames >= 3 || ++attempts > 90) {
-      target.scrollIntoView();
+      // Snap, never animate — this corrects a stale load position, not a user action.
+      target.scrollIntoView({ behavior: 'instant' });
     } else {
       requestAnimationFrame(tick);
     }
@@ -75,7 +76,7 @@ allDefined().then(() => {
     // Re-align after hydration; the browser's initial hash jump landed at a stale position.
     alignToHashTarget(hashTarget);
   } else if (navigationType === 'reload' && scrollY) {
-    window.scrollTo(0, scrollY);
+    window.scrollTo({ top: Number(scrollY), behavior: 'instant' });
   } else {
     sessionStorage.removeItem(key);
   }

--- a/packages/webawesome/docs/assets/styles/outline.css
+++ b/packages/webawesome/docs/assets/styles/outline.css
@@ -64,7 +64,7 @@
 
   #outline-standard {
     position: sticky;
-    inset-block-start: calc(var(--docs-header-height) + 3.5rem);
+    inset-block-start: var(--scroll-margin-top);
     inline-size: 15rem;
   }
 

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -45,6 +45,16 @@
     --nav-products-fill-quiet-build: color-mix(in oklab, var(--brand-build-awesome-green), black 65%);
   }
 
+  /* Smooth in-page anchor scrolling. Snaps for reduced-motion users; themes can override. */
+  :root {
+    scroll-behavior: smooth;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    :root {
+      scroll-behavior: auto;
+    }
+  }
+
   /* #region layout utilities */
 
   /* DO NOT redefine this base class anywhere else (no shadow rules in


### PR DESCRIPTION
Deep-linking to a heading in the docs (e.g. `/docs/resources/changelog#wa_3100`) often landed in the wrong place, with the target hidden behind the sticky header. This fixes the landing position and tidies up the surrounding scroll behavior.

### Landing on the Right Spot
On a cold load to a `#hash`, the page scrolled to the anchor before the sticky header had finished measuring its height, so the target ended up tucked behind it. We now wait until the header/subheader is measured, then align to the target. The offset itself already comes from `wa-page`.

### Smooth-Link Clicks
Simplified in-page link clicks to a plain `scrollIntoView()`, which also fixes a related bug where clicks didn't account for the subheader height.

### Outline Offset
Fixed the right-hand "On this page" outline (`outline.css`), whose sticky offset referenced an undefined variable and silently did nothing.

### Reduced Motion
Smooth scrolling now lives in CSS (`scroll-behavior` in the shared `utils.css`) instead of a hard-coded JS option, so it respects `prefers-reduced-motion` and themes can override it. The load and reload scroll corrections stay instant.

### Follow-up
The root cause lives in `<wa-page>`'s measurement timing, so it affects every `wa-page` consumer, not just our docs. We should consider making the fix to `<wa-page>` in the future.
