### PR TITLE
Fix: Safari Visual Seam on Tooltip and Popover Arrows

### DIFF
--- a/packages/webawesome/docs/docs/components/popup.md
+++ b/packages/webawesome/docs/docs/components/popup.md
@@ -544,9 +544,10 @@ When adding borders to the popup element which has an arrow, make sure to set th
       --arrow-color: var(--wa-color-brand-on-loud);
       --popup-border-width: var(--wa-panel-border-width);
 
+      /* Inset box-shadow, not a border: Safari seams a clip-path edge that runs along a border. */
       &::part(arrow) {
-        border-bottom: var(--wa-panel-border-width) var(--wa-panel-border-style) var(--wa-color-brand-border-loud);
-        border-right: var(--wa-panel-border-width) var(--wa-panel-border-style) var(--wa-color-brand-border-loud);
+        box-shadow: inset calc(-1 * var(--wa-panel-border-width)) calc(-1 * var(--wa-panel-border-width)) 0 0
+          var(--wa-color-brand-border-loud);
       }
     }
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -33,6 +33,10 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 :::fixed
 
+- Fixed a Safari-only clip-path/border seam along the arrow's outer edges by painting the arrow border with an inset box-shadow instead of a `border`
+  - `<wa-tooltip>` — surfaced as a stark white hairline on the dark arrow over light backgrounds
+  - `<wa-popover>` — same latent seam on the arrow's border
+  - The arrow border is now always solid; `--wa-tooltip-border-style` / `--wa-panel-border-style` no longer apply to it. No visual change, since all themes use `solid`
 - Fixed type resolution issues with `pro` components like `<wa-file-input>`, `<wa-combobox>`, etc. [pr:2577]
 - Fixed an issue where some fonts wouldn't load in themes that import multiple fonts [pr:2582]
 - Fixed an issue with an improper custom elements manifest path. [pr:2590]

--- a/packages/webawesome/src/components/popover/popover.styles.ts
+++ b/packages/webawesome/src/components/popover/popover.styles.ts
@@ -48,13 +48,12 @@ export default css`
 
     pointer-events: auto;
 
+    /* Inset box-shadow, not a border: Safari seams a clip-path edge that runs along a border. */
     &::part(arrow) {
       background-color: var(--wa-color-surface-default);
-      border-top: none;
-      border-left: none;
-      border-bottom: solid var(--wa-panel-border-width) var(--wa-color-surface-border);
-      border-right: solid var(--wa-panel-border-width) var(--wa-color-surface-border);
-      box-shadow: none;
+      border: none;
+      box-shadow: inset calc(-1 * var(--wa-panel-border-width)) calc(-1 * var(--wa-panel-border-width)) 0 0
+        var(--wa-color-surface-border);
     }
   }
 

--- a/packages/webawesome/src/components/tooltip/tooltip.styles.ts
+++ b/packages/webawesome/src/components/tooltip/tooltip.styles.ts
@@ -56,9 +56,10 @@ export default css`
   .tooltip {
     --popup-border-width: var(--wa-tooltip-border-width);
 
+    /* Inset box-shadow, not a border: Safari seams a clip-path edge that runs along a border. */
     &::part(arrow) {
-      border-bottom: var(--wa-tooltip-border-width) var(--wa-tooltip-border-style) var(--wa-tooltip-border-color);
-      border-right: var(--wa-tooltip-border-width) var(--wa-tooltip-border-style) var(--wa-tooltip-border-color);
+      box-shadow: inset calc(-1 * var(--wa-tooltip-border-width)) calc(-1 * var(--wa-tooltip-border-width)) 0 0
+        var(--wa-tooltip-border-color);
     }
   }
 `;


### PR DESCRIPTION
Our Tooltip and Popover-based visual arrows are rotated squares with `clip-path` plus `border-bottom`/`border-right`.

But Safari leaves a transparent gap between a `border` and the background fill of a clipped, rotated element.

To sidestep this bug, this work paints the arrow's border with `box-shadow: inset` instead of `border`, on both components. No border means no border/fill boundary, so nothing seams. 

| Safari (pre-fix)  | Safari (post-fix) |
|--------|--------|
| <img width="350" height="266" alt="CleanShot 2026-07-14 at 12 36 00@2x" src="https://github.com/user-attachments/assets/8290e03a-dd62-43d4-8ad8-273e95b196c9" /> | <img width="332" height="284" alt="CleanShot 2026-07-14 at 12 35 48@2x" src="https://github.com/user-attachments/assets/0859d28a-004c-44fe-9517-6a66b8e08084" /> | 

It reads the same tokens as before (`--wa-tooltip-border-color`, `--wa-tooltip-border-width`, and the popover's `--wa-color-surface-border` / `--wa-panel-border-width`), so nothing changes outside Safari.

### One Tradeoff
`--wa-tooltip-border-style` and `--wa-panel-border-style` no longer reach the arrow. `box-shadow` is always solid. This may be okay because:

- Every shipped theme currently uses `solid`, so there's no visual change. 
- And a dashed arrow never actually worked: the rotated arrow's dashes fall out of phase with the body and collide at the base. We dropped a broken mode, not a real one.

### Verifications
- Tested across all placements
- Tested across Core and Pro themes
- Tested across Light and Dark modes
- Tested across size/color overrides.
- `::part(base__arrow)` stays fully overridable (users can clear it with `box-shadow: none` or paint their own). 
- Tooltip and Popover suites pass in Chromium, Firefox, and WebKit.

### Docs
Updated the `wa-popup` "border on popup" example to the `box-shadow` pattern so nobody copies the seaming version.
