### PR TITLE
Page: Fix Empty `navigation-footer` in Mobile Drawer

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -35,9 +35,9 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 - Fixed type resolution issues with `pro` components like `<wa-file-input>`, `<wa-combobox>`, etc. [pr:2577]
 - Fixed an issue where some fonts wouldn't load in themes that import multiple fonts [pr:2582]
+- Fixed `<wa-page>` rendering an empty footer in its mobile navigation drawer when no `navigation-footer` is slotted, which left dead space below the sidebar
 
 :::
-
 
 ## 3.10.0
 

--- a/packages/webawesome/src/components/page/page.test.ts
+++ b/packages/webawesome/src/components/page/page.test.ts
@@ -124,6 +124,21 @@ describe('<wa-page>', () => {
         });
       });
 
+      describe('mobile drawer footer', () => {
+        it('should not forward a footer slot into the drawer when no navigation-footer is slotted', async () => {
+          const el = await fixture<WaPage>(html`<wa-page>Content</wa-page>`);
+          await el.updateComplete;
+          expect(el.shadowRoot!.querySelector('slot[slot="footer"]')).to.be.null;
+        });
+
+        it('should forward a footer slot into the drawer when navigation-footer is slotted', async () => {
+          const el = await fixture<WaPage>(html`<wa-page><div slot="navigation-footer">Nav Footer</div></wa-page>`);
+          el.requestUpdate(); // re-render so HasSlotController re-checks the slot
+          await el.updateComplete;
+          expect(el.shadowRoot!.querySelector('slot[slot="footer"]')).to.exist;
+        });
+      });
+
       describe('CSS parts', () => {
         it('should have a base part', async () => {
           const el = await fixture<WaPage>(html`<wa-page>Content</wa-page>`);

--- a/packages/webawesome/src/components/page/page.ts
+++ b/packages/webawesome/src/components/page/page.ts
@@ -1,8 +1,9 @@
 import type { PropertyValues } from 'lit';
-import { html, isServer } from 'lit';
+import { html, isServer, nothing } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
 import { live } from 'lit/directives/live.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
+import { HasSlotController } from '../../internal/slot.js';
 import WebAwesomeElement from '../../internal/webawesome-element.js';
 import visuallyHidden from '../../styles/component/visually-hidden.styles.js';
 import '../button/button.js';
@@ -172,6 +173,8 @@ export default class WaPage extends WebAwesomeElement {
   @query("[part~='drawer']") navigationDrawer: WaDrawer;
   @query("slot[name~='navigation-toggle']") navigationToggleSlot: HTMLSlotElement;
 
+  private readonly hasSlotController = new HasSlotController(this, 'navigation-footer');
+
   /**
    * The view is a reflection of the "mobileBreakpoint", when the page is larger than the `mobile-breakpoint` (768px by
    * default), it is considered to be a "desktop" view. The view is merely a way to distinguish when to show/hide the
@@ -204,6 +207,12 @@ export default class WaPage extends WebAwesomeElement {
    */
   @property({ attribute: 'disable-navigation-toggle', reflect: true, type: Boolean }) disableNavigationToggle: boolean =
     false;
+
+  /**
+   * Only required for SSR. Set to `true` if you're slotting in a `navigation-footer` element so the server-rendered
+   * markup includes the mobile drawer footer before the component hydrates on the client.
+   */
+  @property({ attribute: 'with-navigation-footer', type: Boolean }) withNavigationFooter = false;
 
   pageResizeObserver =
     typeof ResizeObserver !== 'undefined'
@@ -341,6 +350,9 @@ export default class WaPage extends WebAwesomeElement {
   }
 
   render() {
+    // Forward the footer only when slotted — wa-drawer shows an empty padded footer for any forwarded slot.
+    const hasNavigationFooter = this.hasSlotController.test('navigation-footer', 'withNavigationFooter');
+
     return html`
       <a href="#main-content" part="skip-to-content" class="wa-visually-hidden">
         <slot name="skip-to-content">Skip to content</slot>
@@ -435,9 +447,11 @@ export default class WaPage extends WebAwesomeElement {
           <slot name=${this.view === 'mobile' ? 'navigation' : '____'}></slot>
         </slot>
 
-        <slot slot="footer" name="mobile-navigation-footer">
-          <slot part="navigation-footer" name=${this.view === 'mobile' ? 'navigation-footer' : '___'}></slot>
-        </slot>
+        ${hasNavigationFooter
+          ? html`<slot slot="footer" name="mobile-navigation-footer">
+              <slot part="navigation-footer" name=${this.view === 'mobile' ? 'navigation-footer' : '___'}></slot>
+            </slot>`
+          : nothing}
       </wa-drawer>
     `;
   }


### PR DESCRIPTION
### Issue
`wa-page` unconditionally forwards a `<slot slot="footer">` into its mobile `<wa-drawer>`. 

Because `wa-drawer` decides footer visibility structurally, that forwarded slot counts as content even when it projects nothing. So the drawer renders an empty `.footer` whose padding steals the bottom of the nav area. 

FYI, on desktop the footer lives in a grid row that collapses to zero, so only the mobile drawer shows the dead space.

### Proposed Fix
Detect a slotted `navigation-footer` with a `HasSlotController` and only forward the mobile footer slot when it has content, following the same idiom as `wa-drawer`, `wa-dialog`, and `wa-card`.

With no forwarded slot, `wa-drawer`'s `hasFooter` is correctly `false` and its footer stays `hidden`, so the nav fills the drawer.

### Notes

- Added `mobile drawer footer` tests (CSR + SSR-hydrated), asserting the footer slot is forwarded only when `navigation-footer` is slotted. All 60-page tests pass in Chromium/Firefox/WebKit.

## Related PRs

- Docs band-aid that hides the empty footer until this lands: https://github.com/shoelace-style/webawesome/pull/2604
