### PR TITLE
Preserve color picker HEXA initial values

### DIFF
--- a/packages/webawesome/src/components/color-picker/color-picker.test.ts
+++ b/packages/webawesome/src/components/color-picker/color-picker.test.ts
@@ -318,6 +318,18 @@ describe('<wa-color-picker>', () => {
       });
 
       describe('form integration', () => {
+        it('should preserve alpha when initialized with a HEXA value and opacity enabled', async () => {
+          const form = await fixture<HTMLFormElement>(html`
+            <form>
+              <wa-color-picker name="a" format="hex" opacity value="#4d64d54d"></wa-color-picker>
+            </form>
+          `);
+          const colorPicker = form.querySelector<WaColorPicker>('wa-color-picker')!;
+
+          expect(colorPicker.value).to.equal('#4d64d54d');
+          expect(new FormData(form).get('a')).to.equal('#4d64d54d');
+        });
+
         it('should serialize its name and value with FormData', async () => {
           const form = await fixture<HTMLFormElement>(html`
             <form>

--- a/packages/webawesome/src/components/color-picker/color-picker.ts
+++ b/packages/webawesome/src/components/color-picker/color-picker.ts
@@ -806,7 +806,7 @@ export default class WaColorPicker extends WebAwesomeFormAssociatedElement {
     this.syncValues();
   }
 
-  @watch('opacity')
+  @watch('opacity', { waitUntilFirstUpdate: true })
   handleOpacityChange() {
     this.alpha = 100;
   }
@@ -938,6 +938,14 @@ export default class WaColorPicker extends WebAwesomeFormAssociatedElement {
 
   firstUpdated(changedProperties: PropertyValues<this>): void {
     super.firstUpdated(changedProperties);
+
+    const defaultValue = this.defaultValue;
+    if (defaultValue) {
+      const defaultColor = this.parseColor(defaultValue);
+      if (this.opacity && defaultColor && defaultColor.hsva.a < 1 && this.value === defaultColor.hex) {
+        this.setColor(defaultValue);
+      }
+    }
 
     this.hasEyeDropper = 'EyeDropper' in window;
   }


### PR DESCRIPTION
## Summary

- Preserve HEXA alpha values when a color picker initializes with `opacity`.
- Add a regression test covering the submitted form value for an initial HEXA color.

Fixes #2550

## Test Plan

- npm run build
- CI=true FAIL_FAST=true npx web-test-runner --group color-picker
