### PR TITLE
Improve Helper Components Documentation

### DIFF
--- a/packages/webawesome/docs/docs/components/animation.md
+++ b/packages/webawesome/docs/docs/components/animation.md
@@ -14,7 +14,7 @@ use-cases:
   - scroll animation
 ---
 
-To animate an element, wrap it in `<wa-animation>` and set an animation `name`. The animation will not start until you add the `play` attribute. Refer to the [properties table](#attributes-and-properties) for a list of all animation options.
+To animate an element, wrap it in `<wa-animation>` and set the `name` attribute. The animation will not start until you add the `play` attribute. Refer to the [properties table](#attributes-and-properties) for a list of all animation options.
 
 ```html {.example}
 <div class="animation-overview">
@@ -37,6 +37,11 @@ To animate an element, wrap it in `<wa-animation>` and set an animation `name`. 
 
 :::info
 The animation will only be applied to the first child element found in `<wa-animation>`.
+:::
+
+:::warning
+<strong>Respect users who prefer reduced motion.</strong><br />
+`<wa-animation>` plays regardless of the user's motion preferences. Gate decorative animations behind a [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) media query so they don't play for people who've asked to minimize motion.
 :::
 
 ## Examples
@@ -105,77 +110,6 @@ This example demonstrates all of the baked-in animations and easings. Animations
   }
 
   .animation-sandbox .controls wa-select {
-    margin-bottom: 1rem;
-  }
-</style>
-```
-
-```html {.example}
-<div class="animation-sandbox-combobox">
-  <wa-animation name="bounce" easing="ease-in-out" duration="2000" play>
-    <div class="box"></div>
-  </wa-animation>
-
-  <wa-divider></wa-divider>
-
-  <div class="controls">
-    <wa-combobox label="Animation" placeholder="Select animation..."></wa-combobox>
-    <wa-combobox label="Easing" placeholder="Select easing..."></wa-combobox>
-    <wa-input label="Playback Rate" type="number" min="0" max="2" step=".25" value="1"></wa-input>
-  </div>
-</div>
-
-<script type="module">
-  import { getAnimationNames, getEasingNames } from '/dist/webawesome.js';
-
-  await customElements.whenDefined('wa-combobox');
-  await customElements.whenDefined('wa-option');
-
-  const container = document.querySelector('.animation-sandbox-combobox');
-  const animation = container.querySelector('wa-animation');
-  const animationName = container.querySelector('.controls wa-combobox:nth-child(1)');
-  const easingName = container.querySelector('.controls wa-combobox:nth-child(2)');
-  const playbackRate = container.querySelector('wa-input[type="number"]');
-  const animations = getAnimationNames();
-  const easings = getEasingNames();
-
-  animations.forEach(name => {
-    const option = document.createElement('wa-option');
-    option.value = name;
-    option.textContent = name;
-    animationName.append(option);
-  });
-
-  easings.forEach(name => {
-    const option = document.createElement('wa-option');
-    option.value = name;
-    option.textContent = name;
-    easingName.append(option);
-  });
-
-  await Promise.all([animationName.updateComplete, easingName.updateComplete]);
-
-  animationName.value = 'bounce';
-  easingName.value = 'ease-in-out';
-
-  animationName.addEventListener('change', () => (animation.name = animationName.value));
-  easingName.addEventListener('change', () => (animation.easing = easingName.value));
-  playbackRate.addEventListener('input', () => (animation.playbackRate = playbackRate.value));
-</script>
-
-<style>
-  .animation-sandbox-combobox .box {
-    width: 100px;
-    height: 100px;
-    background-color: var(--wa-color-brand-fill-loud);
-  }
-
-  .animation-sandbox-combobox .controls {
-    max-width: 300px;
-    margin-top: 2rem;
-  }
-
-  .animation-sandbox-combobox .controls wa-combobox {
     margin-bottom: 1rem;
   }
 </style>

--- a/packages/webawesome/docs/docs/components/format-bytes.md
+++ b/packages/webawesome/docs/docs/components/format-bytes.md
@@ -32,7 +32,7 @@ use-cases:
 
 ## Examples
 
-### Formatting Bytes
+### Bytes
 
 Set the `value` attribute to a number to get the value in bytes.
 
@@ -43,7 +43,7 @@ Set the `value` attribute to a number to get the value in bytes.
 <wa-format-bytes value="1200000000"></wa-format-bytes>
 ```
 
-### Formatting Bits
+### Bits
 
 To get the value in bits, set the `unit` attribute to `bit`.
 

--- a/packages/webawesome/docs/docs/components/format-date.md
+++ b/packages/webawesome/docs/docs/components/format-date.md
@@ -12,22 +12,23 @@ use-cases:
   - timestamp
 ---
 
-Localization is handled by the browser's [`Intl.DateTimeFormat` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat). No language packs are required.
-
 ```html {.example}
-<!-- Web Awesome 2 release date 🎉 -->
-<wa-format-date date="2020-07-15T09:17:00-04:00"></wa-format-date>
+<!-- Web Awesome 3 release date 🎉 -->
+<wa-format-date date="2025-12-02T00:00:00-05:00"></wa-format-date>
 ```
+
+Localization is handled by the browser's [`Intl.DateTimeFormat` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat). No language packs are required.
 
 The `date` attribute determines the date/time to use when formatting. It must be a string that [`Date.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse) can interpret or a [`Date`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) object set via JavaScript. If omitted, the current date/time will be assumed.
 
 :::info
-When using strings, avoid ambiguous dates such as `03/04/2020` which can be interpreted as March 4 or April 3 depending on the user's browser and locale. Instead, always use a valid [ISO 8601 date time string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse#Date_Time_String_Format) to ensure the date will be parsed properly by all clients.
+<strong>Always use ISO 8601 date strings.</strong><br />
+Ambiguous formats like `03/04/2020` can be read as March 4 or April 3 depending on the user's browser and locale. A valid [ISO 8601 date time string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse#Date_Time_String_Format) parses the same for every client.
 :::
 
 ## Examples
 
-### Date & Time Formatting
+### Date & Time Format
 
 Formatting options are based on those found in the [`Intl.DateTimeFormat` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat). When formatting options are provided, the date/time will be formatted according to those values. When no formatting options are provided, a localized, numeric date will be displayed instead.
 
@@ -51,7 +52,7 @@ Formatting options are based on those found in the [`Intl.DateTimeFormat` API](h
 <wa-format-date></wa-format-date>
 ```
 
-### Hour Formatting
+### Hour Format
 
 By default, the browser will determine whether to use 12-hour or 24-hour time. To force one or the other, set the `hour-format` attribute to `12` or `24`.
 

--- a/packages/webawesome/docs/docs/components/format-number.md
+++ b/packages/webawesome/docs/docs/components/format-number.md
@@ -12,8 +12,6 @@ use-cases:
   - currency display
 ---
 
-Localization is handled by the browser's [`Intl.NumberFormat` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat). No language packs are required.
-
 ```html {.example}
 <div class="format-number-overview">
   <wa-format-number value="1000"></wa-format-number>
@@ -32,9 +30,11 @@ Localization is handled by the browser's [`Intl.NumberFormat` API](https://devel
 </script>
 ```
 
+Localization is handled by the browser's [`Intl.NumberFormat` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat). No language packs are required.
+
 ## Examples
 
-### Percentages
+### Percentage
 
 To get the value as a percent, set the `type` attribute to `percent`.
 
@@ -58,7 +58,7 @@ Russian: <wa-format-number value="2000" lang="ru" minimum-fraction-digits="2"></
 
 ### Currency
 
-To format a number as a monetary value, set the `type` attribute to `currency` and set the `currency` attribute to the desired ISO 4217 currency code. You should also specify `lang` to ensure the the number is formatted correctly for the target locale.
+To format a number as a monetary value, set the `type` attribute to `currency` and set the `currency` attribute to the desired ISO 4217 currency code. You should also specify `lang` to ensure the number is formatted correctly for the target locale.
 
 ```html {.example}
 <wa-format-number type="currency" currency="USD" value="2000" lang="en-US"></wa-format-number><br />

--- a/packages/webawesome/docs/docs/components/include.md
+++ b/packages/webawesome/docs/docs/components/include.md
@@ -12,13 +12,13 @@ use-cases:
   - server-side include
 ---
 
+```html {.example}
+<wa-include src="/assets/examples/include.html"></wa-include>
+```
+
 Included files are asynchronously requested using `window.fetch()`. Requests are cached, so the same file can be included multiple times, but only one request will be made.
 
 The included content will be inserted into the `<wa-include>` element's default slot so it can be easily accessed and styled through the light DOM.
-
-```html {.example}
-<wa-include src="https://shoelace.style/assets/examples/include.html"></wa-include>
-```
 
 ## Examples
 
@@ -29,7 +29,7 @@ When an include file loads successfully, the `wa-load` event will be emitted. Yo
 If the request fails, the `wa-include-error` event will be emitted. In this case, `event.detail.status` will contain the resulting HTTP status code of the request, e.g. 404 (not found).
 
 ```html
-<wa-include src="https://shoelace.style/assets/examples/include.html"></wa-include>
+<wa-include src="/assets/examples/include.html"></wa-include>
 
 <script>
   const include = document.querySelector('wa-include');

--- a/packages/webawesome/docs/docs/components/intersection-observer.md
+++ b/packages/webawesome/docs/docs/components/intersection-observer.md
@@ -66,7 +66,7 @@ This component uses the [IntersectionObserver API](https://developer.mozilla.org
       }
 
       &.visible {
-        background-color: var(--wa-color-brand-60);
+        background-color: var(--wa-color-brand-fill-loud);
         color: var(--wa-color-brand-on-loud);
       }
     }

--- a/packages/webawesome/docs/docs/components/intersection-observer.md
+++ b/packages/webawesome/docs/docs/components/intersection-observer.md
@@ -12,7 +12,7 @@ use-cases:
   - element visibility
 ---
 
-This component leverages the [IntersectionObserver API](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver) to track when its direct children enter or leave a designated root element. The `wa-intersect` event fires whenever elements cross the visibility threshold.
+This component uses the [IntersectionObserver API](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver) to track when its direct children enter or leave a designated root element. The `wa-intersect` event fires whenever elements cross the visibility threshold.
 
 ```html {.example}
 <div id="intersection__overview">
@@ -67,7 +67,7 @@ This component leverages the [IntersectionObserver API](https://developer.mozill
 
       &.visible {
         background-color: var(--wa-color-brand-60);
-        color: white;
+        color: var(--wa-color-brand-on-loud);
       }
     }
 
@@ -81,42 +81,13 @@ This component leverages the [IntersectionObserver API](https://developer.mozill
 ```
 
 :::info
-Keep in mind that only direct children of the host element are monitored. Nested elements won't trigger intersection events.
+<strong>Only direct children of the host are monitored.</strong><br />
+Nested elements won't trigger intersection events.
 :::
 
-## Usage Examples
+## Examples
 
-### Adding Observable Content
-
-The intersection observer tracks only its direct children. The component uses [`display: contents`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#contents) styling, which makes it seamless to integrate with flex and grid layouts from a parent container.
-
-```html
-<div style="display: flex; flex-direction: column;">
-  <wa-intersection-observer>
-    <div class="box">Box 1</div>
-    <div class="box">Box 2</div>
-    <div class="box">Box 3</div>
-  </wa-intersection-observer>
-</div>
-```
-
-The component tracks elements as they enter and exit the root element (viewport by default) and emits the `wa-intersect` event on state changes. The event provides `event.detail.entry`, an [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry) object with intersection details.
-
-You can identify the triggering element through `entry.target`. Check `entry.isIntersecting` to determine if an element is entering or exiting the viewport.
-
-```javascript
-observer.addEventListener('wa-intersect', event => {
-  const entry = event.detail.entry;
-
-  if (entry.isIntersecting) {
-    console.log('Element entered viewport:', entry.target);
-  } else {
-    console.log('Element left viewport:', entry.target);
-  }
-});
-```
-
-### Setting a Custom Root Element
+### Root Element
 
 You can observe intersections within a specific container by assigning the `root` attribute to the [root element's](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/root) ID. Apply [`rootMargin`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/rootMargin) with the `root-margin` attribute to expand or contract the observation area.
 
@@ -126,7 +97,7 @@ You can observe intersections within a specific container by assigning the `root
 </div>
 ```
 
-### Configuring Multiple Thresholds
+### Thresholds
 
 Track different visibility percentages by providing multiple [`threshold`](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#threshold) values as a space-separated list.
 
@@ -134,7 +105,7 @@ Track different visibility percentages by providing multiple [`threshold`](https
 <wa-intersection-observer threshold="0 0.25 0.5 0.75 1"> ... </wa-intersection-observer>
 ```
 
-### Applying Classes on Intersect
+### Intersect Class
 
 The `intersect-class` attribute automatically toggles the specified class on direct children when they become visible. This enables pure CSS styling without JavaScript event handlers.
 
@@ -189,7 +160,7 @@ The `intersect-class` attribute automatically toggles the specified class on dir
       align-items: center;
       justify-content: center;
       text-align: center;
-      color: white;
+      color: var(--wa-color-brand-on-loud);
       opacity: 0;
       padding: 2rem;
       margin-inline: auto;
@@ -302,4 +273,34 @@ The `intersect-class` attribute automatically toggles the specified class on dir
     }
   }
 </style>
+```
+
+### Reacting to Intersections
+
+The intersection observer tracks only its direct children. The component uses [`display: contents`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#contents) styling, so it integrates cleanly with flex and grid layouts from a parent container.
+
+```html
+<div style="display: flex; flex-direction: column;">
+  <wa-intersection-observer>
+    <div class="box">Box 1</div>
+    <div class="box">Box 2</div>
+    <div class="box">Box 3</div>
+  </wa-intersection-observer>
+</div>
+```
+
+The component tracks elements as they enter and exit the root element (viewport by default) and emits the `wa-intersect` event on state changes. The event provides `event.detail.entry`, an [`IntersectionObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry) object with intersection details.
+
+You can identify the triggering element through `entry.target`. Check `entry.isIntersecting` to determine if an element is entering or exiting the viewport.
+
+```javascript
+observer.addEventListener('wa-intersect', event => {
+  const entry = event.detail.entry;
+
+  if (entry.isIntersecting) {
+    console.log('Element entered viewport:', entry.target);
+  } else {
+    console.log('Element left viewport:', entry.target);
+  }
+});
 ```

--- a/packages/webawesome/docs/docs/components/mutation-observer.md
+++ b/packages/webawesome/docs/docs/components/mutation-observer.md
@@ -12,21 +12,19 @@ use-cases:
   - child list observer
 ---
 
-The mutation observer will report changes to the content it wraps through the `wa-mutation` event. When emitted, a collection of [MutationRecord](https://developer.mozilla.org/en-US/docs/Web/API/MutationRecord) objects will be attached to `event.detail` that contains information about how it changed.
-
 ```html {.example}
 <div class="mutation-overview">
   <wa-mutation-observer attr="variant">
     <wa-button appearance="filled" variant="brand">Click to mutate</wa-button>
   </wa-mutation-observer>
 
-  <br />
-  👆 Click the button and watch the console
+  <p>The observer saw the variant change to <span class="current">brand</span>.</p>
 
   <script>
     const container = document.querySelector('.mutation-overview');
     const mutationObserver = container.querySelector('wa-mutation-observer');
     const button = container.querySelector('wa-button');
+    const current = container.querySelector('.current');
     const variants = ['brand', 'success', 'neutral', 'warning', 'danger'];
     let clicks = 0;
 
@@ -36,9 +34,9 @@ The mutation observer will report changes to the content it wraps through the `w
       button.setAttribute('variant', variants[clicks % variants.length]);
     });
 
-    // Log mutations
-    mutationObserver.addEventListener('wa-mutation', event => {
-      console.log(event.detail);
+    // The observer reports each change it detects
+    mutationObserver.addEventListener('wa-mutation', () => {
+      current.textContent = button.getAttribute('variant');
     });
   </script>
 
@@ -50,8 +48,11 @@ The mutation observer will report changes to the content it wraps through the `w
 </div>
 ```
 
+The mutation observer will report changes to the content it wraps through the `wa-mutation` event. When emitted, `event.detail.mutationList` holds a collection of [MutationRecord](https://developer.mozilla.org/en-US/docs/Web/API/MutationRecord) objects describing how it changed.
+
 :::info
-When you create a mutation observer, you must indicate what changes it should respond to by including at least one of `attr`, `child-list`, or `char-data`. If you don't specify at least one of these attributes, no mutation events will be emitted.
+<strong>Specify at least one of `attr`, `child-list`, or `char-data`.</strong><br />
+These attributes tell the observer what changes to watch. Without at least one, no `wa-mutation` events are emitted.
 :::
 
 ## Examples
@@ -68,18 +69,20 @@ Use the `child-list` attribute to watch for new child elements that are added or
     </div>
   </wa-mutation-observer>
 
-  👆 Add and remove buttons and watch the console
+  <p>Add buttons, then click a numbered one to remove it. The observer saw <span class="log">no changes yet</span>.</p>
 
   <script>
     const container = document.querySelector('.mutation-child-list');
     const mutationObserver = container.querySelector('wa-mutation-observer');
     const buttons = container.querySelector('.buttons');
     const button = container.querySelector('wa-button[variant="brand"]');
+    const log = container.querySelector('.log');
     let i = 0;
 
     // Add a button
     button.addEventListener('click', () => {
       const button = document.createElement('wa-button');
+      button.setAttribute('appearance', 'filled');
       button.textContent = ++i;
       buttons.append(button);
     });
@@ -94,9 +97,10 @@ Use the `child-list` attribute to watch for new child elements that are added or
       }
     });
 
-    // Log mutations
+    // The observer reports each change it detects
     mutationObserver.addEventListener('wa-mutation', event => {
-      console.log(event.detail);
+      const [record] = event.detail.mutationList;
+      log.textContent = record.addedNodes.length ? 'a button added' : 'a button removed';
     });
   </script>
 

--- a/packages/webawesome/docs/docs/components/popover.md
+++ b/packages/webawesome/docs/docs/components/popover.md
@@ -112,7 +112,7 @@ Use the `--arrow-size` custom property to change the size of the popover's arrow
 </div>
 ```
 
-### Maximum Width
+### Max Width
 
 Use the `--max-width` custom property to control the maximum width of the popover.
 

--- a/packages/webawesome/docs/docs/components/popover.md
+++ b/packages/webawesome/docs/docs/components/popover.md
@@ -13,22 +13,22 @@ use-cases:
   - click popup
 ---
 
-Popovers display interactive content when their anchor element is clicked. Unlike [tooltips](/docs/components/tooltip), popovers can contain links, buttons, and form controls. They appear without an overlay and will close when you click outside or press [[Escape]]. Only one popover can be open at a time.
-
 ```html {.example}
 <wa-popover for="popover__overview">
   <div style="display: flex; flex-direction: column; gap: 1rem;">
     <p>This popover contains interactive content that users can engage with directly.</p>
-    <wa-button appearance="filled" variant="primary" size="s">Take Action</wa-button>
+    <wa-button appearance="filled" variant="brand" size="s">Take Action</wa-button>
   </div>
 </wa-popover>
 
 <wa-button appearance="filled" id="popover__overview">Show popover</wa-button>
 ```
 
+Unlike [tooltips](/docs/components/tooltip), popovers can contain links, buttons, and form controls. They appear without an overlay and close when you click outside or press [[Escape]]. Only one popover can be open at a time.
+
 ## Examples
 
-### Assigning an Anchor
+### Anchor
 
 Use `<wa-button>` or `<button>` elements as popover anchors. Connect the popover to its anchor by setting the `for` attribute to match the anchor's `id`.
 
@@ -45,7 +45,8 @@ Use `<wa-button>` or `<button>` elements as popover anchors. Connect the popover
 ```
 
 :::warning
-Make sure the anchor element exists in the DOM before the popover connects. If it doesn't exist, the popover won't attach and you'll see a console warning.
+<strong>The anchor must exist in the DOM before the popover connects.</strong><br />
+Otherwise the popover won't attach and you'll see a console warning.
 :::
 
 ### Opening & Closing
@@ -57,7 +58,7 @@ Use `data-popover="close"` on any button inside a popover to close it automatica
 ```html {.example}
 <wa-popover for="popover__opening">
   <p>The button below has <code>data-popover="close"</code> so clicking it will close the popover.</p>
-  <wa-button appearance="filled" data-popover="close" variant="primary">Dismiss</wa-button>
+  <wa-button appearance="filled" data-popover="close" variant="brand">Dismiss</wa-button>
 </wa-popover>
 
 <wa-button appearance="filled" id="popover__opening">Show popover</wa-button>
@@ -111,7 +112,7 @@ Use the `--arrow-size` custom property to change the size of the popover's arrow
 </div>
 ```
 
-### Setting a Maximum Width
+### Maximum Width
 
 Use the `--max-width` custom property to control the maximum width of the popover.
 
@@ -122,7 +123,7 @@ Use the `--max-width` custom property to control the maximum width of the popove
 </wa-popover>
 ```
 
-### Setting Focus
+### Initial Focus
 
 Use the [`autofocus`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus) global attribute to move focus to a specific form control when the popover opens.
 
@@ -130,7 +131,7 @@ Use the [`autofocus`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_a
 <wa-popover for="popover__autofocus">
   <div style="display: flex; flex-direction: column; gap: 1rem;">
     <wa-textarea autofocus placeholder="What's on your mind?" size="s" resize="none" rows="2"></wa-textarea>
-    <wa-button appearance="filled" variant="primary" size="s" data-popover="close"> Submit </wa-button>
+    <wa-button appearance="filled" variant="brand" size="s" data-popover="close"> Submit </wa-button>
   </div>
 </wa-popover>
 

--- a/packages/webawesome/docs/docs/components/popup.md
+++ b/packages/webawesome/docs/docs/components/popup.md
@@ -12,14 +12,6 @@ use-cases:
   - floating UI
 ---
 
-This component's name is inspired by [`<popup>`](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/Popup/explainer.md). It uses [Floating UI](https://floating-ui.com/) under the hood to provide a well-tested, lightweight, and fully declarative positioning utility for tooltips, dropdowns, and more.
-
-Popup doesn't provide any styles — just positioning! The popup's preferred placement, distance, and skidding (offset) can be configured using attributes. An arrow that points to the anchor can be shown and customized to your liking. Additional positioning options are available and described in more detail below.
-
-:::warning
-Popup is a low-level utility built specifically for positioning elements. Do not mistake it for a [tooltip](/docs/components/tooltip) or similar because _it does not facilitate an accessible experience!_ Almost every correct usage of `<wa-popup>` will involve building other components. It should rarely, if ever, occur directly in your HTML.
-:::
-
 ```html {.example}
 <div class="popup-overview">
   <wa-popup placement="top" active>
@@ -134,8 +126,18 @@ Popup is a low-level utility built specifically for positioning elements. Do not
 </style>
 ```
 
+This component's name is inspired by [`<popup>`](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/Popup/explainer.md). It uses [Floating UI](https://floating-ui.com/) under the hood to provide a well-tested, lightweight, and fully declarative positioning utility for tooltips, dropdowns, and more.
+
+Popup doesn't provide any styles — just positioning! The popup's preferred placement, distance, and skidding (offset) can be configured using attributes. An arrow that points to the anchor can be shown and customized to your liking. Additional positioning options are available and described in more detail below.
+
+:::warning
+<strong>Popup is a low-level positioning utility, not an accessible component.</strong><br />
+Don't use it as a [tooltip](/docs/components/tooltip) or similar — it doesn't facilitate an accessible experience. Almost every correct use builds it into another component rather than placing `<wa-popup>` directly in your HTML.
+:::
+
 :::info
-A popup's anchor should not be styled with `display: contents` since the coordinates will not be eligible for calculation. However, if the anchor is a `<slot>` element, popup will use the first assigned element as the anchor. This behavior allows other components to pass anchors through more easily via composition.
+<strong>Don't style a popup's anchor with `display: contents`.</strong><br />
+The coordinates won't be eligible for calculation. If the anchor is a `<slot>`, popup uses the first assigned element as the anchor, so components can pass anchors through via composition.
 :::
 
 ## Examples
@@ -497,7 +499,7 @@ By default, the arrow will be aligned as close to the center of the _anchor_ as 
 </div>
 ```
 
-### Adding a Border
+### Border
 
 Borders can also be added to the popup element by targeting the contents of the `wa-popup` element. This styling can also be extended to the arrow itself by targeting `.arrow` class in the popup.
 
@@ -602,7 +604,7 @@ When adding borders to the popup element which has an arrow, make sure to set th
 
 {# TODO: this example totally destroys browsers. Needs investigation.
 
-### Syncing with the Anchor's Dimensions
+### Sync
 
 Use the `sync` attribute to make the popup the same width or height as the anchor element. This is useful for controls that need the popup to stay the same width or height as the trigger.
 
@@ -928,7 +930,7 @@ When a gap exists between the anchor and the popup element, this option will add
   }
 
   .popup-hover-bridge wa-popup::part(hover-bridge) {
-    background: tomato;
+    background: var(--wa-color-warning-fill-loud);
     opacity: 0.5;
   }
 </style>

--- a/packages/webawesome/docs/docs/components/random-content.md
+++ b/packages/webawesome/docs/docs/components/random-content.md
@@ -68,7 +68,7 @@ Slot virtually any HTML — text, badges, cards, images, or other components —
 </div>
 ```
 
-### Setting the Number of Items
+### Number of Items
 
 Set `items` to show more than one child at a time. The value is clamped to the number of available children.
 

--- a/packages/webawesome/docs/docs/components/relative-time.md
+++ b/packages/webawesome/docs/docs/components/relative-time.md
@@ -13,22 +13,23 @@ use-cases:
   - time since
 ---
 
-Localization is handled by the browser's [`Intl.RelativeTimeFormat` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat). No language packs are required.
-
 ```html {.example}
-<!-- Shoelace 2 release date 🎉 -->
-<wa-relative-time date="2020-07-15T09:17:00-04:00"></wa-relative-time>
+<!-- Web Awesome 3 release date 🎉 -->
+<wa-relative-time date="2025-12-02T00:00:00-05:00"></wa-relative-time>
 ```
+
+Localization is handled by the browser's [`Intl.RelativeTimeFormat` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/RelativeTimeFormat). No language packs are required.
 
 The `date` attribute determines when the date/time is calculated from. It must be a string that [`Date.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse) can interpret or a [`Date`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) object set via JavaScript.
 
 :::info
-When using strings, avoid ambiguous dates such as `03/04/2020` which can be interpreted as March 4 or April 3 depending on the user's browser and locale. Instead, always use a valid [ISO 8601 date time string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse#Date_Time_String_Format) to ensure the date will be parsed properly by all clients.
+<strong>Always use ISO 8601 date strings.</strong><br />
+Ambiguous formats like `03/04/2020` can be read as March 4 or April 3 depending on the user's browser and locale. A valid [ISO 8601 date time string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse#Date_Time_String_Format) parses the same for every client.
 :::
 
 ## Examples
 
-### Keeping Time in Sync
+### Sync
 
 Use the `sync` attribute to update the displayed value automatically as time passes.
 
@@ -45,14 +46,14 @@ Use the `sync` attribute to update the displayed value automatically as time pas
 </script>
 ```
 
-### Formatting Styles
+### Format
 
 You can change how the time is displayed using the `format` attribute. Note that some locales may display the same values for `narrow` and `short` formats.
 
 ```html {.example}
-<wa-relative-time date="2020-07-15T09:17:00-04:00" format="narrow"></wa-relative-time><br />
-<wa-relative-time date="2020-07-15T09:17:00-04:00" format="short"></wa-relative-time><br />
-<wa-relative-time date="2020-07-15T09:17:00-04:00" format="long"></wa-relative-time>
+<wa-relative-time date="2025-12-02T00:00:00-05:00" format="narrow"></wa-relative-time><br />
+<wa-relative-time date="2025-12-02T00:00:00-05:00" format="short"></wa-relative-time><br />
+<wa-relative-time date="2025-12-02T00:00:00-05:00" format="long"></wa-relative-time>
 ```
 
 ### Localization
@@ -60,9 +61,9 @@ You can change how the time is displayed using the `format` attribute. Note that
 Use the `lang` attribute to set the desired locale.
 
 ```html {.example}
-English: <wa-relative-time date="2020-07-15T09:17:00-04:00" lang="en-US"></wa-relative-time><br />
-Chinese: <wa-relative-time date="2020-07-15T09:17:00-04:00" lang="zh-CN"></wa-relative-time><br />
-German: <wa-relative-time date="2020-07-15T09:17:00-04:00" lang="de"></wa-relative-time><br />
-Greek: <wa-relative-time date="2020-07-15T09:17:00-04:00" lang="el"></wa-relative-time><br />
-Russian: <wa-relative-time date="2020-07-15T09:17:00-04:00" lang="ru"></wa-relative-time>
+English: <wa-relative-time date="2025-12-02T00:00:00-05:00" lang="en-US"></wa-relative-time><br />
+Chinese: <wa-relative-time date="2025-12-02T00:00:00-05:00" lang="zh-CN"></wa-relative-time><br />
+German: <wa-relative-time date="2025-12-02T00:00:00-05:00" lang="de"></wa-relative-time><br />
+Greek: <wa-relative-time date="2025-12-02T00:00:00-05:00" lang="el"></wa-relative-time><br />
+Russian: <wa-relative-time date="2025-12-02T00:00:00-05:00" lang="ru"></wa-relative-time>
 ```

--- a/packages/webawesome/docs/docs/components/resize-observer.md
+++ b/packages/webawesome/docs/docs/components/resize-observer.md
@@ -12,32 +12,47 @@ use-cases:
   - container query
 ---
 
-The resize observer will report changes to the dimensions of the elements it wraps through the `wa-resize` event. When emitted, a collection of [`ResizeObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry) objects will be attached to `event.detail` that contains the target element and information about its dimensions.
-
 ```html {.example}
 <div class="resize-observer-overview">
   <wa-resize-observer>
-    <div>Resize this box and watch the console 👉</div>
+    <div class="box"><span class="dimensions">0 × 0</span></div>
   </wa-resize-observer>
+  <small>Drag the box's bottom-right corner to resize it.</small>
 </div>
 
 <script>
   const container = document.querySelector('.resize-observer-overview');
+  const dimensions = container.querySelector('.dimensions');
   const resizeObserver = container.querySelector('wa-resize-observer');
 
   resizeObserver.addEventListener('wa-resize', event => {
-    console.log(event.detail);
+    const { width, height } = event.detail.entries[0].contentRect;
+    dimensions.textContent = `${Math.round(width)} × ${Math.round(height)}`;
   });
 </script>
 
 <style>
-  .resize-observer-overview div {
+  .resize-observer-overview .box {
     display: flex;
-    border: solid 2px var(--wa-color-surface-border);
+    resize: both;
+    overflow: auto;
+    width: 20rem;
+    height: 8rem;
+    min-width: 8rem;
+    min-height: 5rem;
     align-items: center;
     justify-content: center;
-    text-align: center;
-    padding: 4rem 2rem;
+    border: dashed 2px var(--wa-color-surface-border);
+    border-radius: var(--wa-border-radius-m);
+    font-size: 1.25rem;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .resize-observer-overview small {
+    display: block;
+    margin-block-start: var(--wa-space-s);
   }
 </style>
 ```
+
+The resize observer will report changes to the dimensions of the elements it wraps through the `wa-resize` event. When emitted, `event.detail.entries` holds a collection of [`ResizeObserverEntry`](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry) objects describing the observed elements and their new dimensions.


### PR DESCRIPTION
This work applies the `.house-rules/` docs conventions to Helpers category.

### Fixes
- `popover`: examples used `variant="primary"` on `<wa-button>`, which isn't a valid variant (`neutral|brand|success|warning|danger`); it was silently rendering as `neutral`. Now `brand`, verified against `button.ts`
- `relative-time`: the hero comment still reads `Shoelace 2 release date`; now `Web Awesome 3`, matching `format-date`
- `format-number`: fixed a "the the" double-word typo

### Rebuilt Example Demos
- `resize-observer`: the hero said "Resize this box" but had no resize handle and only logged to the console. The box is now directly drag-resizable and shows its live dimensions on the page
- `mutation-observer`: was "watch the console"; the observer's detection now updates a visible readout
- `animation`: removed a second, near-identical interactive sandbox (a `wa-combobox` clone of the `wa-select` one); one interactive demo per capability

### Accessibility and Tokens
- `animation`: added a reduced-motion `:::warning` - `<wa-animation>` doesn't auto-respect `prefers-reduced-motion`, so the note is author-guidance to gate motion themselves
- `popup`: `background: tomato` on the `hover-bridge` part → `var(--wa-color-warning-fill-loud)`
- `intersection-observer`: two `color: white` → `var(--wa-color-brand-on-loud)`

### Sticking to Conventions
- Ordering examples first across the formatters, observers, `include`, `popover`, and `popup`; `intersection-observer`
- Normalized heading throughout (e.g. `Setting a Maximum Width` → `Maximum Width`, `Setting Focus` → `Initial Focus`, `Configuring Multiple Thresholds` → `Thresholds`, `Adding a Border` → `Border`, `Formatting Bytes`/`Bits` → `Bytes`/`Bits`)
- Callouts across six files now lead with a `<strong>` takeaway instead of burying it
