### PR TITLE
Update `@shoelace-style/localize`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13863,7 +13863,7 @@
         "@lit/context": "^1.1.6",
         "@lit/react": "^1.0.8",
         "@shoelace-style/animations": "^1.2.0",
-        "@shoelace-style/localize": "^3.2.2",
+        "@shoelace-style/localize": "^3.2.3",
         "composed-offset-position": "^0.0.6",
         "lit": "^3.2.1",
         "marked": "^11.2.0",
@@ -14983,6 +14983,12 @@
         "lit": "^3.1.2",
         "lit-html": "^3.1.2"
       }
+    },
+    "packages/webawesome/node_modules/@shoelace-style/localize": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@shoelace-style/localize/-/localize-3.2.3.tgz",
+      "integrity": "sha512-pWoZywizMilenLfQcpE9bjaqi7WKiQXJB42cxvmSPwYS76U776wJ7B5QQ0P28yVit1vpHuFZzq1CtfVFv32jaQ==",
+      "license": "MIT"
     },
     "packages/webawesome/node_modules/define-lazy-prop": {
       "version": "3.0.0",

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -61,6 +61,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 :::changed
 
 - Removed `font-variant-numeric: tabular-nums;` from default `<table>` styles in Native Styles in lieu of an opt-in `wa-tabular-nums` class [pr:2613]
+- Updated `@shoelace-style/localize` to 3.2.3 to fix a bug that caused a `RangeException` to be thrown when using Google Chrome's "Detect Language" translation feature [issue:2479]
 
 :::
 

--- a/packages/webawesome/package.json
+++ b/packages/webawesome/package.json
@@ -98,7 +98,7 @@
     "@lit/context": "^1.1.6",
     "@lit/react": "^1.0.8",
     "@shoelace-style/animations": "^1.2.0",
-    "@shoelace-style/localize": "^3.2.2",
+    "@shoelace-style/localize": "^3.2.3",
     "composed-offset-position": "^0.0.6",
     "lit": "^3.2.1",
     "marked": "^11.2.0",


### PR DESCRIPTION
I [just updated](https://github.com/shoelace-style/localize/commit/4b0c2d8d634ab0f3149623ec0477f5d14a69eb90) and published a new version of [`@shoelace-style/localize`](https://github.com/shoelace-style/localize). This PR upgrades Web Awesome to use the latest version, which solves #2479.