### PR TITLE
Docs: Normalize Color Picker's "Initial Value" Heading

### DIFF
--- a/packages/webawesome/docs/docs/components/color-picker.md
+++ b/packages/webawesome/docs/docs/components/color-picker.md
@@ -40,7 +40,7 @@ Add a descriptive hint with the `hint` attribute. For hints that contain HTML, u
 <wa-color-picker label="Accent" hint="Pick something with enough contrast to read against white."></wa-color-picker>
 ```
 
-### Setting an Initial Value
+### Initial Value
 
 Use the `value` attribute to set a starting color. The value's format follows the `format` attribute, but any parsable color (including CSS color names) is accepted as input.
 


### PR DESCRIPTION
This is a quick follow-up to https://github.com/shoelace-style/webawesome/pull/2576. 

- `color-picker` was the lone form component still using the gerund `### Setting an Initial Value`.
- This renames it to plain-noun `### Initial Value` to match the other seven forms components (plain nouns for attribute-config sections, gerunds reserved for behaviors).