### PR TITLE
Improve Layout Components Documentation

### DIFF
--- a/packages/webawesome/docs/docs/components/accordion.md
+++ b/packages/webawesome/docs/docs/components/accordion.md
@@ -16,8 +16,6 @@ use-cases:
   - collapsible navigation
 ---
 
-Accordions use [accordion items](/docs/components/accordion-item) to create a vertically stacked set of expandable sections.
-
 ```html {.example}
 <wa-accordion>
   <wa-accordion-item label="What is Web Awesome?">
@@ -34,6 +32,8 @@ Accordions use [accordion items](/docs/components/accordion-item) to create a ve
   </wa-accordion-item>
 </wa-accordion>
 ```
+
+Accordions use [accordion items](/docs/components/accordion-item) to create a vertically stacked set of expandable sections.
 
 ## Examples
 
@@ -52,7 +52,7 @@ Use the `expanded` attribute on an accordion item to expand it by default.
 </wa-accordion>
 ```
 
-### Disabled Items
+### Disabled
 
 Use the `disabled` attribute on an accordion item to prevent it from being toggled.
 
@@ -65,22 +65,9 @@ Use the `disabled` attribute on an accordion item to prevent it from being toggl
 </wa-accordion>
 ```
 
-### Without a Heading
-
-The [W3C accordion pattern](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/examples/accordion/) recommends wrapping each accordion trigger in a heading element so screen reader users can navigate the page outline and locate accordion sections using heading navigation. Each accordion item uses an `<h3>` by default for this reason.
-
-But if an accordion lives outside the document outline, for example, inside a nav or another component that has its own structure, set `heading-level="none"` on the accordion to omit the heading wrapper and render the button directly.
-
-```html {.example}
-<wa-accordion heading-level="none">
-  <wa-accordion-item label="Settings"> Adjust your preferences here. </wa-accordion-item>
-  <wa-accordion-item label="Notifications"> Manage how and when you receive notifications. </wa-accordion-item>
-</wa-accordion>
-```
-
 ### Heading Level
 
-The default heading level is `3`. Use `heading-level` on the accordion to match the level to your page's hierarchy. Values outside 1–6 fall back to `3`. The heading level is a semantic choice only — the accordion inherits the surrounding font, so the visual appearance is identical at every level.
+Each accordion item wraps its trigger in a heading so screen reader users can navigate to it, per the [W3C accordion pattern](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/examples/accordion/). The default is `<h3>`. Set the `heading-level` attribute to match your page's hierarchy (values outside 1–6 fall back to `3`). The level is semantic only; the accordion inherits the surrounding font, so the appearance is identical at every level.
 
 ```html {.example}
 <wa-accordion heading-level="2">
@@ -91,7 +78,16 @@ The default heading level is `3`. Use `heading-level` on the accordion to match 
 </wa-accordion>
 ```
 
-### Sizing
+If an accordion lives outside the document outline (inside a nav or another component with its own structure), set `heading-level="none"` to omit the heading wrapper and render the button directly.
+
+```html {.example}
+<wa-accordion heading-level="none">
+  <wa-accordion-item label="Settings"> Adjust your preferences here. </wa-accordion-item>
+  <wa-accordion-item label="Notifications"> Manage how and when you receive notifications. </wa-accordion-item>
+</wa-accordion>
+```
+
+### Size
 
 The accordion's text and expand/collapse icon scale with `font-size`. Setting `font-size` on a `<wa-accordion>` proportionally resizes the type and icon together.
 
@@ -156,11 +152,13 @@ Use the `appearance` attribute to change the accordion's visual appearance.
 
 ### Mode
 
-Use the `mode` attribute to control how items can be expanded:
+Use the `mode` attribute to control how items can be expanded.
 
