### PR TITLE
Improve Tokens Documentation

### DIFF
--- a/packages/webawesome/docs/docs/tokens/borders.md
+++ b/packages/webawesome/docs/docs/tokens/borders.md
@@ -9,7 +9,7 @@ use-cases:
   - border width
   - border style
   - border color
-hasOutline: true
+layout: docs
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/tokens/color.md
+++ b/packages/webawesome/docs/docs/tokens/color.md
@@ -247,7 +247,7 @@ Surfaces are background layers that content rests on. They convey elevation hier
 
 ### Text
 
-Text colors are used for readable content, and should maintain a minimum 4.5:1 contrast ratio against surface colors.
+Text colors are used for readable content and should meet a minimum 4.5:1 contrast ratio against surface colors.
 
 <wa-scroller>
   <table class="token-table wa-hover-rows">

--- a/packages/webawesome/docs/docs/tokens/color.md
+++ b/packages/webawesome/docs/docs/tokens/color.md
@@ -1,7 +1,7 @@
 ---
 title: Color
-description: Ensure consistent use of color and readable contrast with Web Awesome's color properties.
-hasOutline: true
+description: Color tokens provide a full palette, semantic variants, and themed element colors with readable contrast.
+layout: docs
 synonyms:
   - palette
   - color system
@@ -195,7 +195,7 @@ Each core color also has a paired _on color_ (`--wa-color-{variant}-on`) guarant
 
 ### Changing Variant Colors
 
-Any hue from your color palette can be assigned to any variant without redefining the tokens in your own stylesheet. To use a different hue, simply apply the class `"wa-{variant}-{hue}` to the `<html>` element.
+Any hue from your color palette can be assigned to any variant without redefining the tokens in your own stylesheet. To use a different hue, apply the `wa-{variant}-{hue}` class to the `<html>` element.
 
 ```html
 <html class="wa-brand-purple wa-success-cyan"></html>
@@ -247,7 +247,7 @@ Surfaces are background layers that content rests on. They convey elevation hier
 
 ### Text
 
-Text colors are used for readable content. We recommend a minimum 4.5:1 contrast ratio against surface colors for text colors.
+Text colors are used for readable content, and should maintain a minimum 4.5:1 contrast ratio against surface colors.
 
 <wa-scroller>
   <table class="token-table wa-hover-rows">
@@ -308,7 +308,7 @@ Overlays provide a backdrop that isolates content, often with some transparency 
 
 ### Shadow
 
-A single color is used for all drop shadows. Use it alongside the [shadow tokens](?active_tab=shadows) to construct realistic shadows.
+A single color is used for all drop shadows. Use it alongside the [shadow tokens](/docs/tokens/shadows) to construct realistic shadows.
 
 <wa-scroller>
   <table class="token-table wa-hover-rows">
@@ -345,7 +345,7 @@ These tokens power the consistent hover, active, and focus feedback you see acro
     <tbody>
       <tr id="token-wa-color-focus">
         <td class="token-name"><code>--wa-color-focus</code></td>
-        <td>Outline color for keyboard focus rings. Used alongside <a href="?active_tab=focus">focus tokens</a>.</td>
+        <td>Outline color for keyboard focus rings. Used alongside <a href="/docs/tokens/focus">focus tokens</a>.</td>
         <td><div class="swatch" style="outline: var(--wa-focus-ring)"></div></td>
       </tr>
       <tr id="token-wa-color-mix-hover">

--- a/packages/webawesome/docs/docs/tokens/component-groups.md
+++ b/packages/webawesome/docs/docs/tokens/component-groups.md
@@ -1,8 +1,8 @@
 ---
 title: Component Groups
-description: Style groups of components that share similar qualities with these Web Awesome tokens.
+description: Component group tokens style sets of related components that share visual qualities.
 order: 9999
-layout: page-outline
+layout: docs
 synonyms:
   - component tokens
   - group tokens
@@ -152,12 +152,12 @@ In addition to sharing styles with form controls, [buttons](/docs/components/but
       <tr><th>Custom Property</th><th>Description</th><th>Preview</th></tr>
     </thead>
     <tbody>
-      <tr id="token-wa-panel-border-style">
+      <tr id="token-wa-button-transform-hover">
         <td class="token-name"><code>--wa-button-transform-hover</code></td>
         <td>A transform function to apply to buttons on mouseover/hover</td>
         <td><wa-button variant="brand" appearance="filled">Mouse Over Me</wa-button></td>
       </tr>
-      <tr id="token-wa-panel-border-style">
+      <tr id="token-wa-button-transform-active">
         <td class="token-name"><code>--wa-button-transform-active</code></td>
         <td>A transform function to apply to buttons when pressed/active</td>
         <td><wa-button variant="brand" appearance="filled">Press Me</wa-button></td>
@@ -199,9 +199,7 @@ Panel tokens apply to components with larger, contained surface areas, like [cal
     This is a simple callout with an icon.
   </wa-callout>
   <wa-card>Here's a basic, no-nonsense card.</wa-card>
-  <wa-details summary="Details">
-    <code>wa-details</code>, at your service.
-  </wa-details>
+  <wa-details summary="Details"> <code>wa-details</code>, at your service. </wa-details>
 </div>
 ```
 

--- a/packages/webawesome/docs/docs/tokens/focus.md
+++ b/packages/webawesome/docs/docs/tokens/focus.md
@@ -1,6 +1,6 @@
 ---
 title: Focus
-description: Configure recognizable focus states with Web Awesome's focus tokens.
+description: Focus tokens define a consistent, recognizable focus ring for keyboard users.
 synonyms:
   - focus ring
   - focus outline
@@ -9,10 +9,10 @@ use-cases:
   - keyboard focus
   - accessibility focus
   - tab focus
