### PR TITLE
Docs: Polish + Standardize Framework Docs (including SSR)

### DIFF
--- a/packages/webawesome/docs/_layouts/framework.njk
+++ b/packages/webawesome/docs/_layouts/framework.njk
@@ -9,10 +9,57 @@
 
 {%- block afterContent -%}
 
-{% markdown %}
-:::info
-Are you using Web Awesome with {{ title }}? [Help us improve this page!](https://github.com/shoelace-style/webawesome/blob/next/packages/webawesome/docs/{{ page | relativeInputPath }})
-:::
-{% endmarkdown %}
+{%- set feedbackTitle = "Docs feedback: " + title -%}
+{%- set feedbackBody = "Feedback on the " + title + " docs (" + page.url + ") — bug, use case, or feature request:" -%}
+{%- set feedbackUrl = "https://github.com/shoelace-style/webawesome/discussions/new?category=ideas-suggestions&title=" + (feedbackTitle | urlencode) + "&body=" + (feedbackBody | urlencode) -%}
+
+<h2>Next Steps</h2>
+
+<div class="modern-card-list info-cards">
+  <section class="search-list-grid">
+    <a class="hover-grow hover-emphasize-border duotone-hover-context" data-duotone-hover-trigger href="/docs/components">
+      <wa-card>
+        <wa-icon class="info-card-icon duotone-illustrated duotone-secondary-reveal" name="puzzle-piece" family="duotone" variant="regular"></wa-icon>
+        <span class="page-name">Components</span>
+        <p class="modern-card-summary">Start building your interface.</p>
+      </wa-card>
+    </a>
+    <a class="hover-grow hover-emphasize-border duotone-hover-context" data-duotone-hover-trigger href="/docs/utilities">
+      <wa-card>
+        <wa-icon class="info-card-icon duotone-illustrated duotone-secondary-reveal" name="wand-magic-sparkles" family="duotone" variant="regular"></wa-icon>
+        <span class="page-name">CSS Utilities</span>
+        <p class="modern-card-summary">Lay out and style without custom CSS.</p>
+      </wa-card>
+    </a>
+    <a class="hover-grow hover-emphasize-border duotone-hover-context" data-duotone-hover-trigger href="/docs/themes">
+      <wa-card>
+        <wa-icon class="info-card-icon duotone-illustrated duotone-secondary-reveal" name="palette" family="duotone" variant="regular"></wa-icon>
+        <span class="page-name">Theming</span>
+        <p class="modern-card-summary">Match Web Awesome to your brand.</p>
+      </wa-card>
+    </a>
+    {% if officialDocs -%}
+    <a class="hover-grow hover-emphasize-border duotone-hover-context" data-duotone-hover-trigger href="{{ officialDocs }}" target="_blank" rel="noopener noreferrer">
+      <wa-card>
+        <wa-icon class="info-card-icon duotone-illustrated duotone-secondary-reveal" name="book" family="duotone" variant="regular"></wa-icon>
+        <span class="page-name">{{ title }} Docs</span>
+        <p class="modern-card-summary">The official {{ title }} documentation.</p>
+      </wa-card>
+    </a>
+    {%- endif %}
+  </section>
+</div>
+
+<wa-callout variant="neutral">
+  <div class="wa-flank:end wa-gap-xl">
+    <p><strong>Using Web Awesome with {{ title }}?</strong><br />
+    Found a bug or have a suggestion? Help make things more awesome!</p>
+
+    <wa-button size="small" href="{{ feedbackUrl }}" target="_blank" rel="noopener noreferrer">
+      <wa-icon slot="start" name="lightbulb-on" variant="regular"></wa-icon>
+      Share feedback
+    </wa-button>
+  </div>
+</wa-callout>
 
 {% endblock %}

--- a/packages/webawesome/docs/_layouts/framework.njk
+++ b/packages/webawesome/docs/_layouts/framework.njk
@@ -13,42 +13,63 @@
 {%- set feedbackBody = "Feedback on the " + title + " docs (" + page.url + ") — bug, use case, or feature request:" -%}
 {%- set feedbackUrl = "https://github.com/shoelace-style/webawesome/discussions/new?category=ideas-suggestions&title=" + (feedbackTitle | urlencode) + "&body=" + (feedbackBody | urlencode) -%}
 
-<h2>Next Steps</h2>
+{% set nextSteps = [
+  {
+    title: "Components",
+    href: "/docs/components",
+    external: false,
+    icon_name: "puzzle-piece",
+    summary: "Start building your interface."
+  },
+  {
+    title: "CSS Utilities",
+    href: "/docs/utilities",
+    external: false,
+    icon_name: "wand-magic-sparkles",
+    summary: "Lay out and style without custom CSS."
+  },
+  {
+    title: "Theming",
+    href: "/docs/themes",
+    external: false,
+    icon_name: "palette",
+    summary: "Match Web Awesome to your brand."
+  }
+] %}
 
-<div class="modern-card-list info-cards">
-  <section class="search-list-grid">
-    <a class="hover-grow hover-emphasize-border duotone-hover-context" data-duotone-hover-trigger href="/docs/components">
-      <wa-card>
-        <wa-icon class="info-card-icon duotone-illustrated duotone-secondary-reveal" name="puzzle-piece" family="duotone" variant="regular"></wa-icon>
-        <span class="page-name">Components</span>
-        <p class="modern-card-summary">Start building your interface.</p>
-      </wa-card>
-    </a>
-    <a class="hover-grow hover-emphasize-border duotone-hover-context" data-duotone-hover-trigger href="/docs/utilities">
-      <wa-card>
-        <wa-icon class="info-card-icon duotone-illustrated duotone-secondary-reveal" name="wand-magic-sparkles" family="duotone" variant="regular"></wa-icon>
-        <span class="page-name">CSS Utilities</span>
-        <p class="modern-card-summary">Lay out and style without custom CSS.</p>
-      </wa-card>
-    </a>
-    <a class="hover-grow hover-emphasize-border duotone-hover-context" data-duotone-hover-trigger href="/docs/themes">
-      <wa-card>
-        <wa-icon class="info-card-icon duotone-illustrated duotone-secondary-reveal" name="palette" family="duotone" variant="regular"></wa-icon>
-        <span class="page-name">Theming</span>
-        <p class="modern-card-summary">Match Web Awesome to your brand.</p>
-      </wa-card>
-    </a>
-    {% if officialDocs -%}
-    <a class="hover-grow hover-emphasize-border duotone-hover-context" data-duotone-hover-trigger href="{{ officialDocs }}" target="_blank" rel="noopener noreferrer">
-      <wa-card>
-        <wa-icon class="info-card-icon duotone-illustrated duotone-secondary-reveal" name="book" family="duotone" variant="regular"></wa-icon>
-        <span class="page-name">{{ title }} Docs</span>
-        <p class="modern-card-summary">The official {{ title }} documentation.</p>
-      </wa-card>
-    </a>
-    {%- endif %}
-  </section>
-</div>
+{% if officialDocs %}
+  {% set nextSteps = nextSteps.concat([{
+    title: title + " Docs",
+    href: officialDocs,
+    external: true,
+    icon_name: "book",
+    summary: "The official " + title + " documentation."
+  }]) %}
+{% endif %}
+
+
+<section class="modern-card-list info-cards">
+  <h2>Next Steps</h2>
+
+  <div class="search-list-grid">
+    {% for step in nextSteps %}
+      <a
+        class="hover-grow hover-emphasize-border duotone-hover-context"
+        data-duotone-hover-trigger
+        href="{{ step.href }}"
+        {% if step.external -%}
+        target="_blank" rel="noopener noreferrer"
+        {%- endif -%}
+      >
+        <wa-card>
+          <wa-icon class="info-card-icon duotone-illustrated duotone-secondary-reveal" name="{{ step.icon_name }}" family="duotone" variant="regular"></wa-icon>
+          <span class="page-name">{{ step.title }}</span>
+          <p class="modern-card-summary">{{ step.summary }}</p>
+        </wa-card>
+      </a>
+    {% endfor %}
+  </div>
+</section>
 
 <wa-callout variant="neutral">
   <div class="wa-flank:end wa-gap-xl">

--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -428,6 +428,10 @@ wa-card .page-name {
       font-size: var(--wa-font-size-s);
       line-height: var(--wa-line-height-normal);
       margin: 0 0 var(--wa-space-m);
+
+      &:last-child {
+        margin-block-end: 0;
+      }
     }
 
     .component-list-badges {

--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -476,6 +476,70 @@ wa-card .page-name {
   }
 }
 
+/* Framework docs: hub logo cards + framework-page info cards */
+
+/* Hub: brand logos sit in a fixed-height row, always in full brand color */
+.framework-logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  block-size: 2.5rem;
+}
+
+.framework-icon {
+  max-inline-size: 6.5rem;
+  font-size: var(--wa-font-size-3xl);
+  color: var(--color, currentColor);
+}
+
+.search-list-grid .framework-card::part(body) {
+  align-items: center;
+  justify-content: center;
+  gap: var(--wa-space-s);
+  min-block-size: 8rem;
+  text-align: center;
+}
+
+.framework-card .page-name {
+  margin: 0;
+}
+
+/* Framework pages: "next steps" / "see it in action" info cards */
+.info-cards .search-list-grid wa-card {
+  --spacing: var(--wa-space-l);
+}
+
+.info-cards .search-list-grid .page-name {
+  font-size: var(--wa-font-size-m);
+}
+
+.info-card-icon {
+  margin-block-end: var(--wa-space-s);
+  font-size: var(--wa-font-size-xl);
+}
+
+/* Duotone icon whose secondary (brand) color fades in on hover.
+   Companion to .duotone-illustrated (utils.css); ported so it also works on the free docs build. */
+.duotone-hover-context wa-icon.duotone-illustrated.duotone-secondary-reveal {
+  --secondary-opacity: 0;
+  transition: --secondary-opacity var(--wa-transition-slow) ease-in-out;
+}
+
+.duotone-hover-context[data-duotone-hover-trigger]:is(:hover, :focus-visible)
+  wa-icon.duotone-illustrated.duotone-secondary-reveal,
+.duotone-hover-context:has(:is(a, button):is(:hover, :focus-visible))
+  wa-icon.duotone-illustrated.duotone-secondary-reveal {
+  --secondary-opacity: 1;
+}
+
+/* Reduced motion + touch: show the two-tone icon up front instead of on hover */
+@media (prefers-reduced-motion: reduce), (hover: none) {
+  .duotone-hover-context wa-icon.duotone-illustrated.duotone-secondary-reveal {
+    transition: none;
+    --secondary-opacity: 1;
+  }
+}
+
 /* Design Tokens Swatches */
 .swatch {
   position: relative;

--- a/packages/webawesome/docs/docs/frameworks.md
+++ b/packages/webawesome/docs/docs/frameworks.md
@@ -1,7 +1,7 @@
 ---
 title: Frameworks
 description: Using Web Awesome with frameworks.
-layout: page-outline
+layout: docs
 hasOutline: false
 synonyms:
   - integrations
@@ -56,7 +56,7 @@ frameworks:
       icon_src: "/assets/images/logos/logo-express-white.svg"
 
   # Astro
-  - color: "#41b883"
+  - color: "#ff5d01"
     title: Astro
     icon_src: "/assets/images/logos/astro-logo-dark.svg"
     href: "/docs/frameworks/astro"
@@ -70,23 +70,14 @@ frameworks:
     href: "/docs/frameworks/buildawesome"
 ---
 
-<style>
-  .framework-icon {
-    font-size: var(--wa-font-size-4xl);
-    color: var(--color, currentColor);
-  }
-</style>
+Web Awesome is built on standard web components, so it works with any framework. These guides cover setup and known limitations for the most common ones.
 
-Web Awesome is designed to work in harmony with various frameworks. We have documented some of the most common ones including setup and limitations.
-
-Select your framework below to get started.
-
-<div class="wa-grid" style="--min-column-size: 20ch;">
-  {# sort alphabetically #}
+<div class="modern-card-list">
+  <section class="search-list-grid">
   {%- for framework in frameworks | sort(false, true, 'title') -%}
     <a href="{{ framework.href }}" class="wa-link-plain hover-grow hover-emphasize-border">
-      <wa-card appearance="outlined" style="height: 100%;">
-        <div class="wa-stack wa-align-items-center">
+      <wa-card class="framework-card">
+        <div class="framework-logo">
           <wa-icon
             class="
               framework-icon
@@ -115,18 +106,25 @@ Select your framework below to get started.
               style="--color: {{ framework.dark.color or framework.color or "currentColor" }};"
             ></wa-icon>
           {%- endif -%}
-          <span class="wa-heading-m">
-            {{ framework.title }}
-          </span>
         </div>
+        <span class="page-name">
+          {{ framework.title }}
+        </span>
       </wa-card>
     </a>
   {%- endfor -%}
+  </section>
 </div>
 
 
-<p style="margin-top: 4rem; text-align: center;">
-  <a href="https://github.com/shoelace-style/webawesome/discussions/new?category=ideas-suggestions">
-    Don't see your framework here? Feel free to open a discussion!
-  </a>
-</p>
+<div class="wa-placeholder wa-stack wa-gap-2xl wa-align-items-center wa-justify-content-center wa-text-center">
+  <div class="wa-stack wa-align-items-center">
+    <wa-icon name="puzzle" variant="regular" class="wa-font-size-3xl"></wa-icon>
+    <h3 class="font-brand wa-heading-xl" data-no-anchor>Don't See Your Framework?</h3>
+    <p class="text-wrap-balance line-length line-length-m">We document the most common frameworks, but we're always adding more. Tell us what you're building with and we'll consider a guide.</p>
+  </div>
+  <wa-button href="{{ site.github.ideas }}">
+    <wa-icon name="lightbulb-on" slot="start" variant="regular"></wa-icon>
+    Request a Framework
+  </wa-button>
+</div>

--- a/packages/webawesome/docs/docs/frameworks/angular.md
+++ b/packages/webawesome/docs/docs/frameworks/angular.md
@@ -2,13 +2,12 @@
 title: Angular
 description: Tips for using Web Awesome in your Angular app.
 layout: framework
+officialDocs: https://angular.dev
 ---
 
 Angular [plays nice](https://custom-elements-everywhere.com/#angular) with custom elements, so you can use Web Awesome in your Angular apps with ease.
 
 ## Installation
-
-### Download the npm Package
 
 To add Web Awesome to your Angular app, install the package from npm.
 
@@ -16,11 +15,11 @@ To add Web Awesome to your Angular app, install the package from npm.
 npm install @awesome.me/webawesome
 ```
 
-### Update the Angular Configuration
+## Configuration
 
-Next, [include a theme](/docs/themes). In this example, we'll import the light theme.
+### Load the Theme
 
-Its also important to load the components by using a `<script>` tag into the index.html file. However, the Angular way to do it is by adding a script configurations into your angular.json file as follows:
+[Include a theme](/docs/themes) by adding the stylesheet to the `styles` array in your `angular.json` file:
 
 ```json
 "architect": {
@@ -38,9 +37,9 @@ Its also important to load the components by using a `<script>` tag into the ind
 }
 ```
 
-## Configuration
+### Apply the Custom Elements Schema
 
-Then make sure to apply the custom elements schema as shown below.
+Apply the custom elements schema so Angular allows Web Awesome's `wa-*` tags:
 
 ```js
 import { BrowserModule } from '@angular/platform-browser';
@@ -53,43 +52,36 @@ import { AppComponent } from './app.component';
   imports: [BrowserModule],
   providers: [],
   bootstrap: [AppComponent],
-  schemas: [CUSTOM_ELEMENTS_SCHEMA]
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class AppModule {}
 ```
 
-## Reference Web Awesome Components in Your Angular Component Code
+## Usage
+
+Reference Web Awesome components from your component code. Import both the component and its type — otherwise Angular tree-shakes the component out of your build:
 
 ```js
-// need to have both or Angular will tree shake the component out.
 import type { WaDrawer } from '@awesome.me/webawesome/dist/components/drawer/drawer.js';
-import "@awesome.me/webawesome/dist/components/drawer/drawer.js";
+import '@awesome.me/webawesome/dist/components/drawer/drawer.js';
 
 @Component({
   selector: 'app-drawer-example',
-  template: '<div id="page"><button (click)="showDrawer()">Show drawer</button><wa-drawer #drawer label="Drawer" class="drawer-focus" style="--size: 50vw"><p>Drawer content</p></wa-drawer></div>'
+  template: '<div id="page"><button (click)="showDrawer()">Show drawer</button><wa-drawer #drawer label="Drawer" class="drawer-focus" style="--size: 50vw"><p>Drawer content</p></wa-drawer></div>',
 })
-export class DrawerExampleComponent implements OnInit {
-
-  // use @ViewChild to get a reference to the #drawer element within component template
+export class DrawerExampleComponent {
+  // @ViewChild gives a typed reference to the <wa-drawer> element
   @ViewChild('drawer')
   drawer?: ElementRef<WaDrawer>;
 
-  ...
-
-  constructor(...) {
-  }
-
-  ngOnInit() {
-  }
-
-  ...
-
   showDrawer() {
-    // use nativeElement to access Web Awesome components
+    // Access Web Awesome methods via nativeElement
     this.drawer?.nativeElement.show();
   }
 }
 ```
 
-Now you can start using Web Awesome components in your app!
+<wa-callout variant="success">
+  <strong>Web Awesome is ready to use.</strong><br />
+  Explore components, utilities, and theming to start building.
+</wa-callout>

--- a/packages/webawesome/docs/docs/frameworks/astro.md
+++ b/packages/webawesome/docs/docs/frameworks/astro.md
@@ -2,15 +2,20 @@
 title: Astro
 description: Tips for using Web Awesome in your Astro app.
 layout: framework
+officialDocs: https://docs.astro.build
 ---
 
-To get started using Web Awesome in Astro, you must first install it from NPM.
+## Installation
+
+To add Web Awesome to your Astro app, install the package from npm.
 
 ```bash
 npm install @awesome.me/webawesome
 ```
 
-Once you've installed it from NPM, you can import component as "client" scripts, and add the "global" stylesheet in the frontmatter.
+## Usage
+
+Web Awesome components render on the client. Import the ones you need as client scripts, and add the global stylesheet in your frontmatter:
 
 ```jsx
 ---
@@ -24,21 +29,35 @@ import "@awesome.me/webawesome/dist/components/button/button.js"
 <wa-button>Hello World</wa-button>
 ```
 
-These components will be "client" side rendered.
+<wa-callout variant="success">
+  <div class="wa-flank:end wa-gap-xl">
+    <p>
+      <strong>Web Awesome is ready to use.</strong><br />
+      Want server-side rendering too?
+    </p>
+    <wa-button size="small" variant="success" href="#server-side-rendering">
+      Add SSR
+    </wa-button>
+  </div>
+</wa-callout>
 
-## SSR (Server Side Rendering)
+## Server-Side Rendering
 
-The Web Awesome team maintains an Astro adapter to help you get started with SSR.
+With server-side rendering, your Web Awesome components render to HTML on the server, so pages display fully styled before client-side JavaScript loads. Learn more in the [SSR docs](/docs/ssr).
 
-<https://github.com/shoelace-style/astro-lit>
+To add SSR support to Astro, follow the steps below.
 
-To get started, install the adapter from NPM.
+### Install the Adapter
+
+The Web Awesome team maintains an [Astro adapter](https://github.com/shoelace-style/astro-lit) to help you set up SSR. Install it from npm:
 
 ```bash
 npm install @awesome.me/astro-lit
 ```
 
-Now you have to register the plugin in your `astro.config.mjs`
+### Register the Plugin
+
+Once installed, you can register the plugin in your `astro.config.mjs` file.
 
 ```js
 // astro.config.mjs
@@ -53,9 +72,16 @@ export default defineConfig({
 });
 ```
 
-Once your plugin is setup, you must now register components in 2 places, one on the "server", one on the "client", as well as make sure the `hydration` script runs before any client components register.
+### Register Components
 
-So the previous example should look like this:
+With the plugin in place, register your components in two places — once on the **server** and once on the **client** — and make sure the hydration scripts run before any client components.
+
+:::warning
+<strong>Import the hydration scripts before any client components.</strong><br />
+Otherwise components hydrate more than once and the page breaks.
+:::
+
+Here's the previous example updated:
 
 ```jsx
 ---
@@ -67,8 +93,7 @@ import "@awesome.me/webawesome/dist/components/button/button.js"
 ---
 
 <script>
-// **!! VERY IMPORTANT !!**
-// These 2 imports must come first before importing any components on the client. If not, you will end up with things rendering more than once and things will look very, very broken.
+// Must run before any client component imports
 import "@awesome.me/astro-lit/dsd-polyfill.js"
 import "@awesome.me/astro-lit/hydration-support.js"
 
@@ -79,10 +104,29 @@ import "@awesome.me/webawesome/dist/components/button/button.js"
 <wa-button>Hello World</wa-button>
 ```
 
-An example can be found here:
+<wa-callout variant="success">
+  <strong>That's it!</strong> You're set up to use Web Awesome with SSR.
+</wa-callout>
 
-<https://github.com/KonnorRogers/webawesome-astro-ssr/>
+### See It in Action
 
-As well as a demo:
+Need an example of a complete Astro SSR project using Web Awesome?
 
-<https://webawesome-astro.netlify.app>
+<div class="modern-card-list info-cards">
+  <section class="search-list-grid">
+    <a class="hover-grow hover-emphasize-border duotone-hover-context" data-duotone-hover-trigger href="https://github.com/KonnorRogers/webawesome-astro-ssr/" target="_blank" rel="noopener noreferrer">
+      <wa-card>
+        <wa-icon class="info-card-icon duotone-illustrated duotone-secondary-reveal" name="file-code" family="duotone" variant="regular"></wa-icon>
+        <span class="page-name">Example Repository</span>
+        <p class="modern-card-summary">A complete Astro SSR project using Web Awesome.</p>
+      </wa-card>
+    </a>
+    <a class="hover-grow hover-emphasize-border duotone-hover-context" data-duotone-hover-trigger href="https://webawesome-astro.netlify.app" target="_blank" rel="noopener noreferrer">
+      <wa-card>
+        <wa-icon class="info-card-icon duotone-illustrated duotone-secondary-reveal" name="globe" family="duotone" variant="regular"></wa-icon>
+        <span class="page-name">Live Demo</span>
+        <p class="modern-card-summary">See the Astro SSR example deployed and running.</p>
+      </wa-card>
+    </a>
+  </section>
+</div>

--- a/packages/webawesome/docs/docs/frameworks/buildawesome.md
+++ b/packages/webawesome/docs/docs/frameworks/buildawesome.md
@@ -2,36 +2,35 @@
 title: Build Awesome (11ty)
 description: Tips for using Web Awesome in your Build Awesome (11ty) app.
 layout: framework
+officialDocs: https://www.11ty.dev
 ---
 
-Due to Build Awesome (11ty) being relatively unopinionated, there are many different ways to setup Web Awesome with your Build Awesome / 11ty site.
-
-The easiest way to use Web Awesome with Build Awesome is via NPM, since you're most likely using Build Awesome via NPM.
+Build Awesome (11ty) is relatively unopinionated, so there are several ways to add Web Awesome — the simplest is via npm, which your project most likely already uses.
 
 ## Installation
 
+To add Web Awesome to your Build Awesome site, install the package from npm.
 
-```js
+```bash
 npm install @awesome.me/webawesome
 ```
 
-After installing Web Awesome, we need to make our components available to the "frontend", we can do so by using `addPassthroughCopy`.
+## Usage
 
-If you haven't already, create a `eleventy.config.js`
+### Copy the Assets
 
-
-and do the following:
+Web Awesome's assets must be available to the browser. Add `addPassthroughCopy` to your `eleventy.config.js` to copy them into your build output — create the file if you don't have one yet:
 
 ```js
 // eleventy.config.js
 
-const webawesomeDir = "./node_modules/@awesome.me/webawesome"
+const webawesomeDir = './node_modules/@awesome.me/webawesome';
 
-export default async function(eleventyConfig) {
+export default async function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy({
-    webawesomeDir: "webawesome",
+    webawesomeDir: 'webawesome',
   });
-};
+}
 
 export const config = {
   markdownTemplateEngine: 'njk',
@@ -44,7 +43,9 @@ export const config = {
 };
 ```
 
-And then in the `<head>` of your layout, add the following:
+### Load the Styles & Loader
+
+Add the stylesheet and component loader to your layout's `<head>`:
 
 ```html
 <head>
@@ -53,17 +54,35 @@ And then in the `<head>` of your layout, add the following:
 </head>
 ```
 
-And you're all set up to use Web Awesome! But you can still go 1 step further and add [SSR](/docs/ssr).
+<wa-callout variant="success">
+  <div class="wa-flank:end wa-gap-xl">
+    <p>
+      <strong>Web Awesome is ready to use.</strong><br />
+      Want server-side rendering too?
+    </p>
+    <wa-button size="small" variant="success" href="#server-side-rendering">
+      Add SSR
+    </wa-button>
+  </div>
+</wa-callout>
 
-## Adding SSR
+## Server-Side Rendering
 
-To add SSR, first install the `@lit-labs/eleventy-plugin-lit` plugin.
+With server-side rendering, your Web Awesome components render to HTML on the server, so pages display fully styled before client-side JavaScript loads. Learn more in the [SSR docs](/docs/ssr).
+
+To add SSR support to Build Awesome (11ty), follow the steps below.
+
+### Install the Plugin
+
+Install the `@lit-labs/eleventy-plugin-lit` plugin from npm:
 
 ```bash
 npm install @lit-labs/eleventy-plugin-lit
 ```
 
-And now you can update your `eleventy.config.js` to add the plugin.
+### Register the Plugin
+
+Once installed, register the plugin in your `eleventy.config.js` file.
 
 ```diff
 // eleventy.config.js
@@ -100,7 +119,9 @@ export const config = {
 };
 ```
 
-And now you must update your layout file to use the SSR loader instead of the regular loader.
+### Swap in the SSR Loader
+
+Update your layout to use the SSR loader instead of the default loader:
 
 ```html
 <head>
@@ -109,14 +130,25 @@ And now you must update your layout file to use the SSR loader instead of the re
 </head>
 ```
 
-And thats it! You should be all setup with Web Awesome + SSR!
+### See It in Action
 
-There are many other different ways to setup Web Awesome including things like bundlers, CDN only, preprocessing CSS, etc. This we felt was the simplest and still robust setup to get you started. A nice, middleground for both new and experienced Build Awesome users.
+Need an example of a complete Build Awesome (11ty) SSR project using Web Awesome?
 
-An example repo can be found here:
-
-<https://github.com/KonnorRogers/11ty-webawesome-ssr>
-
-As well as the deployed site:
-
-<https://konnorrogers.github.io/11ty-webawesome-ssr/>
+<div class="modern-card-list info-cards">
+  <section class="search-list-grid">
+    <a class="hover-grow hover-emphasize-border duotone-hover-context" data-duotone-hover-trigger href="https://github.com/KonnorRogers/11ty-webawesome-ssr" target="_blank" rel="noopener noreferrer">
+      <wa-card>
+        <wa-icon class="info-card-icon duotone-illustrated duotone-secondary-reveal" name="file-code" family="duotone" variant="regular"></wa-icon>
+        <span class="page-name">Example Repository</span>
+        <p class="modern-card-summary">A complete Build Awesome (11ty) SSR project using Web Awesome.</p>
+      </wa-card>
+    </a>
+    <a class="hover-grow hover-emphasize-border duotone-hover-context" data-duotone-hover-trigger href="https://konnorrogers.github.io/11ty-webawesome-ssr/" target="_blank" rel="noopener noreferrer">
+      <wa-card>
+        <wa-icon class="info-card-icon duotone-illustrated duotone-secondary-reveal" name="globe" family="duotone" variant="regular"></wa-icon>
+        <span class="page-name">Live Demo</span>
+        <p class="modern-card-summary">See the 11ty SSR example deployed and running.</p>
+      </wa-card>
+    </a>
+  </section>
+</div>

--- a/packages/webawesome/docs/docs/frameworks/buildawesome.md
+++ b/packages/webawesome/docs/docs/frameworks/buildawesome.md
@@ -84,29 +84,29 @@ npm install @lit-labs/eleventy-plugin-lit
 
 Once installed, register the plugin in your `eleventy.config.js` file.
 
-```diff
+```js
 // eleventy.config.js
 
-import litPlugin from '@lit-labs/eleventy-plugin-lit'
-import * as fs from "node:fs"
-import * as path from "node:path"
+import litPlugin from '@lit-labs/eleventy-plugin-lit';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
-const webawesomeDir = "./node_modules/@awesome.me/webawesome"
-const webawesomeComponentsDir = path.join(webawesomeDir, "dist", "components")
-const webawesomeComponents = fs.readdirSync(webawesomeComponentsDir).map((componentName) => {
-  return path.join(webawesomeComponentsDir, componentName, componentName + ".js")
-})
+const webawesomeDir = './node_modules/@awesome.me/webawesome';
+const webawesomeComponentsDir = path.join(webawesomeDir, 'dist', 'components');
+const webawesomeComponents = fs.readdirSync(webawesomeComponentsDir).map(componentName => {
+  return path.join(webawesomeComponentsDir, componentName, componentName + '.js');
+});
 
-export default async function(eleventyConfig) {
+export default async function (eleventyConfig) {
   eleventyConfig.addPlugin(litPlugin, {
     mode: 'worker',
-    componentModules: webawesomeComponents
+    componentModules: webawesomeComponents,
   });
 
   eleventyConfig.addPassthroughCopy({
-    webawesomeDir: "webawesome",
+    webawesomeDir: 'webawesome',
   });
-};
+}
 
 export const config = {
   markdownTemplateEngine: 'njk',

--- a/packages/webawesome/docs/docs/frameworks/express.md
+++ b/packages/webawesome/docs/docs/frameworks/express.md
@@ -2,15 +2,14 @@
 title: Express
 description: Tips for using Web Awesome in your Express app.
 layout: framework
+officialDocs: https://expressjs.com
 ---
 
-There isn't much to know with Express as it is relatively unopinionated.
+Express is relatively unopinionated, so there isn't much to know.
 
-If you're using a frontend framework with Express such as [React](/docs/frameworks/react), [Vue](/docs/frameworks/vue), [Svelte](/docs/frameworks/svelte), etc. Please refer to those specific frameworks as they may have different setup and integration instructions.
+## Usage
 
-[Framework Integrations](/docs/frameworks)
-
-In a bare minimal Express app the following will work "as expected"
+In a bare-minimum Express app, the following works as expected:
 
 ```js
 import express from 'express';
@@ -32,7 +31,7 @@ app.get('/', (req, res) => {
         </wa-page>
       </body>
     </html>
-  `)
+  `);
 });
 
 app.listen(port, () => {
@@ -40,7 +39,7 @@ app.listen(port, () => {
 });
 ```
 
-The key piece is:
+The key piece is loading Web Awesome's stylesheet and loader in your `<head>`:
 
 ```html
 <head>
@@ -49,78 +48,63 @@ The key piece is:
 </head>
 ```
 
-Which is what will load Web Awesome.
+There are other ways to set up Web Awesome, such as with npm or downloading ZIP files, which are documented on the [Installation](/docs) page.
 
-There are other ways to setup Web Awesome such as with NPM or downloading ZIP files which are documented on our [Installation](/docs) page
+<wa-callout variant="success">
+  <div class="wa-flank:end wa-gap-xl">
+    <p>
+      <strong>Web Awesome is ready to use.</strong><br />
+      Want server-side rendering too?
+    </p>
+    <wa-button size="small" variant="success" href="#server-side-rendering">
+      Add SSR
+    </wa-button>
+  </div>
+</wa-callout>
 
-## Adding SSR (Server Side Rendering)
+:::info
+**Using Express with a frontend framework?** <br>Follow the [React](/docs/frameworks/react), [Vue](/docs/frameworks/vue), or [Svelte](/docs/frameworks/svelte) page instead, since their setup differs.
+:::
 
-SSR can be added to your express app by "transforming" your responses.
+## Server-Side Rendering
 
-The first step is to install Web Awesome to your `node_modules` folder.
+SSR works by rendering your HTML through Lit on the server. First, install Web Awesome locally:
 
-```js
+```bash
 npm install @awesome.me/webawesome
 ```
 
-After installing, you will need to do a few things:
-
-1. Register the Web Awesome components in the "server" component registry
-1. import the `renderString` function from `@awesome.me/webawesome/dist/ssr/render-string.js`
-1. Setup the `LitElementRenderer`
-1. Modify the `response` call to "transform" the string with Lit SSR.
-
-```diff-javascript
-+ // Will register all web awesome components on your server
-+ import "@awesome.me/webawesome/dist/ssr.js"
-+ // Will transform a plain HTML string into a Lit Template, run SSR, and then turn it back into a string.
-+ import { renderString } from "@awesome.me/webawesome/dist/ssr/render-string.js";
-+ import {LitElementRenderer} from '@lit-labs/ssr';
-+ // Call connectedCallback for `my-element` by returning an options object with `connectedCallback` set to true.
-+ LitElementRenderer.renderOptions.push(
-+  (element) => element.localName.startsWith('wa-') ? {connectedCallback: true} : undefined
-+ );
-
-import express from 'express';
-
-const app = express();
-const port = 3000;
-
-app.get('/', (req, res) => {
-+  res.send(renderString(`
--  res.send(`
-    <!doctype html>
-    <html>
-      <head>
-        <link rel="stylesheet" href="{% cdnUrl 'styles/webawesome.css' %}" />
-        <script type="module" src="{% cdnUrl 'webawesome.loader.js' %}"></script>
-      </head>
-      <body>
-        <wa-page>
-          <wa-button>Hello World</wa-button>
-        </wa-page>
-      </body>
-    </html>
-+  `))
--  `)
-});
-
-app.listen(port, () => {
-  console.log(`Example app listening on port ${port}`);
-});
-```
-
-<wa-details summary="Full code without diff">
+Then add the SSR setup to the top of your server. This registers the components and tells Lit to run each one's `connectedCallback` while rendering:
 
 ```js
-// Will register all web awesome components on your server
-import "@awesome.me/webawesome/dist/ssr.js"
-// Will transform a plain HTML string into a Lit Template, run SSR, and then turn it back into a string.
-import { renderString } from "@awesome.me/webawesome/dist/ssr/render-string.js";
-import {LitElementRenderer} from '@lit-labs/ssr';
-// Call connectedCallback for all Web Awesome elements by returning an options object with `connectedCallback` set to true.
-LitElementRenderer.renderOptions.push(
- (element) => element.localName.startsWith('wa-') ? {connectedCallback: true} : undefined
+// Register all Web Awesome components on the server
+import '@awesome.me/webawesome/dist/ssr.js';
+// renderString turns an HTML string into a Lit template, runs SSR, and returns a string
+import { renderString } from '@awesome.me/webawesome/dist/ssr/render-string.js';
+import { LitElementRenderer } from '@lit-labs/ssr';
+
+LitElementRenderer.renderOptions.push(element =>
+  element.localName.startsWith('wa-') ? { connectedCallback: true } : undefined,
+);
+```
+
+Finally, wrap each HTML response in `renderString()`:
+
+```diff
+- res.send(`...your HTML...`);
++ res.send(renderString(`...your HTML...`));
+```
+
+<wa-details summary="Full example">
+
+```js
+// Register all Web Awesome components on the server
+import '@awesome.me/webawesome/dist/ssr.js';
+// renderString turns an HTML string into a Lit template, runs SSR, and returns a string
+import { renderString } from '@awesome.me/webawesome/dist/ssr/render-string.js';
+import { LitElementRenderer } from '@lit-labs/ssr';
+LitElementRenderer.renderOptions.push(element =>
+  element.localName.startsWith('wa-') ? { connectedCallback: true } : undefined,
 );
 
 import express from 'express';
@@ -129,7 +113,8 @@ const app = express();
 const port = 3000;
 
 app.get('/', (req, res) => {
-  res.send(renderString(`
+  res.send(
+    renderString(`
     <!doctype html>
     <html>
       <head>
@@ -142,7 +127,8 @@ app.get('/', (req, res) => {
         </wa-page>
       </body>
     </html>
-  `))
+  `),
+  );
 });
 
 app.listen(port, () => {
@@ -152,72 +138,49 @@ app.listen(port, () => {
 
 </wa-details>
 
-<br><br>
+### Using a View Engine
 
-If you're using a view engine library such as Pug, Haml, Nunjucks, etc, you can add a middleware to capture the rendering function and transform the string.
+If you use a view engine such as Pug, Haml, or Nunjucks, add a middleware that runs each rendered view through `renderString`. It reuses the same SSR setup from above:
 
 :::warning
-The below middleware is a quick and dirty hack. If these routes ever serve non-HTML routes such as JSON, CSV, even emails for older clients, etc, it is worth adding a content-type check or some sort of flag on the rendering not to transform it with Lit. It is out of the scope of this page to cover that however.
+<strong>This middleware transforms every response through Lit.</strong><br />
+If a route can return non-HTML like JSON or CSV, add a content-type check so it skips the transform.
 :::
 
 ```js
-// Will register all web awesome components on your server
-import "@awesome.me/webawesome/dist/ssr.js"
-// Will transform a plain HTML string into a Lit Template, run SSR, and then turn it back into a string.
-import { renderString } from "@awesome.me/webawesome/dist/ssr/render-string.js";
-import {LitElementRenderer} from '@lit-labs/ssr';
-// Call connectedCallback for all Web Awesome elements by returning an options object with `connectedCallback` set to true.
-LitElementRenderer.renderOptions.push(
- (element) => element.localName.startsWith('wa-') ? {connectedCallback: true} : undefined
-);
+app.set('view engine', 'nunjucks');
 
-import express from 'express';
-
-const app = express();
-const port = 3000;
-
-app.set('view engine', 'nunjucks')
-app.set('views', 'views')
-
+// Transform each rendered view through Lit before sending
 app.use((req, res, next) => {
-  // Store the original render function
   const original = res.render.bind(res);
 
-  // re-define it
   res.render = (view, options, callback) => {
-    if (typeof options === "function") {
+    if (typeof options === 'function') {
       callback = options;
       options = {};
     }
 
     original(view, options, (err, html) => {
-      if (err) {
-        return typeof callback === "function" ? callback(err) : next(err);
-      }
-
+      if (err) return typeof callback === 'function' ? callback(err) : next(err);
       const out = renderString(html);
-
-      if (typeof callback === "function") {
-        return callback(null, out);
-      }
-
-      return res.send(out);
+      return typeof callback === 'function' ? callback(null, out) : res.send(out);
     });
   };
 
   next();
 });
-
-app.get('/', (req, res) => {
-  // Assumes you have something like `views/index.njk`
-  res.render("index")
-});
-
-app.listen(port, () => {
-  console.log(`Example app listening on port ${port}`);
-});
 ```
 
-If you'd like to see an example repo, one can be found here:
+### See It in Action
 
-<https://github.com/KonnorRogers/webawesome-ssr-express>
+<div class="modern-card-list info-cards">
+  <section class="search-list-grid">
+    <a class="hover-grow hover-emphasize-border duotone-hover-context" data-duotone-hover-trigger href="https://github.com/KonnorRogers/webawesome-ssr-express" target="_blank" rel="noopener noreferrer">
+      <wa-card>
+        <wa-icon class="info-card-icon duotone-illustrated duotone-secondary-reveal" name="file-code" family="duotone" variant="regular"></wa-icon>
+        <span class="page-name">Example Repository</span>
+        <p class="modern-card-summary">A complete Express SSR project using Web Awesome.</p>
+      </wa-card>
+    </a>
+  </section>
+</div>

--- a/packages/webawesome/docs/docs/frameworks/express.md
+++ b/packages/webawesome/docs/docs/frameworks/express.md
@@ -5,7 +5,10 @@ layout: framework
 officialDocs: https://expressjs.com
 ---
 
-Express is relatively unopinionated, so there isn't much to know.
+:::info
+**Using Express with a frontend framework?** <br>Follow the [React](/docs/frameworks/react), [Vue](/docs/frameworks/vue), or [Svelte](/docs/frameworks/svelte) page instead, since their setup differs.
+:::
+
 
 ## Usage
 
@@ -61,10 +64,6 @@ There are other ways to set up Web Awesome, such as with npm or downloading ZIP 
     </wa-button>
   </div>
 </wa-callout>
-
-:::info
-**Using Express with a frontend framework?** <br>Follow the [React](/docs/frameworks/react), [Vue](/docs/frameworks/vue), or [Svelte](/docs/frameworks/svelte) page instead, since their setup differs.
-:::
 
 ## Server-Side Rendering
 

--- a/packages/webawesome/docs/docs/frameworks/react.md
+++ b/packages/webawesome/docs/docs/frameworks/react.md
@@ -2,6 +2,7 @@
 title: React
 description: Tips for using Web Awesome in your React app.
 layout: framework
+officialDocs: https://react.dev
 ---
 
 ## Installation
@@ -64,7 +65,7 @@ declare module 'react' {
 
 ## Event Handling
 
-Many Web Awesome components emit [native events](https://developer.mozilla.org/en-US/docs/Web/API/Event). For example, the [input component](/components/input) emits the `input` event when it receives input. In React, you can listen for the event using `onInput`.
+Many Web Awesome components emit [native events](https://developer.mozilla.org/en-US/docs/Web/API/Event). For example, the [input component](/docs/components/input) emits the `input` event when it receives input. In React, you can listen for the event using `onInput`.
 
 Here's how you can bind the input's value to a state variable.
 
@@ -202,63 +203,33 @@ However, tree-shaking extra Web Awesome components proved to be a challenge. As 
 
 ### Event Handling with React Wrappers
 
-Many Web Awesome components emit [native events](https://developer.mozilla.org/en-US/docs/Web/API/Event). For example, the [input component](/components/input) emits the `input` event when it receives input. In React, you can listen for the event using `onInput`.
+Event handling works the same as with [native custom elements](#event-handling) — bind to `onInput` and type `event.target` identically, just importing the `WaInput` wrapper instead of the custom element.
 
-Here's how you can bind the input's value to a state variable.
+Wrappers add two conveniences. Pass `defaultValue` for an uncontrolled input:
 
 ```jsx
-import { useState } from 'react';
 import WaInput from '@awesome.me/webawesome/dist/react/input/index.js';
 
-function MyComponent() {
-  const [value, setValue] = useState('');
-
-  return (
-    <>
-      <WaInput value={value} onInput={event => setValue(event.target.value)} />;
-      <WaInput defaultValue={'Foo'} /> {/* This is an "uncontrolled input" */}
-    </>
-  );
-}
-
-export default MyComponent;
+<WaInput defaultValue="Foo" />;
 ```
 
-If you're using TypeScript, it's important to note that `event.target` will be a reference to the underlying custom element. You can use `(event.target as any).value` as a quick fix, or you can strongly type the event target as shown below.
-
-```tsx
-import { useState } from 'react';
-import WaInput from '@awesome.me/webawesome/dist/react/input/index.js';
-import type WaInputElement from '@awesome.me/webawesome/dist/components/input/input.js';
-
-function MyComponent() {
-  const [value, setValue] = useState('');
-
-  return <WaInput value={value} onInput={event => setValue((event.target as WaInputElement).value)} />;
-}
-
-export default MyComponent;
-```
-
-You can also import the event type for use in your callbacks, shown below.
+And import the component's event type to type your callbacks directly:
 
 ```tsx
 import { useCallback, useState } from 'react';
 import WaInput, { type WaInputEvent } from '@awesome.me/webawesome/dist/react/input/index.js';
-import type WaInputElement from '@awesome.me/webawesome/dist/components/input/input.js';
 
 function MyComponent() {
   const [value, setValue] = useState('');
-  const onInput = useCallback((event: WaInputEvent) => {
-    setValue(event.detail);
-  }, []);
+  const onInput = useCallback((event: WaInputEvent) => setValue(event.detail), []);
 
-  return <WaInput value={value} onInput={event => setValue((event.target as WaInputElement).value)} />;
+  return <WaInput value={value} onInput={onInput} />;
 }
 
 export default MyComponent;
 ```
 
-:::info
-Are you using Web Awesome with React? [Help us improve this page!](https://github.com/shoelace-style/webawesome/blob/next/packages/webawesome/docs/docs/frameworks/react.md)
-:::
+<wa-callout variant="success">
+  <strong>Web Awesome is ready to use.</strong><br />
+  Explore components, utilities, and theming to start building.
+</wa-callout>

--- a/packages/webawesome/docs/docs/frameworks/svelte.md
+++ b/packages/webawesome/docs/docs/frameworks/svelte.md
@@ -2,6 +2,7 @@
 title: Svelte
 description: Tips for using Web Awesome in your Svelte app.
 layout: framework
+officialDocs: https://svelte.dev
 ---
 
 Svelte [plays nice](https://custom-elements-everywhere.com/#svelte) with custom elements, so you can use Web Awesome in your Svelte apps with ease.
@@ -16,9 +17,9 @@ npm install @awesome.me/webawesome
 
 ## Usage
 
-Next, import the Web Awesome stylesheet, import the components you need, and then start using Web Awesome!
+Import the Web Awesome stylesheet and the components you need, then start using them:
 
-```jsx
+```html
 <!-- app.html -->
 <script>
   import '@awesome.me/webawesome/dist/styles/webawesome.css';
@@ -40,9 +41,9 @@ Next, import the Web Awesome stylesheet, import the components you need, and the
 
 ### Two-Way Binding
 
-One caveat is there's currently Svelte only supports `bind:value` directive in `<input>`, `<textarea>` and `<select>`, but you can still achieve two-way binding manually.
+One caveat: Svelte currently only supports the `bind:value` directive on `<input>`, `<textarea>`, and `<select>`, but you can still achieve two-way binding manually.
 
-```jsx
+```html
 // ❌ These do not work
 <wa-input bind:value="name"></wa-input>
 
@@ -66,7 +67,7 @@ Slots in Web Awesome/web components are functionally the same as basic slots in 
 
 Here is an example:
 
-```jsx
+```html
 <wa-drawer label="Drawer" placement="start" class="drawer-placement-start" bind:open={drawerIsOpen}>
   This drawer slides in from the start.
   <div slot="footer">
@@ -77,6 +78,7 @@ Here is an example:
 </wa-drawer>
 ```
 
-:::info
-Are you using Web Awesome with Svelte? [Help us improve this page!](https://github.com/shoelace-style/webawesome/blob/next/packages/webawesome/docs/docs/frameworks/svelte.md)
-:::
+<wa-callout variant="success">
+  <strong>Web Awesome is ready to use.</strong><br />
+  Explore components, utilities, and theming to start building.
+</wa-callout>

--- a/packages/webawesome/docs/docs/frameworks/vue-2.md
+++ b/packages/webawesome/docs/docs/frameworks/vue-2.md
@@ -2,12 +2,13 @@
 title: Vue (version 2)
 description: Tips for using Web Awesome in your Vue 2 app.
 layout: framework
+officialDocs: https://v2.vuejs.org
 ---
 
 Vue [plays nice](https://custom-elements-everywhere.com/#vue) with custom elements, so you can use Web Awesome in your Vue apps with ease.
 
 :::info
-These instructions are for Vue 2. If you're using Vue 3 or above, please see the [Vue 3 instructions](/frameworks/vue).
+These instructions are for Vue 2. If you're using Vue 3 or above, please see the [Vue 3 instructions](/docs/frameworks/vue).
 :::
 
 ## Installation
@@ -18,7 +19,7 @@ To add Web Awesome to your Vue app, install the package from npm.
 npm install @awesome.me/webawesome
 ```
 
-Next, import the Web Awesome stylesheet, import the components you need, and then start using Web Awesome!
+Then import the Web Awesome stylesheet and the components you need:
 
 ```jsx
 // main.js or main.ts
@@ -28,7 +29,7 @@ import '@awesome.me/webawesome/dist/components/button/button.js';
 
 ## Configuration
 
-You'll need to tell Vue to ignore Web Awesome components. This is pretty easy because they all start with `wa-`.
+Tell Vue to ignore Web Awesome's custom elements. Because they all start with `wa-`, a single rule covers them:
 
 ```js
 import Vue from 'vue';
@@ -37,13 +38,11 @@ import App from './App.vue';
 Vue.config.ignoredElements = [/wa-/];
 
 const app = new Vue({
-  render: h => h(App)
+  render: h => h(App),
 });
 
 app.$mount('#app');
 ```
-
-Now you can start using Web Awesome components in your app!
 
 ## Usage
 
@@ -57,7 +56,7 @@ When binding complex data such as objects and arrays, use the `.prop` modifier t
 
 ### Two-Way Binding
 
-One caveat is there's currently [no support for v-model on custom elements](https://github.com/vuejs/vue/issues/7830), but you can still achieve two-way binding manually.
+One caveat: custom elements [don't support `v-model`](https://github.com/vuejs/vue/issues/7830), but you can still bind two ways manually.
 
 ```html
 <!-- ❌ This doesn't work -->
@@ -66,6 +65,7 @@ One caveat is there's currently [no support for v-model on custom elements](http
 <wa-input :value="name" @input="name = $event.target.value"></wa-input>
 ```
 
-:::info
-Are you using Web Awesome with Vue 2? [Help us improve this page!](https://github.com/shoelace-style/webawesome/blob/next/packages/webawesome/docs/docs/frameworks/vue-2.md)
-:::
+<wa-callout variant="success">
+  <strong>Web Awesome is ready to use.</strong><br />
+  Explore components, utilities, and theming to start building.
+</wa-callout>

--- a/packages/webawesome/docs/docs/frameworks/vue.md
+++ b/packages/webawesome/docs/docs/frameworks/vue.md
@@ -2,12 +2,13 @@
 title: Vue 3
 description: Tips for using Web Awesome in your Vue 3 app.
 layout: framework
+officialDocs: https://vuejs.org
 ---
 
 Vue [plays nice](https://custom-elements-everywhere.com/#vue) with custom elements, so you can use Web Awesome in your Vue apps with ease.
 
 :::info
-These instructions are for Vue 3 and above. If you're using Vue 2, please see the [Vue 2 instructions](/frameworks/vue-2).
+These instructions are for Vue 3 and above. If you're using Vue 2, please see the [Vue 2 instructions](/docs/frameworks/vue-2).
 :::
 
 ## Installation
@@ -18,9 +19,9 @@ To add Web Awesome to your Vue app, install the package from npm.
 npm install @awesome.me/webawesome
 ```
 
-Next, import the Web Awesome stylesheet, import the components you need, and then start using Web Awesome!
+Then import the Web Awesome stylesheet and the components you need:
 
-```jsx
+```js
 // main.js or main.ts
 import '@awesome.me/webawesome/dist/styles/webawesome.css';
 import '@awesome.me/webawesome/dist/components/button/button.js';
@@ -28,13 +29,11 @@ import '@awesome.me/webawesome/dist/components/button/button.js';
 
 ## Configuration
 
-If you haven't configured your Vue.js project to work with custom elements/web components, follow [the instructions here](https://vuejs.org/guide/extras/web-components.html#using-custom-elements-in-vue) based on your project type to ensure your project will not throw an error when it encounters a custom element.
-
-Now you can start using Web Awesome components in your app!
+If you haven't configured your Vue project to recognize custom elements, follow [Vue's guide](https://vuejs.org/guide/extras/web-components.html#using-custom-elements-in-vue) for your project type so it doesn't error on Web Awesome's `wa-*` tags.
 
 ## Types
 
-Once you have configured your application for custom elements, you should be able to use Shoelace in your application without it causing any errors. Unfortunately, this doesn't register the custom elements to behave like components built using Vue. To provide autocomplete information and type safety for your components, you can import the Shoelace Vue types into your `tsconfig.json` to get better integration in your standard Vue and JSX templates.
+Configuring custom elements stops the errors, but it doesn't give the `wa-*` tags Vue's component typing. For autocomplete and type safety, add the Web Awesome Vue types to your `tsconfig.json`:
 
 ```json
 {
@@ -46,7 +45,7 @@ Once you have configured your application for custom elements, you should be abl
 
 ## Usage
 
-### QR Code Generator Example
+### Basic Usage
 
 ```html
 <template>
@@ -85,10 +84,10 @@ When binding complex data such as objects and arrays, use the `.prop` modifier t
 
 ### Two-Way Binding
 
-One caveat is there's currently [varying levels of support for v-model on custom elements](https://github.com/vuejs/vue/issues/7830), but you can still achieve two-way binding manually.
+One caveat: [v-model support on custom elements varies](https://github.com/vuejs/vue/issues/7830), but you can still bind two ways manually.
 
 ```html
-<!-- ❌ This _sometimes_ work (some things have changed internally in v-model in Vue 3) -->
+<!-- ❌ This _sometimes_ works (v-model internals changed in Vue 3) -->
 <wa-input v-model="name"></wa-input>
 <!-- ✅ This should always work, but it's a bit longer -->
 <wa-input :value="name" @input="name = $event.target.value"></wa-input>
@@ -109,14 +108,36 @@ Here is an example:
 </wa-drawer>
 ```
 
-For more on slots and limitations with Web Components, check out the Vue documentation here: <https://vuejs.org/guide/extras/web-components#slots>
+For more on slots and their limitations with web components, see [Vue's documentation](https://vuejs.org/guide/extras/web-components#slots).
 
-### SSR
+<wa-callout variant="success">
+  <div class="wa-flank:end wa-gap-xl">
+    <p>
+      <strong>Web Awesome is ready to use.</strong><br />
+      Want server-side rendering too?
+    </p>
+    <wa-button size="small" variant="success" href="#server-side-rendering">
+      Add SSR
+    </wa-button>
+  </div>
+</wa-callout>
 
-SSR in Vue is going to be wildly different depending on your setup.
+## Server-Side Rendering
 
-There is an example here:
+SSR in Vue varies widely depending on your setup. For a working reference, see the example below.
 
-<https://github.com/KonnorRogers/webawesome-vite-vue-ssr> using Vite + Vue.
+### See It in Action
 
-We are aware there are other plugins and meta frameworks out there like Vike and Vite plugin SSR, so we will give those some time to shake out before we add documentation for them as they're still experimental.
+<div class="modern-card-list info-cards">
+  <section class="search-list-grid">
+    <a class="hover-grow hover-emphasize-border duotone-hover-context" data-duotone-hover-trigger href="https://github.com/KonnorRogers/webawesome-vite-vue-ssr" target="_blank" rel="noopener noreferrer">
+      <wa-card>
+        <wa-icon class="info-card-icon duotone-illustrated duotone-secondary-reveal" name="file-code" family="duotone" variant="regular"></wa-icon>
+        <span class="page-name">Example Repository</span>
+        <p class="modern-card-summary">A Vite + Vue SSR project using Web Awesome.</p>
+      </wa-card>
+    </a>
+  </section>
+</div>
+
+Other plugins and meta-frameworks like Vike and vite-plugin-ssr are still experimental, so they aren't documented here yet.


### PR DESCRIPTION
This work builds on framework-docs work in https://github.com/shoelace-style/webawesome/pull/2548.

It polishes the three surfaces it introduced — the `/docs/frameworks` hub, the shared `framework.njk` layout, and the individual guide pages — and brings them in line with our internal `.house-rules/` docs conventions.

> [!TIP]
> Live Preview things at https://webawesome-git-talbs-ssr-docs-font-awesome.vercel.app/docs/frameworks/. 

### Frameworks Hub
- Switches `frameworks.md` to `layout: docs` and the shared `.modern-card-list` grid so its width and card layout match `/docs/patterns` and `/docs/utilities`. 
- Grays the framework logos by default and restores full color on hover (with an `@media (hover: none)` fallback so touch devices still show color)
- Caps the wide wordmark logos
- Replaces the plain "don't see your framework" link with the docs empty-state pattern. 
- Tightens the intro copy

### Shared Page Chrome (`framework.njk`)
- Adds a **Next Steps** card grid — Components, CSS Utilities, Theming, and the framework's official docs — with category-matched duotone icons
- The official-docs link is driven by a new `officialDocs` front-matter key.
- Formats a feedback callout that opens a prefilled GitHub discussion. 

### Framework Pages
- Normalizes each page to `Installation` / `Usage` / `Server-Side Rendering` with task-named `###` subsections
- Standardizes the SSR heading (previously `SSR`, `Adding SSR`, `SSR (Server Side Rendering)`) 
- Each page ends its setup with a confirmation callout — an **Add SSR** action on SSR-capable frameworks, a plain confirmation elsewhere
- SSR pages gain a "See It in Action" example-repo/demo card row
- Removes the duplicate "help us improve" callouts now injected by the layout
- Corrects the code-fence languages
- Simplifies several examples.

### Styles
- Moves the hub logo-card and framework-page info-card styles out of inline `<style>` blocks into `docs.css`
- Adds a reusable duotone hover-reveal (ported from `site.css`) so it works on the free docs build too.
