### PR TITLE
Improve Utilities Documentation

### DIFF
--- a/packages/webawesome/docs/docs/utilities/cluster.md
+++ b/packages/webawesome/docs/docs/utilities/cluster.md
@@ -99,13 +99,7 @@ Clusters are great for inline lists and aligning items of varying sizes.
 
 ## Align Items
 
-By default, items are centered in the block direction of the `wa-cluster` container. You can add any of the following [`wa-align-items-*`](/docs/utilities/align-items) classes to an element with `wa-cluster` to specify how items are aligned in the block direction:
-
-- `wa-align-items-start`
-- `wa-align-items-end`
-- `wa-align-items-center`
-- `wa-align-items-stretch`
-- `wa-align-items-baseline`
+By default, items are centered in the block direction of the `wa-cluster` container. Add any [`wa-align-items-*`](/docs/utilities/align-items) class to change how items line up in the block direction.
 
 ```html {.example}
 <div class="wa-stack">
@@ -134,20 +128,7 @@ By default, items are centered in the block direction of the `wa-cluster` contai
 
 ## Gap
 
-By default, the gap between cluster items uses `--wa-space-m` from your theme. You can add any of the following [`wa-gap-*`](/docs/utilities/gap) classes to an element with `wa-cluster` to specify the gap between items:
-
-- `wa-gap-0`
-- `wa-gap-3xs`
-- `wa-gap-2xs`
-- `wa-gap-xs`
-- `wa-gap-s`
-- `wa-gap-m`
-- `wa-gap-l`
-- `wa-gap-xl`
-- `wa-gap-2xl`
-- `wa-gap-3xl`
-- `wa-gap-4xl`
-- `wa-gap-5xl`
+By default, the gap between cluster items uses `--wa-space-m` from your theme. Add any [`wa-gap-*`](/docs/utilities/gap) class to change the spacing between items.
 
 ```html {.example}
 <div class="wa-stack">

--- a/packages/webawesome/docs/docs/utilities/color.md
+++ b/packages/webawesome/docs/docs/utilities/color.md
@@ -26,7 +26,7 @@ Add one of these classes to any element to apply a semantic color:
 
 | Class Name   | Best For                              |
 | ------------ | ------------------------------------- |
-| `wa-brand`   | Primary emphasis and brand moments    |
+| `wa-brand`   | Primary emphasis and brand color      |
 | `wa-neutral` | Default, low-emphasis UI              |
 | `wa-success` | Positive or confirming states         |
 | `wa-warning` | Cautionary states that need attention |