-- `multiple` (default): any number of items can be open at once, and each item toggles independently.
-- `single`: only one item can be open at a time. Opening a new item collapses the previously open one, and clicking the open item is a no-op — once an item is open, it stays open until another is opened.
-- `single-collapsible`: at most one item can be open at a time. Same as `single`, except clicking the open item closes it, so zero open items is a valid state.
+| Mode                                                                                 | Behavior                                                                                          |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| `multiple` <wa-badge appearance="outlined" variant="neutral" pill style="font-size: var(--wa-font-size-2xs);">default</wa-badge> | Any number of items open at once; each toggles independently                                     |
+| `single`                                                                             | One item open at a time; opening another collapses it, and clicking the open item keeps it open  |
+| `single-collapsible`                                                                 | Like `single`, but clicking the open item closes it — so zero open items is a valid state        |
 
 ```html {.example}
 <wa-accordion mode="single">

--- a/packages/webawesome/docs/docs/components/card.md
+++ b/packages/webawesome/docs/docs/components/card.md
@@ -41,7 +41,7 @@ use-cases:
 
 ### Basic Card
 
-Basic cards aren't very exciting, but they can display any content you want them to.
+A card can hold any content. Media, a header, and a footer are all optional.
 
 ```html {.example}
 <wa-card class="card-basic">
@@ -55,7 +55,7 @@ Basic cards aren't very exciting, but they can display any content you want them
 </style>
 ```
 
-### Card with Header
+### Header
 
 Headers can be used to display titles and more.
 If using SSR, you need to also use the `with-header` attribute to add a header to the card (if not, it is added automatically).
@@ -80,7 +80,7 @@ If using SSR, you need to also use the `with-header` attribute to add a header t
 </style>
 ```
 
-### Card with Footer
+### Footer
 
 Footers can be used to display actions, summaries, or other relevant content.
 If using SSR, you need to also use the `with-footer` attribute to add a footer to the card (if not, it is added automatically).
@@ -165,7 +165,7 @@ Use the `appearance` attribute to change the card's visual appearance.
 Set the `orientation` attribute to `horizontal` to create a card with a horizontal, side-by-side layout. Make sure to set a width or maximum width for the media slot. Horizontal cards do not currently contain the header and footer slots.
 
 :::info
-The `actions` slot is only available for the horizontal orientation
+The `actions` slot is only available for the horizontal orientation.
 :::
 
 ```html {.example}

--- a/packages/webawesome/docs/docs/components/details.md
+++ b/packages/webawesome/docs/docs/components/details.md
@@ -46,7 +46,7 @@ Use the `disabled` attribute to prevent the details from expanding.
 </wa-details>
 ```
 
-### Customizing the Summary Icon
+### Expand & Collapse Icons
 
 Use the `expand-icon` and `collapse-icon` slots to change the expand and collapse icons, respectively. To disable the animation, override the `rotate` property on the `icon` part as shown below.
 
@@ -67,7 +67,7 @@ Use the `expand-icon` and `collapse-icon` slots to change the expand and collaps
 </style>
 ```
 
-### Icon Position
+### Icon Placement
 
 The default position for the expand and collapse icons is at the end of the summary. Set the `icon-placement` attribute to `start` to place the icon at the start of the summary.
 

--- a/packages/webawesome/docs/docs/components/dialog.md
+++ b/packages/webawesome/docs/docs/components/dialog.md
@@ -34,7 +34,7 @@ use-cases:
 
 ## Examples
 
-### Dialog Without Header
+### Without a Header
 
 Headers are enabled by default. To render a dialog without a header, add the `without-header` attribute.
 
@@ -54,7 +54,7 @@ Headers are enabled by default. To render a dialog without a header, add the `wi
 </script>
 ```
 
-### Dialog with Footer
+### Footer
 
 Footers can be used to display titles and more. Use the `footer` slot to add a footer to the dialog.
 
@@ -74,7 +74,7 @@ Footers can be used to display titles and more. Use the `footer` slot to add a f
 </script>
 ```
 
-### Opening & Closing Dialogs Declaratively
+### Opening & Closing Declaratively
 
 You can open and close dialogs with JavaScript by toggling the `open` attribute, but you can also do it declaratively. Add the `data-dialog="open id"` to any button on the page, where `id` is the ID of the dialog you want to open.
 
