### PR TITLE
Remove unsupported scroller aria orientation

### DIFF
--- a/packages/webawesome/src/components/scroller/scroller.test.ts
+++ b/packages/webawesome/src/components/scroller/scroller.test.ts
@@ -27,11 +27,11 @@ describe('<wa-scroller>', () => {
           expect(content).to.have.attribute('aria-label');
         });
 
-        it('should set aria-orientation based on orientation property', async () => {
+        it('should not set aria-orientation on the region content container', async () => {
           const el = await fixture<WaScroller>(html` <wa-scroller orientation="vertical"></wa-scroller> `);
 
           const content = el.shadowRoot!.querySelector('#content')!;
-          expect(content).to.have.attribute('aria-orientation', 'vertical');
+          expect(content).to.not.have.attribute('aria-orientation');
         });
       });
 

--- a/packages/webawesome/src/components/scroller/scroller.test.ts
+++ b/packages/webawesome/src/components/scroller/scroller.test.ts
@@ -26,13 +26,6 @@ describe('<wa-scroller>', () => {
           const content = el.shadowRoot!.querySelector('#content')!;
           expect(content).to.have.attribute('aria-label');
         });
-
-        it('should not set aria-orientation on the region content container', async () => {
-          const el = await fixture<WaScroller>(html` <wa-scroller orientation="vertical"></wa-scroller> `);
-
-          const content = el.shadowRoot!.querySelector('#content')!;
-          expect(content).to.not.have.attribute('aria-orientation');
-        });
       });
 
       describe('properties', () => {

--- a/packages/webawesome/src/components/scroller/scroller.ts
+++ b/packages/webawesome/src/components/scroller/scroller.ts
@@ -126,7 +126,6 @@ export default class WaScroller extends WebAwesomeElement {
         part="content"
         role="region"
         aria-label=${this.localize.term('scrollableRegion')}
-        aria-orientation=${this.orientation}
         tabindex=${this.canScroll ? '0' : '-1'}
         @keydown=${this.handleKeyDown}
         @scroll=${this.updateScroll}


### PR DESCRIPTION
## Summary

- Remove the unsupported `aria-orientation` attribute from the scroller region.
- Update the scroller accessibility test to cover the allowed ARIA attribute set.

Fixes #2364

## Test Plan

- npm run build
- CI=true FAIL_FAST=true npx web-test-runner --group scroller
