### PR TITLE
Improve Navigation Components Documentation

### DIFF
--- a/packages/webawesome/docs/docs/components/breadcrumb.md
+++ b/packages/webawesome/docs/docs/components/breadcrumb.md
@@ -12,8 +12,6 @@ use-cases:
   - hierarchy navigation
 ---
 
-Breadcrumbs are usually placed before a page's main content with the current page shown last to indicate the user's position in the navigation.
-
 ```html {.example}
 <wa-breadcrumb>
   <wa-breadcrumb-item>Catalog</wa-breadcrumb-item>
@@ -23,9 +21,11 @@ Breadcrumbs are usually placed before a page's main content with the current pag
 </wa-breadcrumb>
 ```
 
+Breadcrumbs are usually placed before a page's main content with the current page shown last to indicate the user's position in the navigation.
+
 ## Examples
 
-### Breadcrumb Links
+### Links
 
 By default, breadcrumb items are rendered as buttons so you can use them to navigate single-page applications. In this case, you'll need to add event listeners to handle clicks.
 
@@ -63,7 +63,7 @@ Use the `start` and `end` slots to add presentational elements like `<wa-icon>` 
 </wa-breadcrumb>
 ```
 
-### Custom Separators
+### Separator
 
 Use the `separator` slot to change the separator that goes between breadcrumb items. Icons work well, but you can also use text or an image.
 
@@ -94,20 +94,20 @@ Use the `separator` slot to change the separator that goes between breadcrumb it
 </wa-breadcrumb>
 ```
 
-### Custom Colors
+### Colors
 
 Breadcrumb labels match the color set on `<wa-breadcrumb-item>`. Content in the `start`, `end`, and `separator` slots can be styled using CSS parts.
 
 ```html {.example}
 <style>
   .redcrumbs wa-breadcrumb-item {
-    color: firebrick;
+    color: var(--wa-color-red-40);
   }
   .redcrumbs wa-breadcrumb-item:last-of-type {
-    color: crimson;
+    color: var(--wa-color-red-60);
   }
   .redcrumbs wa-breadcrumb-item::part(separator) {
-    color: pink;
+    color: var(--wa-color-red-80);
   }
   .redcrumbs wa-breadcrumb-item::part(start),
   .redcrumbs wa-breadcrumb-item::part(end) {
@@ -124,7 +124,7 @@ Breadcrumb labels match the color set on `<wa-breadcrumb-item>`. Content in the 
 </wa-breadcrumb>
 ```
 
-### With Dropdowns
+### Dropdowns
 
 Dropdown menus can be placed in the default slot to provide additional options.
 
@@ -143,26 +143,5 @@ Dropdown menus can be placed in the default slot to provide additional options.
   </wa-breadcrumb-item>
   <wa-breadcrumb-item>Our Services</wa-breadcrumb-item>
   <wa-breadcrumb-item>Digital Media</wa-breadcrumb-item>
-</wa-breadcrumb>
-```
-
-Alternatively, you can place dropdown menus in a `start` or `end` slot.
-
-```html {.example}
-<wa-breadcrumb>
-  <wa-breadcrumb-item>Homepage</wa-breadcrumb-item>
-  <wa-breadcrumb-item>Our Services</wa-breadcrumb-item>
-  <wa-breadcrumb-item>Digital Media</wa-breadcrumb-item>
-  <wa-breadcrumb-item>
-    Web Design
-    <wa-dropdown slot="end">
-      <wa-button slot="trigger" size="s" appearance="filled" pill>
-        <wa-icon label="More options" name="ellipsis" variant="solid"></wa-icon>
-      </wa-button>
-      <wa-dropdown-item type="checkbox" checked>Web Design</wa-dropdown-item>
-      <wa-dropdown-item type="checkbox">Web Development</wa-dropdown-item>
-      <wa-dropdown-item type="checkbox">Marketing</wa-dropdown-item>
-    </wa-dropdown>
-  </wa-breadcrumb-item>
 </wa-breadcrumb>
 ```

--- a/packages/webawesome/docs/docs/components/tab-group.md
+++ b/packages/webawesome/docs/docs/components/tab-group.md
@@ -14,8 +14,6 @@ use-cases:
   - settings tabs
 ---
 
-Tab groups make use of [tabs](/docs/components/tab) and [tab panels](/docs/components/tab-panel). Each panel should have a name that's unique within the tab group, and tabs should have a `panel` attribute that points to the respective panel's name.
-
 ```html {.example}
 <wa-tab-group>
   <wa-tab panel="general">General</wa-tab>