@@ -98,9 +98,9 @@ Similarly, you can add `data-dialog="close"` to a button _inside_ of a dialog to
 <wa-button appearance="filled" data-dialog="open dialog-dismiss">Open Dialog</wa-button>
 ```
 
-### Custom Width
+### Width
 
-Just use the `--width` custom property to set the dialog's width.
+Use the `--width` custom property to set the dialog's width.
 
 ```html {.example}
 <wa-dialog label="Dialog" class="dialog-width" style="--width: 50vw;">
@@ -217,7 +217,7 @@ You can use `event.detail.source` to determine which element triggered the reque
 </script>
 ```
 
-### Setting Initial Focus
+### Initial Focus
 
 To give focus to a specific element when the dialog opens, use the `autofocus` attribute.
 

--- a/packages/webawesome/docs/docs/components/divider.md
+++ b/packages/webawesome/docs/docs/components/divider.md
@@ -33,12 +33,12 @@ Use the `--width` custom property to change the width of the divider.
 Use the `--color` custom property to change the color of the divider.
 
 ```html {.example}
-<wa-divider style="--color: tomato;"></wa-divider>
+<wa-divider style="--color: var(--wa-color-brand-fill-loud);"></wa-divider>
 ```
 
 ### Spacing
 
-Use the `--spacing` custom property to change the amount of space between the divider and it's neighboring elements.
+Use the `--spacing` custom property to change the amount of space between the divider and its neighboring elements.
 
 ```html {.example}
 <div class="wa-text-center">
@@ -50,7 +50,7 @@ Use the `--spacing` custom property to change the amount of space between the di
 
 ### Orientation
 
-The default orientation for dividers is `horizontal`. Set `orientation` attribute to `vertical` to draw a vertical divider. The divider will span the full height of its [Flexbox](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/CSS_layout/Flexbox) or [CSS Grid](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/grid) container.
+The default orientation for dividers is `horizontal`. Set the `orientation` attribute to `vertical` to draw a vertical divider. The divider will span the full height of its [Flexbox](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/CSS_layout/Flexbox) or [CSS Grid](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/grid) container.
 
 ```html {.example}
 <div style="display: flex; align-items: center;">

--- a/packages/webawesome/docs/docs/components/drawer.md
+++ b/packages/webawesome/docs/docs/components/drawer.md
@@ -34,7 +34,7 @@ use-cases:
 
 ## Examples
 
-### Drawer Without Header
+### Without a Header
 
 Headers are enabled by default. To render a drawer without a header, add the `without-header` attribute.
 
@@ -54,7 +54,7 @@ Headers are enabled by default. To render a drawer without a header, add the `wi
 </script>
 ```
 
-### Drawer with Footer
+### Footer
 
 Footers can be used to display titles and more. Use the `footer` slot to add a footer to the drawer.
 
@@ -74,7 +74,7 @@ Footers can be used to display titles and more. Use the `footer` slot to add a f
 </script>
 ```
 
-### Opening & Closing Drawers Declaratively
+### Opening & Closing Declaratively
 
 You can open and close drawers with JavaScript by toggling the `open` attribute, but you can also do it declaratively. Add the `data-drawer="open id"` to any button on the page, where `id` is the ID of the drawer you want to open.
 
@@ -98,9 +98,16 @@ Similarly, you can add `data-drawer="close"` to a button _inside_ of a drawer to
 <wa-button appearance="filled" data-drawer="open drawer-dismiss">Open Drawer</wa-button>
 ```
 
-### Slide in from Start
+### Placement
 
-By default, drawers slide in from the end. To make the drawer slide in from the start, set the `placement` attribute to `start`.
+Drawers slide in from the end by default. Set the `placement` attribute to slide in from a different edge.
+
+| Placement                                                                       | Slides in from           |
+| ------------------------------------------------------------------------------- | ------------------------ |
+| `end` <wa-badge appearance="outlined" variant="neutral" pill style="font-size: var(--wa-font-size-2xs);">default</wa-badge> | The end (right, in LTR)  |
+| `start`                                                                         | The start (left, in LTR) |
+| `top`                                                                           | The top                  |
+| `bottom`                                                                        | The bottom               |
 
 ```html {.example}
 <wa-drawer label="Drawer" placement="start" class="drawer-placement-start">
