### PR TITLE
OTP: Keyboard, RTL, and Autofill Fixes

### DIFF
--- a/packages/webawesome/docs/docs/components/otp-input.md
+++ b/packages/webawesome/docs/docs/components/otp-input.md
@@ -319,9 +319,10 @@ The component uses a single visually hidden `<input>` as the focus and form targ
 
 Keyboard interaction follows the single-input model:
 
-| Key                                   | Behavior                                                             |
-| ------------------------------------- | -------------------------------------------------------------------- |
-| <kbd>←</kbd> <kbd>→</kbd>             | Move between segments                                                |
-| <kbd>Tab</kbd> / <kbd>Shift+Tab</kbd> | Move between segments; leaves the field at the first or last segment |
-| <kbd>Backspace</kbd>                  | Clears the current segment and moves back (no character shift)       |
-| <kbd>Delete</kbd>                     | Clears the current segment without moving                            |
+| Key                       | Behavior                                                       |
+| ------------------------- | -------------------------------------------------------------- |
+| <kbd>←</kbd> <kbd>→</kbd> | Move between segments                                          |
+| <kbd>Tab</kbd>            | Moves focus to the next form control                           |
+| <kbd>Enter</kbd>          | Submits the containing form                                    |
+| <kbd>Backspace</kbd>      | Clears the current segment and moves back (no character shift) |
+| <kbd>Delete</kbd>         | Clears the current segment without moving                      |

--- a/packages/webawesome/docs/docs/components/otp-input.md
+++ b/packages/webawesome/docs/docs/components/otp-input.md
@@ -167,7 +167,7 @@ Use the `readonly` attribute to display a value without allowing edits. Unlike `
 Use the `value` attribute to prefill the segments — for example, when a code arrives in a link's query parameter.
 
 ```html {.example}
-<wa-otp-input label="Magic link code" value="483920"></wa-otp-input>
+<wa-otp-input label="Magic link code" value="271828"></wa-otp-input>
 ```
 
 ### Pasting

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -31,6 +31,12 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 ## Unreleased
 
+:::added
+
+- Added the experimental `<wa-otp-input>` component for entering fixed-length codes — one-time passcodes, PINs, and verification codes [pr:2584]
+
+:::
+
 :::fixed
 
 - Fixed type resolution issues with `pro` components like `<wa-file-input>`, `<wa-combobox>`, etc. [pr:2577]
@@ -48,7 +54,6 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 :::added
 
-- Added the experimental `<wa-otp-input>` component for entering fixed-length codes — one-time passcodes, PINs, and verification codes [pr:2584]
 - Added the experimental `<wa-random-content>` component, which randomly shows one or more of its children — handy for rotating testimonials, tips, or featured content
 - Added the Mosaic, Pixel, Vellum, Slab Duo, and Slab Press Duo Pro+ icon families to `<wa-icon>` [pr:2562]
 - Added the `buzz`, `flip-360`, `float`, `jello`, `spin-snap`, `spin-snap-4`, `spin-snap-8`, `swing`, and `wag` animations to `<wa-icon>` [pr:2562]

--- a/packages/webawesome/src/components/otp-input/otp-input.styles.ts
+++ b/packages/webawesome/src/components/otp-input/otp-input.styles.ts
@@ -8,6 +8,9 @@ export default css`
   /* Segments container */
   .segments {
     position: relative;
+    /* Codes read left-to-right regardless of locale — keep segment order and caret movement LTR
+       even when the surrounding page is RTL. */
+    direction: ltr;
     display: inline-flex;
     align-items: center;
     align-self: start;

--- a/packages/webawesome/src/components/otp-input/otp-input.styles.ts
+++ b/packages/webawesome/src/components/otp-input/otp-input.styles.ts
@@ -130,8 +130,8 @@ export default css`
     }
   }
 
-  /* Separator character between segment groups */
-  .segment-separator {
+  /* Literal separator character between segment groups */
+  .segment-literal {
     display: inline-block;
     flex-shrink: 0;
     color: var(--wa-color-text-quiet);
@@ -179,7 +179,7 @@ export default css`
 
   /* Dividers between contained segments */
   :host([appearance='contained']) .segment + .segment,
-  :host([appearance='contained']) .segment-separator + .segment {
+  :host([appearance='contained']) .segment-literal + .segment {
     border-left: var(--wa-form-control-border-width) var(--wa-form-control-border-style)
       var(--wa-form-control-border-color);
   }

--- a/packages/webawesome/src/components/otp-input/otp-input.test.ts
+++ b/packages/webawesome/src/components/otp-input/otp-input.test.ts
@@ -596,6 +596,70 @@ describe('<wa-otp-input>', () => {
           expect(segments.getAttribute('role')).to.equal('group');
         });
       });
