### PR TITLE
Unpinning the `client_test` Check from the Node Version

### DIFF
--- a/.github/workflows/client_tests.yml
+++ b/.github/workflows/client_tests.yml
@@ -1,6 +1,3 @@
-# # This workflow will do a clean install of node dependencies, cache/restore them, build the source code and run tests across different versions of node
-# # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
 name: Client Tests
 
 on:
@@ -10,22 +7,16 @@ on:
   pull_request:
     branches: [next]
 
-
 jobs:
   client_test:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [24.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 24.x
           cache: 'npm'
 
       - name: Install dependencies
@@ -43,6 +34,5 @@ jobs:
         working-directory: ./packages/webawesome
 
       - name: Run CSR tests
-        # FAIL_FAST to fail on first failing test.
         run: FAIL_FAST="true" CSR_ONLY="true" npm run test
         working-directory: ./packages/webawesome


### PR DESCRIPTION
Every PR into `next` has been silently blocked by a `client_test` check stuck on "Expected — waiting for status to be reported" that never resolves. This unsticks it and prevents it from happening again on the next Node bump.

Nothing was actually hanging. The `you-shall-not-pass-next` ruleset requires a check named `client_test (20.x)`, but the Node bump in #2598 moved the matrix to `24.x`, so the job started reporting as `client_test (24.x)`. The required `20.x` name never appeared, and GitHub waited forever. 

**The real problem: the Node version was baked into the check name**, so every future bump renames the check out from under the rule.

### What Changed
- Dropped `strategy.matrix` from the `client_test` job — it only ever ran one Node version (leftover from GitHub's starter template) — and set `node-version: 24.x` directly.
- The check now reports as plain `client_test`, with no `(24.x)` suffix to drift.

### Scope
Only `client_tests.yml`. It's the one check the ruleset actually requires. `anatomy`, `css_parts`, `hydration_tests`, and `ssr_tests` carry the same single-value matrix but aren't required checks, so I left them alone. Worth a follow-up if any of them ever gets promoted to required.

### Merge Order (this check gates its own PR)
This PR's `client_test` run can't satisfy a rule that still names `client_test (24.x)`, so:
1. Ruleset repointed to `client_test (24.x)` as an interim unblock for the current backlog.
2. Merge this via admin bypass, or flip the required context to `client_test` right before merging.
3. After merge, set the ruleset to require `client_test` and drop `client_test (24.x)`.
4. Rebase any open PRs onto `next` to pick up the renamed check.
