### PR TITLE
Document Mechanical Code Conventions in `CLAUDE.md`

### DIFF
--- a/packages/webawesome/CLAUDE.md
+++ b/packages/webawesome/CLAUDE.md
@@ -49,7 +49,13 @@ Instantiate in the class body (not constructor):
 
 ## Code Conventions
 
-- Event handler parameters are named `event`, not `e` — read from it directly (`event.key`, `event.target`, `event.preventDefault()`). Keeps handlers consistent across the codebase.
+The published [contributing guide](docs/docs/resources/contributing.md) is the canonical convention doc (component structure, BEM class names, `with-*`/`without-*` boolean props, event naming). The rules below are the mechanical ones most often gotten wrong:
+
+- Event handler parameters are named `event`, not `e`. Read from it directly (`event.key`, `event.target`, `event.preventDefault()`).
+- Event handlers are named `handle<Subject>` (`handleInput`, `handleClearClick`), not `onX`.
+- Relative imports end in `.js` (NodeNext ESM), e.g. `import styles from './button.styles.js'`.
+- Custom events are one class per file in `src/events/`: `class Wa<Name>Event extends Event`, dispatched via `super('wa-<kebab>', { bubbles, cancelable, composed: true })`, augmenting `GlobalEventHandlersEventMap`. Fire them with `this.dispatchEvent(new Wa<Name>Event(...))`. There is no `emit()` helper.
+- Multi-word properties declare an explicit kebab `attribute:`. Lit lowercases attribute names, so `passwordToggle` needs `attribute: 'password-toggle'`.
 
 ## Style Conventions
 

--- a/packages/webawesome/CLAUDE.md
+++ b/packages/webawesome/CLAUDE.md
@@ -47,6 +47,10 @@ Instantiate in the class body (not constructor):
 - `HasSlotController(this, 'slot-name')` — Tracks whether named slots have content. Used for conditional rendering.
 - `LocalizeController(this)` — i18n/l10n for component strings. Translations in `src/translations/`.
 
+## Code Conventions
+
+- Event handler parameters are named `event`, not `e` — read from it directly (`event.key`, `event.target`, `event.preventDefault()`). Keeps handlers consistent across the codebase.
+
 ## Style Conventions
 
 - Export default `css` tagged template literal from `component.styles.ts`.


### PR DESCRIPTION
This work adds a `## Code Conventions` section to `packages/webawesome/CLAUDE.md` capturing the mechanical, easy-to-miss conventions a contributor (or coding agent) tends to get wrong. 

It grew out of [#2650](https://github.com/shoelace-style/webawesome/pull/2650), where the `event`-not-`e` handler-param preference came up in review.

Rather than leave it as one-off feedback, this writes it down alongside the other conventions at the same level.

The section leads with a pointer to the published [contributing guide](https://webawesome.com/docs/resources/contributing/) as the canonical convention doc, then lists only rules that are genuinely undocumented there and verifiable across the codebase:

### What's Documented
- Event handler parameters are named `event`, not `e`
- Event handlers are named `handle<Subject>` (`handleInput`, `handleClearClick`)
- Relative imports end in `.js` (NodeNext ESM)
- Custom events are one `class Wa<Name>Event extends Event` per file in `src/events/`, dispatched with `new Wa…Event()`
- Multi-word properties declare an explicit kebab `attribute:`, since Lit lowercases attribute names.