-hasOutline: true
+layout: docs
 ---
 
-Focus tokens create a consistent, recognizable outline that lets keyboard users track where they are on the page. Together with [`--wa-color-focus`](?active_tab=color), these tokens assemble the focus ring applied to all interactive Web Awesome components.
+Focus tokens create a consistent, recognizable outline that lets keyboard users track where they are on the page. Together with [`--wa-color-focus`](/docs/tokens/color), these tokens assemble the focus ring applied to all interactive Web Awesome components.
 
 <wa-scroller>
   <table class="token-table wa-hover-rows">

--- a/packages/webawesome/docs/docs/tokens/shadows.md
+++ b/packages/webawesome/docs/docs/tokens/shadows.md
@@ -1,6 +1,6 @@
 ---
 title: Shadows
-description: Elevate your components with Web Awesome's shadow tokens.
+description: Shadow tokens convey elevation and depth in Web Awesome components.
 synonyms:
   - box shadow
   - elevation
@@ -9,10 +9,10 @@ use-cases:
   - drop shadow
   - card shadow
   - overlay shadow
-hasOutline: true
+layout: docs
 ---
 
-Shadow tokens indicate elevation and, often, interactivity. Web Awesome provides three size-based shadow shorthands built from modular offset, blur, and spread tokens. Together with [`--wa-color-shadow`](?active_tab=color), these tokens create realistic drop shadows.
+Shadow tokens indicate elevation and, often, interactivity. Web Awesome provides three size-based shadow shorthands built from modular offset, blur, and spread tokens. Together with [`--wa-color-shadow`](/docs/tokens/color), these tokens create realistic drop shadows.
 
 Larger shadows have greater offset and blur values to suggest greater distance from the surface below. Any shadow can also be used as an inner shadow with the `inset` keyword, e.g. `box-shadow: inset var(--wa-shadow-s)`.
 

--- a/packages/webawesome/docs/docs/tokens/space.md
+++ b/packages/webawesome/docs/docs/tokens/space.md
@@ -1,6 +1,6 @@
 ---
 title: Space
-description: Lock down consistent spacing Web Awesome's space tokens.
+description: Space tokens define a consistent spacing scale in rem units.
 synonyms:
   - spacing
   - spacing scale
@@ -10,7 +10,7 @@ use-cases:
   - margin
   - gap
   - spacing tokens
-hasOutline: true
+layout: docs
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/tokens/transitions.md
+++ b/packages/webawesome/docs/docs/tokens/transitions.md
@@ -1,6 +1,6 @@
 ---
 title: Transitions
-description: Customize your theme's built-in transitions with Web Awesome's transition tokens.
+description: Transition tokens define the duration and easing of motion across Web Awesome.
 synonyms:
   - animation timing
   - easing
@@ -8,7 +8,7 @@ synonyms:
 use-cases:
   - transition speed
   - motion tokens
-hasOutline: true
+layout: docs
 ---
 
 <style>

--- a/packages/webawesome/docs/docs/tokens/typography.md
+++ b/packages/webawesome/docs/docs/tokens/typography.md
@@ -1,7 +1,7 @@
 ---
 title: Typography
-description: Get consistent font styles and vertical rhythm with Web Awesome's typography tokens.
-layout: page-outline
+description: Typography tokens define font styles, sizing, and vertical rhythm across Web Awesome.
+layout: docs
 synonyms:
   - fonts
   - type scale
@@ -51,7 +51,7 @@ Font family tokens are assigned to specific roles — body text, headings, code,
 
 ## Font Size
 
-Font sizes use a ratio of 1.125 to scale proportionally. The medium size (`m`) is the base; sizes below are 1.125× smaller and sizes above are *twice* 1.125× larger to maximize visual contrast between larger sizes. All values use `rem` units and round to the nearest whole pixel.
+Font sizes use a ratio of 1.125 to scale proportionally. The medium size (`m`) is the base; sizes below are 1.125× smaller and sizes above are _twice_ 1.125× larger to maximize visual contrast between larger sizes. All values use `rem` units and round to the nearest whole pixel.
 
 Use `--wa-font-size-scale` to proportionally increase or decrease all sizes at once.
 
@@ -225,7 +225,7 @@ Line heights are unitless to scale proportionately with text size. For readabili
 
 ## Link Decoration
 
-Together with [`--wa-color-text-link`](?active_tab=color), these tokens add text decoration to `<a>` elements to signal their role as hyperlinks.
+Together with [`--wa-color-text-link`](/docs/tokens/color), these tokens add text decoration to `<a>` elements to signal their role as hyperlinks.
 
 <wa-scroller>
   <table class="token-table wa-hover-rows">


### PR DESCRIPTION
This work applies the same House Rules pass as https://github.com/shoelace-style/webawesome/pull/2647, this time over the 8 design-token docs.

### Layout Consistency
- Unified all 8 pages on `layout: docs`, dropping the redundant `hasOutline: true` and `layout: page-outline`. 
- Every token page now gets the same outline and section nav instead of three different setups.

### Descriptions
- Rewrote the front-matter descriptions to neutral reference voice
- `space`'s was also just broken ("Lock down consistent spacing Web Awesome's space tokens") and now reads like a sentence.

### Bug Fixes
- fixed a stray-quote typo in the variant-hue class example
- `component-groups` had two Button rows, both carrying `id="token-wa-panel-border-style"`, copy-pasted from Panels. Now `token-wa-button-transform-hover` and `-active`

### Links and Copy
- Converted the vestigial `?active_tab=…` cross-links to site-relative `/docs/tokens/…` paths. Nothing consumes that query param anymore, and each token has its own URL
- Dropped "We recommend" from the text-color contrast note
