### PR TITLE
Fix compact color picker swatches

### DIFF
--- a/packages/webawesome/src/components/color-picker/color-picker.styles.ts
+++ b/packages/webawesome/src/components/color-picker/color-picker.styles.ts
@@ -216,7 +216,7 @@ export default css`
 
   .swatches {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(min(1.5em, 100%), 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(min(1.5em, 100%), 1fr));
     grid-gap: 0.5em;
     justify-items: center;
     border-block-start: var(--wa-form-control-border-style) var(--wa-form-control-border-width)

--- a/packages/webawesome/src/components/color-picker/color-picker.test.ts
+++ b/packages/webawesome/src/components/color-picker/color-picker.test.ts
@@ -36,6 +36,22 @@ describe('<wa-color-picker>', () => {
           expect(getComputedStyle(swatches[2]).backgroundColor).to.equal('rgb(0, 0, 255)');
         });
 
+        it('should keep swatches compact when there are fewer swatches than a full row', async () => {
+          const el = await fixture<WaColorPicker>(html`
+            <wa-color-picker swatches="red; green; blue;"></wa-color-picker>
+          `);
+          const trigger = el.shadowRoot!.querySelector<HTMLButtonElement>('[part~="trigger"]')!;
+          const swatch = el.shadowRoot!.querySelector<HTMLElement>('[part~="swatch"]')!;
+
+          await clickOnElement(trigger);
+          await aTimeout(200);
+
+          const fontSize = parseFloat(getComputedStyle(swatch).fontSize);
+          const swatchWidth = swatch.getBoundingClientRect().width;
+
+          expect(swatchWidth).to.be.lessThan(fontSize * 2);
+        });
+
         it('should render the correct swatches when passing an array of color values', async () => {
           const el = await fixture<WaColorPicker>(html` <wa-color-picker></wa-color-picker> `);
           el.swatches = ['red', '#008000', 'rgb(0,0,255)'];


### PR DESCRIPTION
## Summary

- Prevent color picker swatches from stretching when only a few presets are provided.
- Add a regression test covering compact swatch sizing.

Fixes #2571

## Test Plan

- npm run build
- CI=true FAIL_FAST=true npx web-test-runner --group color-picker
