### PR TITLE
Docs/Site: Fix Sidebar's Icon Clip + Extra Space

### DIFF
--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -499,6 +499,11 @@
     overflow: clip;
   }
 
+  /* Hide the empty forwarded footer that steals the drawer's bottom space (band-aid; see wa-page footer fix). */
+  wa-page[view='mobile']::part(drawer__footer) {
+    display: none;
+  }
+
   /* pro badge */
   wa-badge.pro {
     color: var(--wa-color-brand-on-loud);
@@ -926,8 +931,7 @@
     max-block-size: 100%;
   }
 
-  /* Mobile zeroes the nav padding, so the icon-heading outdent (-space-xs) escapes #sidebar's
-   * overflow box and gets clipped. Reserve it as padding, pull the box back so nothing shifts. */
+  /* Reserve the icon-heading outdent as padding so #sidebar's overflow box doesn't clip it on mobile. */
   wa-page[view='mobile'] > #sidebar {
     padding-inline-start: var(--wa-space-xs);
     margin-inline-start: calc(var(--wa-space-xs) * -1);

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -926,6 +926,13 @@
     max-block-size: 100%;
   }
 
+  /* Mobile zeroes the nav padding, so the icon-heading outdent (-space-xs) escapes #sidebar's
+   * overflow box and gets clipped. Reserve it as padding, pull the box back so nothing shifts. */
+  wa-page[view='mobile'] > #sidebar {
+    padding-inline-start: var(--wa-space-xs);
+    margin-inline-start: calc(var(--wa-space-xs) * -1);
+  }
+
   wa-page:not([view='mobile']) > #sidebar {
     padding-block: var(--wa-space-2xl);
   }


### PR DESCRIPTION
This work includes 2 fixes for the docs sidebar when it renders inside `wa-page`'s responsive navigation drawer on narrow viewports.

### Category Icon Clipping

Category icons were clipped on their leading edge. Category headings outdent their icon by `-var(--wa-space-xs)` to optically align with the page chrome; on desktop the nav's `padding-inline` absorbs that outdent, but the mobile drawer zeroes the nav padding, so the icon landed past `#sidebar`'s content box.

### Empty Footer Gap
The sidebar stopped `~var(--wa-space-l)` short of the viewport bottom. `wa-page` always forwards a footer slot into the mobile drawer, and `wa-drawer` decides footer visibility structurally, so it renders a padded footer even when the docs supply no `navigation-footer` — and that empty footer steals the sidebar's bottom space.

| Before | After |
|--------|--------|
| <img width="1440" height="1636" alt="image" src="https://github.com/user-attachments/assets/852fb8da-518f-4fdc-8fac-6f29625cb4b1" /> | <img width="1440" height="1636" alt="image" src="https://github.com/user-attachments/assets/cfad46e3-6252-401d-bd12-c69467d6e0d8" /> | 