### PR TITLE
OTP: Improve Docs + Apply House Rules

### DIFF
--- a/packages/webawesome/docs/docs/components/otp-input.md
+++ b/packages/webawesome/docs/docs/components/otp-input.md
@@ -319,9 +319,10 @@ The component uses a single visually hidden `<input>` as the focus and form targ
 
 Keyboard interaction follows the single-input model:
 
-| Key                                   | Behavior                                                             |
-| ------------------------------------- | -------------------------------------------------------------------- |
-| <kbd>←</kbd> <kbd>→</kbd>             | Move between segments                                                |
-| <kbd>Tab</kbd> / <kbd>Shift+Tab</kbd> | Move between segments; leaves the field at the first or last segment |
-| <kbd>Backspace</kbd>                  | Clears the current segment and moves back (no character shift)       |
-| <kbd>Delete</kbd>                     | Clears the current segment without moving                            |
+| Key                       | Behavior                                                       |
+| ------------------------- | -------------------------------------------------------------- |
+| <kbd>←</kbd> <kbd>→</kbd> | Move between segments                                          |
+| <kbd>Tab</kbd>            | Moves focus to the next form control                           |
+| <kbd>Enter</kbd>          | Submits the containing form                                    |
+| <kbd>Backspace</kbd>      | Clears the current segment and moves back (no character shift) |
+| <kbd>Delete</kbd>         | Clears the current segment without moving                      |

