### PR TITLE
Remove XML-like tags from design skill description

### DIFF
--- a/packages/webawesome/scripts/design-skill/SKILL.md
+++ b/packages/webawesome/scripts/design-skill/SKILL.md
@@ -4,9 +4,9 @@ description: >
   Design and lay out user interfaces with Web Awesome. Use this when building or styling a PAGE,
   LAYOUT, or SECTION; choosing or customizing a THEME; applying brand COLORS or design tokens; or
   composing a polished, good-looking UI with Web Awesome components and utilities. Triggers on requests
-  like "build a landing page", "make an app layout", "set up <wa-page>", "add a sidebar", "apply a
+  like "build a landing page", "make an app layout", "set up wa-page", "add a sidebar", "apply a
   theme", "match our brand color", "style this to look designed", "build a settings page", or "lay out
-  a dashboard". Teaches layout (when and how to use <wa-page>), theming (--wa-* tokens), and visual
+  a dashboard". Teaches layout (when and how to use wa-page), theming (--wa-* tokens), and visual
   composition. Pair with the `webawesome` skill, which documents individual component APIs.
 license: MIT / Commercial (for Web Awesome Pro)
 metadata:

--- a/packages/webawesome/scripts/verify-skills.js
+++ b/packages/webawesome/scripts/verify-skills.js
@@ -14,9 +14,11 @@
  *     components aren't marked Pro.
  *  3. Every relative markdown link in `agent-skill/choosing-components.md` and `design-skill/**.md`
  *     resolves to a file that exists.
+ *  4. Design skill frontmatter descriptions don't contain XML-like tags rejected by Claude.ai Skills.
  */
 
 import fs from 'fs';
+import matter from 'gray-matter';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -32,6 +34,7 @@ const PRO_CEM = path.join(REPO_ROOT, 'packages', 'webawesome-pro', 'dist', 'cust
 
 const CHOOSING_COMPONENTS = path.join(__dirname, 'agent-skill', 'choosing-components.md');
 const DESIGN_SKILL_DIR = path.join(__dirname, 'design-skill');
+const DESIGN_SKILL = path.join(DESIGN_SKILL_DIR, 'SKILL.md');
 
 // `choosing-components.md` lives at source in `scripts/agent-skill/` but ships into the same
 // `references/` dir as everything else the agent-skill generator produces — so relative links it
@@ -97,6 +100,17 @@ const cemAvailable = cemByTag.size > 0;
 if (!cemAvailable) {
   warnings.push(
     `Custom Elements Manifests not found (run \`npm run build\` first); skipping attribute-existence check.`,
+  );
+}
+
+// --- Check: Skill descriptions must be accepted by Claude.ai Skills ---
+const designSkillMd = fs.readFileSync(DESIGN_SKILL, 'utf-8');
+const designFrontmatter = matter(designSkillMd).data;
+const designDescription = String(designFrontmatter.description || '');
+const xmlLikeTagRegex = /<\/?[A-Za-z][A-Za-z0-9-]*(?:\s[^>]*)?>/;
+if (xmlLikeTagRegex.test(designDescription)) {
+  errors.push(
+    `design-skill/SKILL.md frontmatter description contains XML-like tags; use plain component names such as \`wa-page\` instead of \`<wa-page>\``,
   );
 }
 


### PR DESCRIPTION
## Summary

- Remove custom-element angle brackets from the `webawesome-design` skill frontmatter description so Claude.ai Skills accepts it.
- Add a `verify-skills` guard that rejects XML-like tags in the design skill description.

Fixes #2558

## Test Plan

- `npm run build`
- `node -e "const fs = require('fs'); const files = ['scripts/design-skill/SKILL.md', 'dist/skills/webawesome-design/SKILL.md', 'dist-cdn/skills/webawesome-design/SKILL.md']; const tag = /<\/?[A-Za-z][A-Za-z0-9-]*(?:\s[^>]*)?>/; for (const file of files) { const content = fs.readFileSync(file, 'utf8'); const frontmatter = content.match(/^---\n([\s\S]*?)\n---/)?.[1] || ''; const description = frontmatter.match(/^description:\s*>\n((?:\s+.*\n?)*)/m)?.[1] || ''; if (tag.test(description)) { console.error(file + ' description has XML-like tags'); process.exit(1); } }"`
- `npx prettier --check --log-level=warn --ignore-path="../../.prettierignore" scripts/design-skill/SKILL.md scripts/verify-skills.js`

Note: `node scripts/verify-skills.js` runs with this change, and the new description error is gone. In this checkout it still reports pre-existing missing Pro component/link errors unrelated to this PR.
