### PR TITLE
Initial HEXA value bug

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -56,6 +56,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 - Fixed a bug in `<wa-dialog>` and `<wa-drawer>` that left the page permanently scroll locked and inert when third-party CSS, e.g. from ad blockers, hides an open dialog or drawer with `display: none`
 - Fixed `<wa-page>` documenting `skip-links` and `skip-link` CSS parts that don't render; replaced them with the `skip-to-content` part it actually exposes [pr:2633]
 - Fixed `x-label` and `y-label` attributes not working on `<wa-chart>` and its variants
+- Fixed a bug in `<wa-color-picker>` where an initial value with alpha, e.g. `#f5a62315` with `opacity`, would lose its alpha channel on load [issue:2550]
 
 :::
 

--- a/packages/webawesome/src/components/color-picker/color-picker.test.ts
+++ b/packages/webawesome/src/components/color-picker/color-picker.test.ts
@@ -330,6 +330,18 @@ describe('<wa-color-picker>', () => {
           expect(new FormData(form).get('a')).to.equal('#4d64d54d');
         });
 
+        it('should preserve alpha and letter case when initialized with an uppercase HEXA value', async () => {
+          const form = await fixture<HTMLFormElement>(html`
+            <form>
+              <wa-color-picker name="a" format="hex" opacity uppercase value="#4d64d54d"></wa-color-picker>
+            </form>
+          `);
+          const colorPicker = form.querySelector<WaColorPicker>('wa-color-picker')!;
+
+          expect(colorPicker.value).to.equal('#4D64D54D');
+          expect(new FormData(form).get('a')).to.equal('#4D64D54D');
+        });
+
         it('should serialize its name and value with FormData', async () => {
           const form = await fixture<HTMLFormElement>(html`
             <form>

--- a/packages/webawesome/src/components/color-picker/color-picker.test.ts
+++ b/packages/webawesome/src/components/color-picker/color-picker.test.ts
@@ -318,6 +318,18 @@ describe('<wa-color-picker>', () => {
       });
 
       describe('form integration', () => {
+        it('should preserve alpha when initialized with a HEXA value and opacity enabled', async () => {
+          const form = await fixture<HTMLFormElement>(html`
+            <form>
+              <wa-color-picker name="a" format="hex" opacity value="#4d64d54d"></wa-color-picker>
+            </form>
+          `);
+          const colorPicker = form.querySelector<WaColorPicker>('wa-color-picker')!;
+
+          expect(colorPicker.value).to.equal('#4d64d54d');
+          expect(new FormData(form).get('a')).to.equal('#4d64d54d');
+        });
+
         it('should serialize its name and value with FormData', async () => {
           const form = await fixture<HTMLFormElement>(html`
             <form>

--- a/packages/webawesome/src/components/color-picker/color-picker.ts
+++ b/packages/webawesome/src/components/color-picker/color-picker.ts
@@ -275,6 +275,16 @@ export default class WaColorPicker extends WebAwesomeFormAssociatedElement {
       this.addEventListener('focusout', this.handleFocusOut);
     }
 
+    // Attribute values aren't applied to properties until the first update, but the initial value sync below serializes
+    // the value using them. Read them off the element directly, like defaultValue above, so an initial HEXA/RGBA/HSLA
+    // value keeps its alpha, format, and letter case.
+    this.opacity = this.hasAttribute('opacity');
+    this.uppercase = this.hasAttribute('uppercase');
+    const format = this.getAttribute('format');
+    if (format === 'rgb' || format === 'hsl' || format === 'hsv') {
+      this.format = format;
+    }
+
     // need to set initial values on the server. looks funky, but it works.
     this.handleValueChange('', this.value || '');
   }
@@ -940,14 +950,6 @@ export default class WaColorPicker extends WebAwesomeFormAssociatedElement {
 
   firstUpdated(changedProperties: PropertyValues<this>): void {
     super.firstUpdated(changedProperties);
-
-    const defaultValue = this.defaultValue;
-    if (defaultValue) {
-      const defaultColor = this.parseColor(defaultValue);
-      if (this.opacity && defaultColor && defaultColor.hsva.a < 1 && this.value === defaultColor.hex) {
-        this.setColor(defaultValue);
-      }
-    }
 
     this.hasEyeDropper = 'EyeDropper' in window;
   }

--- a/packages/webawesome/src/components/color-picker/color-picker.ts
+++ b/packages/webawesome/src/components/color-picker/color-picker.ts
@@ -806,7 +806,7 @@ export default class WaColorPicker extends WebAwesomeFormAssociatedElement {
     this.syncValues();
   }
 
-  @watch('opacity')
+  @watch('opacity', { waitUntilFirstUpdate: true })
   handleOpacityChange() {
     this.alpha = 100;
   }
@@ -938,6 +938,14 @@ export default class WaColorPicker extends WebAwesomeFormAssociatedElement {
 
   firstUpdated(changedProperties: PropertyValues<this>): void {
     super.firstUpdated(changedProperties);
+
+    const defaultValue = this.defaultValue;
+    if (defaultValue) {
+      const defaultColor = this.parseColor(defaultValue);
+      if (this.opacity && defaultColor && defaultColor.hsva.a < 1 && this.value === defaultColor.hex) {
+        this.setColor(defaultValue);
+      }
+    }
 
     this.hasEyeDropper = 'EyeDropper' in window;
   }


### PR DESCRIPTION
This builds off PR https://github.com/shoelace-style/webawesome/pull/2588 to solve https://github.com/shoelace-style/webawesome/issues/2550.

The PR fixes a bug where `<wa-color-picker>` would lose the alpha channel of an initial HEXA/RGBA/HSLA value, causing the form to submit a plain hex value. The color picker now reads its `opacity`, `format`, and `uppercase` attributes before the initial value sync so the value is never re-serialized with default settings, and no longer resets alpha to 100 on first render.

Tested using the original test case found in #2550.