### PR TITLE
Docs: Note Page & Toast Now in Core (+ new `:::new` callout)

### DIFF
--- a/packages/webawesome/docs/_utils/markdown.js
+++ b/packages/webawesome/docs/_utils/markdown.js
@@ -37,6 +37,18 @@ markdown.use(markdownItMark);
   });
 });
 
+markdown.use(markdownItContainer, 'new', {
+  render: function (tokens, idx) {
+    if (tokens[idx].nesting === 1) {
+      return `
+        <wa-callout variant="neutral" class="new">
+          <wa-icon slot="icon" name="bullhorn" variant="solid"></wa-icon>
+      `;
+    }
+    return '</wa-callout>\n';
+  },
+});
+
 markdown.use(markdownItContainer, 'pro', {
   validate: params => /^pro(\s+.+)?$/.test(params.trim()),
   render: function (tokens, idx) {

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -571,6 +571,11 @@
     --wa-color-text-link: var(--wa-color-brand-70);
   }
 
+  /* Keep the "new in Core" callout's version link in the neutral scheme, not brand blue. */
+  wa-callout.new {
+    --wa-color-text-link: var(--wa-color-text-normal);
+  }
+
   /* free badge */
   wa-badge.free {
     + wa-tooltip {

--- a/packages/webawesome/docs/docs/components/page.md
+++ b/packages/webawesome/docs/docs/components/page.md
@@ -16,6 +16,11 @@ use-cases:
 
 The page component is designed to power full webpages. It is flexible enough to handle most modern designs and includes a simple mechanism for handling desktop and mobile navigation.
 
+:::new
+<strong>Now Available in Web Awesome Core</strong><br />
+Page moved over from Pro in [**3.5.0**](/docs/resources/changelog#wa_350). On an earlier Core version? Upgrade to use it.
+:::
+
 ## Layout Anatomy
 
 This image depicts a page's anatomy, including the default positions of each section. The labels represent the [named slots](#slots) you can use to populate them.

--- a/packages/webawesome/docs/docs/components/toast-item.md
+++ b/packages/webawesome/docs/docs/components/toast-item.md
@@ -2,6 +2,7 @@
 title: Toast Item
 layout: component
 category: Feedback
+parent: toast
 isProComponent: false
 synonyms:
   - notification item

--- a/packages/webawesome/docs/docs/components/toast-item.md
+++ b/packages/webawesome/docs/docs/components/toast-item.md
@@ -19,6 +19,11 @@ use-cases:
 </wa-toast-item>
 ```
 
+:::new
+<strong>Now Available in Web Awesome Core</strong><br />
+Toast Item moved over from Pro in [**3.11.0**](/docs/resources/changelog#unreleased). On an earlier Core version? Upgrade to use it.
+:::
+
 :::info
 <strong>Toast items are meant to live inside a `<wa-toast>` container.</strong><br />
 The container manages their lifecycle and positioning. For usage examples showing how to display notifications, see the [Toast documentation](/docs/components/toast).

--- a/packages/webawesome/docs/docs/components/toast.md
+++ b/packages/webawesome/docs/docs/components/toast.md
@@ -31,6 +31,11 @@ use-cases:
 </script>
 ```
 
+:::new
+<strong>Now Available in Web Awesome Core</strong><br />
+Toast moved over from Pro in [**3.11.0**](/docs/resources/changelog#unreleased). On an earlier Core version? Upgrade to use it.
+:::
+
 Adding a single `<wa-toast>` element to the page gives you the ability to dispatch notifications at any time. Toast notifications appear in a stack that renders in the [top layer](https://developer.mozilla.org/en-US/docs/Glossary/Top_layer), showing above everything else on the page.
 
 You can put the `<wa-toast>` element anywhere in the DOM, as long as it's somewhere inside the `<body>`. In most apps, a single toast element is optimal.

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -31,8 +31,18 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 ## Unreleased
 
+:::added
+
+- Moved `<wa-toast>` and `<wa-toast-item>` from Pro to Core [pr:2631]
+
+:::
+
 :::fixed
 
+- Fixed a Safari-only clip-path/border seam along the arrow's outer edges by painting the arrow border with an inset box-shadow instead of a `border` [pr:2638]
+  - `<wa-tooltip>` — surfaced as a stark white hairline on the dark arrow over light backgrounds
+  - `<wa-popover>` — same latent seam on the arrow's border
+  - The arrow border is now always solid; `--wa-tooltip-border-style` / `--wa-panel-border-style` no longer apply to it. No visual change, since all themes use `solid`
 - Fixed type resolution issues with `pro` components like `<wa-file-input>`, `<wa-combobox>`, etc. [pr:2577]
 - Fixed an issue where some fonts wouldn't load in themes that import multiple fonts [pr:2582]
 - Fixed an issue with an improper custom elements manifest path. [pr:2590]
@@ -299,7 +309,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 :::added
 
-- Moved `<wa-page>` from pro to core [pr:2244]
+- Moved `<wa-page>` from Pro to Core [pr:2244]
 - Added a new core experimental component: `<wa-markdown>` (#6 of 14 per stretch goals) [pr:2170]
 - Added the `data-wa-preload` attribute for preloading components that aren't on the page yet when using the autoloader [issue:1501] [pr:2238]
 - Added `placement` attribute to `<wa-color-picker>` [issue:2099]


### PR DESCRIPTION
This work adds the documentation side of the Toast Pro → Core move...

- a reusable availability callout pattern
- the changelog entry 
- and the same retroactive treatment for `<wa-page>`. 

| Page | Toast |
|--------|--------|
| <img width="2928" height="1636" alt="image" src="https://github.com/user-attachments/assets/3501daad-bef2-43da-9960-bfb2ff693dd8" /> | <img width="2928" height="1636" alt="image" src="https://github.com/user-attachments/assets/ff16a122-0f5b-4913-9e58-20de7b773adf" /> | 

Users on an older Core version receive a clear heads-up that these components were only introduced in Core at a specific release, as the `Since` badge still reflects their earlier Pro origin.

### New `:::new` callout container
- Registers a `:::new` markdown container rendering `<wa-callout variant="neutral">` with a `bullhorn` icon — a reusable home for "now available in Core" as well as other News-like notices.
- Scoped CSS keeps the version link in the neutral scheme while preserving the underline affordance.

### Sidebar/Org
- Nests `<wa-toast-item>` under `<wa-toast>` via `parent:` front matter which matches every other sub-component (`accordion-item`, `tree-item`, `option`, etc.).

### Availability Callouts
- Added to `page.md`, `toast.md`, and `toast-item.md`, positioned just after each page's opening beat (hero demo or intro sentence).
- Each links its version to the changelog: `Page` → `#wa_350`, `Toast`/`Toast Item` → `#unreleased` (flip to `#wa_3110` once `3.11.0` ships).

### Changelog
- Logs `Moved <wa-toast> and <wa-toast-item> from Pro to Core` under `Unreleased`.
- Tags the existing Safari arrow-seam fix with `[pr:2638]`. #badtalbs
