### PR TITLE
Expose npm custom elements manifest path

### DIFF
--- a/packages/webawesome/custom-elements-manifest.js
+++ b/packages/webawesome/custom-elements-manifest.js
@@ -31,6 +31,7 @@ export default {
   exclude: ['**/*.styles.ts', '**/*.test.ts'],
   litelement: true,
   dependencies: true,
+  packagejson: false,
   outdir,
   // Give the plugin access to the TypeScript type checker
   overrideModuleCreation({ ts, globs }) {

--- a/packages/webawesome/package.json
+++ b/packages/webawesome/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://webawesome.com/",
   "author": "Web Awesome",
   "license": "MIT",
-  "customElements": "dist-cdn/custom-elements.json",
+  "customElements": "dist/custom-elements.json",
   "web-types": "./dist/web-types.json",
   "type": "module",
   "types": "dist/webawesome.d.ts",

--- a/packages/webawesome/src/internal/package-metadata.test.ts
+++ b/packages/webawesome/src/internal/package-metadata.test.ts
@@ -1,0 +1,12 @@
+import { expect } from '@open-wc/testing';
+import { readFile } from '@web/test-runner-commands';
+
+describe('package metadata', () => {
+  it('should expose the custom elements manifest from the npm package exports', async () => {
+    const packageJson = JSON.parse(await readFile({ path: '../../package.json' }));
+    const customElementsPath = packageJson.customElements;
+
+    expect(customElementsPath).to.equal('dist/custom-elements.json');
+    expect(packageJson.exports).to.have.property(`./${customElementsPath}`);
+  });
+});


### PR DESCRIPTION
## Summary

- Point the package `customElements` field at the exported npm manifest path.
- Keep the CEM analyzer from rewriting the package metadata during builds.
- Add a package metadata regression test to keep the field aligned with package exports.

Fixes #2574

## Test Plan

- `npm run build`
- `CI=true FAIL_FAST=true npx web-test-runner --group package-metadata`