+
+      describe('enter key', () => {
+        it('should submit the containing form when enter is pressed', async () => {
+          const form = await fixture<HTMLFormElement>(
+            html`<form><wa-otp-input name="code" length="3" value="123"></wa-otp-input></form>`,
+          );
+          const el = form.querySelector<WaOtpInput>('wa-otp-input')!;
+          const submitHandler = sinon.spy((event: SubmitEvent) => event.preventDefault());
+
+          form.addEventListener('submit', submitHandler);
+          el.focus();
+          await sendKeys({ press: 'Enter' });
+          await waitUntil(() => submitHandler.calledOnce);
+
+          expect(submitHandler).to.have.been.calledOnce;
+        });
+      });
+
+      describe('tab key', () => {
+        it('should move focus out of the field when tab is pressed', async () => {
+          const container = await fixture<HTMLDivElement>(
+            html`<div>
+              <wa-otp-input label="Code"></wa-otp-input>
+              <button type="button">After</button>
+            </div>`,
+          );
+          const el = container.querySelector<WaOtpInput>('wa-otp-input')!;
+          const button = container.querySelector('button')!;
+
+          el.focus();
+          await sendKeys({ press: 'Tab' });
+
+          expect(document.activeElement).to.equal(button);
+        });
+      });
+
+      describe('right-to-left', () => {
+        it('should keep segments laid out left-to-right in RTL contexts', async () => {
+          const container = await fixture<HTMLDivElement>(
+            html`<div dir="rtl"><wa-otp-input label="Code" value="12"></wa-otp-input></div>`,
+          );
+          const el = container.querySelector<WaOtpInput>('wa-otp-input')!;
+          await el.updateComplete;
+          const segments = el.shadowRoot!.querySelector('.segments')!;
+          expect(getComputedStyle(segments).direction).to.equal('ltr');
+        });
+      });
+
+      describe('autofill', () => {
+        it('should filter, not truncate, raw values that exceed the segment count', async () => {
+          const el = await fixture<WaOtpInput>(html`<wa-otp-input label="Code"></wa-otp-input>`);
+          await el.updateComplete;
+          const input = el.shadowRoot!.querySelector<HTMLInputElement>('.hidden-input')!;
+
+          // Simulate browser autofill: set the raw input value (with separators) and fire input
+          input.value = '123 456';
+          input.dispatchEvent(new InputEvent('input', { bubbles: true, composed: true }));
+          await el.updateComplete;
+
+          // maxlength would truncate an autofilled "123 456" to "123 45" before filtering ran
+          expect(input.hasAttribute('maxlength')).to.be.false;
+          expect(el.value).to.equal('123456');
+        });
+      });
     });
   }
 });

--- a/packages/webawesome/src/components/otp-input/otp-input.test.ts
+++ b/packages/webawesome/src/components/otp-input/otp-input.test.ts
@@ -120,7 +120,7 @@ describe('<wa-otp-input>', () => {
 
         it('should render separators from the format string', async () => {
           const el = await fixture<WaOtpInput>(html`<wa-otp-input format="###-###"></wa-otp-input>`);
-          const separators = el.shadowRoot!.querySelectorAll('[part~="segment-separator"]');
+          const separators = el.shadowRoot!.querySelectorAll('[part~="segment-literal"]');
           expect(separators.length).to.equal(1);
           expect(separators[0].textContent).to.equal('-');
         });

--- a/packages/webawesome/src/components/otp-input/otp-input.test.ts
+++ b/packages/webawesome/src/components/otp-input/otp-input.test.ts
@@ -581,6 +581,24 @@ describe('<wa-otp-input>', () => {
         });
       });
 
