### PR TITLE
Docs: Revise `:::pro` Callouts' Icon + Brand Coloring

### DIFF
--- a/packages/webawesome/docs/_utils/markdown.js
+++ b/packages/webawesome/docs/_utils/markdown.js
@@ -41,13 +41,10 @@ markdown.use(markdownItContainer, 'pro', {
   validate: params => /^pro(\s+.+)?$/.test(params.trim()),
   render: function (tokens, idx) {
     if (tokens[idx].nesting === 1) {
-      const info = tokens[idx].info.trim().replace(/^pro\s*/, '');
-      const iconMatch = info.match(/^\{([\w-]+)\}\s*(.*)$/);
-      const iconName = iconMatch ? iconMatch[1] : 'hand-wave';
-      const title = iconMatch ? iconMatch[2].trim() : info.trim();
+      const title = tokens[idx].info.trim().replace(/^pro\s*/, '');
       return `
-        <wa-callout class="pro">
-          <wa-icon slot="icon" name="${markdown.utils.escapeHtml(iconName)}"></wa-icon>
+        <wa-callout class="pro wa-brand-orange">
+          <wa-icon slot="icon" name="crown" family="duotone" variant="regular" class="duotone-illustrated"></wa-icon>
           ${title ? `<strong>${markdown.utils.escapeHtml(title)}</strong>` : ''}
       `;
     }

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -532,6 +532,11 @@
     border-color: color-mix(in oklab, var(--wa-brand-orange) 30%, var(--wa-color-surface-default));
     color: var(--wa-color-text-normal);
 
+    /* Re-declare --wa-color-text-link so its var() substitution resolves in the orange-scoped
+       context (callouts carry .wa-brand-orange). The theme sets it at :root where brand is still
+       blue, so inheritance alone keeps links blue. */
+    --wa-color-text-link: var(--wa-color-brand-40);
+
     &::part(icon) {
       align-items: flex-start;
       color: var(--wa-brand-orange);
@@ -539,11 +544,6 @@
 
     wa-icon[slot='icon'] {
       font-size: var(--wa-font-size-xl);
-    }
-
-    strong {
-      display: block;
-      margin-block-end: var(--wa-space-2xs);
     }
 
     strong a {
@@ -565,6 +565,10 @@
     wa-details [slot='summary'] u {
       --underline-color: var(--wa-color-brand);
     }
+  }
+
+  .wa-dark wa-callout.pro {
+    --wa-color-text-link: var(--wa-color-brand-70);
   }
 
   /* free badge */

--- a/packages/webawesome/docs/docs/frameworks/react.md
+++ b/packages/webawesome/docs/docs/frameworks/react.md
@@ -28,8 +28,8 @@ React 19+ [supports custom elements](https://react.dev/blog/2024/04/25/react-19#
 
 If you're using React 18 or below, skip to the [legacy React wrappers](#legacy-react-wrappers-react-18-and-below) section.
 
-:::pro Using Web Awesome Pro?
-Get personalized installation instructions from <a href="/workspaces">your&nbsp;workspaces</a> instead.
+:::pro
+**Using Web Awesome Pro?** Visit [your workspaces](/workspaces) for personalized installation docs.
 :::
 
 ## TypeScript

--- a/packages/webawesome/docs/docs/index.md
+++ b/packages/webawesome/docs/docs/index.md
@@ -25,8 +25,8 @@ Now you can [use any Web Awesome component](/docs/components)! Try putting a but
 <wa-button variant="brand">Click me!</wa-button>
 ```
 
-:::pro Using Web Awesome Pro?
-Get personalized installation instructions from <a href="/workspaces">your&nbsp;workspaces</a> instead.
+:::pro
+**Using Web Awesome Pro?** Visit [your workspaces](/workspaces) for personalized installation docs.
 :::
 
 ## Installing with npm
@@ -50,10 +50,9 @@ import '@awesome.me/webawesome/dist/components/input/input.js';
 
 Once a component has been imported, you can use it in your HTML normally. Components are cherry picked to ensure you're getting the smallest possible bundle. You can find each component import in the "Importing" section of its documentation.
 
-:::pro Using Web Awesome Pro?
-Get personalized installation instructions from <a href="/workspaces">your&nbsp;workspaces</a> instead.
+:::pro
+**Using Web Awesome Pro?** Visit [your workspaces](/workspaces) for personalized installation docs.
 :::
-
 ## Get the Download (Advanced)
 
 You can download Web Awesome from npm and self-host it.


### PR DESCRIPTION
Gives the `:::pro` docs callout a revised consistent visual treatment: 
- a duotone crown icon in a brand-orange scope
- brand-orange-scoped link colors that resolve correctly

| Using Pro Callout | Pro Notice |
|--------|--------|
| <img width="3038" height="1782" alt="image" src="https://github.com/user-attachments/assets/a039bca6-1b55-4db9-9d91-0585e24c1903" /> | <img width="3038" height="1782" alt="image" src="https://github.com/user-attachments/assets/d780ae83-fb6b-4437-af2b-cfc1a9bc7697" /> |

## Companion PR
- https://github.com/shoelace-style/webawesome-pro/pull/259