@@ -108,7 +115,7 @@ By default, drawers slide in from the end. To make the drawer slide in from the 
   <wa-button slot="footer" variant="brand" data-drawer="close">Close</wa-button>
 </wa-drawer>
 
-<wa-button appearance="filled">Open Drawer</wa-button>
+<wa-button appearance="filled">Open from Start</wa-button>
 
 <script>
   const drawer = document.querySelector('.drawer-placement-start');
@@ -118,37 +125,13 @@ By default, drawers slide in from the end. To make the drawer slide in from the 
 </script>
 ```
 
-### Slide in from Top
-
-To make the drawer slide in from the top, set the `placement` attribute to `top`.
-
-```html {.example}
-<wa-drawer label="Drawer" placement="top" class="drawer-placement-top">
-  This drawer slides in from the top.
-  <wa-button slot="footer" variant="brand" data-drawer="close">Close</wa-button>
-</wa-drawer>
-
-<wa-button appearance="filled">Open Drawer</wa-button>
-
-<script>
-  const drawer = document.querySelector('.drawer-placement-top');
-  const openButton = drawer.nextElementSibling;
-
-  openButton.addEventListener('click', () => (drawer.open = true));
-</script>
-```
-
-### Slide in from Bottom
-
-To make the drawer slide in from the bottom, set the `placement` attribute to `bottom`.
-
 ```html {.example}
 <wa-drawer label="Drawer" placement="bottom" class="drawer-placement-bottom">
   This drawer slides in from the bottom.
   <wa-button slot="footer" variant="brand" data-drawer="close">Close</wa-button>
 </wa-drawer>
 
-<wa-button appearance="filled">Open Drawer</wa-button>
+<wa-button appearance="filled">Open from Bottom</wa-button>
 
 <script>
   const drawer = document.querySelector('.drawer-placement-bottom');
@@ -158,7 +141,7 @@ To make the drawer slide in from the bottom, set the `placement` attribute to `b
 </script>
 ```
 
-### Custom Size
+### Size
 
 Use the `--size` custom property to set the drawer's size. This will be applied to the drawer's width or height depending on its `placement`.
 
@@ -277,7 +260,7 @@ You can use `event.detail.source` to determine what triggered the request to clo
 </script>
 ```
 
-### Setting Initial Focus
+### Initial Focus
 
 To give focus to a specific element when the drawer opens, use the `autofocus` attribute.
 

--- a/packages/webawesome/docs/docs/components/page.md
+++ b/packages/webawesome/docs/docs/components/page.md
@@ -26,7 +26,7 @@ Most slots are optional. Slots that have no content will not be shown, allowing 
   <fieldset>
     <legend>Slots</legend>
     <div class="wa-grid">
-      <wa-checkbox name="slot" value="banner" checked title="The banner that gets display above the header. The banner will not be shown if no content is provided.">
+      <wa-checkbox name="slot" value="banner" checked title="The banner that gets displayed above the header. The banner will not be shown if no content is provided.">
         banner
       </wa-checkbox>
       <wa-checkbox name="slot" value="header" checked title="The header to display at the top of the page. If a banner is present, the header will appear below the banner. The header will not be shown if there is no content.">
@@ -185,7 +185,7 @@ When you use the `navigation` slot, your slotted content automatically collapses
 
 By default, a "hamburger" button appears at the start of the `header` to toggle the navigation menu on smaller screens. You can customize what this looks like by slotting your own button into the `navigation-toggle` slot, or place the `data-toggle-nav` attribute on any button on your page. This _does not_ have to be a Web Awesome element.
 
-The default button will not be shown when using either of these methods — if you want to use multiple navigation toggles on your page, simply add the `data-toggle-nav` attribute to multiple elements.
+The default button will not be shown when using either of these methods — if you want to use multiple navigation toggles on your page, add the `data-toggle-nav` attribute to multiple elements.
 
 ```html
 <wa-page mobile-breakpoint="600">