+      describe('caret', () => {
+        it('should show the caret in an empty active segment', async () => {
+          const el = await fixture<WaOtpInput>(html`<wa-otp-input label="Code"></wa-otp-input>`);
+          el.focus();
+          await el.updateComplete;
+          expect(el.shadowRoot!.querySelector('.caret')).to.exist;
+        });
+
+        it('should not draw the caret over a filled segment', async () => {
+          // A filled active segment is in replace mode — the ring marks it; a caret
+          // through the existing character reads as a strikethrough.
+          const el = await fixture<WaOtpInput>(html`<wa-otp-input label="Code" value="123456"></wa-otp-input>`);
+          el.focus();
+          await el.updateComplete;
+          expect(el.shadowRoot!.querySelector('.caret')).to.not.exist;
+        });
+      });
+
       describe('accessibility', () => {
         it('should have aria-describedby pointing to the hint element', async () => {
           const el = await fixture<WaOtpInput>(html`<wa-otp-input hint="Enter your code"></wa-otp-input>`);

--- a/packages/webawesome/src/components/otp-input/otp-input.test.ts
+++ b/packages/webawesome/src/components/otp-input/otp-input.test.ts
@@ -595,6 +595,14 @@ describe('<wa-otp-input>', () => {
           const segments = el.shadowRoot!.querySelector('.segments')!;
           expect(segments.getAttribute('role')).to.equal('group');
         });
+
+        it('should pass accessibility checks', async () => {
+          const el = await fixture<WaOtpInput>(
+            html`<wa-otp-input label="Verification code" hint="Check your email for a 6-digit code."></wa-otp-input>`,
+          );
+          await el.updateComplete;
+          await expect(el).to.be.accessible();
+        });
       });
 
       describe('enter key', () => {

--- a/packages/webawesome/src/components/otp-input/otp-input.ts
+++ b/packages/webawesome/src/components/otp-input/otp-input.ts
@@ -16,7 +16,8 @@ import sizeStyles from '../../styles/component/size.styles.js';
 import styles from './otp-input.styles.js';
 
 /**
- * @summary OTP inputs collect one-time passcodes, PINs, and other fixed-length codes, one character per segment. Use them for SMS verification, two-factor authentication, and invite codes.
+ * @summary OTP inputs collect one-time passcodes, PINs, and other fixed-length codes, one character per segment.
+ * Use them for SMS verification, two-factor authentication, and invite codes.
  * @documentation https://webawesome.com/docs/components/otp-input
  * @status experimental
  * @since 3.10

--- a/packages/webawesome/src/components/otp-input/otp-input.ts
+++ b/packages/webawesome/src/components/otp-input/otp-input.ts
@@ -554,7 +554,7 @@ export default class WaOtpInput extends WebAwesomeFormAssociatedElement {
                 : this.placeholder
                   ? html`<span class="segment--placeholder">${this.placeholder}</span>`
                   : ''}
-              ${isActive ? html`<span class="caret"></span>` : ''}
+              ${isActive && !char ? html`<span class="caret"></span>` : ''}
             </div>
           `;
         })}

--- a/packages/webawesome/src/components/otp-input/otp-input.ts
+++ b/packages/webawesome/src/components/otp-input/otp-input.ts
@@ -350,6 +350,11 @@ export default class WaOtpInput extends WebAwesomeFormAssociatedElement {
       }
     } else if (this.readonly) {
       // All character-mutating keys are blocked when readonly; navigation above still works.
+      // preventDefault matters here: a readonly input isn't an editable context, so WebKit
+      // treats an unhandled Backspace as the history-back gesture and navigates away.
+      if (e.key === 'Backspace' || e.key === 'Delete') {
+        e.preventDefault();
+      }
     } else if (e.key === 'Backspace') {
       // Prevent browser from shifting chars; manually splice the slot and move back.
       e.preventDefault();

--- a/packages/webawesome/src/components/otp-input/otp-input.ts
+++ b/packages/webawesome/src/components/otp-input/otp-input.ts
@@ -7,7 +7,7 @@ import { WaCompleteEvent } from '../../events/complete.js';
 import { scrollIntoView } from '../../internal/scroll.js';
 import { warnDeprecatedSize } from '../../internal/size.js';
 import { HasSlotController } from '../../internal/slot.js';
-import { submitForm } from '../../internal/submit-on-enter.js';
+import { submitForm, submitOnEnter } from '../../internal/submit-on-enter.js';
 import { MirrorValidator } from '../../internal/validators/mirror-validator.js';
 import { watch } from '../../internal/watch.js';
 import { WebAwesomeFormAssociatedElement } from '../../internal/webawesome-form-associated-element.js';
@@ -330,15 +330,10 @@ export default class WaOtpInput extends WebAwesomeFormAssociatedElement {
     if (e.isComposing) return;
     const max = this.effectiveLength;
 
-    if (e.key === 'Tab') {
-      if (!e.shiftKey && this._activeIndex < max - 1) {
-        e.preventDefault();
-        this.setCaretIndex(this._activeIndex + 1);
-      } else if (e.shiftKey && this._activeIndex > 0) {
-        e.preventDefault();
-        this.setCaretIndex(this._activeIndex - 1);
-      }
-      // else: Tab/Shift-Tab at boundary → propagate out of component
+    // Tab is deliberately not handled — it moves focus to the next control like any single input;
+    // arrow keys handle movement between segments.
+    if (e.key === 'Enter') {
+      submitOnEnter(e, this);
     } else if (e.key === 'ArrowRight') {
       e.preventDefault();
       if (this.hasSelection) {
@@ -566,7 +561,6 @@ export default class WaOtpInput extends WebAwesomeFormAssociatedElement {
           class="hidden-input"
           type="text"
           .value=${live(this._value)}
-          maxlength=${this.effectiveLength}
           minlength=${this.effectiveLength}
           autocomplete=${this.autocomplete}
           inputmode=${this.type === 'numeric' ? 'numeric' : 'text'}

--- a/packages/webawesome/src/components/otp-input/otp-input.ts
+++ b/packages/webawesome/src/components/otp-input/otp-input.ts
@@ -37,7 +37,7 @@ import styles from './otp-input.styles.js';
  * @csspart label - The label element.
  * @csspart hint - The hint element.
  * @csspart segments - The wrapper around all segment cells and separators.
- * @csspart segment - An individual character segment cell. Use `[part~="segment"]` to style all.
+ * @csspart segment - An individual character segment cell.
  * @csspart segment-literal - Inert literal text between segment groups (e.g. space or dash).
  *
  * @cssstate --blank - Applied when no characters have been entered.

--- a/packages/webawesome/src/components/otp-input/otp-input.ts
+++ b/packages/webawesome/src/components/otp-input/otp-input.ts
@@ -37,8 +37,8 @@ import styles from './otp-input.styles.js';
  * @csspart label - The label element.
  * @csspart hint - The hint element.
  * @csspart segments - The wrapper around all segment cells and separators.
- * @csspart segment - An individual character segment cell.
- * @csspart segment-separator - A literal separator character between segment groups (e.g. space or dash).
+ * @csspart segment - An individual character segment cell. Use `[part~="segment"]` to style all.
+ * @csspart segment-literal - Inert literal text between segment groups (e.g. space or dash).
  *
  * @cssstate --blank - Applied when no characters have been entered.
  * @cssstate --filled - Applied when all segments are filled.
@@ -46,9 +46,9 @@ import styles from './otp-input.styles.js';
  * @cssstate readonly - Applied when the component is readonly.
  * @cssstate user-invalid - Applied when validation fails after interaction.
  *
- * @cssproperty --segment-size - Width and height of each segment cell. Default: `2.5em`.
- * @cssproperty --segment-gap - Gap between segments (not used in `contained` appearance). Default: themed.
- * @cssproperty --segment-border-radius - Corner radius of each segment. Default: themed.
+ * @cssproperty [--segment-size=2.5em] - Width and height of each segment cell.
+ * @cssproperty [--segment-gap=var(--wa-space-xs)] - Gap between segments (not used in `contained` appearance).
+ * @cssproperty [--segment-border-radius=var(--wa-form-control-border-radius)] - Corner radius of each segment.
  */
 @customElement('wa-otp-input')
 export default class WaOtpInput extends WebAwesomeFormAssociatedElement {
@@ -523,9 +523,7 @@ export default class WaOtpInput extends WebAwesomeFormAssociatedElement {
       <div part="segments" class="segments" role="group" aria-labelledby="label" @click=${this.handleSegmentsClick}>
         ${parts.map(part => {
           if (part.type === 'separator') {
-            return html`<span part="segment-separator" class="segment-separator" aria-hidden="true"
-              >${part.char}</span
-            >`;
+            return html`<span part="segment-literal" class="segment-literal" aria-hidden="true">${part.char}</span>`;
           }
 
           const i = segmentIndex++;


### PR DESCRIPTION
(Currently built on top of/based on https://github.com/shoelace-style/webawesome/pull/2650...)

This work includes behavior fixes for the `<wa-otp-input>` component added in https://github.com/shoelace-style/webawesome/pull/2584:

### Keyboard Interactions
- `Enter` now submits the containing form through the shared `submitOnEnter` helper, same as `wa-input`.  Previously, nothing happened because the hidden input wasn't the form owner, and native implicit submission never fired.
- `Tab` no longer walks the segments; arrows already handle movement within the field, and `Tab` should leave it like any single input. **That reverses a deliberate choice from the original PR, so push back if you disagree**, but a keyboard user landing on an empty six-segment field was pressing `Tab` six times to escape it.

### WebKit-Based Fix
`Backspace` in a `readonly` field navigated the page back. The readonly branch blocked mutating keys without `preventDefault()`, and WebKit reads an unhandled `Backspace` in a non-editable context as the history-back gesture. 

This also broke the test suite, which had zero coverage in Safari as a result. This is fixed, and the suite now runs 178/178 on all three browsers.

### RTL Support
Segments stay left-to-right under `dir="rtl"`. Codes read the same in any locale, but the flex row was flipping while the string indexes weren't, so typing filled right-to-left. One `direction: ltr` on `.segments`.

### Autofill Updates
Dropped `maxlength` from the hidden input. Autofill isn't a paste event, so a separator-laden value could truncate before the filter ran. `handleInput` already filters and slices, and `minlength` stays to drive `tooShort`.

### Visual Polish
Hid the cursor caret over a filled segment. A filled active segment is in replace mode, and the ring already marks it; a caret drawn through the character is confusing and unfinished. 

### API Syncing
- Renamed the `segment-separator` part to `segment-literal` to match `time-input`'s name for the same thing
- switched the `--segment-*` custom properties to bracketed JSDoc defaults so they render in the API table.