@@ -30,9 +28,11 @@ Tab groups make use of [tabs](/docs/components/tab) and [tab panels](/docs/compo
 </wa-tab-group>
 ```
 
+Tab groups make use of [tabs](/docs/components/tab) and [tab panels](/docs/components/tab-panel). Each panel should have a name that's unique within the tab group, and tabs should have a `panel` attribute that points to the respective panel's name.
+
 ## Examples
 
-### Setting the Active Tab
+### Active Tab
 
 To make a tab active, set the `active` attribute to the name of the appropriate panel.
 
@@ -48,9 +48,16 @@ To make a tab active, set the `active` attribute to the name of the appropriate 
 </wa-tab-group>
 ```
 
-### Tabs on Bottom
+### Placement
 
-Tabs can be shown on the bottom by setting `placement` to `bottom`.
+Set the `placement` attribute to move the tabs to a different edge of the panels.
+
+| Placement                                                                       | Tabs appear                       |
+| ------------------------------------------------------------------------------- | --------------------------------- |
+| `top` <wa-badge appearance="outlined" variant="neutral" pill style="font-size: var(--wa-font-size-2xs);">default</wa-badge> | Above the panels, horizontally    |
+| `bottom`                                                                        | Below the panels, horizontally    |
+| `start`                                                                         | Before the panels, stacked vertically |
+| `end`                                                                           | After the panels, stacked vertically  |
 
 ```html {.example}
 <wa-tab-group placement="bottom">
@@ -59,16 +66,12 @@ Tabs can be shown on the bottom by setting `placement` to `bottom`.
   <wa-tab panel="advanced">Advanced</wa-tab>
   <wa-tab panel="disabled" disabled>Disabled</wa-tab>
 
-  <wa-tab-panel name="general">This is the general tab panel.</wa-tab-panel>
+  <wa-tab-panel name="general" active>This is the general tab panel.</wa-tab-panel>
   <wa-tab-panel name="custom">This is the custom tab panel.</wa-tab-panel>
   <wa-tab-panel name="advanced">This is the advanced tab panel.</wa-tab-panel>
   <wa-tab-panel name="disabled">This is a disabled tab panel.</wa-tab-panel>
 </wa-tab-group>
 ```
-
-### Tabs on Start
-
-Tabs can be shown on the starting side by setting `placement` to `start`.
 
 ```html {.example}
 <wa-tab-group placement="start">
@@ -77,25 +80,7 @@ Tabs can be shown on the starting side by setting `placement` to `start`.
   <wa-tab panel="advanced">Advanced</wa-tab>
   <wa-tab panel="disabled" disabled>Disabled</wa-tab>
 
-  <wa-tab-panel name="general">This is the general tab panel.</wa-tab-panel>
-  <wa-tab-panel name="custom">This is the custom tab panel.</wa-tab-panel>
-  <wa-tab-panel name="advanced">This is the advanced tab panel.</wa-tab-panel>
-  <wa-tab-panel name="disabled">This is a disabled tab panel.</wa-tab-panel>
-</wa-tab-group>
-```
-
-### Tabs on End
-
-Tabs can be shown on the ending side by setting `placement` to `end`.
-
-```html {.example}
-<wa-tab-group placement="end">
-  <wa-tab panel="general">General</wa-tab>
-  <wa-tab panel="custom">Custom</wa-tab>
-  <wa-tab panel="advanced">Advanced</wa-tab>
-  <wa-tab panel="disabled" disabled>Disabled</wa-tab>
-
-  <wa-tab-panel name="general">This is the general tab panel.</wa-tab-panel>
+  <wa-tab-panel name="general" active>This is the general tab panel.</wa-tab-panel>
   <wa-tab-panel name="custom">This is the custom tab panel.</wa-tab-panel>
   <wa-tab-panel name="advanced">This is the advanced tab panel.</wa-tab-panel>
   <wa-tab-panel name="disabled">This is a disabled tab panel.</wa-tab-panel>
@@ -113,7 +98,7 @@ You can make a tab closable by adding a close button next to the tab and inside 
   <wa-button slot="nav" tabindex="-1" appearance="plain" size="s">
     <wa-icon name="xmark" label="Close the closable tab"></wa-icon>
   </wa-button>
-  <wa-tab panel="closable-2">Advanced</wa-tab>
+  <wa-tab panel="advanced">Advanced</wa-tab>
 
   <wa-tab-panel name="general">This is the general tab panel.</wa-tab-panel>
   <wa-tab-panel name="closable">This is the closable tab panel.</wa-tab-panel>

--- a/packages/webawesome/docs/docs/components/tree.md
+++ b/packages/webawesome/docs/docs/components/tree.md
@@ -54,14 +54,16 @@ use-cases:
 
 ## Examples
 
-### Selection Modes
+### Selection
 
-The `selection` attribute lets you change the selection behavior of the tree.
+Set the `selection` attribute to change what a tree lets you select.
 
-- Use `single` to allow the selection of a single item (default).
-- Use `multiple` to allow the selection of multiple items.
-- Use `leaf` to only allow leaf nodes to be selected.
-- Use `leaf-multiple` to allow the selection of multiple leaf nodes.
+| Value                                                                              | Selects                              |
+| ---------------------------------------------------------------------------------- | ------------------------------------ |
+| `single` <wa-badge appearance="outlined" variant="neutral" pill style="font-size: var(--wa-font-size-2xs);">default</wa-badge> | One item at a time                   |
+| `multiple`                                                                         | Any number of items                  |
+| `leaf`                                                                             | One leaf node (a node with no children) |
+| `leaf-multiple`                                                                    | Any number of leaf nodes             |
 
 ```html {.example}
 <div>
@@ -156,9 +158,9 @@ Trees inherit their font size by default. You can change the size of a tree and 
 </wa-tree>
 ```
 
-### Showing Indent Guides
+### Indent Guides
 
-Indent guides can be drawn by setting `--indent-guide-width`. You can also change the color, offset, and style, using `--indent-guide-color`, `--indent-guide-style`, and `--indent-guide-offset`, respectively.
+Set the `--indent-guide-width` custom property to draw indent guides. The `--indent-guide-color`, `--indent-guide-style`, and `--indent-guide-offset` custom properties tune their color, style, and offset.
 
 ```html {.example}
 <wa-tree class="tree-with-lines">
@@ -200,39 +202,7 @@ Indent guides can be drawn by setting `--indent-guide-width`. You can also chang
 </style>
 ```
 
-### Lazy Loading
-
-Use the `lazy` attribute on a tree item to indicate that the content is not yet present and will be loaded later. When the user tries to expand the node, the `loading` state is set to `true` and the `wa-lazy-load` event will be emitted to allow you to load data asynchronously. The item will remain in a loading state until its content is changed.
-
-If you want to disable this behavior after the first load, simply remove the `lazy` attribute and, on the next expand, the existing content will be shown instead.
-
-```html {.example}
-<wa-tree>
-  <wa-tree-item lazy>Remote Repositories</wa-tree-item>
-</wa-tree>
-
-<script type="module">
-  const lazyItem = document.querySelector('wa-tree-item[lazy]');
-
-  lazyItem.addEventListener('wa-lazy-load', () => {
-    // Simulate fetching data from a server
-    setTimeout(() => {
-      const repos = ['design-system', 'marketing-site', 'mobile-app', 'api-gateway'];
-
-      for (const repo of repos) {
-        const treeItem = document.createElement('wa-tree-item');
-        treeItem.innerText = repo;
-        lazyItem.append(treeItem);
-      }
-
-      // Disable lazy mode once the content has been loaded
-      lazyItem.lazy = false;
-    }, 1000);
-  });
-</script>
-```
-
-### Customizing the Expand & Collapse Icons
+### Expand & Collapse Icons
 
 Use the `expand-icon` and `collapse-icon` slots to change the expand and collapse icons, respectively. To disable the animation, override the `rotate` property on the `expand-button` part as shown below.
 
@@ -278,7 +248,7 @@ Use the `expand-icon` and `collapse-icon` slots to change the expand and collaps
 </style>
 ```
 
-### With Icons
+### Item Icons
 
 Decorative icons can be used before labels to provide hints for each node.
 
@@ -349,4 +319,36 @@ Decorative icons can be used before labels to provide hints for each node.
     </wa-tree-item>
   </wa-tree-item>
 </wa-tree>
+```
+
+### Lazy Loading
+
+Use the `lazy` attribute on a tree item to indicate that the content is not yet present and will be loaded later. When the user tries to expand the node, the `loading` state is set to `true` and the `wa-lazy-load` event will be emitted to allow you to load data asynchronously. The item will remain in a loading state until its content is changed.
+
+If you want to disable this behavior after the first load, remove the `lazy` attribute and, on the next expand, the existing content will be shown instead.
+
+```html {.example}
+<wa-tree>
+  <wa-tree-item lazy>Remote Repositories</wa-tree-item>
+</wa-tree>
+
+<script type="module">
+  const lazyItem = document.querySelector('wa-tree-item[lazy]');
+
+  lazyItem.addEventListener('wa-lazy-load', () => {
+    // Simulate fetching data from a server
+    setTimeout(() => {
+      const repos = ['design-system', 'marketing-site', 'mobile-app', 'api-gateway'];
+
+      for (const repo of repos) {
+        const treeItem = document.createElement('wa-tree-item');
+        treeItem.innerText = repo;
+        lazyItem.append(treeItem);
+      }
+
+      // Disable lazy mode once the content has been loaded
+      lazyItem.lazy = false;
+    }, 1000);
+  });
+</script>
 ```


### PR DESCRIPTION
This work applies the `.house-rules/` docs conventions to the Navigation category — `breadcrumb`, `tab-group`, and `tree`.

### Breadcrumb
- Showing the opening example first
- The `Colors` demo now uses red-palette tokens instead of `firebrick`/`crimson`/`pink`.
- Dropped the `end`-slot dropdown example — `<wa-dropdown>` is a boxless wrapper, so the slot's margin landed on nothing, and the trigger crowded the label.
- `With Dropdowns` → `Dropdowns`, the lone prepositional heading among the section's nouns

### Tab-Group
- Collapsed the three `Tabs on Bottom` / `Start` / `End` sections into one `Placement` section
- `Placement` section contains a four-value table plus `bottom` and `start` examples
- `Setting the Active Tab` → `Active Tab`
- Showing the opening example first
- Fixed the `Closable Tabs` example: the third tab pointed at `panel="closable-2"`, which had no matching panel

### Tree
- `Selection Modes` → `Selection`, with the bulleted mode list turned into a table
- `Showing Indent Guides` → `Indent Guides`
- `Customizing the Expand & Collapse Icons` → `Expand & Collapse Icons`
- `With Icons` → `Item Icons`, disambiguating it from `Expand & Collapse Icons`
- Moved `Lazy Loading` to the end : it's the most advanced behavior
