### PR TITLE
Docs: Add a Log In Link to Pro Callouts

### DIFF
--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -546,7 +546,8 @@
       font-size: var(--wa-font-size-xl);
     }
 
-    strong a {
+    strong a,
+    [class*='wa-caption'] a {
       color: inherit;
     }
 

--- a/packages/webawesome/docs/docs/color-palettes.njk
+++ b/packages/webawesome/docs/docs/color-palettes.njk
@@ -19,7 +19,7 @@ hasOutline: false
 {% raw %}
 {% if not currentUser or not currentUser.hasPro %}
 {% endraw %}
-<wa-callout class="pro">
+<wa-callout class="pro wa-brand-orange">
   <wa-icon slot="icon" name="hand-wave" animation="shake"
     style="--animation-delay: 2s; --animation-duration: 4s;"></wa-icon>
   <strong>

--- a/packages/webawesome/docs/docs/color-palettes.njk
+++ b/packages/webawesome/docs/docs/color-palettes.njk
@@ -22,23 +22,29 @@ hasOutline: false
 <wa-callout class="pro wa-brand-orange">
   <wa-icon slot="icon" name="hand-wave" animation="shake"
     style="--animation-delay: 2s; --animation-duration: 4s;"></wa-icon>
-  <strong>
-    <a href="/purchase?from=pro-docs&context=color-palettes">Unlock every color palette with {{ site.namePro }}!</a>
-  </strong>
+  <div class="wa-stack">
+    <div class="wa-stack wa-gap-2xs">
+      <strong>
+        <a href="/purchase?from=pro-docs&context=color-palettes">Unlock every color palette with {{ site.namePro }}!</a>
+      </strong>
 
-  <wa-details appearance="plain">
-    <span slot="summary">Subscribing to {{ site.namePro }} unlocks every color palette, plus premium themes, the visual
-      Theme Builder, and <u class="appearance-underlined variant-drawn">more</u>.</span>
+      <wa-details appearance="plain">
+        <span slot="summary">Subscribing to {{ site.namePro }} unlocks every color palette, plus premium themes, the
+          visual Theme Builder, and <u class="appearance-underlined variant-drawn">more</u>.</span>
 
-    <div class="wa-stack wa-gap-xl">
-      {% include "pro-perks.njk" ignore missing %}
+        <div class="wa-stack wa-gap-xl">
+          {% include "pro-perks.njk" ignore missing %}
 
-      <wa-button href="/purchase?from=pro-docs&context=color-palettes">
-        Get {{ site.namePro }}
-        <wa-icon slot="end" name="arrow-right"></wa-icon>
-      </wa-button>
+          <wa-button href="/purchase?from=pro-docs&context=color-palettes">
+            Get {{ site.namePro }}
+            <wa-icon slot="end" name="arrow-right"></wa-icon>
+          </wa-button>
+        </div>
+      </wa-details>
     </div>
-  </wa-details>
+
+    {% include "pro-login-cta.njk" ignore missing %}
+  </div>
 </wa-callout>
 {% raw %}
 {% endif %}

--- a/packages/webawesome/docs/docs/themes.njk
+++ b/packages/webawesome/docs/docs/themes.njk
@@ -19,7 +19,7 @@ layout: page
 {% raw %}
 {% if not currentUser or not currentUser.hasPro %}
 {% endraw %}
-<wa-callout class="pro">
+<wa-callout class="pro wa-brand-orange">
   <wa-icon slot="icon" name="hand-wave" animation="shake"
     style="--animation-delay: 2s; --animation-duration: 4s;"></wa-icon>
   <strong>

--- a/packages/webawesome/docs/docs/themes.njk
+++ b/packages/webawesome/docs/docs/themes.njk
@@ -22,23 +22,29 @@ layout: page
 <wa-callout class="pro wa-brand-orange">
   <wa-icon slot="icon" name="hand-wave" animation="shake"
     style="--animation-delay: 2s; --animation-duration: 4s;"></wa-icon>
-  <strong>
-    <a href="/purchase?from=pro-docs&context=themes">Unlock every theme with {{ site.namePro }}!</a>
-  </strong>
+  <div class="wa-stack">
+    <div class="wa-stack wa-gap-2xs">
+      <strong>
+        <a href="/purchase?from=pro-docs&context=themes">Unlock every theme with {{ site.namePro }}!</a>
+      </strong>
 
-  <wa-details appearance="plain">
-    <span slot="summary">Subscribing to {{ site.namePro }} unlocks every theme, plus premium color palettes, the visual
-      Theme Builder, and <u class="appearance-underlined variant-drawn">more</u>.</span>
+      <wa-details appearance="plain">
+        <span slot="summary">Subscribing to {{ site.namePro }} unlocks every theme, plus premium color palettes, the
+          visual Theme Builder, and <u class="appearance-underlined variant-drawn">more</u>.</span>
 
-    <div class="wa-stack wa-gap-xl">
-      {% include "pro-perks.njk" ignore missing %}
+        <div class="wa-stack wa-gap-xl">
+          {% include "pro-perks.njk" ignore missing %}
 
-      <wa-button href="/purchase?from=pro-docs&context=themes">
-        Get {{ site.namePro }}
-        <wa-icon slot="end" name="arrow-right"></wa-icon>
-      </wa-button>
+          <wa-button href="/purchase?from=pro-docs&context=themes">
+            Get {{ site.namePro }}
+            <wa-icon slot="end" name="arrow-right"></wa-icon>
+          </wa-button>
+        </div>
+      </wa-details>
     </div>
-  </wa-details>
+
+    {% include "pro-login-cta.njk" ignore missing %}
+  </div>
 </wa-callout>
 {% raw %}
 {% endif %}


### PR DESCRIPTION
This work gives logged-out Pro subscribers a way back in from the Themes and Color Palettes docs, and fixes a color bug on both callouts.

- Both callouts were missing `wa-brand-orange`, so `--wa-color-brand` stayed blue at `:root` and the drawn underline under "more" rendered blue on an orange callout. Adding the class fixes it.

- Includes `pro-login-cta.njk` from the app, with the callout body wrapped in a `wa-stack` to match the Pro component notice. `utils.css` gains `[class*='wa-caption'] a` alongside the existing `strong a` rule so the link inherits the caption's quiet color.

## Companion PRs
- https://github.com/shoelace-style/webawesome-app/pull/410
- https://github.com/shoelace-style/webawesome-pro/pull/266
