### PR TITLE
Docs: Fix Page `skip-to-content` Part

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -53,6 +53,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 - Fixed the remove button in `<wa-tag>` to match the tag's `size` [pr:2615]
 - Fixed missing CSS parts documentation for `<wa-card>`, `<wa-color-picker>`, `<wa-textarea>`, `<wa-scroller>`, and `<wa-page>` [pr:2623]
 - Fixed `<wa-checkbox>` rendering its checked icon under the undocumented `check-icon` CSS part; it now uses the documented `checked-icon` part, matching `<wa-radio>`
+- Fixed `<wa-page>` documenting `skip-links` and `skip-link` CSS parts that don't render; replaced them with the `skip-to-content` part it actually exposes
 
 :::
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -42,6 +42,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 - Fixed a bug in `<wa-checkbox>` where it would improperly submit values after it was enabled after being disabled. [pr:2607]
 - Fixed the remove button in `<wa-tag>` to match the tag's `size` [pr:2615]
 - Fixed missing CSS parts documentation for `<wa-card>`, `<wa-color-picker>`, `<wa-textarea>`, `<wa-scroller>`, and `<wa-page>` [pr:2623]
+- Fixed `<wa-page>` documenting `skip-links` and `skip-link` CSS parts that don't render; replaced them with the `skip-to-content` part it actually exposes
 
 :::
 

--- a/packages/webawesome/scripts/check-css-parts.js
+++ b/packages/webawesome/scripts/check-css-parts.js
@@ -37,12 +37,11 @@ async function readComponentSource(dir) {
   return contents.join('\n');
 }
 
-// Rendered but undocumented on purpose — pending API-shape decisions (form-control label naming;
-// `page` renders `skip-to-content` but documents `skip-link`). Drop each as it's resolved.
+// Rendered but undocumented on purpose — pending API-shape decisions (form-control label naming).
+// Drop each as it's resolved.
 const DEFAULT_ALLOWLIST = {
   'color-picker': ['form-control', 'form-control-input', 'form-control-label', 'hint'],
   input: ['form-control-label'],
-  page: ['skip-to-content'],
   select: ['label'],
   textarea: ['form-control-label'],
   'time-input': ['label'],

--- a/packages/webawesome/scripts/check-css-parts.js
+++ b/packages/webawesome/scripts/check-css-parts.js
@@ -36,12 +36,11 @@ async function readComponentSource(dir) {
   return contents.join('\n');
 }
 
-// Rendered but undocumented on purpose — pending API-shape decisions (form-control label naming;
-// `page` renders `skip-to-content` but documents `skip-link`). Drop each as it's resolved.
+// Rendered but undocumented on purpose — pending API-shape decisions (form-control label naming).
+// Drop each as it's resolved.
 const ALLOWLIST = {
   'color-picker': ['form-control', 'form-control-input', 'form-control-label', 'hint'],
   input: ['form-control-label'],
-  page: ['skip-to-content'],
   select: ['label'],
   textarea: ['form-control-label'],
   'time-input': ['label'],

--- a/packages/webawesome/src/components/page/page.ts
+++ b/packages/webawesome/src/components/page/page.ts
@@ -106,8 +106,7 @@ function toLength(px: number | string): string {
  * @csspart main-content - The main content.
  * @csspart main-footer - The footer below main content.
  * @csspart aside - The right hand side of the page. Used for things like table of contents, ads, etc.
- * @csspart skip-links - Wrapper around skip-link
- * @csspart skip-link - The "skip to main content" link
+ * @csspart skip-to-content - The "skip to content" link that lets keyboard users bypass navigation.
  * @csspart footer - The footer of the page. This is always below the initial viewport size.
  * @csspart dialog-wrapper - A wrapper around elements such as dialogs or other modal-like elements.
  *

--- a/packages/webawesome/src/components/page/page.ts
+++ b/packages/webawesome/src/components/page/page.ts
@@ -105,8 +105,7 @@ function toLength(px: number | string): string {
  * @csspart main-content - The main content.
  * @csspart main-footer - The footer below main content.
  * @csspart aside - The right hand side of the page. Used for things like table of contents, ads, etc.
- * @csspart skip-links - Wrapper around skip-link
- * @csspart skip-link - The "skip to main content" link
+ * @csspart skip-to-content - The "skip to content" link that lets keyboard users bypass navigation.
  * @csspart footer - The footer of the page. This is always below the initial viewport size.
  * @csspart dialog-wrapper - A wrapper around elements such as dialogs or other modal-like elements.
  *


### PR DESCRIPTION
This resolves item 2 of https://github.com/shoelace-style/webawesome/issues/2624...

> `<wa-page>` documented `@csspart skip-links` and `@csspart skip-link`, but neither renders. 

The element only ever exposes `part="skip-to-content"`, which went undocumented. 

☝️ This points the docs at the part that actually exists. And this also drops the now-stale `page: skip-to-content` entry from the `check-css-parts.js` allowlist which had been suppressing the "rendered but undocumented" warning for exactly this part.