--- a/packages/webawesome/docs/docs/utilities/color.md
+++ b/packages/webawesome/docs/docs/utilities/color.md
@@ -24,11 +24,13 @@ Several Web Awesome components (like [`<wa-badge>`](/docs/components/badge), [`<
 
 Add one of these classes to any element to apply a semantic color:
 
-- `.wa-brand`
-- `.wa-neutral`
-- `.wa-success`
-- `.wa-warning`
-- `.wa-danger`
+| Class Name   | Best For                              |
+| ------------ | ------------------------------------- |
+| `wa-brand`   | Primary emphasis and brand moments    |
+| `wa-neutral` | Default, low-emphasis UI              |
+| `wa-success` | Positive or confirming states         |
+| `wa-warning` | Cautionary states that need attention |
+| `wa-danger`  | Errors and destructive actions        |
 
 ## How Variants Work
 

--- a/packages/webawesome/docs/docs/utilities/color.md
+++ b/packages/webawesome/docs/docs/utilities/color.md
@@ -36,16 +36,16 @@ The variant classes don't apply styles directly. Instead, each one points a gene
 
 Web Awesome's [native styles](/docs/utilities/native/) use this pattern wherever it made sense, which is how a native `<button>` can pick up a `.wa-success` class and just work.
 
-## Example: Custom Class with Variants
+## Custom Class with Variants
 
 Here's a tiny `.callout` class that responds to every color variant without any extra selectors:
 
-```html { .example }
-<p class="callout">This is a callout.</p>
-<p class="callout wa-brand">This is a callout.</p>
-<p class="callout wa-success">This is a callout.</p>
-<p class="callout wa-warning">This is a callout.</p>
-<p class="callout wa-danger">This is a callout.</p>
+```html {.example}
+<p class="callout">Neutral</p>
+<p class="callout wa-brand">Brand</p>
+<p class="callout wa-success">Success</p>
+<p class="callout wa-warning">Warning</p>
+<p class="callout wa-danger">Danger</p>
 
 <style>
   .callout {

--- a/packages/webawesome/docs/docs/utilities/flank.md
+++ b/packages/webawesome/docs/docs/utilities/flank.md
@@ -147,13 +147,7 @@ The main content fills the remaining inline space of the container. By default, 
 
 ## Align Items
 
-By default, items are centered in the block direction of the `wa-flank` container. You can add any of the following [`wa-align-items-*`](/docs/utilities/align-items) classes to an element with `wa-flank` to specify how items are aligned in the block direction:
-
-- `wa-align-items-start`
-- `wa-align-items-end`
-- `wa-align-items-center`
-- `wa-align-items-stretch`
-- `wa-align-items-baseline`
+By default, items are centered in the block direction of the `wa-flank` container. Add any [`wa-align-items-*`](/docs/utilities/align-items) class to change how items line up in the block direction.
 
 ```html {.example}
 <div class="wa-stack">
@@ -178,18 +172,7 @@ By default, items are centered in the block direction of the `wa-flank` containe
 
 ## Gap
 
-By default, the gap between flank items uses `--wa-space-m` from your theme. You can add any of the following [`wa-gap-*`](/docs/utilities/gap) classes to an element with `wa-flank` to specify the gap between items:
-
-- `wa-gap-0`
-- `wa-gap-3xs`
-- `wa-gap-2xs`
-- `wa-gap-xs`
-- `wa-gap-s`
-- `wa-gap-m`
-- `wa-gap-l`
-- `wa-gap-xl`
-- `wa-gap-2xl`
-- `wa-gap-3xl`
+By default, the gap between flank items uses `--wa-space-m` from your theme. Add any [`wa-gap-*`](/docs/utilities/gap) class to change the spacing between items.
 
 ```html {.example}
 <div class="wa-stack">

--- a/packages/webawesome/docs/docs/utilities/flank.md
+++ b/packages/webawesome/docs/docs/utilities/flank.md
@@ -113,9 +113,9 @@ By default, the first item in the `wa-flank` container will flank the other cont
 </div>
 ```
 
-## Sizing
+## Size
 
-The flank's inline size is determined by the size of its content, but you can set a target size using the `--flank-size` property. When the flank wraps, it stretches to fill the inline size of the container.
+The flank's inline size is determined by the size of its content, but you can set a target size using the `--flank-size` custom property. When the flank wraps, it stretches to fill the inline size of the container.
 
 ```html {.example}
 <div class="wa-stack">
@@ -130,7 +130,7 @@ The flank's inline size is determined by the size of its content, but you can se
 </div>
 ```
 
-The main content fills the remaining inline space of the container. By default, the items wrap when the main content is less than 50% of the container. You can change the minimum size of the main content with the `--content-percentage` property.
+The main content fills the remaining inline space of the container. By default, the items wrap when the main content is less than 50% of the container. You can change the minimum size of the main content with the `--content-percentage` custom property.
 
 ```html {.example}
 <div class="wa-stack">

--- a/packages/webawesome/docs/docs/utilities/frame.md
+++ b/packages/webawesome/docs/docs/utilities/frame.md
@@ -151,16 +151,7 @@ Frames have a square aspect ratio by default. You can append `:square` (1 / 1), 
 
 ## Border Radius
 
-Frames have a square border radius by default. You can add any of the following [`wa-border-radius-*`](/docs/utilities/rounding) classes to an element with `wa-frame` to specify the border radius:
-
-- `wa-border-radius-s`
-- `wa-border-radius-m`
-- `wa-border-radius-l`
-- `wa-border-radius-pill`
-- `wa-border-radius-circle`
-- `wa-border-radius-square`
-
-Alternatively, you can define the `border-radius` property to set custom rounding.
+Frames have a square border radius by default. Add any [`wa-border-radius-*`](/docs/utilities/rounding) class to round the corners, or define the `border-radius` property to set custom rounding.
 
 ```html {.example}
 <div class="wa-grid">

--- a/packages/webawesome/docs/docs/utilities/grid.md
+++ b/packages/webawesome/docs/docs/utilities/grid.md
@@ -155,9 +155,9 @@ Grids work especially well for card lists and content designed for browsing.
 </style>
 ```
 
-## Sizing
+## Size
 
-By default, grid items will wrap when the grid's column size is less than `20ch`, but you can set a custom minimum column size using the `--min-column-size` property.
+By default, grid items will wrap when the grid's column size is less than `20ch`, but you can set a custom minimum column size using the `--min-column-size` custom property.
 
 ```html {.example}
 <div class="wa-stack">

--- a/packages/webawesome/docs/docs/utilities/grid.md
+++ b/packages/webawesome/docs/docs/utilities/grid.md
@@ -182,18 +182,7 @@ By default, grid items will wrap when the grid's column size is less than `20ch`
 
 ## Gap
 
-By default, the gap between grid items uses `--wa-space-m` from your theme. You can add any of the following [`wa-gap-*`](/docs/utilities/gap) classes to an element with `wa-grid` to specify the gap between items:
-
-- `wa-gap-0`
-- `wa-gap-3xs`
-- `wa-gap-2xs`
-- `wa-gap-xs`
-- `wa-gap-s`
-- `wa-gap-m`
-- `wa-gap-l`
-- `wa-gap-xl`
-- `wa-gap-2xl`
-- `wa-gap-3xl`
+By default, the gap between grid items uses `--wa-space-m` from your theme. Add any [`wa-gap-*`](/docs/utilities/gap) class to change the spacing between cells.
 
 ```html {.example}
 <div class="wa-stack">

--- a/packages/webawesome/docs/docs/utilities/native.md
+++ b/packages/webawesome/docs/docs/utilities/native.md
@@ -1,7 +1,7 @@
 ---
 title: Native Styles
 description: Native styles apply your theme to native HTML elements so they match the look and feel of Web Awesome components.
-layout: page-outline
+layout: docs
 tags: styleUtilities
 synonyms:
   - browser default
@@ -404,7 +404,7 @@ Add the `wa-hover-rows` class to highlight table rows on hover and the `wa-zebra
 </table>
 ```
 
-For tables with a lot of numeric date, add the `wa-tabular-nums` class to any row, column, or whole table to ensure digits align.
+For tables with a lot of numeric data, add the `wa-tabular-nums` class to any row, column, or whole table to ensure digits align.
 
 ```html {.example}
 <table class="wa-tabular-nums">

--- a/packages/webawesome/docs/docs/utilities/prose.md
+++ b/packages/webawesome/docs/docs/utilities/prose.md
@@ -1,7 +1,7 @@
 ---
 title: Prose
 description: The wa-prose utility applies hierarchical, asymmetric typographic rhythm to long-form content like documentation, articles, and marketing copy.
-layout: page-outline
+layout: docs
 tags: styleUtilities
 synonyms:
   - prose
@@ -193,7 +193,7 @@ A few quieter refinements come along with the rhythm:
 Apply any [`wa-font-size-*`](/docs/utilities/text/#font-size) utility to a `wa-prose` container and text, headings, and rhythm scale together. No size variants required.
 
 ```html {.example}
-<div class="wa-cluster wa-align-items-flex-start" style="gap: var(--wa-space-l);">
+<div class="wa-cluster wa-align-items-start" style="gap: var(--wa-space-l);">
   <article class="wa-prose" style="--wa-prose-line-length: 28ch;">
     <h3>Default size</h3>
     <p>A quiet morning is the rarest hour of the day — claim it before the world wakes up.</p>
@@ -219,7 +219,7 @@ Apply any [`wa-font-size-*`](/docs/utilities/text/#font-size) utility to a `wa-p
 Set `--wa-prose-rhythm-scale` on the prose container to multiply every margin in the system. Values below `1` tighten the rhythm; values above loosen it. Type sizes are unaffected.
 
 ```html {.example}
-<div class="wa-cluster wa-align-items-flex-start" style="gap: var(--wa-space-l);">
+<div class="wa-cluster wa-align-items-start" style="gap: var(--wa-space-l);">
   <article class="wa-prose" style="--wa-prose-line-length: 28ch;">
     <h3>Default rhythm</h3>
     <p>Two paragraphs of the same length, at the same size.</p>
@@ -263,7 +263,7 @@ Apply `wa-not-prose` to any element inside a `wa-prose` container to disable pro
 <article class="wa-prose wa-font-size-s">
   <h3>Ready when you are</h3>
   <p>
-    The content in this section follows prose rhythm and adopt a smaller font size. The callout below is given
+    The content in this section follows prose rhythm and adopts a smaller font size. The callout below is given
     <code>wa-not-prose</code>, so its spacing and font sizing revert to element defaults.
   </p>
 
@@ -271,7 +271,10 @@ Apply `wa-not-prose` to any element inside a `wa-prose` container to disable pro
     <wa-icon slot="icon" name="highlighter"></wa-icon>
     <div class="wa-stack wa-gap-s">
       <h4>Leave it to the prose</h4>
-      <p>This callout and its child elements are exempt from <code>wa-prose</code> rules, thanks to <code>wa-not-prose</code>.</p>
+      <p>
+        This callout and its child elements are exempt from <code>wa-prose</code> rules, thanks to
+        <code>wa-not-prose</code>.
+      </p>
     </div>
   </wa-callout>
 

--- a/packages/webawesome/docs/docs/utilities/split.md
+++ b/packages/webawesome/docs/docs/utilities/split.md
@@ -118,15 +118,7 @@ Items can be split across a row or a column by appending `:row` or `:column` to 
 
 ## Align Items
 
-By default, items are centered on the cross axis of the `wa-split` container. You can add any of the following [`wa-align-items-*`](/docs/utilities/align-items) classes to an element with `wa-split` to specify how items are aligned:
-
-- `wa-align-items-start`
-- `wa-align-items-end`
-- `wa-align-items-center`
-- `wa-align-items-stretch`
-- `wa-align-items-baseline`
-
-These modifiers specify how items are aligned in the block direction for `wa-split:row` and in the inline direction for `wa-split:column`.
+By default, items are centered on the cross axis of the `wa-split` container. Add any [`wa-align-items-*`](/docs/utilities/align-items) class to change how items line up: in the block direction for `wa-split:row` and in the inline direction for `wa-split:column`.
 
 ```html {.example}
 <div class="wa-stack">
@@ -151,18 +143,7 @@ These modifiers specify how items are aligned in the block direction for `wa-spl
 
 ## Gap
 
-A split's gap determines how close items can be before they wrap. By default, the gap between split items uses `--wa-space-m` from your theme. You can add any of the following [`wa-gap-*`](/docs/utilities/gap) classes to an element with `wa-split` to specify the gap between items:
-
-- `wa-gap-0`
-- `wa-gap-3xs`
-- `wa-gap-2xs`
-- `wa-gap-xs`
-- `wa-gap-s`
-- `wa-gap-m`
-- `wa-gap-l`
-- `wa-gap-xl`
-- `wa-gap-2xl`
-- `wa-gap-3xl`
+A split's gap determines how close items can be before they wrap. By default, the gap between split items uses `--wa-space-m` from your theme. Add any [`wa-gap-*`](/docs/utilities/gap) class to change the spacing between items.
 
 ```html {.example}
 <div class="wa-stack">

--- a/packages/webawesome/docs/docs/utilities/stack.md
+++ b/packages/webawesome/docs/docs/utilities/stack.md
@@ -75,13 +75,7 @@ Stacks are well suited for forms, text, and ensuring consistent spacing between 
 
 ## Align Items
 
-By default, items stretch to fill the inline size of the `wa-stack` container. You can add any of the following [`wa-align-items-*`](/docs/utilities/align-items) classes to an element with `wa-stack` to specify how items are aligned in the inline direction:
-
-- `wa-align-items-start`
-- `wa-align-items-end`
-- `wa-align-items-center`
-- `wa-align-items-stretch`
-- `wa-align-items-baseline`
+By default, items stretch to fill the inline size of the `wa-stack` container. Add any [`wa-align-items-*`](/docs/utilities/align-items) class to change how items line up in the inline direction.
 
 ```html {.example}
 <div class="wa-grid">
@@ -105,20 +99,7 @@ By default, items stretch to fill the inline size of the `wa-stack` container. Y
 
 ## Gap
 
-By default, the gap between stack items uses `--wa-space-m` from your theme. You can add any of the following [`wa-gap-*`](/docs/utilities/gap) classes to an element with `wa-stack` to specify the gap between items:
-
-- `wa-gap-0`
-- `wa-gap-3xs`
-- `wa-gap-2xs`
-- `wa-gap-xs`
-- `wa-gap-s`
-- `wa-gap-m`
-- `wa-gap-l`
-- `wa-gap-xl`
-- `wa-gap-2xl`
-- `wa-gap-3xl`
-- `wa-gap-4xl`
-- `wa-gap-5xl`
+By default, the gap between stack items uses `--wa-space-m` from your theme. Add any [`wa-gap-*`](/docs/utilities/gap) class to change the spacing between items.
 
 ```html {.example}
 <div class="wa-grid">

--- a/packages/webawesome/docs/docs/utilities/text.md
+++ b/packages/webawesome/docs/docs/utilities/text.md
@@ -1,6 +1,6 @@
 ---
 title: Text
-description: Text utility classes use custom properties from your Web Awesome theme and other standard CSS properties to style text elements on the fly.
+description: Text utility classes use design tokens from your Web Awesome theme and standard CSS properties to style text elements on the fly.
 layout: docs
 tags: styleUtilities
 synonyms:
@@ -190,7 +190,7 @@ Use these classes to control how text wraps across lines. They apply standard CS
 :::
 
 :::info
-The original `wa-text-wrap-nowrap`, `wa-text-wrap-balance`, and `wa-text-wrap-pretty` class names continue to work as aliases for backwards compatibility. These older names are deprecated and will be removed in a future major version — we recommend updating to the shorter `wa-text-*` names above.
+The original `wa-text-wrap-nowrap`, `wa-text-wrap-balance`, and `wa-text-wrap-pretty` class names continue to work as aliases for backwards compatibility. These older names are deprecated and will be removed in a future major version; update to the shorter `wa-text-*` names above.
 :::
 
 ## Transform
@@ -226,7 +226,7 @@ Use these classes to align text within its container. They apply standard CSS [`
 | `wa-text-end`     | <div class="wa-text-end preview-wrapper">Five boxing wizards</div>                                                            |
 | `wa-text-justify` | <div class="wa-text-justify preview-wrapper">The five boxing wizards jump quickly. How quickly daft jumping zebras vex!</div> |
 
-::: info
+:::info
 Justified text can create uneven word spacing that's [harder for everyone to read](https://www.w3.org/WAI/WCAG21/Understanding/visual-presentation.html) and especially difficult for folks with dyslexia. Reserve it for short, narrow text columns.
 :::
 

--- a/packages/webawesome/docs/docs/utilities/visually-hidden.md
+++ b/packages/webawesome/docs/docs/utilities/visually-hidden.md
@@ -42,7 +42,7 @@ In this example, the link will open a new window. Screen readers will announce "
 
 ### Content Conveyed by Context
 
-Adding a label may seem redundant at times, but they're very helpful for unsighted users. Rather than omit them, you can provide context to unsighted users with visually hidden content that will be announced by assistive devices such as screen readers.
+Adding a label may seem redundant at times, but labels are very helpful for unsighted users. Rather than omit them, you can provide context with visually hidden content that will be announced by assistive devices such as screen readers.
 
 ```html {.example}
 <wa-card style="width: 100%; max-width: 360px;">


### PR DESCRIPTION
A House Rules pass is applied over all 17 CSS Utility Docs, following the same playbook as the component-docs passes (Actions, Forms, Feedback, Media). 

### Conventions
- Singularized heading drift: `Sizing` → `Size` on `flank` and `grid`.
- Named the utility-exposed custom properties as such: `--flank-size`, `--content-percentage`, `--min-column-size`. `text`'s description now calls the theme values design tokens, not custom properties.

### Examples
- `color`'s bare variant-class list is now presented in a table with more details.
- Each section keeps its in-context live example and links out to the canonical reference.

### Redundancy
- Trimmed the repeated `gap`, `align-items`, and `border-radius` class lists on the layout pages. They duplicated the canonical `gap`/`align-items`/`rounding` pages (full tables, previews, the works) and had drifted: `flank`, `grid`, and `split` stopped at `3xl` while `stack` and `cluster` listed `5xl`. 

### Layout Consistency
- `native` and `prose` moved from `layout: page-outline` to `layout: docs`, matching the other 15 utilities. Adds the docs section nav alongside the outline.

### Bug Fixes
- Fixed a broken `{ .example }` fence on `color` (the stray spaces stopped it rendering live)
- Fixed a `::: info` callout on `text` that wasn't parsing.
- `prose` used `wa-align-items-flex-start` in two examples. That class doesn't exist. Fixed to use the real one - `wa-align-items-start`
- Fixed some typos: `native` "numeric date" → "numeric data", `prose` "adopt" → "adopts".
