### PR TITLE
Align button group edge offsets

### DIFF
--- a/packages/webawesome/src/components/button-group/button-group.styles.ts
+++ b/packages/webawesome/src/components/button-group/button-group.styles.ts
@@ -41,11 +41,21 @@ export default css`
   :host([orientation='horizontal']) {
     --_button-horizontal-indent: var(--wa-form-control-border-width);
     --_button-horizontal-indent-outlined: calc(var(--wa-form-control-border-width) * -1);
+
+    ::slotted(:first-child) {
+      --_button-horizontal-indent: 0;
+      --_button-horizontal-indent-outlined: 0;
+    }
   }
 
   :host([orientation='vertical']) {
     --_button-vertical-indent: var(--wa-form-control-border-width);
     --_button-vertical-indent-outlined: calc(var(--wa-form-control-border-width) * -1);
+
+    ::slotted(:first-child) {
+      --_button-vertical-indent: 0;
+      --_button-vertical-indent-outlined: 0;
+    }
   }
 
   /* All buttons that are not in front or at the end get their border radius removed */

--- a/packages/webawesome/src/components/button-group/button-group.test.ts
+++ b/packages/webawesome/src/components/button-group/button-group.test.ts
@@ -98,6 +98,32 @@ describe('<wa-button-group>', () => {
           const buttons = el.querySelectorAll('wa-button');
           expect(buttons.length).to.equal(3);
         });
+
+        for (const appearance of ['accent', 'filled', 'filled-outlined', 'outlined', 'plain'] as const) {
+          it(`should not offset the first ${appearance} button`, async () => {
+            const el = await fixture<WaButtonGroup>(html`
+              <wa-button-group>
+                <wa-button appearance=${appearance}>Button 1</wa-button>
+                <wa-button appearance=${appearance}>Button 2</wa-button>
+              </wa-button-group>
+            `);
+            const firstButton = el.querySelector('wa-button')!;
+
+            expect(getComputedStyle(firstButton).marginInlineStart).to.equal('0px');
+          });
+
+          it(`should not offset the first vertical ${appearance} button`, async () => {
+            const el = await fixture<WaButtonGroup>(html`
+              <wa-button-group orientation="vertical">
+                <wa-button appearance=${appearance}>Button 1</wa-button>
+                <wa-button appearance=${appearance}>Button 2</wa-button>
+              </wa-button-group>
+            `);
+            const firstButton = el.querySelector('wa-button')!;
+
+            expect(getComputedStyle(firstButton).marginBlockStart).to.equal('0px');
+          });
+        }
       });
 
       describe('CSS parts and states', () => {


### PR DESCRIPTION
## Summary

- Reset grouped button indent variables on the first slotted button so the group edge stays aligned across appearances.
- Cover horizontal and vertical groups for all button appearances in regression tests.

Fixes #2587

## Test Plan

- `npm run build`
- `CI=true FAIL_FAST=true npx web-test-runner --group button-group`
