### PR TITLE
Apply inverted colors to native button variants

### DIFF
--- a/packages/webawesome/src/internal/native-styles.test.ts
+++ b/packages/webawesome/src/internal/native-styles.test.ts
@@ -1,0 +1,59 @@
+import { expect, fixture } from '@open-wc/testing';
+import { html } from 'lit';
+
+async function loadNativeStyles() {
+  const existing = document.querySelector<HTMLLinkElement>('link[data-test-native-styles]');
+  if (existing) return;
+
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = '/dist/styles/native.css';
+  link.dataset.testNativeStyles = '';
+  document.head.append(link);
+
+  await new Promise<void>((resolve, reject) => {
+    link.addEventListener('load', () => resolve(), { once: true });
+    link.addEventListener('error', () => reject(new Error('Failed to load native styles')), { once: true });
+  });
+}
+
+function resolvedColor(el: HTMLElement, value: string) {
+  el.style.color = value;
+  return getComputedStyle(el).color;
+}
+
+describe('native styles', () => {
+  before(async () => {
+    await loadNativeStyles();
+  });
+
+  it('should apply inverted neutral colors to native buttons inside wa-invert', async () => {
+    const el = await fixture<HTMLElement>(html`
+      <div class="wa-invert">
+        <span data-token></span>
+        <button class="wa-filled">Button</button>
+      </div>
+    `);
+    const token = el.querySelector<HTMLElement>('[data-token]')!;
+    const button = el.querySelector('button')!;
+
+    expect(getComputedStyle(button).backgroundColor).to.equal(
+      resolvedColor(token, 'var(--wa-color-neutral-fill-normal)'),
+    );
+  });
+
+  it('should apply inverted neutral colors to native buttons with wa-invert', async () => {
+    const el = await fixture<HTMLElement>(html`
+      <div>
+        <span class="wa-invert" data-token></span>
+        <button class="wa-invert wa-filled">Button</button>
+      </div>
+    `);
+    const token = el.querySelector<HTMLElement>('[data-token]')!;
+    const button = el.querySelector('button')!;
+
+    expect(getComputedStyle(button).backgroundColor).to.equal(
+      resolvedColor(token, 'var(--wa-color-neutral-fill-normal)'),
+    );
+  });
+});

--- a/packages/webawesome/src/styles/utilities/variants.css
+++ b/packages/webawesome/src/styles/utilities/variants.css
@@ -1,6 +1,7 @@
 @layer wa-utilities {
   :where(:root),
-  .wa-neutral {
+  .wa-neutral,
+  .wa-invert {
     --wa-color-fill-loud: var(--wa-color-neutral-fill-loud);
     --wa-color-fill-normal: var(--wa-color-neutral-fill-normal);
     --wa-color-fill-quiet: var(--wa-color-neutral-fill-quiet);


### PR DESCRIPTION
## Summary

- Let `.wa-invert` establish the default neutral variant aliases used by native styles.
- Add native style regression tests for buttons inside `.wa-invert` and buttons with `.wa-invert` directly applied.

Fixes #2533

## Test Plan

- `npm run build`
- `CI=true FAIL_FAST=true npx web-test-runner --group native-styles`