--- a/packages/webawesome/docs/docs/components/otp-input.md
+++ b/packages/webawesome/docs/docs/components/otp-input.md
@@ -212,12 +212,14 @@ On Android, Chrome can also read the code from an incoming SMS with the [WebOTP 
 Add the `autosubmit` attribute to submit the containing form automatically when the last segment is filled. The `wa-complete` event fires first and is cancelable — call `preventDefault()` to stop the submission.
 
 ```html {.example}
-<form id="autosubmit-form">
+<form class="autosubmit">
   <wa-otp-input name="code" label="SMS verification code" autosubmit></wa-otp-input>
 </form>
 
 <script type="module">
-  document.querySelector('#autosubmit-form').addEventListener('submit', event => {
+  const form = document.querySelector('.autosubmit');
+
+  form.addEventListener('submit', event => {
     event.preventDefault();
     alert(`Submitted code: ${new FormData(event.target).get('code')}`);
   });
@@ -231,14 +233,16 @@ To run your own logic on completion instead — verify the code over the network
 Add the `required` attribute to require a value before submission. A partial entry (some segments filled, but not all) is always invalid regardless of `required`, with the `tooShort` validity flag set.
 
 ```html {.example}
-<form id="mfa-form">
+<form class="validation">
   <wa-otp-input name="code" label="Two-factor code" required></wa-otp-input>
   <br />
   <wa-button appearance="filled" type="submit">Continue</wa-button>
 </form>
 
 <script type="module">
-  document.querySelector('#mfa-form').addEventListener('submit', event => {
+  const form = document.querySelector('.validation');
+
+  form.addEventListener('submit', event => {
     event.preventDefault();
     alert('Code accepted!');
   });
@@ -250,17 +254,18 @@ Add the `required` attribute to require a value before submission. A partial ent
 Use the `setCustomValidity()` method to set a custom validation message. This will prevent the form from submitting and make the browser display the error message you provide. To clear the error, call this function with an empty string.
 
 ```html {.example}
-<form id="custom-validity-form">
+<form class="custom-validity">
   <wa-otp-input name="code" label="Verification code" hint="The correct code is 314159." required></wa-otp-input>
   <br />
   <wa-button appearance="filled" type="submit">Verify</wa-button>
 </form>
 
 <script type="module">
-  const form = document.getElementById('custom-validity-form');
+  const form = document.querySelector('.custom-validity');
   const otp = form.querySelector('wa-otp-input');
 
   otp.addEventListener('input', () => {
+    // Only flag complete entries — partial input is already invalid via tooShort
     const isValid = otp.value.length < otp.length || otp.value === '314159';
     otp.setCustomValidity(isValid ? '' : 'That code didn’t match. Check your device and try again.');
   });
@@ -293,27 +298,16 @@ Use the `--segment-size`, `--segment-gap`, and `--segment-border-radius` custom 
 </style>
 ```
 
-Combine CSS parts with [custom states](/docs/form-controls#custom-validation-styles) to style validation feedback — for example, coloring the segments when the `user-invalid` custom state applies. Submit the form with a partial entry to see it:
+Combine CSS parts with [custom states](/docs/form-controls#custom-validation-styles) to style validation feedback — for example, coloring the segments when the `user-invalid` custom state applies. Enter a partial code and click away to see it:
 
 ```html {.example}
-<form id="invalid-style-demo">
-  <wa-otp-input name="code" label="Two-factor code" required></wa-otp-input>
-  <br />
-  <wa-button appearance="filled" type="submit">Continue</wa-button>
-</form>
+<wa-otp-input class="invalid-style" label="Two-factor code" required></wa-otp-input>
 
 <style>
-  #invalid-style-demo wa-otp-input:state(user-invalid)::part(segment) {
+  .invalid-style:state(user-invalid)::part(segment) {
     border-color: var(--wa-color-danger-border-loud);
   }
 </style>
-
-<script type="module">
-  document.querySelector('#invalid-style-demo').addEventListener('submit', event => {
-    event.preventDefault();
-    alert('Code accepted!');
-  });
-</script>
 ```
 
 ## Accessibility Considerations

--- a/packages/webawesome/docs/docs/components/otp-input.md
+++ b/packages/webawesome/docs/docs/components/otp-input.md
@@ -118,11 +118,11 @@ Add the `mask` attribute to display entered characters as bullets (•). The val
 
 ### Appearance
 
-Use the `appearance` attribute to change the visual style of the segments.
+Use the `appearance` attribute to change the visual style of the segments. The default is `outlined`.
 
 ```html {.example}
 <div class="wa-stack">
-  <wa-otp-input label="Outlined (default)" appearance="outlined"></wa-otp-input>
+  <wa-otp-input label="Outlined" appearance="outlined"></wa-otp-input>
   <wa-otp-input label="Filled" appearance="filled"></wa-otp-input>
   <wa-otp-input label="Filled outlined" appearance="filled-outlined"></wa-otp-input>
   <wa-otp-input label="Contained" appearance="contained"></wa-otp-input>
@@ -131,13 +131,13 @@ Use the `appearance` attribute to change the visual style of the segments.
 
 ### Size
 
-Use the `size` attribute to change the size of each segment.
+Use the `size` attribute to change the size of each segment. The default is `m`.
 
 ```html {.example}
 <div class="wa-stack">
   <wa-otp-input label="Extra small" size="xs"></wa-otp-input>
   <wa-otp-input label="Small" size="s"></wa-otp-input>
-  <wa-otp-input label="Medium (default)" size="m"></wa-otp-input>
+  <wa-otp-input label="Medium" size="m"></wa-otp-input>
   <wa-otp-input label="Large" size="l"></wa-otp-input>
   <wa-otp-input label="Extra large" size="xl"></wa-otp-input>
 </div>
@@ -172,26 +172,16 @@ Use the `value` attribute to prefill the segments — for example, when a code a
 Pasting a full code fills all segments in one step. Characters that don't match the `type` attribute are silently dropped, so pasting `"ABC-123"` into a `numeric` field produces `123`.
 
 ```html {.example}
-<div id="paste-demo">
-  <wa-button id="copy-btn" appearance="outlined" size="s">
-    <wa-icon slot="prefix" name="clipboard"></wa-icon>
-    <span id="copy-label">Copy code: 123456</span>
+<wa-copy-button value="314159">
+  <wa-button appearance="filled">
+    <wa-icon slot="start" name="clipboard"></wa-icon>
+    Copy code: 314159
   </wa-button>
+</wa-copy-button>
 
-  <wa-divider></wa-divider>
+<wa-divider></wa-divider>
 
-  <wa-otp-input id="paste-target" label="Paste your code below"></wa-otp-input>
-</div>
-
-<script type="module">
-  const demo = document.getElementById('paste-demo');
-  demo.querySelector('#copy-btn').addEventListener('click', async () => {
-    await navigator.clipboard.writeText('123456');
-    const label = demo.querySelector('#copy-label');
-    label.textContent = 'Copied!';
-    setTimeout(() => (label.textContent = 'Copy code: 123456'), 2000);
-  });
-</script>
+<wa-otp-input label="Paste your code below"></wa-otp-input>
 ```
 
 ### Autofill
@@ -261,7 +251,7 @@ Use the `setCustomValidity()` method to set a custom validation message. This wi
 
 ```html {.example}
 <form id="custom-validity-form">
-  <wa-otp-input name="code" label="Verification code" hint="The correct code is 123456." required></wa-otp-input>
+  <wa-otp-input name="code" label="Verification code" hint="The correct code is 314159." required></wa-otp-input>
   <br />
   <wa-button appearance="filled" type="submit">Verify</wa-button>
 </form>
@@ -271,7 +261,7 @@ Use the `setCustomValidity()` method to set a custom validation message. This wi
   const otp = form.querySelector('wa-otp-input');
 
   otp.addEventListener('input', () => {
-    const isValid = otp.value.length < otp.length || otp.value === '123456';
+    const isValid = otp.value.length < otp.length || otp.value === '314159';
     otp.setCustomValidity(isValid ? '' : 'That code didn’t match. Check your device and try again.');
   });
 

--- a/packages/webawesome/docs/docs/components/otp-input.md
+++ b/packages/webawesome/docs/docs/components/otp-input.md
@@ -21,14 +21,14 @@ use-cases:
 ```
 
 :::info
-This component works with standard `<form>` elements. Please refer to the section on [form controls](/docs/form-controls) to learn more about form submission and client-side validation.
+This component works with standard `<form>` elements. See [form controls](/docs/form-controls) for form submission and client-side validation.
 :::
 
 ## Examples
 
-### Labels
+### Label
 
-Use the `label` attribute to give the field a visible label. For labels that contain HTML, use the `label` slot instead.
+Use the `label` attribute to give the field an accessible label. For labels that contain HTML, use the `label` slot instead.
 
 ```html {.example}
 <wa-otp-input label="Verification code"></wa-otp-input>
@@ -36,101 +36,111 @@ Use the `label` attribute to give the field a visible label. For labels that con
 
 ### Hint
 
-Use the `hint` attribute to provide descriptive help text below the field. For hints that contain HTML, use the `hint` slot instead.
+Add descriptive hint text with the `hint` attribute. For hints that contain HTML, use the `hint` slot instead.
 
 ```html {.example}
 <wa-otp-input label="Verification code" hint="Check your email for a 6-digit code."></wa-otp-input>
 ```
 
+### Placeholder
+
+Use the `placeholder` attribute to show a hint character in each empty segment, making the expected length clear at a glance.
+
+```html {.example}
+<div class="wa-stack">
+  <wa-otp-input label="Access code" placeholder="·"></wa-otp-input>
+  <wa-otp-input label="Verification code" placeholder="0"></wa-otp-input>
+</div>
+```
+
 ### Length
 
-The default length is 6 segments. Use the `length` attribute to change it.
+Use the `length` attribute to change the number of segments. The default is 6.
 
 ```html {.example}
-<wa-otp-input id="length-demo" label="Verification code" length="6"></wa-otp-input>
-
-<wa-divider></wa-divider>
-
-<div class="wa-cluster" style="align-items: flex-end">
-  <wa-select id="length-select" label="Length" value="6" style="width: 8rem">
-    <wa-option value="4">4</wa-option>
-    <wa-option value="5">5</wa-option>
-    <wa-option value="6">6</wa-option>
-    <wa-option value="7">7</wa-option>
-    <wa-option value="8">8</wa-option>
-  </wa-select>
+<div class="wa-stack">
+  <wa-otp-input label="Card PIN" length="4"></wa-otp-input>
+  <wa-otp-input label="Backup code" length="8"></wa-otp-input>
 </div>
-
-<script>
-  document.getElementById('length-select').addEventListener('change', event => {
-    document.getElementById('length-demo').length = Number(event.target.value);
-  });
-</script>
 ```
 
-### Types
+### Type
 
-Use the `type` attribute to restrict which characters are accepted. The default is `numeric`. Use `alpha` for letters only, or `alphanumeric` for both.
+Use the `type` attribute to restrict which characters are accepted.
 
 ```html {.example}
-<wa-otp-input label="Numeric (default)" type="numeric"></wa-otp-input> <br /><br />
-<wa-otp-input label="Alpha" type="alpha" length="6"></wa-otp-input>
-<br /><br />
-<wa-otp-input label="Alphanumeric" type="alphanumeric" length="6"></wa-otp-input>
+<div class="wa-stack">
+  <wa-otp-input label="Numeric" type="numeric"></wa-otp-input>
+  <wa-otp-input label="Alpha" type="alpha"></wa-otp-input>
+  <wa-otp-input label="Alphanumeric" type="alphanumeric"></wa-otp-input>
+</div>
 ```
+
+| Type                                                                                | Accepts            | Best for                     |
+| ----------------------------------------------------------------------------------- | ------------------ | ---------------------------- |
+| `numeric` <wa-badge appearance="outlined" variant="neutral" pill>default</wa-badge> | Digits 0–9         | SMS and 2FA codes, PINs      |
+| `alpha`                                                                             | Letters A–Z        | Letter-only codes            |
+| `alphanumeric`                                                                      | Letters and digits | Invite codes, serial numbers |
+
+The `numeric` type also sets the `inputmode` attribute on the underlying input, so mobile devices show the numeric keyboard.
 
 ### Format
 
-Use the `format` attribute to arrange segments into groups with literal separators. The `#` character marks a segment; any other character becomes a visual separator. Setting `format` implicitly sets `length`, so you do not need to specify both.
+Use the `format` attribute to arrange segments into groups with literal separators. The `#` character marks a segment; any other character becomes a visual separator. Setting `format` overrides `length`, so there is no need to specify both.
 
 ```html {.example}
-<!-- Two groups of three with a space: e.g. "ABC DEF" -->
-<wa-otp-input label="Invite code" type="alphanumeric" format="### ###"></wa-otp-input>
-<br /><br />
-<!-- Two groups of four joined by a dash: e.g. "1234-5678" -->
-<wa-otp-input label="Serial number" format="####-####"></wa-otp-input>
+<div class="wa-stack">
+  <!-- Two groups of three with a space: e.g. "ABC DEF" -->
+  <wa-otp-input label="Invite code" type="alphanumeric" format="### ###"></wa-otp-input>
+  <!-- Two groups of four joined by a dash: e.g. "1234-5678" -->
+  <wa-otp-input label="Serial number" format="####-####"></wa-otp-input>
+</div>
 ```
 
-### Appearances
+### Case
 
-Use the `appearance` attribute to change the visual style of the segments.
+Use the `case` attribute to transform characters as they are entered. The default is `preserve`. Use `upper` to force uppercase or `lower` to force lowercase.
 
 ```html {.example}
-<wa-otp-input label="Outlined (default)" appearance="outlined"></wa-otp-input> <br /><br />
-<wa-otp-input label="Filled" appearance="filled"></wa-otp-input>
-<br /><br />
-<wa-otp-input label="Filled outlined" appearance="filled-outlined"></wa-otp-input>
-<br /><br />
-<wa-otp-input label="Contained" appearance="contained"></wa-otp-input>
+<div class="wa-stack">
+  <wa-otp-input label="Upper" type="alpha" case="upper"></wa-otp-input>
+  <wa-otp-input label="Lower" type="alpha" case="lower"></wa-otp-input>
+</div>
 ```
 
 ### Mask
 
-Add the `mask` attribute to display entered characters as bullets (•). The actual value is still accessible via `el.value`, masking is display-only.
+Add the `mask` attribute to display entered characters as bullets (•). The value remains accessible via the `value` property; masking is display-only. Masking is also visual-only for assistive technology — screen readers still announce entered characters.
 
 ```html {.example}
 <wa-otp-input label="PIN" mask length="4"></wa-otp-input>
 ```
 
-### Case
+### Appearance
 
-Use the `case` attribute to automatically transform characters as they are entered. The default is `preserve`. Use `upper` to force uppercase or `lower` to force lowercase.
+Use the `appearance` attribute to change the visual style of the segments.
 
 ```html {.example}
-<wa-otp-input label="Uppercase invite code" type="alpha" case="upper" length="6"></wa-otp-input> <br /><br />
-<wa-otp-input label="Lowercase code" type="alpha" case="lower" length="6"></wa-otp-input>
+<div class="wa-stack">
+  <wa-otp-input label="Outlined (default)" appearance="outlined"></wa-otp-input>
+  <wa-otp-input label="Filled" appearance="filled"></wa-otp-input>
+  <wa-otp-input label="Filled outlined" appearance="filled-outlined"></wa-otp-input>
+  <wa-otp-input label="Contained" appearance="contained"></wa-otp-input>
+</div>
 ```
 
-### Sizes
+### Size
 
 Use the `size` attribute to change the size of each segment.
 
 ```html {.example}
-<wa-otp-input label="Extra small" size="xs"></wa-otp-input> <br /><br />
-<wa-otp-input label="Small" size="s"></wa-otp-input> <br /><br />
-<wa-otp-input label="Medium (default)" size="m"></wa-otp-input> <br /><br />
-<wa-otp-input label="Large" size="l"></wa-otp-input> <br /><br />
-<wa-otp-input label="Extra large" size="xl"></wa-otp-input>
+<div class="wa-stack">
+  <wa-otp-input label="Extra small" size="xs"></wa-otp-input>
+  <wa-otp-input label="Small" size="s"></wa-otp-input>
+  <wa-otp-input label="Medium (default)" size="m"></wa-otp-input>
+  <wa-otp-input label="Large" size="l"></wa-otp-input>
+  <wa-otp-input label="Extra large" size="xl"></wa-otp-input>
+</div>
 ```
 
 ### Disabled
@@ -138,7 +148,7 @@ Use the `size` attribute to change the size of each segment.
 Use the `disabled` attribute to prevent interaction.
 
 ```html {.example}
-<wa-otp-input label="Verification code" disabled value="1234"></wa-otp-input>
+<wa-otp-input label="Verification code" disabled value="391824"></wa-otp-input>
 ```
 
 ### Readonly
@@ -149,46 +159,35 @@ Use the `readonly` attribute to display a value without allowing edits. Unlike `
 <wa-otp-input label="Confirmation code" readonly value="483920"></wa-otp-input>
 ```
 
-### Placeholder
+### Initial Value
 
-Use the `placeholder` attribute to show a hint character in each empty segment, making the expected length and format clear at a glance.
-
-```html {.example}
-<wa-otp-input label="PIN" length="4" placeholder="·"></wa-otp-input> <br /><br />
-<wa-otp-input label="Verification code" placeholder="0"></wa-otp-input>
-```
-
-### Prefilling a Value
-
-Use the `value` attribute to pre-populate the segments, useful when a code arrives via a URL parameter.
+Use the `value` attribute to prefill the segments — for example, when a code arrives in a link's query parameter.
 
 ```html {.example}
-<wa-otp-input id="magic-code" label="Magic link code" length="6"></wa-otp-input>
-
-<script type="module">
-  const code = new URLSearchParams(location.search).get('code') ?? '';
-  if (code) document.querySelector('#magic-code').value = code;
-</script>
+<wa-otp-input label="Magic link code" value="483920"></wa-otp-input>
 ```
 
 ### Pasting
 
-Paste a full code in one step, the component fills all segments at once. Characters that don't match the `type` setting are silently ignored, so pasting `"ABC-123"` into a `numeric` field produces `123`.
+Pasting a full code fills all segments in one step. Characters that don't match the `type` attribute are silently dropped, so pasting `"ABC-123"` into a `numeric` field produces `123`.
 
 ```html {.example}
-<wa-button id="copy-btn" appearance="outlined" size="small">
-  <wa-icon slot="prefix" name="clipboard"></wa-icon>
-  <span id="copy-label">Copy code: 123456</span>
-</wa-button>
+<div id="paste-demo">
+  <wa-button id="copy-btn" appearance="outlined" size="s">
+    <wa-icon slot="prefix" name="clipboard"></wa-icon>
+    <span id="copy-label">Copy code: 123456</span>
+  </wa-button>
 
-<wa-divider style="margin: var(--wa-space-m) 0;"></wa-divider>
+  <wa-divider></wa-divider>
 
-<wa-otp-input id="paste-target" label="Paste your code below"></wa-otp-input>
+  <wa-otp-input id="paste-target" label="Paste your code below"></wa-otp-input>
+</div>
 
 <script type="module">
-  document.querySelector('#copy-btn').addEventListener('click', async () => {
+  const demo = document.getElementById('paste-demo');
+  demo.querySelector('#copy-btn').addEventListener('click', async () => {
     await navigator.clipboard.writeText('123456');
-    const label = document.querySelector('#copy-label');
+    const label = demo.querySelector('#copy-label');
     label.textContent = 'Copied!';
     setTimeout(() => (label.textContent = 'Copy code: 123456'), 2000);
   });
@@ -197,88 +196,58 @@ Paste a full code in one step, the component fills all segments at once. Charact
 
 ### Autofill
 
-The component sets `autocomplete="one-time-code"` by default, which tells browsers and operating systems to offer autofill for SMS-delivered verification codes. Set `autocomplete="off"` to disable this, for example when the field is used for a PIN that shouldn't be suggested by the browser.
+The `autocomplete` attribute defaults to `one-time-code`, which tells browsers and operating systems to offer autofill for SMS-delivered verification codes. Set `autocomplete="off"` to disable this — for example, when the field is used for a PIN that shouldn't be suggested by the browser.
 
-### Auto-Submit on Completion
+On Android, Chrome can also read the code from an incoming SMS with the [WebOTP API](https://developer.mozilla.org/en-US/docs/Web/API/WebOTP_API), no manual entry required. Feature-detect it and set the field's `value` from the result:
 
-The `wa-complete` event fires once when the last segment is filled. Use it to submit the form immediately without requiring a button click.
+```html
+<wa-otp-input id="sms-code" label="Verification code"></wa-otp-input>
 
-```html {.example}
-<form id="sms-form">
-  <wa-otp-input id="sms-code" name="code" label="SMS verification code"></wa-otp-input>
-  <br />
-  <small id="sms-status"></small>
-</form>
-
-<script type="module">
-  document.querySelector('#sms-code').addEventListener('wa-complete', () => {
-    document.querySelector('#sms-status').textContent = 'Code received — submitting…';
-    // document.querySelector('#sms-form').requestSubmit();
-  });
+<script>
+  if ('OTPCredential' in window) {
+    navigator.credentials
+      .get({ otp: { transport: ['sms'] } })
+      .then(otp => {
+        document.getElementById('sms-code').value = otp.code;
+      })
+      .catch(() => {
+        // The prompt was dismissed or timed out
+      });
+  }
 </script>
 ```
 
-### Form Submission
+### Autosubmit
 
-Use the `name` attribute to include the OTP value in form submissions. The value is included in `FormData` as a plain string.
+Add the `autosubmit` attribute to submit the containing form automatically when the last segment is filled. The `wa-complete` event fires first and is cancelable — call `preventDefault()` to stop the submission.
 
 ```html {.example}
-<form id="verify-form">
-  <wa-otp-input name="code" label="Enter your 6-digit code" required></wa-otp-input>
-  <br /><br />
-  <wa-button type="submit" appearance="filled">Verify</wa-button>
-  <wa-button type="reset" appearance="outlined">Reset</wa-button>
+<form id="autosubmit-form">
+  <wa-otp-input name="code" label="SMS verification code" autosubmit></wa-otp-input>
 </form>
 
 <script type="module">
-  document.querySelector('#verify-form').addEventListener('submit', event => {
+  document.querySelector('#autosubmit-form').addEventListener('submit', event => {
     event.preventDefault();
-    const data = new FormData(event.target);
-    alert(`Submitted code: ${data.get('code')}`);
+    alert(`Submitted code: ${new FormData(event.target).get('code')}`);
   });
 </script>
 ```
 
-### Form Attribute
-
-Use the `form` attribute to associate the field with a `<form>` element elsewhere in the page. This works the same as the native HTML `form` attribute on `<input>`.
-
-```html {.example}
-<wa-otp-input name="code" label="Enter code" form="external-form"></wa-otp-input>
-<br />
-<br />
-<form id="external-form">
-  <wa-button appearance="filled" type="submit">Submit</wa-button>
-</form>
-```
+To run your own logic on completion instead — verify the code over the network, unlock a button — listen for the `wa-complete` event without setting `autosubmit`.
 
 ### Validation
 
-Add the `required` attribute to require a value before submission. A partial entry,some segments filled but not all, is always invalid regardless of `required`, with the `tooShort` validity flag set. Use the `invalid` event to set a custom message via `setCustomValidity()`.
+Add the `required` attribute to require a value before submission. A partial entry (some segments filled, but not all) is always invalid regardless of `required`, with the `tooShort` validity flag set.
 
 ```html {.example}
 <form id="mfa-form">
-  <wa-otp-input id="mfa-code" name="code" label="Two-factor code" required></wa-otp-input>
-  <br />
+  <wa-otp-input name="code" label="Two-factor code" required></wa-otp-input>
   <br />
   <wa-button appearance="filled" type="submit">Continue</wa-button>
 </form>
 
 <script type="module">
-  const el = document.querySelector('#mfa-code');
-
-  el.addEventListener('invalid', () => {
-    if (el.validity.valueMissing) {
-      el.setCustomValidity('Please enter your verification code.');
-    } else if (el.validity.tooShort) {
-      el.setCustomValidity(`Please enter all ${el.length} digits.`);
-    } else {
-      el.setCustomValidity('');
-    }
-  });
-
-  el.addEventListener('input', () => el.setCustomValidity(''));
-
   document.querySelector('#mfa-form').addEventListener('submit', event => {
     event.preventDefault();
     alert('Code accepted!');
@@ -286,12 +255,39 @@ Add the `required` attribute to require a value before submission. A partial ent
 </script>
 ```
 
-### Custom Styles
+### Custom Validity
 
-Use [CSS parts](#css-parts) and CSS custom properties to customize the appearance. The CSS custom properties are scoped to the component and do not use the `--wa-` prefix.
+Use the `setCustomValidity()` method to set a custom validation message. This will prevent the form from submitting and make the browser display the error message you provide. To clear the error, call this function with an empty string.
 
 ```html {.example}
-<wa-otp-input id="styled-otp" label="Styled code" length="4"></wa-otp-input>
+<form id="custom-validity-form">
+  <wa-otp-input name="code" label="Verification code" hint="The correct code is 123456." required></wa-otp-input>
+  <br />
+  <wa-button appearance="filled" type="submit">Verify</wa-button>
+</form>
+
+<script type="module">
+  const form = document.getElementById('custom-validity-form');
+  const otp = form.querySelector('wa-otp-input');
+
+  otp.addEventListener('input', () => {
+    const isValid = otp.value.length < otp.length || otp.value === '123456';
+    otp.setCustomValidity(isValid ? '' : 'That code didn’t match. Check your device and try again.');
+  });
+
+  form.addEventListener('submit', event => {
+    event.preventDefault();
+    alert('Code accepted!');
+  });
+</script>
+```
+
+### Customizing
+
+Use the `--segment-size`, `--segment-gap`, and `--segment-border-radius` custom properties along with [CSS parts](#css-parts) to style the segments.
+
+```html {.example}
+<wa-otp-input id="styled-otp" label="Card PIN" length="4"></wa-otp-input>
 
 <style>
   #styled-otp {
@@ -306,3 +302,39 @@ Use [CSS parts](#css-parts) and CSS custom properties to customize the appearanc
   }
 </style>
 ```
+
+Combine CSS parts with [custom states](/docs/form-controls#custom-validation-styles) to style validation feedback — for example, coloring the segments when the `user-invalid` custom state applies. Submit the form with a partial entry to see it:
+
+```html {.example}
+<form id="invalid-style-demo">
+  <wa-otp-input name="code" label="Two-factor code" required></wa-otp-input>
+  <br />
+  <wa-button appearance="filled" type="submit">Continue</wa-button>
+</form>
+
+<style>
+  #invalid-style-demo wa-otp-input:state(user-invalid)::part(segment) {
+    border-color: var(--wa-color-danger-border-loud);
+  }
+</style>
+
+<script type="module">
+  document.querySelector('#invalid-style-demo').addEventListener('submit', event => {
+    event.preventDefault();
+    alert('Code accepted!');
+  });
+</script>
+```
+
+## Accessibility Considerations
+
+The component uses a single visually hidden `<input>` as the focus and form target — the visible segments are decorative. Screen readers announce it as one text field, named by the `label` attribute or slot. Always provide a label; without one, the field has no accessible name.
+
+Keyboard interaction follows the single-input model:
+
+| Key                                   | Behavior                                                             |
+| ------------------------------------- | -------------------------------------------------------------------- |
+| <kbd>←</kbd> <kbd>→</kbd>             | Move between segments                                                |
+| <kbd>Tab</kbd> / <kbd>Shift+Tab</kbd> | Move between segments; leaves the field at the first or last segment |
+| <kbd>Backspace</kbd>                  | Clears the current segment and moves back (no character shift)       |
+| <kbd>Delete</kbd>                     | Clears the current segment without moving                            |

--- a/packages/webawesome/docs/docs/components/otp-input.md
+++ b/packages/webawesome/docs/docs/components/otp-input.md
@@ -31,7 +31,7 @@ This component works with standard `<form>` elements. See [form controls](/docs/
 Use the `label` attribute to give the field an accessible label. For labels that contain HTML, use the `label` slot instead.
 
 ```html {.example}
-<wa-otp-input label="Verification code"></wa-otp-input>
+<wa-otp-input label="Security code"></wa-otp-input>
 ```
 
 ### Hint
@@ -39,7 +39,7 @@ Use the `label` attribute to give the field an accessible label. For labels that
 Add descriptive hint text with the `hint` attribute. For hints that contain HTML, use the `hint` slot instead.
 
 ```html {.example}
-<wa-otp-input label="Verification code" hint="Check your email for a 6-digit code."></wa-otp-input>
+<wa-otp-input label="Sign-in code" hint="Check your email for a 6-digit code."></wa-otp-input>
 ```
 
 ### Placeholder

--- a/packages/webawesome/docs/docs/components/otp-input.md
+++ b/packages/webawesome/docs/docs/components/otp-input.md
@@ -14,6 +14,9 @@ use-cases:
   - PIN entry
   - invite code
   - serial number
+  - license key
+  - gift card
+  - device pairing
 ---
 
 ```html {.example}
@@ -92,8 +95,8 @@ Use the `format` attribute to arrange segments into groups with literal separato
 <div class="wa-stack">
   <!-- Two groups of three with a space: e.g. "ABC DEF" -->
   <wa-otp-input label="Invite code" type="alphanumeric" format="### ###"></wa-otp-input>
-  <!-- Two groups of four joined by a dash: e.g. "1234-5678" -->
-  <wa-otp-input label="Serial number" format="####-####"></wa-otp-input>
+  <!-- Three groups of four joined by dashes: e.g. "1234-5678-9012" -->
+  <wa-otp-input label="License key" type="alphanumeric" format="####-####-####"></wa-otp-input>
 </div>
 ```
 

--- a/packages/webawesome/docs/docs/components/otp-input.md
+++ b/packages/webawesome/docs/docs/components/otp-input.md
@@ -167,7 +167,7 @@ Use the `readonly` attribute to display a value without allowing edits. Unlike `
 Use the `value` attribute to prefill the segments — for example, when a code arrives in a link's query parameter.
 
 ```html {.example}
-<wa-otp-input label="Magic link code" value="483920"></wa-otp-input>
+<wa-otp-input label="Magic link code" value="271828"></wa-otp-input>
 ```
 
 ### Pasting

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -31,6 +31,12 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 ## Unreleased
 
+:::added
+
+- Added the experimental `<wa-otp-input>` component for entering fixed-length codes — one-time passcodes, PINs, and verification codes [pr:2584]
+
+:::
+
 :::fixed
 
 - Fixed type resolution issues with `pro` components like `<wa-file-input>`, `<wa-combobox>`, etc. [pr:2577]
@@ -48,7 +54,6 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 :::added
 
-- Added the experimental `<wa-otp-input>` component for entering fixed-length codes — one-time passcodes, PINs, and verification codes [pr:2584]
 - Added the experimental `<wa-random-content>` component, which randomly shows one or more of its children — handy for rotating testimonials, tips, or featured content
 - Added the Mosaic, Pixel, Vellum, Slab Duo, and Slab Press Duo Pro+ icon families to `<wa-icon>` [pr:2562]
 - Added the `buzz`, `flip-360`, `float`, `jello`, `spin-snap`, `spin-snap-4`, `spin-snap-8`, `swing`, and `wag` animations to `<wa-icon>` [pr:2562]

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -40,9 +40,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 - Fixed a lifecycle issue in `<wa-option>` [pr:2591]
 - Fixed a bug with extra margin on the first button of a `<wa-button-group>` [pr:2592]
 
-
 :::
-
 
 ## 3.10.0
 
@@ -50,7 +48,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 :::added
 
-- Added an experimental `<wa-otp-input>` component, generally used for fixed length codes (PINs, OTPs, verification codes, etc).
+- Added the experimental `<wa-otp-input>` component for entering fixed-length codes — one-time passcodes, PINs, and verification codes [pr:2584]
 - Added the experimental `<wa-random-content>` component, which randomly shows one or more of its children — handy for rotating testimonials, tips, or featured content
 - Added the Mosaic, Pixel, Vellum, Slab Duo, and Slab Press Duo Pro+ icon families to `<wa-icon>` [pr:2562]
 - Added the `buzz`, `flip-360`, `float`, `jello`, `spin-snap`, `spin-snap-4`, `spin-snap-8`, `swing`, and `wag` animations to `<wa-icon>` [pr:2562]

--- a/packages/webawesome/src/components/otp-input/otp-input.styles.ts
+++ b/packages/webawesome/src/components/otp-input/otp-input.styles.ts
@@ -8,6 +8,9 @@ export default css`
   /* Segments container */
   .segments {
     position: relative;
+    /* Codes read left-to-right regardless of locale — keep segment order and caret movement LTR
+       even when the surrounding page is RTL. */
+    direction: ltr;
     display: inline-flex;
     align-items: center;
     align-self: start;
@@ -127,8 +130,8 @@ export default css`
     }
   }
 
-  /* Separator character between segment groups */
-  .segment-separator {
+  /* Literal separator character between segment groups */
+  .segment-literal {
     display: inline-block;
     flex-shrink: 0;
     color: var(--wa-color-text-quiet);
@@ -176,7 +179,7 @@ export default css`
 
   /* Dividers between contained segments */
   :host([appearance='contained']) .segment + .segment,
-  :host([appearance='contained']) .segment-separator + .segment {
+  :host([appearance='contained']) .segment-literal + .segment {
     border-left: var(--wa-form-control-border-width) var(--wa-form-control-border-style)
       var(--wa-form-control-border-color);
   }

--- a/packages/webawesome/src/components/otp-input/otp-input.test.ts
+++ b/packages/webawesome/src/components/otp-input/otp-input.test.ts
@@ -120,7 +120,7 @@ describe('<wa-otp-input>', () => {
 
         it('should render separators from the format string', async () => {
           const el = await fixture<WaOtpInput>(html`<wa-otp-input format="###-###"></wa-otp-input>`);
-          const separators = el.shadowRoot!.querySelectorAll('[part~="segment-separator"]');
+          const separators = el.shadowRoot!.querySelectorAll('[part~="segment-literal"]');
           expect(separators.length).to.equal(1);
           expect(separators[0].textContent).to.equal('-');
         });
@@ -581,6 +581,24 @@ describe('<wa-otp-input>', () => {
         });
       });
 
+      describe('caret', () => {
+        it('should show the caret in an empty active segment', async () => {
+          const el = await fixture<WaOtpInput>(html`<wa-otp-input label="Code"></wa-otp-input>`);
+          el.focus();
+          await el.updateComplete;
+          expect(el.shadowRoot!.querySelector('.caret')).to.exist;
+        });
+
+        it('should not draw the caret over a filled segment', async () => {
+          // A filled active segment is in replace mode — the ring marks it; a caret
+          // through the existing character reads as a strikethrough.
+          const el = await fixture<WaOtpInput>(html`<wa-otp-input label="Code" value="123456"></wa-otp-input>`);
+          el.focus();
+          await el.updateComplete;
+          expect(el.shadowRoot!.querySelector('.caret')).to.not.exist;
+        });
+      });
+
       describe('accessibility', () => {
         it('should have aria-describedby pointing to the hint element', async () => {
           const el = await fixture<WaOtpInput>(html`<wa-otp-input hint="Enter your code"></wa-otp-input>`);
@@ -594,6 +612,78 @@ describe('<wa-otp-input>', () => {
           await el.updateComplete;
           const segments = el.shadowRoot!.querySelector('.segments')!;
           expect(segments.getAttribute('role')).to.equal('group');
+        });
+
+        it('should pass accessibility checks', async () => {
+          const el = await fixture<WaOtpInput>(
+            html`<wa-otp-input label="Verification code" hint="Check your email for a 6-digit code."></wa-otp-input>`,
+          );
+          await el.updateComplete;
+          await expect(el).to.be.accessible();
+        });
+      });
+
+      describe('enter key', () => {
+        it('should submit the containing form when enter is pressed', async () => {
+          const form = await fixture<HTMLFormElement>(
+            html`<form><wa-otp-input name="code" length="3" value="123"></wa-otp-input></form>`,
+          );
+          const el = form.querySelector<WaOtpInput>('wa-otp-input')!;
+          const submitHandler = sinon.spy((event: SubmitEvent) => event.preventDefault());
+
+          form.addEventListener('submit', submitHandler);
+          el.focus();
+          await sendKeys({ press: 'Enter' });
+          await waitUntil(() => submitHandler.calledOnce);
+
+          expect(submitHandler).to.have.been.calledOnce;
+        });
+      });
+
+      describe('tab key', () => {
+        it('should move focus out of the field when tab is pressed', async () => {
+          const container = await fixture<HTMLDivElement>(
+            html`<div>
+              <wa-otp-input label="Code"></wa-otp-input>
+              <button type="button">After</button>
+            </div>`,
+          );
+          const el = container.querySelector<WaOtpInput>('wa-otp-input')!;
+          const button = container.querySelector('button')!;
+
+          el.focus();
+          await sendKeys({ press: 'Tab' });
+
+          expect(document.activeElement).to.equal(button);
+        });
+      });
+
+      describe('right-to-left', () => {
+        it('should keep segments laid out left-to-right in RTL contexts', async () => {
+          const container = await fixture<HTMLDivElement>(
+            html`<div dir="rtl"><wa-otp-input label="Code" value="12"></wa-otp-input></div>`,
+          );
+          const el = container.querySelector<WaOtpInput>('wa-otp-input')!;
+          await el.updateComplete;
+          const segments = el.shadowRoot!.querySelector('.segments')!;
+          expect(getComputedStyle(segments).direction).to.equal('ltr');
+        });
+      });
+
+      describe('autofill', () => {
+        it('should filter, not truncate, raw values that exceed the segment count', async () => {
+          const el = await fixture<WaOtpInput>(html`<wa-otp-input label="Code"></wa-otp-input>`);
+          await el.updateComplete;
+          const input = el.shadowRoot!.querySelector<HTMLInputElement>('.hidden-input')!;
+
+          // Simulate browser autofill: set the raw input value (with separators) and fire input
+          input.value = '123 456';
+          input.dispatchEvent(new InputEvent('input', { bubbles: true, composed: true }));
+          await el.updateComplete;
+
+          // maxlength would truncate an autofilled "123 456" to "123 45" before filtering ran
+          expect(input.hasAttribute('maxlength')).to.be.false;
+          expect(el.value).to.equal('123456');
         });
       });
     });

--- a/packages/webawesome/src/components/otp-input/otp-input.ts
+++ b/packages/webawesome/src/components/otp-input/otp-input.ts
@@ -16,7 +16,8 @@ import sizeStyles from '../../styles/component/size.styles.js';
 import styles from './otp-input.styles.js';
 
 /**
- * @summary OTP inputs collect one-time passcodes, PINs, and other fixed-length codes, one character per segment. Use them for SMS verification, two-factor authentication, and invite codes.
+ * @summary OTP inputs collect one-time passcodes, PINs, and other fixed-length codes, one character per segment.
+ * Use them for SMS verification, two-factor authentication, and invite codes.
  * @documentation https://webawesome.com/docs/components/otp-input
  * @status experimental
  * @since 3.10

--- a/packages/webawesome/src/components/otp-input/otp-input.ts
+++ b/packages/webawesome/src/components/otp-input/otp-input.ts
@@ -16,7 +16,7 @@ import sizeStyles from '../../styles/component/size.styles.js';
 import styles from './otp-input.styles.js';
 
 /**
- * @summary A form-associated OTP/passcode input that displays a fixed number of character segments.
+ * @summary OTP inputs collect one-time passcodes, PINs, and other fixed-length codes, one character per segment. Use them for SMS verification, two-factor authentication, and invite codes.
  * @documentation https://webawesome.com/docs/components/otp-input
  * @status experimental
  * @since 3.10
@@ -30,6 +30,7 @@ import styles from './otp-input.styles.js';
  * @event change - Emitted when the value changes and the field loses focus.
  * @event wa-complete - Emitted once when all segments are filled. Cancelable — call `preventDefault()` to stop
  *   `autosubmit` from submitting the form for this completion.
+ * @event wa-clear - Emitted when the control's value is cleared.
  * @event wa-invalid - Emitted when the form control has been checked for validity and its constraints aren't satisfied.
  *
  * @csspart label - The label element.

--- a/packages/webawesome/src/components/otp-input/otp-input.ts
+++ b/packages/webawesome/src/components/otp-input/otp-input.ts
@@ -7,7 +7,7 @@ import { WaCompleteEvent } from '../../events/complete.js';
 import { scrollIntoView } from '../../internal/scroll.js';
 import { warnDeprecatedSize } from '../../internal/size.js';
 import { HasSlotController } from '../../internal/slot.js';
-import { submitForm } from '../../internal/submit-on-enter.js';
+import { submitForm, submitOnEnter } from '../../internal/submit-on-enter.js';
 import { MirrorValidator } from '../../internal/validators/mirror-validator.js';
 import { watch } from '../../internal/watch.js';
 import { WebAwesomeFormAssociatedElement } from '../../internal/webawesome-form-associated-element.js';
@@ -38,7 +38,7 @@ import styles from './otp-input.styles.js';
  * @csspart hint - The hint element.
  * @csspart segments - The wrapper around all segment cells and separators.
  * @csspart segment - An individual character segment cell.
- * @csspart segment-separator - A literal separator character between segment groups (e.g. space or dash).
+ * @csspart segment-literal - Inert literal text between segment groups (e.g. space or dash).
  *
  * @cssstate --blank - Applied when no characters have been entered.
  * @cssstate --filled - Applied when all segments are filled.
@@ -46,9 +46,9 @@ import styles from './otp-input.styles.js';
  * @cssstate readonly - Applied when the component is readonly.
  * @cssstate user-invalid - Applied when validation fails after interaction.
  *
- * @cssproperty --segment-size - Width and height of each segment cell. Default: `2.5em`.
- * @cssproperty --segment-gap - Gap between segments (not used in `contained` appearance). Default: themed.
- * @cssproperty --segment-border-radius - Corner radius of each segment. Default: themed.
+ * @cssproperty [--segment-size=2.5em] - Width and height of each segment cell.
+ * @cssproperty [--segment-gap=var(--wa-space-xs)] - Gap between segments (not used in `contained` appearance).
+ * @cssproperty [--segment-border-radius=var(--wa-form-control-border-radius)] - Corner radius of each segment.
  */
 @customElement('wa-otp-input')
 export default class WaOtpInput extends WebAwesomeFormAssociatedElement {
@@ -330,15 +330,10 @@ export default class WaOtpInput extends WebAwesomeFormAssociatedElement {
     if (e.isComposing) return;
     const max = this.effectiveLength;
 
-    if (e.key === 'Tab') {
-      if (!e.shiftKey && this._activeIndex < max - 1) {
-        e.preventDefault();
-        this.setCaretIndex(this._activeIndex + 1);
-      } else if (e.shiftKey && this._activeIndex > 0) {
-        e.preventDefault();
-        this.setCaretIndex(this._activeIndex - 1);
-      }
-      // else: Tab/Shift-Tab at boundary → propagate out of component
+    // Tab is deliberately not handled — it moves focus to the next control like any single input;
+    // arrow keys handle movement between segments.
+    if (e.key === 'Enter') {
+      submitOnEnter(e, this);
     } else if (e.key === 'ArrowRight') {
       e.preventDefault();
       if (this.hasSelection) {
@@ -355,6 +350,11 @@ export default class WaOtpInput extends WebAwesomeFormAssociatedElement {
       }
     } else if (this.readonly) {
       // All character-mutating keys are blocked when readonly; navigation above still works.
+      // preventDefault matters here: a readonly input isn't an editable context, so WebKit
+      // treats an unhandled Backspace as the history-back gesture and navigates away.
+      if (e.key === 'Backspace' || e.key === 'Delete') {
+        e.preventDefault();
+      }
     } else if (e.key === 'Backspace') {
       // Prevent browser from shifting chars; manually splice the slot and move back.
       e.preventDefault();
@@ -528,9 +528,7 @@ export default class WaOtpInput extends WebAwesomeFormAssociatedElement {
       <div part="segments" class="segments" role="group" aria-labelledby="label" @click=${this.handleSegmentsClick}>
         ${parts.map(part => {
           if (part.type === 'separator') {
-            return html`<span part="segment-separator" class="segment-separator" aria-hidden="true"
-              >${part.char}</span
-            >`;
+            return html`<span part="segment-literal" class="segment-literal" aria-hidden="true">${part.char}</span>`;
           }
 
           const i = segmentIndex++;
@@ -556,7 +554,7 @@ export default class WaOtpInput extends WebAwesomeFormAssociatedElement {
                 : this.placeholder
                   ? html`<span class="segment--placeholder">${this.placeholder}</span>`
                   : ''}
-              ${isActive ? html`<span class="caret"></span>` : ''}
+              ${isActive && !char ? html`<span class="caret"></span>` : ''}
             </div>
           `;
         })}
@@ -566,7 +564,6 @@ export default class WaOtpInput extends WebAwesomeFormAssociatedElement {
           class="hidden-input"
           type="text"
           .value=${live(this._value)}
-          maxlength=${this.effectiveLength}
           minlength=${this.effectiveLength}
           autocomplete=${this.autocomplete}
           inputmode=${this.type === 'numeric' ? 'numeric' : 'text'}


### PR DESCRIPTION
Applies the `.house-rules` Docs Rubric to the new `<wa-otp-input>` from https://github.com/shoelace-style/webawesome/pull/2584.

### Structure Changes
- Renamed sections to the shared lexicon (`Labels` → `Label`, `Sizes` → `Size`, `Prefilling a Value` → `Initial Value`, `Custom Styles` → `Customizing`)
- Reordered simple → complex sections, so the plain attribute demos sit up top and the script-driven ones land last
- Cut three examples that weren't earning their place: 
  - the interactive length slider (two static fields show it better)
  - the URL-param prefill script (rendered an empty field on the Docs site)
  - the `Form Submission` / `Form Attribute` sections (no other form control documents these and API table and form-controls already cover them).

### Accuracy Fixes
- `autosubmit` shipped in the component, but the docs never mentioned it. The old auto-submit section hand-rolled the behavior around a commented-out `requestSubmit()`. It's a real section now, and it notes that `wa-complete` is cancelable
- The paste demo also had a dead icon: it used `slot="prefix"`, but `wa-button`'s slot is `start`, so the clipboard icon never rendered. That demo now uses `<wa-copy-button>` with a slotted trigger, which killed the custom clipboard script too

### Docs Additions
- A `type` option table with the default badge, per the rubric
- A WebOTP example for the Android side of SMS autofill (`autocomplete="one-time-code"` handles iOS)
- A `user-invalid` styling example under Customizing
- An `Accessibility Considerations` section covering the `single-hidden-input` model and the keyboard map

### JSDoc & Changelog Edits
- `@summary` reworded task-first, since it renders as the docs page intro
- Added the missing `@event wa-clear`.
- Changelog entry tightened
