### PR TITLE
Replace Generic `base` with Component-Named Parts

### DIFF
--- a/packages/webawesome/custom-elements-manifest.js
+++ b/packages/webawesome/custom-elements-manifest.js
@@ -135,6 +135,22 @@ export default {
       },
     },
     {
+      // Flag `base` in the manifest so editors and other CEM consumers see the deprecation, not just the docs.
+      name: 'wa-deprecate-base-part',
+      packageLinkPhase({ customElementsManifest }) {
+        customElementsManifest?.modules?.forEach(mod => {
+          mod.declarations?.forEach(declaration => {
+            declaration.cssParts?.forEach(part => {
+              if (part.name === 'base') {
+                part.deprecated =
+                  'Use the part named after the component instead. This part will be removed in a future major version.';
+              }
+            });
+          });
+        });
+      },
+    },
+    {
       name: 'wa-translate-module-paths',
       packageLinkPhase({ customElementsManifest }) {
         customElementsManifest?.modules?.forEach(mod => {

--- a/packages/webawesome/docs/_layouts/component.njk
+++ b/packages/webawesome/docs/_layouts/component.njk
@@ -285,7 +285,7 @@
     </thead>
     <tbody>
       {% for cssPart in component.cssParts %}
-      <tr>
+      <tr{% if cssPart.deprecated %} class="wa-color-text-quiet"{% endif %}>
         <td class="table-name"><code>{{ cssPart.name }}</code></td>
         <td class="table-description">{{ cssPart.description | inlineMarkdown | safe }}</td>
         <td class="table-selector">

--- a/packages/webawesome/docs/_utils/manifest.js
+++ b/packages/webawesome/docs/_utils/manifest.js
@@ -22,7 +22,10 @@ export function getComponents() {
         const slots = declaration.slots?.sort(sortByName);
         const events = declaration.events?.sort(sortByName);
         const cssProperties = declaration.cssProperties?.sort(sortByName);
-        const cssParts = declaration.cssParts?.sort(sortByName);
+        // Deprecated parts sort to the bottom so the supported names read first.
+        const cssParts = declaration.cssParts?.sort(
+          (a, b) => Number(Boolean(a.deprecated)) - Number(Boolean(b.deprecated)) || sortByName(a, b),
+        );
         const cssStates = declaration.cssStates?.sort(sortByName);
         const dependencies = declaration.dependencies?.sort((a, b) => a.localeCompare(b));
 

--- a/packages/webawesome/docs/_utils/manifest.js
+++ b/packages/webawesome/docs/_utils/manifest.js
@@ -22,7 +22,8 @@ export function getComponents() {
         const slots = declaration.slots?.sort(sortByName);
         const events = declaration.events?.sort(sortByName);
         const cssProperties = declaration.cssProperties?.sort(sortByName);
-        const cssParts = declaration.cssParts?.sort(sortByName);
+        // Hide the legacy `base` part from the docs table. It still works as a `::part()` target and stays in the manifest.
+        const cssParts = declaration.cssParts?.filter(part => part.name !== 'base').sort(sortByName);
         const cssStates = declaration.cssStates?.sort(sortByName);
         const dependencies = declaration.dependencies?.sort((a, b) => a.localeCompare(b));
 

--- a/packages/webawesome/docs/docs/components/button.md
+++ b/packages/webawesome/docs/docs/components/button.md
@@ -214,7 +214,7 @@ Target the `base` part to restyle a button from the outside. Use a custom class 
 <wa-button class="pink">Pink Button</wa-button>
 
 <style>
-  wa-button.pink::part(base) {
+  wa-button.pink::part(button) {
     border-radius: 6px;
     border: solid 2px;
     background: #ff1493;
@@ -228,11 +228,11 @@ Target the `base` part to restyle a button from the outside. Use a custom class 
     transition: all var(--wa-transition-slow) var(--wa-transition-easing);
   }
 
-  wa-button.pink::part(base):hover {
+  wa-button.pink::part(button):hover {
     transform: scale(1.05);
   }
 
-  wa-button.pink::part(base):active {
+  wa-button.pink::part(button):active {
     border-top-color: #ad005c;
     border-right-color: #ff7ac1;
     border-bottom-color: #ff7ac1;
@@ -240,7 +240,7 @@ Target the `base` part to restyle a button from the outside. Use a custom class 
     transform: translateY(1px);
   }
 
-  wa-button.pink::part(base):focus-visible {
+  wa-button.pink::part(button):focus-visible {
     outline: dashed 2px deeppink;
     outline-offset: 4px;
   }

--- a/packages/webawesome/docs/docs/components/carousel.md
+++ b/packages/webawesome/docs/docs/components/carousel.md
@@ -250,7 +250,7 @@ Setting the `orientation` attribute to `vertical` will render the carousel in a 
     max-height: 400px;
   }
 
-  .vertical::part(base) {
+  .vertical::part(carousel) {
     grid-template-areas: 'slides slides pagination';
   }
 

--- a/packages/webawesome/docs/docs/components/page-samples/media-app.md
+++ b/packages/webawesome/docs/docs/components/page-samples/media-app.md
@@ -318,7 +318,7 @@ eleventyExcludeFromCollections: true
   wa-page[view='mobile'] [slot*='navigation'] {
     padding: 0;
   }
-  wa-page::part(base) {
+  wa-page::part(page) {
     background-color: var(--wa-color-surface-lowered);
   }
   [slot='header'] {

--- a/packages/webawesome/docs/docs/customizing.md
+++ b/packages/webawesome/docs/docs/customizing.md
@@ -298,7 +298,7 @@ Parts allow you to style _any_ standard CSS property, not just those exposed thr
 <wa-button class="gradient-button"> Gradient Button </wa-button>
 
 <style>
-  .gradient-button::part(base) {
+  .gradient-button::part(button) {
     background: linear-gradient(217deg, var(--wa-color-indigo-50), var(--wa-color-purple-50), var(--wa-color-red-50));
     border: solid 1px var(--wa-color-purple-50);
     transition:
@@ -306,12 +306,12 @@ Parts allow you to style _any_ standard CSS property, not just those exposed thr
       box-shadow 100ms;
   }
 
-  .gradient-button::part(base):hover {
+  .gradient-button::part(button):hover {
     box-shadow: var(--wa-shadow-m);
     transform: translateY(-3px);
   }
 
-  .gradient-button::part(base):active {
+  .gradient-button::part(button):active {
     box-shadow: inset var(--wa-shadow-s);
     transform: translateY(0);
   }
@@ -332,6 +332,14 @@ CSS parts have a few important advantages:
 - It encourages us to think more about how components are designed and how customizations should be allowed before users can take advantage of them. Once we opt a part into the component's API, it's guaranteed to be supported and can't be removed until a major version of the library is released.
 
 Most (but not all) components expose parts. You can find them in each component's API documentation under the "CSS Parts" section.
+
+#### The `base` part
+
+Components used to expose a generic `base` part for their outermost element. That name is deprecated in favor of a part named after the component itself, so `<wa-button>` exposes `button` and `<wa-details>` exposes `details`.
+
+Existing `::part(base)` selectors still work and will continue to until the next major version, so there's no rush to change them. New styles should target the component's own name. Deprecated parts appear muted in each component's CSS Parts table.
+
+Not every component has one. When a component's outer element is the host, style it directly instead — `wa-card { ... }` rather than a part.
 
 ### Custom Properties
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -31,6 +31,12 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 ## Unreleased
 
+:::added
+
+- Added a CSS part named after the component to every component that renders a wrapper element (e.g. `button`, `details`, `carousel`), alongside the existing `base` part. Where the component name is already used by an inner part, the wrapper takes a `-wrapper` suffix (`input-wrapper`, `textarea-wrapper`).
+
+:::
+
 :::fixed
 
 - Fixed a Safari-only clip-path/border seam along the arrow's outer edges by painting the arrow border with an inset box-shadow instead of a `border`
@@ -53,6 +59,12 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 :::changed
 
 - Removed `font-variant-numeric: tabular-nums;` from default `<table>` styles in Native Styles in lieu of an opt-in `wa-tabular-nums` class [pr:2613]
+
+:::
+
+:::deprecated
+
+- The generic `base` CSS part is deprecated in favor of the part named after the component. Existing `::part(base)` selectors keep working and will until the next major version; `base` now appears as deprecated in each component's CSS Parts table.
 
 :::
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -31,6 +31,13 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 ## Unreleased
 
+:::added
+
+- Added a canonical CSS part to every component, named after the component (e.g. `accordion`, `card`, `tab-panel`), as the semantic replacement for the generic `base` part. Components whose name is already an inner part use a `-wrapper` suffix (`input-wrapper`, `textarea-wrapper`).
+  - `base` continues to work as a `::part()` target but is now hidden from the documentation in favor of the canonical name.
+
+:::
+
 :::fixed
 
 - Fixed a Safari-only clip-path/border seam along the arrow's outer edges by painting the arrow border with an inset box-shadow instead of a `border`

--- a/packages/webawesome/docs/docs/resources/contributing.md
+++ b/packages/webawesome/docs/docs/resources/contributing.md
@@ -335,14 +335,32 @@ When composing elements, use `part` to export the host element and `exportparts`
 ```js
 render() {
   return html`
-    <div part="base">
-      <wa-icon part="icon" exportparts="base:icon__base" ...></wa-icon>
+    <div part="details">
+      <wa-icon part="icon" exportparts="svg:icon__svg" ...></wa-icon>
     </div>
   `;
 }
 ```
 
-This results in a consistent, easy to understand structure for parts. In this example, the `icon` part will target the host element and the `icon__base` part will target the icon's `base` part.
+This results in a consistent, easy to understand structure for parts. In this example, the `icon` part will target the host element and the `icon__svg` part will target the icon's `svg` part.
+
+#### Wrapper elements and their parts
+
+Let the host do the work. `:host` handles the outer box for nearly every component, so only render a wrapper element when you actually need one. `<wa-accordion>`, `<wa-card>`, and `<wa-dropdown>` render no wrapper at all. Style those directly with `wa-accordion { ... }`.
+
+When a component does need a wrapper, name its part after the component (the tag name without the `wa-` prefix). `<wa-details>` renders `details`; `<wa-carousel>` renders `carousel`. If the component name is already taken by an inner part (`<wa-input>` names its native control `input`), the wrapper takes a `-wrapper` suffix instead: `input-wrapper`, `textarea-wrapper`.
+
+```js
+render() {
+  return html` <div part="details">...</div> `;
+}
+```
+
+:::info
+**Don't add `base` to new components.** Components that already render a wrapper keep `base` alongside their component-named part, so existing `::part(base)` selectors keep working. It's flagged deprecated and will be removed in a future major version.
+:::
+
+Never put a part on a `<slot>`. Slots default to `display: contents`, so a part there can't take a border, background, or padding unless you also set `display`. If slotted content needs a styling hook, wrap it in a real element and put the part there.
 
 ### Dependencies
 

--- a/packages/webawesome/docs/docs/resources/contributing.md
+++ b/packages/webawesome/docs/docs/resources/contributing.md
@@ -344,6 +344,20 @@ render() {
 
 This results in a consistent, easy to understand structure for parts. In this example, the `icon` part will target the host element and the `icon__base` part will target the icon's `base` part.
 
+#### The canonical wrapper part
+
+Every component exposes a canonical part on its outermost rendered element, named after the component (the tag name without the `wa-` prefix). For `<wa-accordion>` that part is `accordion`; for `<wa-tab-panel>` it's `tab-panel`. When the component name is already used for an inner part (for example, `<wa-input>` names its native control `input`), the wrapper takes a `-wrapper` suffix instead: `input-wrapper`, `textarea-wrapper`.
+
+```js
+render() {
+  return html` <div part="base details">...</div> `;
+}
+```
+
+This replaces the older generic `base` part. `base` continues to work as a `::part()` target for backward compatibility, but it is hidden from the documentation in favor of the canonical name and is slated for deprecation in a future major version.
+
+Two cases fall outside the `base` + canonical pattern. A component that renders no `base` — like `<wa-accordion>`, whose wrapper is a `<slot>` — exposes only its canonical part (`part="accordion"`), and new components scaffolded from now on follow suit. Components whose "base" is the host element itself (for example, `<wa-dropdown>` and `<wa-tag>`) render no wrapper at all and are styled directly.
+
 ### Dependencies
 
 TL;DR – a component is a dependency if and only if it's rendered inside another component's shadow root.

--- a/packages/webawesome/docs/docs/theming-overview.md
+++ b/packages/webawesome/docs/docs/theming-overview.md
@@ -47,7 +47,7 @@ A theme is the overall look — fonts, borders, space, shadows, and how each [va
     /* Match the docs' major-block rhythm (#content rules in docs.css). */
     margin-block: var(--wa-space-xl);
   }
-  .theme-showcase::part(base) {
+  .theme-showcase::part(carousel) {
     column-gap: 0;
   }
   

--- a/packages/webawesome/scripts/check-css-parts.js
+++ b/packages/webawesome/scripts/check-css-parts.js
@@ -1,9 +1,10 @@
 /**
- * Fails when a component renders a `part=` with no matching `@csspart`, so the rendered and
- * documented part surfaces can't drift. Static analysis, no build.
+ * Guards the component CSS-part surface statically (no build):
+ *   1. every rendered `part=` has a matching `@csspart`, so docs can't drift from render;
+ *   2. every component that renders `base` also exposes its canonical `<name>` (or `<name>-wrapper`) part.
  *
- * Rendered-but-undocumented only. The reverse has too many false positives: the host `base` part
- * carries no `part=`, and `part=${expr}` can't be resolved without running the component.
+ * Documented-but-unrendered isn't checked — `part=${expr}` can't be resolved statically, so it
+ * produces too many false positives.
  */
 import { globby } from 'globby';
 import { readFile } from 'node:fs/promises';
@@ -38,7 +39,7 @@ async function readComponentSource(dir) {
 
 // Rendered but undocumented on purpose — pending API-shape decisions (form-control label naming;
 // `page` renders `skip-to-content` but documents `skip-link`). Drop each as it's resolved.
-const ALLOWLIST = {
+const DEFAULT_ALLOWLIST = {
   'color-picker': ['form-control', 'form-control-input', 'form-control-label', 'hint'],
   input: ['form-control-label'],
   page: ['skip-to-content'],
@@ -47,8 +48,17 @@ const ALLOWLIST = {
   'time-input': ['label'],
 };
 
+// These render `base` on a `<slot>` rather than a wrapper element. Parts don't belong on slots, and
+// the host does the styling, so they get no component-named part until the legacy `base` is removed.
+const SLOT_BASE = new Set(['button-group', 'tab-panel']);
+
+function hasCanonicalPart(name, rendered, declared) {
+  return [name, `${name}-wrapper`].some(part => rendered.has(part) && declared.has(part));
+}
+
 export async function check(options = {}) {
   const rootDir = options.rootDir || root;
+  const allowlist = options.allowlist ?? DEFAULT_ALLOWLIST;
   const dirs = await globby('src/components/*', {
     cwd: rootDir,
     absolute: true,
@@ -64,7 +74,7 @@ export async function check(options = {}) {
 
     const rendered = collect(source, RENDERED_PART, 2);
     const declared = collect(source, DECLARED_PART, 1);
-    const allowed = new Set(ALLOWLIST[name] ?? []);
+    const allowed = new Set(allowlist[name] ?? []);
 
     const undocumented = [...rendered].filter(part => !declared.has(part));
     const gaps = undocumented.filter(part => !allowed.has(part)).sort();
@@ -72,9 +82,16 @@ export async function check(options = {}) {
     // Flag allowlist entries that are now documented, so the list can't rot.
     for (const part of allowed) if (!undocumented.includes(part)) staleAllowlist.push(`${name}: ${part}`);
 
-    if (gaps.length > 0) {
-      failures.push({ name, gaps });
-      console.log(`❌ ${name} — undocumented part(s): ${gaps.join(', ')}`);
+    const missingCanonical =
+      rendered.has('base') && !SLOT_BASE.has(name) && !hasCanonicalPart(name, rendered, declared);
+
+    const problems = [];
+    if (gaps.length > 0) problems.push(`undocumented part(s): ${gaps.join(', ')}`);
+    if (missingCanonical) problems.push(`missing canonical part (\`${name}\` or \`${name}-wrapper\`)`);
+
+    if (problems.length > 0) {
+      failures.push(name);
+      console.log(`❌ ${name} — ${problems.join('; ')}`);
     } else {
       console.log(`✅ ${name}`);
     }
@@ -88,13 +105,13 @@ export async function check(options = {}) {
   }
 
   if (failures.length > 0) {
-    const total = failures.reduce((sum, f) => sum + f.gaps.length, 0);
-    console.log(`FAILED: ${total} undocumented part(s) across ${failures.length} component(s).`);
-    console.log('Add a matching `@csspart <name> - <description>` tag, or remove the stray `part=`.');
+    console.log(`FAILED: part issues across ${failures.length} component(s).`);
+    console.log('Add a matching `@csspart <name> - <description>` for any stray `part=`, and give each');
+    console.log('component a canonical `<name>` (or `<name>-wrapper`) part on its outer element.');
     process.exit(1);
   }
 
-  console.log('PASSED: every rendered part is documented (or explicitly allowlisted).');
+  console.log('PASSED: every rendered part is documented, and every component exposes its canonical part.');
 }
 
 function isRunAsMain() {

--- a/packages/webawesome/scripts/check-css-parts.js
+++ b/packages/webawesome/scripts/check-css-parts.js
@@ -1,9 +1,10 @@
 /**
- * Fails when a component renders a `part=` with no matching `@csspart`, so the rendered and
- * documented part surfaces can't drift. Static analysis, no build.
+ * Guards the component CSS-part surface statically (no build):
+ *   1. every rendered `part=` has a matching `@csspart`, so docs can't drift from render;
+ *   2. every component that renders `base` also exposes its canonical `<name>` (or `<name>-wrapper`) part.
  *
- * Rendered-but-undocumented only. The reverse has too many false positives: the host `base` part
- * carries no `part=`, and `part=${expr}` can't be resolved without running the component.
+ * Documented-but-unrendered isn't checked — `part=${expr}` can't be resolved statically, so it
+ * produces too many false positives.
  */
 import { globby } from 'globby';
 import { readFile } from 'node:fs/promises';
@@ -38,7 +39,7 @@ async function readComponentSource(dir) {
 
 // Rendered but undocumented on purpose — pending API-shape decisions (form-control label naming;
 // `page` renders `skip-to-content` but documents `skip-link`). Drop each as it's resolved.
-const ALLOWLIST = {
+const DEFAULT_ALLOWLIST = {
   'color-picker': ['form-control', 'form-control-input', 'form-control-label', 'hint'],
   input: ['form-control-label'],
   page: ['skip-to-content'],
@@ -47,8 +48,13 @@ const ALLOWLIST = {
   'time-input': ['label'],
 };
 
+function hasCanonicalPart(name, rendered, declared) {
+  return [name, `${name}-wrapper`].some(part => rendered.has(part) && declared.has(part));
+}
+
 export async function check(options = {}) {
   const rootDir = options.rootDir || root;
+  const allowlist = options.allowlist ?? DEFAULT_ALLOWLIST;
   const dirs = await globby('src/components/*', {
     cwd: rootDir,
     absolute: true,
@@ -64,7 +70,7 @@ export async function check(options = {}) {
 
     const rendered = collect(source, RENDERED_PART, 2);
     const declared = collect(source, DECLARED_PART, 1);
-    const allowed = new Set(ALLOWLIST[name] ?? []);
+    const allowed = new Set(allowlist[name] ?? []);
 
     const undocumented = [...rendered].filter(part => !declared.has(part));
     const gaps = undocumented.filter(part => !allowed.has(part)).sort();
@@ -72,9 +78,15 @@ export async function check(options = {}) {
     // Flag allowlist entries that are now documented, so the list can't rot.
     for (const part of allowed) if (!undocumented.includes(part)) staleAllowlist.push(`${name}: ${part}`);
 
-    if (gaps.length > 0) {
-      failures.push({ name, gaps });
-      console.log(`❌ ${name} — undocumented part(s): ${gaps.join(', ')}`);
+    const missingCanonical = rendered.has('base') && !hasCanonicalPart(name, rendered, declared);
+
+    const problems = [];
+    if (gaps.length > 0) problems.push(`undocumented part(s): ${gaps.join(', ')}`);
+    if (missingCanonical) problems.push(`missing canonical part (\`${name}\` or \`${name}-wrapper\`)`);
+
+    if (problems.length > 0) {
+      failures.push(name);
+      console.log(`❌ ${name} — ${problems.join('; ')}`);
     } else {
       console.log(`✅ ${name}`);
     }
@@ -88,13 +100,13 @@ export async function check(options = {}) {
   }
 
   if (failures.length > 0) {
-    const total = failures.reduce((sum, f) => sum + f.gaps.length, 0);
-    console.log(`FAILED: ${total} undocumented part(s) across ${failures.length} component(s).`);
-    console.log('Add a matching `@csspart <name> - <description>` tag, or remove the stray `part=`.');
+    console.log(`FAILED: part issues across ${failures.length} component(s).`);
+    console.log('Add a matching `@csspart <name> - <description>` for any stray `part=`, and give each');
+    console.log('component a canonical `<name>` (or `<name>-wrapper`) part on its outer element.');
     process.exit(1);
   }
 
-  console.log('PASSED: every rendered part is documented (or explicitly allowlisted).');
+  console.log('PASSED: every rendered part is documented, and every component exposes its canonical part.');
 }
 
 function isRunAsMain() {

--- a/packages/webawesome/scripts/plop/templates/component/component.hbs
+++ b/packages/webawesome/scripts/plop/templates/component/component.hbs
@@ -15,8 +15,6 @@ import styles from './{{ tagWithoutPrefix tag }}.styles.js';
  * @slot - The default slot.
  * @slot example - An example slot.
  *
- * @csspart base - The component's base wrapper.
- *
  * @cssproperty --example - An example CSS custom property.
  */
  @customElement("{{ tag }}")

--- a/packages/webawesome/scripts/plop/templates/component/component.hbs
+++ b/packages/webawesome/scripts/plop/templates/component/component.hbs
@@ -15,7 +15,7 @@ import styles from './{{ tagWithoutPrefix tag }}.styles.js';
  * @slot - The default slot.
  * @slot example - An example slot.
  *
- * @csspart base - The component's base wrapper.
+ * @csspart {{ tagWithoutPrefix tag }} - The component's outer wrapper.
  *
  * @cssproperty --example - An example CSS custom property.
  */
@@ -32,7 +32,7 @@ export default class {{ properCase tag }} extends WebAwesomeElement {
   }
 
   render() {
-    return html` <slot></slot> `;
+    return html` <slot part="{{ tagWithoutPrefix tag }}"></slot> `;
   }
 }
 

--- a/packages/webawesome/src/components/accordion-item/accordion-item.ts
+++ b/packages/webawesome/src/components/accordion-item/accordion-item.ts
@@ -25,6 +25,7 @@ import styles from './accordion-item.styles.js';
  * @slot icon - Optional expand/collapse icon. Works best with `<wa-icon>`.
  *
  * @csspart base - The component's base wrapper.
+ * @csspart accordion-item - The component's outer wrapper.
  * @csspart heading - The heading element wrapping the trigger button. Omitted when `heading-level="none"`.
  * @csspart button - The trigger button that toggles the panel.
  * @csspart label - The container that wraps the label.
@@ -200,7 +201,7 @@ export default class WaAccordionItem extends WebAwesomeElement {
     `;
 
     return html`
-      <div part="base">
+      <div part="base accordion-item">
         ${this.headingLevel === 'none' ? button : this.renderHeadingWrapper(button)}
         <div
           part="panel"

--- a/packages/webawesome/src/components/accordion-item/accordion-item.ts
+++ b/packages/webawesome/src/components/accordion-item/accordion-item.ts
@@ -24,7 +24,7 @@ import styles from './accordion-item.styles.js';
  * @slot label - The accordion item's label. Alternatively, use the `label` attribute.
  * @slot icon - Optional expand/collapse icon. Works best with `<wa-icon>`.
  *
- * @csspart base - The component's base wrapper.
+ * @csspart base - Deprecated. Use the `accordion-item` part instead.
  * @csspart accordion-item - The component's outer wrapper.
  * @csspart heading - The heading element wrapping the trigger button. Omitted when `heading-level="none"`.
  * @csspart button - The trigger button that toggles the panel.

--- a/packages/webawesome/src/components/accordion/accordion.test.ts
+++ b/packages/webawesome/src/components/accordion/accordion.test.ts
@@ -33,6 +33,17 @@ describe('<wa-accordion>', () => {
         });
       });
 
+      describe('css parts', () => {
+        it('should expose the accordion part on the default slot', async () => {
+          const el = await fixture<WaAccordion>(html`
+            <wa-accordion>
+              <wa-accordion-item label="One">Content</wa-accordion-item>
+            </wa-accordion>
+          `);
+          expect(el.shadowRoot!.querySelector('slot[part~="accordion"]')).to.exist;
+        });
+      });
+
       describe('properties', () => {
         it('should default mode to multiple', async () => {
           const el = await fixture<WaAccordion>(html`

--- a/packages/webawesome/src/components/accordion/accordion.ts
+++ b/packages/webawesome/src/components/accordion/accordion.ts
@@ -20,6 +20,8 @@ import styles from './accordion.styles.js';
  *
  * @slot - One or more `<wa-accordion-item>` elements.
  *
+ * @csspart accordion - The component's outer wrapper. As a `<slot>`, set `display` before applying box styles.
+ *
  * @event {{ item: WaAccordionItem }} wa-expand - Emitted before an item expands. Cancelable.
  * @event {{ item: WaAccordionItem }} wa-after-expand - Emitted after an item finishes expanding.
  * @event {{ item: WaAccordionItem }} wa-collapse - Emitted before an item collapses. Cancelable.
@@ -203,6 +205,7 @@ export default class WaAccordion extends WebAwesomeElement {
   render() {
     return html`
       <slot
+        part="accordion"
         @slotchange=${this.handleSlotChange}
         @wa-accordion-item-trigger=${this.handleItemTrigger}
         @focusin=${this.handleFocusIn}

--- a/packages/webawesome/src/components/badge/badge.ts
+++ b/packages/webawesome/src/components/badge/badge.ts
@@ -16,6 +16,7 @@ import styles from './badge.styles.js';
  * @slot end - An element, such as `<wa-icon>`, placed after the label.
  *
  * @csspart base - The component's base wrapper.
+ * @csspart badge - The component's outer wrapper.
  * @csspart start - The container that wraps the `start` slot.
  * @csspart end - The container that wraps the `end` slot.
  *
@@ -44,7 +45,7 @@ export default class WaBadge extends WebAwesomeElement {
         <slot name="start"></slot>
       </span>
 
-      <span part="base" role="status">
+      <span part="base badge" role="status">
         <slot></slot>
       </span>
 

--- a/packages/webawesome/src/components/badge/badge.ts
+++ b/packages/webawesome/src/components/badge/badge.ts
@@ -15,7 +15,7 @@ import styles from './badge.styles.js';
  * @slot start - An element, such as `<wa-icon>`, placed before the label.
  * @slot end - An element, such as `<wa-icon>`, placed after the label.
  *
- * @csspart base - The component's base wrapper.
+ * @csspart base - Deprecated. Use the `badge` part instead.
  * @csspart badge - The component's outer wrapper.
  * @csspart start - The container that wraps the `start` slot.
  * @csspart end - The container that wraps the `end` slot.

--- a/packages/webawesome/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/webawesome/src/components/breadcrumb/breadcrumb.ts
@@ -18,7 +18,7 @@ import styles from './breadcrumb.styles.js';
  *
  * @dependency wa-icon
  *
- * @csspart base - The component's base wrapper.
+ * @csspart base - Deprecated. Use the `breadcrumb` part instead.
  * @csspart breadcrumb - The component's outer wrapper.
  */
 @customElement('wa-breadcrumb')

--- a/packages/webawesome/src/components/breadcrumb/breadcrumb.ts
+++ b/packages/webawesome/src/components/breadcrumb/breadcrumb.ts
@@ -19,6 +19,7 @@ import styles from './breadcrumb.styles.js';
  * @dependency wa-icon
  *
  * @csspart base - The component's base wrapper.
+ * @csspart breadcrumb - The component's outer wrapper.
  */
 @customElement('wa-breadcrumb')
 export default class WaBreadcrumb extends WebAwesomeElement {
@@ -86,7 +87,7 @@ export default class WaBreadcrumb extends WebAwesomeElement {
     }
 
     return html`
-      <nav part="base" class="breadcrumb" aria-label=${this.label}>
+      <nav part="base breadcrumb" class="breadcrumb" aria-label=${this.label}>
         <slot @slotchange=${this.handleSlotChange}></slot>
       </nav>
 

--- a/packages/webawesome/src/components/button-group/button-group.ts
+++ b/packages/webawesome/src/components/button-group/button-group.ts
@@ -14,7 +14,7 @@ import styles from './button-group.styles.js';
  *
  * @slot - One or more `<wa-button>` elements to display in the button group.
  *
- * @csspart base - The component's base wrapper.
+ * @csspart base - Deprecated. Style the host element instead.
  */
 @customElement('wa-button-group')
 export default class WaButtonGroup extends WebAwesomeElement {

--- a/packages/webawesome/src/components/button-group/button-group.ts
+++ b/packages/webawesome/src/components/button-group/button-group.ts
@@ -15,6 +15,7 @@ import styles from './button-group.styles.js';
  * @slot - One or more `<wa-button>` elements to display in the button group.
  *
  * @csspart base - The component's base wrapper.
+ * @csspart button-group - The component's outer wrapper. As a `<slot>`, set `display` before applying box styles.
  */
 @customElement('wa-button-group')
 export default class WaButtonGroup extends WebAwesomeElement {
@@ -65,7 +66,7 @@ export default class WaButtonGroup extends WebAwesomeElement {
   render() {
     return html`
       <slot
-        part="base"
+        part="base button-group"
         class="button-group"
         role="${this.disableRole ? 'presentation' : 'group'}"
         aria-label=${this.label}

--- a/packages/webawesome/src/components/button/button.ts
+++ b/packages/webawesome/src/components/button/button.ts
@@ -34,7 +34,7 @@ import styles from './button.styles.js';
  * @slot start - An element, such as `<wa-icon>`, placed before the label.
  * @slot end - An element, such as `<wa-icon>`, placed after the label.
  *
- * @csspart base - The component's base wrapper.
+ * @csspart base - Deprecated. Use the `button` part instead.
  * @csspart button - The component's outer wrapper.
  * @csspart start - The container that wraps the `start` slot.
  * @csspart label - The button's label.

--- a/packages/webawesome/src/components/button/button.ts
+++ b/packages/webawesome/src/components/button/button.ts
@@ -35,6 +35,7 @@ import styles from './button.styles.js';
  * @slot end - An element, such as `<wa-icon>`, placed after the label.
  *
  * @csspart base - The component's base wrapper.
+ * @csspart button - The component's outer wrapper.
  * @csspart start - The container that wraps the `start` slot.
  * @csspart label - The button's label.
  * @csspart end - The container that wraps the `end` slot.
@@ -304,7 +305,7 @@ export default class WaButton extends WebAwesomeFormAssociatedElement {
     /* eslint-disable lit/binding-positions */
     return html`
       <${tag}
-        part="base"
+        part="base button"
         class=${classMap({
           button: true,
           caret: this.withCaret,

--- a/packages/webawesome/src/components/carousel/carousel.ts
+++ b/packages/webawesome/src/components/carousel/carousel.ts
@@ -35,6 +35,7 @@ import styles from './carousel.styles.js';
  * @slot previous-icon - Optional previous icon to use instead of the default. Works best with `<wa-icon>`.
  *
  * @csspart base - The carousel's internal wrapper.
+ * @csspart carousel - The component's outer wrapper.
  * @csspart scroll-container - The scroll container that wraps the slides.
  * @csspart pagination - The pagination indicators wrapper.
  * @csspart pagination-item - The pagination indicator.
@@ -610,7 +611,7 @@ export default class WaCarousel extends WebAwesomeElement {
     const isRTL = isServer ? this.dir === 'rtl' : this.localize.dir() === 'rtl';
 
     return html`
-      <div part="base" class="carousel">
+      <div part="base carousel" class="carousel">
         <div
           id="scroll-container"
           part="scroll-container"

--- a/packages/webawesome/src/components/carousel/carousel.ts
+++ b/packages/webawesome/src/components/carousel/carousel.ts
@@ -34,7 +34,7 @@ import styles from './carousel.styles.js';
  * @slot next-icon - Optional next icon to use instead of the default. Works best with `<wa-icon>`.
  * @slot previous-icon - Optional previous icon to use instead of the default. Works best with `<wa-icon>`.
  *
- * @csspart base - The carousel's internal wrapper.
+ * @csspart base - Deprecated. Use the `carousel` part instead.
  * @csspart carousel - The component's outer wrapper.
  * @csspart scroll-container - The scroll container that wraps the slides.
  * @csspart pagination - The pagination indicators wrapper.

--- a/packages/webawesome/src/components/checkbox/checkbox.test.ts
+++ b/packages/webawesome/src/components/checkbox/checkbox.test.ts
@@ -331,7 +331,7 @@ describe('<wa-checkbox>', () => {
       describe('CSS parts and states', () => {
         it('should expose CSS parts', async () => {
           const el = await fixture<WaCheckbox>(html`<wa-checkbox hint="Help">Checkbox</wa-checkbox>`);
-          expect(el.shadowRoot!.querySelector('[part="base"]')).to.exist;
+          expect(el.shadowRoot!.querySelector('[part~="base"]')).to.exist;
           expect(el.shadowRoot!.querySelector('[part="control"]')).to.exist;
           expect(el.shadowRoot!.querySelector('[part="label"]')).to.exist;
           expect(el.shadowRoot!.querySelector('[part="hint"]')).to.exist;

--- a/packages/webawesome/src/components/checkbox/checkbox.ts
+++ b/packages/webawesome/src/components/checkbox/checkbox.ts
@@ -33,6 +33,7 @@ import styles from './checkbox.styles.js';
  * @event wa-invalid - Emitted when the form control has been checked for validity and its constraints aren't satisfied.
  *
  * @csspart base - The component's label .
+ * @csspart checkbox - The component's outer wrapper.
  * @csspart control - The square container that wraps the checkbox's checked state.
  * @csspart checked-icon - The checked icon, a `<wa-icon>` element.
  * @csspart indeterminate-icon - The indeterminate icon, a `<wa-icon>` element.
@@ -241,7 +242,7 @@ export default class WaCheckbox extends WebAwesomeFormAssociatedElement {
     //
 
     return html`
-      <label part="base">
+      <label part="base checkbox">
         <span part="control">
           <input
             class="input"

--- a/packages/webawesome/src/components/checkbox/checkbox.ts
+++ b/packages/webawesome/src/components/checkbox/checkbox.ts
@@ -32,7 +32,7 @@ import styles from './checkbox.styles.js';
  * @event input - Emitted when the checkbox receives input.
  * @event wa-invalid - Emitted when the form control has been checked for validity and its constraints aren't satisfied.
  *
- * @csspart base - The component's label .
+ * @csspart base - Deprecated. Use the `checkbox` part instead.
  * @csspart checkbox - The component's outer wrapper.
  * @csspart control - The square container that wraps the checkbox's checked state.
  * @csspart checked-icon - The checked icon, a `<wa-icon>` element.

--- a/packages/webawesome/src/components/color-picker/color-picker.ts
+++ b/packages/webawesome/src/components/color-picker/color-picker.ts
@@ -66,7 +66,7 @@ declare const EyeDropper: EyeDropperConstructor;
  * @event input - Emitted when the color picker receives input.
  * @event wa-invalid - Emitted when the form control has been checked for validity and its constraints aren't satisfied.
  *
- * @csspart base - The component's base wrapper.
+ * @csspart base - Deprecated. Use the `color-picker` part instead.
  * @csspart color-picker - The component's outer wrapper.
  * @csspart trigger - The color picker's dropdown trigger.
  * @csspart trigger-container - The container that wraps the color picker's trigger.

--- a/packages/webawesome/src/components/color-picker/color-picker.ts
+++ b/packages/webawesome/src/components/color-picker/color-picker.ts
@@ -67,6 +67,7 @@ declare const EyeDropper: EyeDropperConstructor;
  * @event wa-invalid - Emitted when the form control has been checked for validity and its constraints aren't satisfied.
  *
  * @csspart base - The component's base wrapper.
+ * @csspart color-picker - The component's outer wrapper.
  * @csspart trigger - The color picker's dropdown trigger.
  * @csspart trigger-container - The container that wraps the color picker's trigger.
  * @csspart swatches - The container that holds the swatches.
@@ -1115,7 +1116,7 @@ export default class WaColorPicker extends WebAwesomeFormAssociatedElement {
 
     const colorPicker = html`
       <div
-        part="base"
+        part="base color-picker"
         class=${classMap({
           'color-picker': true,
         })}

--- a/packages/webawesome/src/components/comparison/comparison.ts
+++ b/packages/webawesome/src/components/comparison/comparison.ts
@@ -24,7 +24,7 @@ import styles from './comparison.styles.js';
  *
  * @event change - Emitted when the position changes.
  *
- * @csspart base - The container that wraps the before and after content.
+ * @csspart base - Deprecated. Use the `comparison` part instead.
  * @csspart comparison - The component's outer wrapper.
  * @csspart before - The container that wraps the before content.
  * @csspart after - The container that wraps the after content.

--- a/packages/webawesome/src/components/comparison/comparison.ts
+++ b/packages/webawesome/src/components/comparison/comparison.ts
@@ -25,6 +25,7 @@ import styles from './comparison.styles.js';
  * @event change - Emitted when the position changes.
  *
  * @csspart base - The container that wraps the before and after content.
+ * @csspart comparison - The component's outer wrapper.
  * @csspart before - The container that wraps the before content.
  * @csspart after - The container that wraps the after content.
  * @csspart divider - The divider that separates the before and after content.
@@ -102,7 +103,7 @@ export default class WaComparison extends WebAwesomeElement {
     const isRtl = this.hasUpdated ? this.localize.dir() === 'rtl' : this.dir === 'rtl';
 
     return html`
-      <div id="comparison" class="image" part="base">
+      <div id="comparison" class="image" part="base comparison">
         <div part="before" class="before">
           <slot name="before"></slot>
         </div>

--- a/packages/webawesome/src/components/details/details.ts
+++ b/packages/webawesome/src/components/details/details.ts
@@ -35,6 +35,7 @@ import styles from './details.styles.js';
  * @event wa-after-hide - Emitted after the details closes and all animations are complete.
  *
  * @csspart base - The inner `<details>` element used to render the component.
+ * @csspart details - The component's outer wrapper.
  *                 Styles you apply to the component are automatically applied to this part, so you usually don't need to deal with it unless you need to set the `display` property.
  * @csspart header - The header that wraps both the summary and the expand/collapse icon.
  * @csspart summary - The container that wraps the summary.
@@ -290,7 +291,7 @@ export default class WaDetails extends WebAwesomeElement {
     const isRtl = !this.hasUpdated ? this.dir === 'rtl' : this.localize.dir() === 'rtl';
 
     return html`
-      <details part="base">
+      <details part="base details">
         <summary
           part="header"
           role="button"

--- a/packages/webawesome/src/components/details/details.ts
+++ b/packages/webawesome/src/components/details/details.ts
@@ -34,9 +34,9 @@ import styles from './details.styles.js';
  * @event wa-hide - Emitted when the details closes.
  * @event wa-after-hide - Emitted after the details closes and all animations are complete.
  *
- * @csspart base - The inner `<details>` element used to render the component.
+ * @csspart base - Deprecated. Use the `details` part instead.
  * @csspart details - The component's outer wrapper.
- *                 Styles you apply to the component are automatically applied to this part, so you usually don't need to deal with it unless you need to set the `display` property.
+ *                    Styles you apply to the component are automatically applied to this part, so you usually don't need to deal with it unless you need to set the `display` property.
  * @csspart header - The header that wraps both the summary and the expand/collapse icon.
  * @csspart summary - The container that wraps the summary.
  * @csspart icon - The container that wraps the expand/collapse icons.

--- a/packages/webawesome/src/components/dropdown/dropdown.test.ts
+++ b/packages/webawesome/src/components/dropdown/dropdown.test.ts
@@ -25,7 +25,7 @@ describe('<wa-dropdown>', () => {
           await customElements.whenDefined('wa-button');
           const waButton = trigger as any;
           await waButton.updateComplete;
-          const nativeButton = waButton.shadowRoot!.querySelector('[part="base"]')!;
+          const nativeButton = waButton.shadowRoot!.querySelector('[part~="base"]')!;
 
           expect(nativeButton.getAttribute('aria-haspopup')).to.equal('menu');
         });
@@ -42,7 +42,7 @@ describe('<wa-dropdown>', () => {
 
           const trigger = el.querySelector<HTMLElement>('[slot="trigger"]')! as any;
           await trigger.updateComplete;
-          const nativeButton = trigger.shadowRoot!.querySelector('[part="base"]')!;
+          const nativeButton = trigger.shadowRoot!.querySelector('[part~="base"]')!;
 
           expect(nativeButton.getAttribute('aria-expanded')).to.equal('true');
         });

--- a/packages/webawesome/src/components/dropdown/dropdown.ts
+++ b/packages/webawesome/src/components/dropdown/dropdown.ts
@@ -45,7 +45,7 @@ const openDropdowns = new Set<WaDropdown>();
  * @slot - The dropdown's items, typically `<wa-dropdown-item>` elements.
  * @slot trigger - The element that triggers the dropdown, such as a `<wa-button>` or `<button>`.
  *
- * @csspart base - The component's host element.
+ * @csspart base - Deprecated. Style the host element instead.
  * @csspart menu - The dropdown menu container.
  *
  * @cssproperty --show-duration - The duration of the show animation.

--- a/packages/webawesome/src/components/dropdown/dropdown.ts
+++ b/packages/webawesome/src/components/dropdown/dropdown.ts
@@ -731,7 +731,7 @@ export default class WaDropdown extends WebAwesomeElement {
     if (trigger.localName === 'wa-button') {
       await customElements.whenDefined('wa-button');
       await (trigger as WaButton).updateComplete;
-      nativeButton = trigger.shadowRoot!.querySelector<HTMLButtonElement>('[part="base"]')!;
+      nativeButton = trigger.shadowRoot!.querySelector<HTMLButtonElement>('[part~="base"]')!;
     } else {
       nativeButton = trigger as HTMLButtonElement;
     }

--- a/packages/webawesome/src/components/input/input.ts
+++ b/packages/webawesome/src/components/input/input.ts
@@ -42,7 +42,7 @@ import styles from './input.styles.js';
  *
  * @csspart label - The label
  * @csspart hint - The hint's wrapper.
- * @csspart base - The wrapper being rendered as an input
+ * @csspart base - Deprecated. Use the `input-wrapper` part instead.
  * @csspart input-wrapper - The component's outer wrapper.
  * @csspart input - The internal `<input>` control.
  * @csspart start - The container that wraps the `start` slot.

--- a/packages/webawesome/src/components/input/input.ts
+++ b/packages/webawesome/src/components/input/input.ts
@@ -43,6 +43,7 @@ import styles from './input.styles.js';
  * @csspart label - The label
  * @csspart hint - The hint's wrapper.
  * @csspart base - The wrapper being rendered as an input
+ * @csspart input-wrapper - The component's outer wrapper.
  * @csspart input - The internal `<input>` control.
  * @csspart start - The container that wraps the `start` slot.
  * @csspart clear-button - The clear button.
@@ -401,7 +402,7 @@ export default class WaInput extends WebAwesomeFormAssociatedElement {
         <slot name="label">${this.label}</slot>
       </label>
 
-      <div part="base" class="text-field">
+      <div part="base input-wrapper" class="text-field">
         <slot name="start" part="start" class="start"></slot>
 
         <input

--- a/packages/webawesome/src/components/known-date/known-date.ts
+++ b/packages/webawesome/src/components/known-date/known-date.ts
@@ -44,7 +44,7 @@ const generateId = (): string => uniqueId('wa-known-date-');
  * @csspart form-control-input - Alias on the fields row matching other form controls.
  * @csspart hint - The hint's wrapper.
  * @csspart label - Alias on the legend's inner label wrapper.
- * @csspart base - The component's outer wrapper (alias of the fields row).
+ * @csspart base - Deprecated. Use the `known-date` part instead.
  * @csspart known-date - The component's outer wrapper.
  * @csspart fieldset - The `<fieldset>` element grouping the three fields (or a `role="group"` div).
  * @csspart legend - The `<legend>` element (when a label is present).

--- a/packages/webawesome/src/components/known-date/known-date.ts
+++ b/packages/webawesome/src/components/known-date/known-date.ts
@@ -45,6 +45,7 @@ const generateId = (): string => uniqueId('wa-known-date-');
  * @csspart hint - The hint's wrapper.
  * @csspart label - Alias on the legend's inner label wrapper.
  * @csspart base - The component's outer wrapper (alias of the fields row).
+ * @csspart known-date - The component's outer wrapper.
  * @csspart fieldset - The `<fieldset>` element grouping the three fields (or a `role="group"` div).
  * @csspart legend - The `<legend>` element (when a label is present).
  * @csspart fields - The flex row holding the three field blocks.
@@ -433,7 +434,7 @@ export default class WaKnownDate extends WebAwesomeFormAssociatedElement {
     const fields = this.fieldOrder().map(field => this.renderField(field, describedBy, userInvalid));
 
     const groupContent = html`
-      <div part="base form-control-input fields" class="fields">${fields}</div>
+      <div part="base known-date form-control-input fields" class="fields">${fields}</div>
 
       <slot
         name="hint"

--- a/packages/webawesome/src/components/number-input/number-input.ts
+++ b/packages/webawesome/src/components/number-input/number-input.ts
@@ -42,7 +42,7 @@ import styles from './number-input.styles.js';
  * @csspart label - The label element.
  * @csspart form-control-label - Alias for the label element.
  * @csspart hint - The hint element.
- * @csspart base - The wrapper containing the input and steppers.
+ * @csspart base - Deprecated. Use the `number-input` part instead.
  * @csspart number-input - The component's outer wrapper.
  * @csspart input - The internal `<input>` control.
  * @csspart start - The container that wraps the `start` slot.

--- a/packages/webawesome/src/components/number-input/number-input.ts
+++ b/packages/webawesome/src/components/number-input/number-input.ts
@@ -43,6 +43,7 @@ import styles from './number-input.styles.js';
  * @csspart form-control-label - Alias for the label element.
  * @csspart hint - The hint element.
  * @csspart base - The wrapper containing the input and steppers.
+ * @csspart number-input - The component's outer wrapper.
  * @csspart input - The internal `<input>` control.
  * @csspart start - The container that wraps the `start` slot.
  * @csspart end - The container that wraps the `end` slot.
@@ -330,7 +331,7 @@ export default class WaNumberInput extends WebAwesomeFormAssociatedElement {
         <slot name="label">${this.label}</slot>
       </label>
 
-      <div part="base" class="number-field">
+      <div part="base number-input" class="number-field">
         ${!this.withoutSteppers
           ? html`
               <button

--- a/packages/webawesome/src/components/page/page.ts
+++ b/packages/webawesome/src/components/page/page.ts
@@ -88,6 +88,7 @@ function toLength(px: number | string): string {
  * @slot footer - The content to display in the footer. This is always displayed underneath the viewport so will always make the page "scrollable".
  *
  * @csspart base - The component's base wrapper.
+ * @csspart page - The component's outer wrapper.
  * @csspart banner - The banner to show above header.
  * @csspart header - The header, usually for top level navigation / branding.
  * @csspart subheader - Shown below the header, usually intended for things like breadcrumbs and other page level navigation.
@@ -356,7 +357,7 @@ export default class WaPage extends WebAwesomeElement {
         </style>
       `)}
 
-      <div class="base" part="base">
+      <div class="base" part="base page">
         <div class="banner" part="banner">
           <slot name="banner"></slot>
         </div>

--- a/packages/webawesome/src/components/page/page.ts
+++ b/packages/webawesome/src/components/page/page.ts
@@ -87,7 +87,7 @@ function toLength(px: number | string): string {
  * @slot skip-to-content - The "skip to content" slot. You can override this If you would like to override the `Skip to content` button and add additional "Skip to X", they can be inserted here.
  * @slot footer - The content to display in the footer. This is always displayed underneath the viewport so will always make the page "scrollable".
  *
- * @csspart base - The component's base wrapper.
+ * @csspart base - Deprecated. Use the `page` part instead.
  * @csspart page - The component's outer wrapper.
  * @csspart banner - The banner to show above header.
  * @csspart header - The header, usually for top level navigation / branding.

--- a/packages/webawesome/src/components/progress-bar/progress-bar.ts
+++ b/packages/webawesome/src/components/progress-bar/progress-bar.ts
@@ -16,7 +16,7 @@ import styles from './progress-bar.styles.js';
  *
  * @slot - A label to show inside the progress indicator.
  *
- * @csspart base - The component's base wrapper.
+ * @csspart base - Deprecated. Use the `progress-bar` part instead.
  * @csspart progress-bar - The component's outer wrapper.
  * @csspart indicator - The progress bar's indicator.
  * @csspart label - The progress bar's label.

--- a/packages/webawesome/src/components/progress-bar/progress-bar.ts
+++ b/packages/webawesome/src/components/progress-bar/progress-bar.ts
@@ -17,6 +17,7 @@ import styles from './progress-bar.styles.js';
  * @slot - A label to show inside the progress indicator.
  *
  * @csspart base - The component's base wrapper.
+ * @csspart progress-bar - The component's outer wrapper.
  * @csspart indicator - The progress bar's indicator.
  * @csspart label - The progress bar's label.
  *
@@ -62,7 +63,7 @@ export default class WaProgressBar extends WebAwesomeElement {
   render() {
     return html`
       <div
-        part="base"
+        part="base progress-bar"
         class="progress-bar"
         role="progressbar"
         title=${ifDefined(this.title)}

--- a/packages/webawesome/src/components/progress-ring/progress-ring.ts
+++ b/packages/webawesome/src/components/progress-ring/progress-ring.ts
@@ -15,7 +15,7 @@ import styles from './progress-ring.styles.js';
  *
  * @slot - A label to show inside the ring.
  *
- * @csspart base - The component's base wrapper.
+ * @csspart base - Deprecated. Use the `progress-ring` part instead.
  * @csspart progress-ring - The component's outer wrapper.
  * @csspart label - The progress ring label.
  * @csspart track - The progress ring's track.

--- a/packages/webawesome/src/components/progress-ring/progress-ring.ts
+++ b/packages/webawesome/src/components/progress-ring/progress-ring.ts
@@ -16,6 +16,7 @@ import styles from './progress-ring.styles.js';
  * @slot - A label to show inside the ring.
  *
  * @csspart base - The component's base wrapper.
+ * @csspart progress-ring - The component's outer wrapper.
  * @csspart label - The progress ring label.
  * @csspart track - The progress ring's track.
  * @csspart indicator - The progress ring's indicator.
@@ -63,7 +64,7 @@ export default class WaProgressRing extends WebAwesomeElement {
   render() {
     return html`
       <div
-        part="base"
+        part="base progress-ring"
         class="progress-ring"
         role="progressbar"
         aria-label=${this.label.length > 0 ? this.label : this.localize.term('progress')}

--- a/packages/webawesome/src/components/qr-code/qr-code.ts
+++ b/packages/webawesome/src/components/qr-code/qr-code.ts
@@ -14,6 +14,7 @@ import styles from './qr-code.styles.js';
  * @since 2.0
  *
  * @csspart base - The component's base wrapper.
+ * @csspart qr-code - The component's outer wrapper.
  */
 @customElement('wa-qr-code')
 export default class WaQrCode extends WebAwesomeElement {
@@ -103,7 +104,7 @@ export default class WaQrCode extends WebAwesomeElement {
   render() {
     return html`
       <canvas
-        part="base"
+        part="base qr-code"
         class="qr-code"
         role="img"
         aria-label=${this.label?.length > 0 ? this.label : this.value}

--- a/packages/webawesome/src/components/qr-code/qr-code.ts
+++ b/packages/webawesome/src/components/qr-code/qr-code.ts
@@ -13,7 +13,7 @@ import styles from './qr-code.styles.js';
  * @status stable
  * @since 2.0
  *
- * @csspart base - The component's base wrapper.
+ * @csspart base - Deprecated. Use the `qr-code` part instead.
  * @csspart qr-code - The component's outer wrapper.
  */
 @customElement('wa-qr-code')

--- a/packages/webawesome/src/components/rating/rating.ts
+++ b/packages/webawesome/src/components/rating/rating.ts
@@ -30,6 +30,7 @@ import styles from './rating.styles.js';
  * @event wa-invalid - Emitted when the form control has been checked for validity and its constraints aren't satisfied.
  *
  * @csspart base - The component's base wrapper.
+ * @csspart rating - The component's outer wrapper.
  *
  * @cssproperty --symbol-color - The inactive color for symbols.
  * @cssproperty --symbol-color-active - The active color for symbols.
@@ -317,7 +318,7 @@ export default class WaRating extends WebAwesomeFormAssociatedElement {
 
     return html`
       <div
-        part="base"
+        part="base rating"
         class=${classMap({
           rating: true,
           'rating-readonly': this.readonly,

--- a/packages/webawesome/src/components/rating/rating.ts
+++ b/packages/webawesome/src/components/rating/rating.ts
@@ -29,7 +29,7 @@ import styles from './rating.styles.js';
  *  rating's value would be if the user were to commit to the hovered value.
  * @event wa-invalid - Emitted when the form control has been checked for validity and its constraints aren't satisfied.
  *
- * @csspart base - The component's base wrapper.
+ * @csspart base - Deprecated. Use the `rating` part instead.
  * @csspart rating - The component's outer wrapper.
  *
  * @cssproperty --symbol-color - The inactive color for symbols.

--- a/packages/webawesome/src/components/spinner/spinner.ts
+++ b/packages/webawesome/src/components/spinner/spinner.ts
@@ -11,7 +11,7 @@ import styles from './spinner.styles.js';
  * @status stable
  * @since 2.0
  *
- * @csspart base - The component's base wrapper.
+ * @csspart base - Deprecated. Use the `spinner` part instead.
  * @csspart spinner - The component's outer wrapper.
  *
  * @cssproperty --track-width - The width of the track.

--- a/packages/webawesome/src/components/spinner/spinner.ts
+++ b/packages/webawesome/src/components/spinner/spinner.ts
@@ -12,6 +12,7 @@ import styles from './spinner.styles.js';
  * @since 2.0
  *
  * @csspart base - The component's base wrapper.
+ * @csspart spinner - The component's outer wrapper.
  *
  * @cssproperty --track-width - The width of the track.
  * @cssproperty --track-color - The color of the track.
@@ -27,7 +28,7 @@ export default class WaSpinner extends WebAwesomeElement {
   render() {
     return html`
       <svg
-        part="base"
+        part="base spinner"
         role="progressbar"
         aria-label=${this.localize.term('loading')}
         fill="none"

--- a/packages/webawesome/src/components/switch/switch.test.ts
+++ b/packages/webawesome/src/components/switch/switch.test.ts
@@ -350,7 +350,7 @@ describe('<wa-switch>', () => {
       describe('CSS parts and states', () => {
         it('should expose CSS parts', async () => {
           const el = await fixture<WaSwitch>(html`<wa-switch hint="Help">Switch</wa-switch>`);
-          expect(el.shadowRoot!.querySelector('[part="base"]')).to.exist;
+          expect(el.shadowRoot!.querySelector('[part~="base"]')).to.exist;
           expect(el.shadowRoot!.querySelector('[part="control"]')).to.exist;
           expect(el.shadowRoot!.querySelector('[part="thumb"]')).to.exist;
           expect(el.shadowRoot!.querySelector('[part="label"]')).to.exist;

--- a/packages/webawesome/src/components/switch/switch.ts
+++ b/packages/webawesome/src/components/switch/switch.ts
@@ -31,6 +31,7 @@ import styles from './switch.styles.js';
  * @event wa-invalid - Emitted when the form control has been checked for validity and its constraints aren't satisfied.
  *
  * @csspart base - The component's base wrapper.
+ * @csspart switch - The component's outer wrapper.
  * @csspart control - The control that houses the switch's thumb.
  * @csspart thumb - The switch's thumb.
  * @csspart label - The switch's label.
@@ -228,7 +229,7 @@ export default class WaSwitch extends WebAwesomeFormAssociatedElement {
 
     return html`
       <label
-        part="base"
+        part="base switch"
         class=${classMap({
           checked: this.checked,
           disabled: this.disabled,

--- a/packages/webawesome/src/components/switch/switch.ts
+++ b/packages/webawesome/src/components/switch/switch.ts
@@ -30,7 +30,7 @@ import styles from './switch.styles.js';
  * @event focus - Emitted when the control gains focus.
  * @event wa-invalid - Emitted when the form control has been checked for validity and its constraints aren't satisfied.
  *
- * @csspart base - The component's base wrapper.
+ * @csspart base - Deprecated. Use the `switch` part instead.
  * @csspart switch - The component's outer wrapper.
  * @csspart control - The control that houses the switch's thumb.
  * @csspart thumb - The switch's thumb.

--- a/packages/webawesome/src/components/tab-group/tab-group.ts
+++ b/packages/webawesome/src/components/tab-group/tab-group.ts
@@ -32,7 +32,7 @@ import styles from './tab-group.styles.js';
  * @event {{ name: String }} wa-tab-show - Emitted when a tab is shown.
  * @event {{ name: String }} wa-tab-hide - Emitted when a tab is hidden.
  *
- * @csspart base - The component's base wrapper.
+ * @csspart base - Deprecated. Use the `tab-group` part instead.
  * @csspart tab-group - The component's outer wrapper.
  * @csspart nav - The tab group's navigation container where tabs are slotted in.
  * @csspart tabs - The container that wraps the tabs.

--- a/packages/webawesome/src/components/tab-group/tab-group.ts
+++ b/packages/webawesome/src/components/tab-group/tab-group.ts
@@ -33,6 +33,7 @@ import styles from './tab-group.styles.js';
  * @event {{ name: String }} wa-tab-hide - Emitted when a tab is hidden.
  *
  * @csspart base - The component's base wrapper.
+ * @csspart tab-group - The component's outer wrapper.
  * @csspart nav - The tab group's navigation container where tabs are slotted in.
  * @csspart tabs - The container that wraps the tabs.
  * @csspart body - The tab group's body where tab panels are slotted in.
@@ -396,7 +397,7 @@ export default class WaTabGroup extends WebAwesomeElement {
 
     return html`
       <div
-        part="base"
+        part="base tab-group"
         class=${classMap({
           'tab-group': true,
           'tab-group-top': this.placement === 'top',

--- a/packages/webawesome/src/components/tab-panel/tab-panel.ts
+++ b/packages/webawesome/src/components/tab-panel/tab-panel.ts
@@ -15,7 +15,7 @@ let id = 0;
  *
  * @slot - The tab panel's content.
  *
- * @csspart base - The component's base wrapper.
+ * @csspart base - Deprecated. Style the host element instead.
  *
  * @cssproperty --padding - The tab panel's padding.
  */

--- a/packages/webawesome/src/components/tab-panel/tab-panel.ts
+++ b/packages/webawesome/src/components/tab-panel/tab-panel.ts
@@ -16,6 +16,7 @@ let id = 0;
  * @slot - The tab panel's content.
  *
  * @csspart base - The component's base wrapper.
+ * @csspart tab-panel - The component's outer wrapper. As a `<slot>`, set `display` before applying box styles.
  *
  * @cssproperty --padding - The tab panel's padding.
  */
@@ -47,7 +48,7 @@ export default class WaTabPanel extends WebAwesomeElement {
   render() {
     return html`
       <slot
-        part="base"
+        part="base tab-panel"
         class=${classMap({
           'tab-panel': true,
           'tab-panel-active': this.active,

--- a/packages/webawesome/src/components/tab/tab.ts
+++ b/packages/webawesome/src/components/tab/tab.ts
@@ -16,6 +16,7 @@ let id = 0;
  * @slot - The tab's label.
  *
  * @csspart base - The component's base wrapper.
+ * @csspart tab - The component's outer wrapper.
  */
 @customElement('wa-tab')
 export default class WaTab extends WebAwesomeElement {
@@ -71,7 +72,7 @@ export default class WaTab extends WebAwesomeElement {
 
     return html`
       <div
-        part="base"
+        part="base tab"
         class=${classMap({
           tab: true,
           'tab-active': this.active,

--- a/packages/webawesome/src/components/tab/tab.ts
+++ b/packages/webawesome/src/components/tab/tab.ts
@@ -15,7 +15,7 @@ let id = 0;
  *
  * @slot - The tab's label.
  *
- * @csspart base - The component's base wrapper.
+ * @csspart base - Deprecated. Use the `tab` part instead.
  * @csspart tab - The component's outer wrapper.
  */
 @customElement('wa-tab')

--- a/packages/webawesome/src/components/tag/tag.ts
+++ b/packages/webawesome/src/components/tag/tag.ts
@@ -23,7 +23,7 @@ import styles from './tag.styles.js';
  *
  * @event wa-remove - Emitted when the remove button is activated.
  *
- * @csspart base - The component's base wrapper.
+ * @csspart base - Deprecated. Style the host element instead.
  * @csspart content - The tag's content.
  * @csspart remove-button - The tag's remove button, a `<wa-button>`.
  * @csspart remove-button__base - The remove button's exported `base` part.

--- a/packages/webawesome/src/components/textarea/textarea.ts
+++ b/packages/webawesome/src/components/textarea/textarea.ts
@@ -35,6 +35,7 @@ import styles from './textarea.styles.js';
  * @csspart hint - The hint's wrapper.
  * @csspart textarea - The internal `<textarea>` control.
  * @csspart base - The wrapper around the `<textarea>` control.
+ * @csspart textarea-wrapper - The component's outer wrapper.
  * @csspart textarea-adjuster - The invisible sizer that grows the control to fit its content when `resize` is `auto`.
  * @csspart count - The character count element, rendered when the `with-count` attribute is present.
  *
@@ -450,7 +451,7 @@ export default class WaTextarea extends WebAwesomeFormAssociatedElement {
         <slot name="label">${this.label}</slot>
       </label>
 
-      <div part="base" class="textarea">
+      <div part="base textarea-wrapper" class="textarea">
         <textarea
           part="textarea"
           id="input"

--- a/packages/webawesome/src/components/textarea/textarea.ts
+++ b/packages/webawesome/src/components/textarea/textarea.ts
@@ -34,7 +34,7 @@ import styles from './textarea.styles.js';
  * @csspart form-control-input - The input's wrapper.
  * @csspart hint - The hint's wrapper.
  * @csspart textarea - The internal `<textarea>` control.
- * @csspart base - The wrapper around the `<textarea>` control.
+ * @csspart base - Deprecated. Use the `textarea-wrapper` part instead.
  * @csspart textarea-wrapper - The component's outer wrapper.
  * @csspart textarea-adjuster - The invisible sizer that grows the control to fit its content when `resize` is `auto`.
  * @csspart count - The character count element, rendered when the `with-count` attribute is present.

--- a/packages/webawesome/src/components/time-input/time-input.ts
+++ b/packages/webawesome/src/components/time-input/time-input.ts
@@ -82,7 +82,7 @@ const SINGLE_GROUP = 'single';
  * @csspart form-control-label - The label's wrapper.
  * @csspart form-control-input - The input's wrapper.
  * @csspart hint - The hint's wrapper.
- * @csspart base - The component's base wrapper.
+ * @csspart base - Deprecated. Use the `time-input` part instead.
  * @csspart time-input - The component's outer wrapper.
  * @csspart input-wrapper - The container around the start slot, segmented input, clear button, and expand button.
  * @csspart start - The container that wraps the `start` slot.

--- a/packages/webawesome/src/components/time-input/time-input.ts
+++ b/packages/webawesome/src/components/time-input/time-input.ts
@@ -83,6 +83,7 @@ const SINGLE_GROUP = 'single';
  * @csspart form-control-input - The input's wrapper.
  * @csspart hint - The hint's wrapper.
  * @csspart base - The component's base wrapper.
+ * @csspart time-input - The component's outer wrapper.
  * @csspart input-wrapper - The container around the start slot, segmented input, clear button, and expand button.
  * @csspart start - The container that wraps the `start` slot.
  * @csspart end - The container that wraps the `end` slot.
@@ -976,7 +977,7 @@ export default class WaTimeInput extends WebAwesomeFormAssociatedElement {
             shift
           >
             <div
-              part="base input-wrapper"
+              part="base time-input input-wrapper"
               class="input-wrapper"
               slot="anchor"
               @pointerdown=${this.handleInputWrapperPointerDown}

--- a/packages/webawesome/src/components/tooltip/tooltip.ts
+++ b/packages/webawesome/src/components/tooltip/tooltip.ts
@@ -30,6 +30,7 @@ import styles from './tooltip.styles.js';
  * @event wa-after-hide - Emitted after the tooltip has hidden and all animations are complete.
  *
  * @csspart base - The component's base wrapper, an `<wa-popup>` element.
+ * @csspart tooltip - The component's outer wrapper.
  * @csspart base__popup - The popup's exported `popup` part. Use this to target the tooltip's popup container.
  * @csspart base__arrow - The popup's exported `arrow` part. Use this to target the tooltip's arrow.
  * @csspart body - The tooltip's body where its content is rendered.
@@ -382,7 +383,7 @@ export default class WaTooltip extends WebAwesomeElement {
   render() {
     return html`
       <wa-popup
-        part="base"
+        part="base tooltip"
         exportparts="
           popup:base__popup,
           arrow:base__arrow

--- a/packages/webawesome/src/components/tooltip/tooltip.ts
+++ b/packages/webawesome/src/components/tooltip/tooltip.ts
@@ -29,7 +29,7 @@ import styles from './tooltip.styles.js';
  * @event wa-hide - Emitted when the tooltip begins to hide.
  * @event wa-after-hide - Emitted after the tooltip has hidden and all animations are complete.
  *
- * @csspart base - The component's base wrapper, an `<wa-popup>` element.
+ * @csspart base - Deprecated. Use the `tooltip` part instead.
  * @csspart tooltip - The component's outer wrapper.
  * @csspart base__popup - The popup's exported `popup` part. Use this to target the tooltip's popup container.
  * @csspart base__arrow - The popup's exported `arrow` part. Use this to target the tooltip's arrow.

--- a/packages/webawesome/src/components/tree-item/tree-item.ts
+++ b/packages/webawesome/src/components/tree-item/tree-item.ts
@@ -48,6 +48,7 @@ export const treeItemContext = createContext<TreeItemContext>('wa-tree-item');
  * @slot collapse-icon - The icon to show when the tree item is collapsed.
  *
  * @csspart base - The component's base wrapper.
+ * @csspart tree-item - The component's outer wrapper.
  * @csspart item - The tree item's container. This element wraps everything except slotted tree item children.
  * @csspart indentation - The tree item's indentation container.
  * @csspart expand-button - The container that wraps the tree item's expand button and spinner.
@@ -315,7 +316,7 @@ export default class WaTreeItem extends WebAwesomeElement {
 
     return html`
       <div
-        part="base"
+        part="base tree-item"
         class="${classMap({
           'tree-item': true,
           'tree-item-expanded': this.expanded,

--- a/packages/webawesome/src/components/tree-item/tree-item.ts
+++ b/packages/webawesome/src/components/tree-item/tree-item.ts
@@ -47,7 +47,7 @@ export const treeItemContext = createContext<TreeItemContext>('wa-tree-item');
  * @slot expand-icon - The icon to show when the tree item is expanded.
  * @slot collapse-icon - The icon to show when the tree item is collapsed.
  *
- * @csspart base - The component's base wrapper.
+ * @csspart base - Deprecated. Use the `tree-item` part instead.
  * @csspart tree-item - The component's outer wrapper.
  * @csspart item - The tree item's container. This element wraps everything except slotted tree item children.
  * @csspart indentation - The tree item's indentation container.

--- a/packages/webawesome/src/components/tree/tree.ts
+++ b/packages/webawesome/src/components/tree/tree.ts
@@ -63,7 +63,7 @@ function syncCheckboxes(changedTreeItem: WaTreeItem, initialSync = false) {
  * @slot expand-icon - The icon to show when the tree item is expanded. Works best with `<wa-icon>`.
  * @slot collapse-icon - The icon to show when the tree item is collapsed. Works best with `<wa-icon>`.
  *
- * @csspart base - The component's base wrapper.
+ * @csspart base - Deprecated. Use the `tree` part instead.
  * @csspart tree - The component's outer wrapper.
  *
  * @cssproperty [--indent-size=var(--wa-space-m)] - The size of the indentation for nested items.

--- a/packages/webawesome/src/components/tree/tree.ts
+++ b/packages/webawesome/src/components/tree/tree.ts
@@ -64,6 +64,7 @@ function syncCheckboxes(changedTreeItem: WaTreeItem, initialSync = false) {
  * @slot collapse-icon - The icon to show when the tree item is collapsed. Works best with `<wa-icon>`.
  *
  * @csspart base - The component's base wrapper.
+ * @csspart tree - The component's outer wrapper.
  *
  * @cssproperty [--indent-size=var(--wa-space-m)] - The size of the indentation for nested items.
  * @cssproperty [--indent-guide-color=var(--wa-color-surface-border)] - The color of the indentation line.
@@ -420,7 +421,7 @@ export default class WaTree extends WebAwesomeElement {
   render() {
     return html`
       <div
-        part="base"
+        part="base tree"
         class="tree"
         @click=${this.handleClick}
         @keydown=${this.handleKeyDown}


### PR DESCRIPTION
This work supersedes the closed https://github.com/shoelace-style/webawesome/pull/2632 .

It attempts to settle the naming question from https://github.com/shoelace-style/webawesome/issues/2624 and https://github.com/shoelace-style/webawesome/issues/2626. 

`base` is a generic name we've been stuck with since v3. This gives every component a part named after itself (`accordion`, `details`, `tab-panel`) and quietly demotes `base` to an alias that still works.

### The Convention
- Every component that renders a `base` wrapper now renders its own name alongside it. 
- `<wa-details>` becomes `part="base details"`, `<wa-tab-panel>` becomes `part="base tab-panel"`, and so on. 
- Where the component name is already spoken for — `input` and `textarea` use it for their native control:  the wrapper takes a `-wrapper` suffix instead: `input-wrapper`, `textarea-wrapper`.
- `accordion` never had a `base` (it was a bare `<slot>`), so it just gets `part="accordion"`, no `base` at all. 
- New components work the same way: the Plop scaffold now emits the canonical part and drops `base` entirely, so it stops spreading.
- Components with no wrapper to name are left alone. `card`, `dropdown`, and `tag` are the container themselves, so you style them on the host. The headless utilities (`format-*`, the observers) render nothing and get nothing.

### `base` Doesn't Go Away
- `base` is still a real `::part()` target. 
- Every `wa-foo::part(base)` selector out there keeps working, and it stays in the custom-elements manifest so tooling and IDEs still see it. 
- The only change: it's filtered out of the generated CSS Parts table in the docs, so the canonical name is what people actually read. 
- Deprecating it is a v4 job, removing it a v5 one.

### Enforcement
`check-css-parts.js` fails the build if a `base`-rendering component forgets its canonical part, so this can't rot back to `base`-only.  Its allowlist is parameterized so the Pro package reuses the same checker instead of duplicating it.

### One Bug Fix
`dropdown` was grabbing its trigger button's base with an exact `[part="base"]` selector. 

That broke the second the button started rendering `part="base button"` — the query returned null and `aria` attributes stopped getting set. Switched it to `[part~="base"]`.

## Companion PRs
- https://github.com/shoelace-style/webawesome-pro/pull/263
