### PR TITLE
Checkbox: Render the Documented `checked-icon` CSS Part

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -46,6 +46,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 - Fixed a bug in `<wa-checkbox>` where it would improperly submit values after it was enabled after being disabled. [pr:2607]
 - Fixed the remove button in `<wa-tag>` to match the tag's `size` [pr:2615]
 - Fixed missing CSS parts documentation for `<wa-card>`, `<wa-color-picker>`, `<wa-textarea>`, `<wa-scroller>`, and `<wa-page>` [pr:2623]
+- Fixed `<wa-checkbox>` rendering its checked icon under the undocumented `check-icon` CSS part; it now uses the documented `checked-icon` part, matching `<wa-radio>`
 
 :::
 

--- a/packages/webawesome/src/components/checkbox/checkbox.test.ts
+++ b/packages/webawesome/src/components/checkbox/checkbox.test.ts
@@ -426,7 +426,7 @@ describe('<wa-checkbox>', () => {
 
         it('should show check icon instead of indeterminate icon when checked', async () => {
           const el = await fixture<WaCheckbox>(html`<wa-checkbox checked></wa-checkbox>`);
-          expect(el.shadowRoot!.querySelector('[part~="check-icon"]')).to.exist;
+          expect(el.shadowRoot!.querySelector('[part~="checked-icon"]')).to.exist;
           expect(el.shadowRoot!.querySelector('[part~="indeterminate-icon"]')).to.be.null;
         });
       });

--- a/packages/webawesome/src/components/checkbox/checkbox.ts
+++ b/packages/webawesome/src/components/checkbox/checkbox.ts
@@ -227,7 +227,7 @@ export default class WaCheckbox extends WebAwesomeFormAssociatedElement {
     const isIndeterminate = !this.checked && this.indeterminate;
 
     const iconName = isIndeterminate ? 'indeterminate' : 'check';
-    const iconState = isIndeterminate ? 'indeterminate' : 'check';
+    const iconState = isIndeterminate ? 'indeterminate' : 'checked';
 
     // We need to use the attribute for SSR, because for some reason Lit SSR always sets `.checked=${live(this.checked)}` as "true"
     // TODO: Tell Konnor to submit a bug report + repo about this.


### PR DESCRIPTION
`<wa-checkbox>` has always documented a `checked-icon` CSS part — it's in the JSDoc, it's in the CEM, and `<wa-radio>` uses that same name. 

But a checked checkbox was actually rendering that icon under `check-icon`, a part name that shows up nowhere in the docs. Follow the docs, write `::part(checked-icon)`, get nothing.

### The Fix 
- The part name comes from `iconState`, which was `'check'` for the checked state. 
- It's now `'checked'`, so the rendered part is `checked-icon`. 
- The icon glyph itself (`iconName`) didn't change: only the part label was wrong, and only for the checked state.
- Also updated the test that was still asserting the old `check-icon`
- Added a changelog line

FYI - Found during work and review on #2621.
