### PR TITLE
Docs: Highlight "Docs" in Site Nav

### DIFF
--- a/packages/webawesome/docs/_includes/subheader-links.njk
+++ b/packages/webawesome/docs/_includes/subheader-links.njk
@@ -3,10 +3,10 @@
   <wa-button appearance="plain" size="s" href="/docs" data-track-event="navigation:header_link_click" data-track-destination="start">
     Start
   </wa-button>
-  <wa-button appearance="plain" size="s" href="/docs/components" data-track-event="navigation:header_link_click" data-track-destination="components">
+  <wa-button appearance="plain" size="s" href="/docs/components" data-match="section" data-track-event="navigation:header_link_click" data-track-destination="components">
     Components
   </wa-button>
-  <wa-button appearance="plain" size="s" href="/docs" data-track-event="navigation:header_link_click" data-track-destination="docs">
+  <wa-button appearance="plain" size="s" href="/docs" data-match="section" data-track-event="navigation:header_link_click" data-track-destination="docs">
     Docs
   </wa-button>
   <wa-button appearance="plain" size="s" href="{{ site.urls.support }}/" data-track-event="navigation:header_link_click" data-track-destination="help">

--- a/packages/webawesome/docs/_transformers/current-link.js
+++ b/packages/webawesome/docs/_transformers/current-link.js
@@ -26,7 +26,7 @@ function markCurrent(el, pageUrl, className) {
   }
   const normalizedHref = normalize(href);
   const normalizedPageUrl = normalize(pageUrl);
-  const isSectionLink = href.endsWith('/') && href !== '/';
+  const isSectionLink = (href.endsWith('/') && href !== '/') || el.getAttribute('data-match') === 'section';
   const isExactMatch = normalizedHref === normalizedPageUrl;
   const isChildOfSection = isSectionLink && normalizedPageUrl.startsWith(normalizedHref + '/');
   if (isExactMatch || isChildOfSection) {
@@ -42,6 +42,7 @@ export function currentLinkTransformer(options = {}) {
   options = {
     container: 'body',
     className: 'current',
+    exclusiveGroups: ['.subheader-links'],
     ...options,
   };
 
@@ -61,5 +62,23 @@ export function currentLinkTransformer(options = {}) {
     container.querySelectorAll('wa-button[href]').forEach(btn => {
       markCurrent(btn, pageUrl, options.className);
     });
+
+    // Keep only the most specific match per group. Every match is a prefix of the same pageUrl,
+    // so the longest href is the deepest — e.g. a component page lights "Components", not "/docs".
+    const depth = el => normalize(el.getAttribute('href') || '').length;
+    for (const selector of options.exclusiveGroups) {
+      container.querySelectorAll(selector).forEach(group => {
+        const marked = [...group.querySelectorAll('.' + options.className)];
+        if (marked.length < 2) {
+          return;
+        }
+        const maxDepth = Math.max(...marked.map(depth));
+        marked.forEach(el => {
+          if (depth(el) < maxDepth) {
+            el.classList.remove(options.className);
+          }
+        });
+      });
+    }
   };
 }


### PR DESCRIPTION
This work fixes the subheader nav's active state so it reflects where you actually are. 

Previously, `Docs` and `Components` only showed as current/highlighted on their exact URL, so any nested docs page — `/docs/usage`, a component page, or the changelog — left the nav empty.

### Behavior
- Component pages (`/docs/components/**`) light **Components**.
- Every other docs page (`/docs`, `/docs/usage`, `/docs/frameworks/**`, resources, …) lights **Docs**.

### How
- The `current-link` transformer gains a `data-match="section"` opt-in (a link matches its whole subtree without changing its `href`) plus a most-specific-wins tie-break scoped to the subheader nav — so `Docs` yields to the deeper `Components` under `/docs/components/**`.
- `Components` and `Docs` opt in via `data-match="section"`. `href`s are unchanged, so navigation targets and analytics destinations are untouched, and the sidebar's exact-match behavior is unaffected.
