### PR TITLE
Accordion: Expose `base` Part

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -33,7 +33,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 :::added
 
-- Added a `base` CSS part to `<wa-accordion>` for styling the component's container.
+- Added a `base` CSS part to `<wa-accordion>` for styling the component's container. [pr:2632]
 
 :::
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -31,6 +31,12 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 ## Unreleased
 
+:::added
+
+- Added a `base` CSS part to `<wa-accordion>` for styling the component's container.
+
+:::
+
 :::fixed
 
 - Fixed type resolution issues with `pro` components like `<wa-file-input>`, `<wa-combobox>`, etc. [pr:2577]

--- a/packages/webawesome/src/components/accordion/accordion.test.ts
+++ b/packages/webawesome/src/components/accordion/accordion.test.ts
@@ -33,6 +33,17 @@ describe('<wa-accordion>', () => {
         });
       });
 
+      describe('css parts', () => {
+        it('should expose the base part on the default slot', async () => {
+          const el = await fixture<WaAccordion>(html`
+            <wa-accordion>
+              <wa-accordion-item label="One">Content</wa-accordion-item>
+            </wa-accordion>
+          `);
+          expect(el.shadowRoot!.querySelector('slot[part~="base"]')).to.exist;
+        });
+      });
+
       describe('properties', () => {
         it('should default mode to multiple', async () => {
           const el = await fixture<WaAccordion>(html`

--- a/packages/webawesome/src/components/accordion/accordion.ts
+++ b/packages/webawesome/src/components/accordion/accordion.ts
@@ -20,6 +20,9 @@ import styles from './accordion.styles.js';
  *
  * @slot - One or more `<wa-accordion-item>` elements.
  *
+ * @csspart base - The default slot's container. Because it's a `<slot>` (`display: contents`), set `display` on it
+ *                 before applying box styles such as borders, backgrounds, or padding.
+ *
  * @event {{ item: WaAccordionItem }} wa-expand - Emitted before an item expands. Cancelable.
  * @event {{ item: WaAccordionItem }} wa-after-expand - Emitted after an item finishes expanding.
  * @event {{ item: WaAccordionItem }} wa-collapse - Emitted before an item collapses. Cancelable.
@@ -203,6 +206,7 @@ export default class WaAccordion extends WebAwesomeElement {
   render() {
     return html`
       <slot
+        part="base"
         @slotchange=${this.handleSlotChange}
         @wa-accordion-item-trigger=${this.handleItemTrigger}
         @focusin=${this.handleFocusIn}


### PR DESCRIPTION
This work resolves item 3 of https://github.com/shoelace-style/webawesome/issues/2624...

>  `<wa-accordion>` rendered only a bare `<slot>` and exposed no `::part()` hook for its container, the one gap among its container siblings. 

☝️ This adds a `base` part.

### Y U NO Use Wrapper?
The issue floated wrapping the slot in a `<div part="base">`. Putting the part on the existing `<slot>` instead — the way `<wa-button-group>` already does it — means zero new DOM, so there's no risk of disturbing the accordion's layout, which was the open concern in the thread.