@@ -210,7 +210,7 @@ wa-page[view='desktop'] [data-toggle-nav] {
 ```
 
 :::info
-If you use [native styles](/docs/utilities/native/), this is already taken care for you, and the `data-toggle-nav` button is already hidden on wider screens.
+If you use [native styles](/docs/utilities/native/), this is handled for you, and the `data-toggle-nav` button is already hidden on wider screens.
 :::
 
 #### Custom Widths

--- a/packages/webawesome/docs/docs/components/scroller.md
+++ b/packages/webawesome/docs/docs/components/scroller.md
@@ -84,7 +84,7 @@ use-cases:
 
 ### Adding Content
 
-The scroller component automatically provides a scrollable container for any content that exceeds the available space. Simply add your content as children of the `<wa-scroller>` element, and it will handle the rest.
+The scroller component automatically provides a scrollable container for any content that exceeds the available space. Add your content as children of the `<wa-scroller>` element, and it handles the rest.
 
 ```html {.example}
 <wa-scroller>
@@ -226,5 +226,6 @@ Use the `without-scrollbar` attribute to hide the scrollbar while maintaining sc
 ```
 
 :::warning
-Hiding scrollbars can negatively impact accessibility. Users who rely on visible scrollbars to navigate content may have difficulty recognizing that content is scrollable or controlling their scrolling position. Consider the needs of all users when implementing this option.
+<strong>Hiding the scrollbar can hurt accessibility.</strong><br />
+People who rely on a visible scrollbar may not realize the content scrolls, or may struggle to control their position. Weigh that before turning it off.
 :::

--- a/packages/webawesome/docs/docs/components/split-panel.md
+++ b/packages/webawesome/docs/docs/components/split-panel.md
@@ -15,74 +15,49 @@ use-cases:
 
 ```html {.example}
 <wa-split-panel>
-  <div
-    slot="start"
-    style="height: 200px; background: var(--wa-color-surface-lowered); display: flex; align-items: center; justify-content: center; overflow: hidden;"
-  >
+  <div slot="start" class="split-demo">
     Start
   </div>
-  <div
-    slot="end"
-    style="height: 200px; background: var(--wa-color-surface-lowered); display: flex; align-items: center; justify-content: center; overflow: hidden;"
-  >
+  <div slot="end" class="split-demo">
     End
   </div>
 </wa-split-panel>
+
+<style>
+  .split-demo {
+    height: 200px;
+    background: var(--wa-color-surface-lowered);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+  }
+</style>
 ```
 
 ## Examples
 
 ### Initial Position
 
-To set the initial position, use the `position` attribute. If no position is provided, it will default to 50% of the available space.
+Set the `position` attribute to change the divider's starting position, given as a percentage of the available space (`50` by default). To set it in pixels instead, use the `position-in-pixels` attribute.
 
 ```html {.example}
 <wa-split-panel position="75">
-  <div
-    slot="start"
-    style="
-      height: 200px;
-      background: var(--wa-color-surface-lowered);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      overflow: hidden;
-    "
-  >
+  <div slot="start" class="split-demo">
     Start
   </div>
-  <div
-    slot="end"
-    style="
-      height: 200px;
-      background: var(--wa-color-surface-lowered);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      overflow: hidden;
-    "
-  >
+  <div slot="end" class="split-demo">
     End
   </div>
 </wa-split-panel>
 ```
 
-### Initial Position in Pixels
-
-To set the initial position in pixels instead of a percentage, use the `position-in-pixels` attribute.
-
 ```html {.example}
 <wa-split-panel position-in-pixels="150">
-  <div
-    slot="start"
-    style="height: 200px; background: var(--wa-color-surface-lowered); display: flex; align-items: center; justify-content: center; overflow: hidden;"
-  >
+  <div slot="start" class="split-demo">
     Start
   </div>
-  <div
-    slot="end"
-    style="height: 200px; background: var(--wa-color-surface-lowered); display: flex; align-items: center; justify-content: center; overflow: hidden;"
-  >
+  <div slot="end" class="split-demo">
     End
   </div>
 </wa-split-panel>
@@ -94,16 +69,10 @@ Set the `orientation` attribute to `vertical` and provide a height to render the
 
 ```html {.example}
 <wa-split-panel orientation="vertical" style="height: 400px;">
-  <div
-    slot="start"
-    style="height: 100%; background: var(--wa-color-surface-lowered); display: flex; align-items: center; justify-content: center; overflow: hidden;"
-  >
+  <div slot="start" class="split-demo" style="height: 100%;">
     Start
   </div>
-  <div
-    slot="end"
-    style="height: 100%; background: var(--wa-color-surface-lowered); display: flex; align-items: center; justify-content: center; overflow: hidden;"
-  >
+  <div slot="end" class="split-demo" style="height: 100%;">
     End
   </div>
 </wa-split-panel>
@@ -116,16 +85,10 @@ To snap panels at specific positions while dragging, add the `snap` attribute wi
 ```html {.example}
 <div class="split-panel-snapping">
   <wa-split-panel snap="100px 50%">
-    <div
-      slot="start"
-      style="height: 200px; background: var(--wa-color-surface-lowered); display: flex; align-items: center; justify-content: center; overflow: hidden;"
-    >
+    <div slot="start" class="split-demo">
       Start
     </div>
-    <div
-      slot="end"
-      style="height: 200px; background: var(--wa-color-surface-lowered); display: flex; align-items: center; justify-content: center; overflow: hidden;"
-    >
+    <div slot="end" class="split-demo">
       End
     </div>
   </wa-split-panel>
@@ -166,22 +129,16 @@ Add the `disabled` attribute to prevent the divider from being repositioned.
 
 ```html {.example}
 <wa-split-panel disabled>
-  <div
-    slot="start"
-    style="height: 200px; background: var(--wa-color-surface-lowered); display: flex; align-items: center; justify-content: center; overflow: hidden;"
-  >
+  <div slot="start" class="split-demo">
     Start
   </div>
-  <div
-    slot="end"
-    style="height: 200px; background: var(--wa-color-surface-lowered); display: flex; align-items: center; justify-content: center; overflow: hidden;"
-  >
+  <div slot="end" class="split-demo">
     End
   </div>
 </wa-split-panel>
 ```
 
-### Setting the Primary Panel
+### Primary Panel
 
 By default, both panels will grow or shrink proportionally when the host element is resized. If a primary panel is designated, it will maintain its size and the secondary panel will grow or shrink to fit the remaining space. You can set the primary panel to `start` or `end` using the `primary` attribute.
 
@@ -190,16 +147,10 @@ Try resizing the example below with each option and notice how the panels respon
 ```html {.example}
 <div class="split-panel-primary">
   <wa-split-panel>
-    <div
-      slot="start"
-      style="height: 200px; background: var(--wa-color-surface-lowered); display: flex; align-items: center; justify-content: center; overflow: hidden;"
-    >
+    <div slot="start" class="split-demo">
       Start
     </div>
-    <div
-      slot="end"
-      style="height: 200px; background: var(--wa-color-surface-lowered); display: flex; align-items: center; justify-content: center; overflow: hidden;"
-    >
+    <div slot="end" class="split-demo">
       End
     </div>
   </wa-split-panel>
@@ -230,16 +181,10 @@ This examples demonstrates how you can ensure both panels are at least 150px usi
 
 ```html {.example}
 <wa-split-panel style="--min: 150px; --max: calc(100% - 150px);">
-  <div
-    slot="start"
-    style="height: 200px; background: var(--wa-color-surface-lowered); display: flex; align-items: center; justify-content: center; overflow: hidden;"
-  >
+  <div slot="start" class="split-demo">
     Start
   </div>
-  <div
-    slot="end"
-    style="height: 200px; background: var(--wa-color-surface-lowered); display: flex; align-items: center; justify-content: center; overflow: hidden;"
-  >
+  <div slot="end" class="split-demo">
     End
   </div>
 </wa-split-panel>
@@ -251,24 +196,15 @@ Create complex layouts that can be repositioned independently by nesting split p
 
 ```html {.example}
 <wa-split-panel>
-  <div
-    slot="start"
-    style="height: 400px; background: var(--wa-color-surface-lowered); display: flex; align-items: center; justify-content: center; overflow: hidden"
-  >
+  <div slot="start" class="split-demo" style="height: 400px;">
     Start
   </div>
   <div slot="end">
     <wa-split-panel orientation="vertical" style="height: 400px;">
-      <div
-        slot="start"
-        style="height: 100%; background: var(--wa-color-surface-lowered); display: flex; align-items: center; justify-content: center; overflow: hidden"
-      >
+      <div slot="start" class="split-demo" style="height: 100%;">
         Top
       </div>
-      <div
-        slot="end"
-        style="height: 100%; background: var(--wa-color-surface-lowered); display: flex; align-items: center; justify-content: center; overflow: hidden"
-      >
+      <div slot="end" class="split-demo" style="height: 100%;">
         Bottom
       </div>
     </wa-split-panel>
@@ -283,30 +219,10 @@ You can target the `divider` part to apply CSS properties to the divider. To add
 ```html {.example}
 <wa-split-panel style="--divider-width: 20px;">
   <wa-icon slot="divider" name="grip-vertical" variant="solid"></wa-icon>
-  <div
-    slot="start"
-    style="
-      height: 200px;
-      background: var(--wa-color-surface-lowered);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      overflow: hidden;
-    "
-  >
+  <div slot="start" class="split-demo">
     Start
   </div>
-  <div
-    slot="end"
-    style="
-      height: 200px;
-      background: var(--wa-color-surface-lowered);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      overflow: hidden;
-    "
-  >
+  <div slot="end" class="split-demo">
     End
   </div>
 </wa-split-panel>
@@ -318,30 +234,10 @@ Here's a more elaborate example that changes the divider's color and width and a
 <div class="split-panel-divider">
   <wa-split-panel>
     <wa-icon slot="divider" name="grip-vertical" variant="solid"></wa-icon>
-    <div
-      slot="start"
-      style="
-        height: 200px;
-        background: var(--wa-color-surface-lowered);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        overflow: hidden;
-      "
-    >
+    <div slot="start" class="split-demo">
       Start
     </div>
-    <div
-      slot="end"
-      style="
-        height: 200px;
-        background: var(--wa-color-surface-lowered);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        overflow: hidden;
-      "
-    >
+    <div slot="end" class="split-demo">
       End
     </div>
   </wa-split-panel>


### PR DESCRIPTION
This work applies the `.house-rules/` docs conventions to the Layout category — `accordion`, `card`, `details`, `dialog`, `divider`, `drawer`, `page`, `scroller`, and `split-panel`.

### Drawer
- Collapsed three `Slide in from Start/Top/Bottom` sections into one `Placement` table (`end`/`start`/`top`/`bottom`) with 2 examples
- `Drawer Without Header` → `Without a Header`
- `Custom Size` → `Size`
- `Setting Initial Focus` → `Initial Focus`.

### Accordion
- Merged `Without a Heading` into `Heading Level`
- The `mode` bullet list → `mode` table
-`Sizing` → `Size`
`Disabled Items` → `Disabled`
- Revised opening example first

### Split-Panel
- Merged `Initial Position in Pixels` into `Initial Position`
-`Setting the Primary Panel` → `Primary Panel`
- Extracted the repeated panel box styling into a shared `.split-demo` class.

### Dialog / Details / Card
- `dialog`: `Dialog Without Header` → `Without a Header`, `Custom Width` → `Width`
- `details`: Aligned to its siblings (`Customizing the Summary Icon` → `Expand & Collapse Icons`, `Icon Position` → `Icon Placement`)
- `card`: `Card with Header/Footer` → `Header`/`Footer`.

### Divider / Scroller / Page
- `divider`: Use design token in `--color` styling, fix an `it's` → `its`typo. 
- `scroller`: Reworked a11y warning. 
- `page`: Revised grammar and prose in the hybrid guide.
