### PR TITLE
Fix carousel loop dynamic slides

### DIFF
--- a/packages/webawesome/docs/docs/components/carousel.md
+++ b/packages/webawesome/docs/docs/components/carousel.md
@@ -286,7 +286,7 @@ The content of the carousel can be changed by adding or removing carousel items.
 
 ```html {.example}
 <div>
-  <wa-carousel class="dynamic-carousel" pagination navigation>
+  <wa-carousel class="dynamic-carousel" pagination navigation loop>
     <wa-carousel-item style="background: red">Slide 1</wa-carousel-item>
     <wa-carousel-item style="background: orange">Slide 2</wa-carousel-item>
     <wa-carousel-item style="background: yellow">Slide 3</wa-carousel-item>
@@ -322,21 +322,22 @@ The content of the carousel can be changed by adding or removing carousel items.
     const colors = ['red', 'orange', 'yellow', 'green', 'blue', 'purple'];
     let colorIndex = 2;
 
+    const slides = () => [...dynamicCarousel.children].filter(child => !child.hasAttribute('data-clone'));
+
     const addSlide = () => {
       const slide = document.createElement('wa-carousel-item');
       const color = colors[++colorIndex % colors.length];
-      slide.innerText = `Slide ${dynamicCarousel.children.length + 1}`;
+      slide.innerText = `Slide ${slides().length + 1}`;
       slide.style.setProperty('background', color);
-      dynamicCarousel.appendChild(slide);
+      dynamicCarousel.addSlide(slide);
       dynamicRemove.disabled = false;
     };
 
     const removeSlide = () => {
-      const slide = dynamicCarousel.children[dynamicCarousel.children.length - 1];
-      const numSlides = dynamicCarousel.querySelectorAll('wa-carousel-item').length;
+      const numSlides = slides().length;
 
       if (numSlides > 1) {
-        slide.remove();
+        dynamicCarousel.removeSlide(numSlides - 1);
         colorIndex--;
       }
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -34,6 +34,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 :::added
 
 - Added a CSS part named after the component to every component that renders a wrapper element (e.g. `button`, `details`, `carousel`), alongside the existing `base` part. Where the component name is already used by an inner part, the wrapper takes a `-wrapper` suffix (`input-wrapper`, `textarea-wrapper`).
+- Added `addSlide()` and `removeSlide()` methods to `<wa-carousel>` for adding and removing slides dynamically, including when `loop` is enabled [issue:2173]
 
 :::
 

--- a/packages/webawesome/src/components/carousel/carousel.test.ts
+++ b/packages/webawesome/src/components/carousel/carousel.test.ts
@@ -673,6 +673,64 @@ describe('<wa-carousel>', () => {
             expect(el.activeSlide).to.be.equal(2);
           });
         });
+
+        describe('#addSlide', () => {
+          it('should add a slide before the trailing loop clones', async () => {
+            const el = await fixture<WaCarousel>(html`
+              <wa-carousel loop>
+                <wa-carousel-item>Node 1</wa-carousel-item>
+                <wa-carousel-item>Node 2</wa-carousel-item>
+                <wa-carousel-item>Node 3</wa-carousel-item>
+              </wa-carousel>
+            `);
+            const slide = document.createElement('wa-carousel-item');
+            slide.textContent = 'Node 4';
+
+            el.addSlide(slide);
+            await nextFrame();
+            await el.updateComplete;
+
+            const slides = [...el.children].filter(child => !child.hasAttribute('data-clone'));
+            const clones = [...el.children].filter(child => child.hasAttribute('data-clone'));
+
+            expect(slides.map(slide => slide.textContent?.trim())).to.deep.equal([
+              'Node 1',
+              'Node 2',
+              'Node 3',
+              'Node 4',
+            ]);
+            expect(el.children[el.children.length - 2]).to.equal(slide);
+            expect(clones).to.have.lengthOf(2);
+          });
+        });
+
+        describe('#removeSlide', () => {
+          it('should remove real slides and keep the active slide in range when looping', async () => {
+            const el = await fixture<WaCarousel>(html`
+              <wa-carousel loop>
+                <wa-carousel-item>Node 1</wa-carousel-item>
+                <wa-carousel-item>Node 2</wa-carousel-item>
+                <wa-carousel-item>Node 3</wa-carousel-item>
+              </wa-carousel>
+            `);
+
+            el.goToSlide(2, 'auto');
+            await oneEvent(el.scrollContainer, 'scrollend');
+            await intersectionObserverCallbacks();
+            await el.updateComplete;
+
+            el.removeSlide(2);
+            await nextFrame();
+            await el.updateComplete;
+
+            const slides = [...el.children].filter(child => !child.hasAttribute('data-clone'));
+            const clones = [...el.children].filter(child => child.hasAttribute('data-clone'));
+
+            expect(slides.map(slide => slide.textContent?.trim())).to.deep.equal(['Node 1', 'Node 2']);
+            expect(el.activeSlide).to.equal(1);
+            expect(clones).to.have.lengthOf(2);
+          });
+        });
       });
 
       describe('when inside a hidden container', () => {

--- a/packages/webawesome/src/components/carousel/carousel.ts
+++ b/packages/webawesome/src/components/carousel/carousel.ts
@@ -518,6 +518,41 @@ export default class WaCarousel extends WebAwesomeElement {
     this.goToSlide(this.activeSlide + this.slidesPerMove, behavior);
   }
 
+  /** Adds a carousel item as the last real slide. */
+  addSlide(slide: WaCarouselItem) {
+    if (!this.isCarouselItem(slide) || slide.hasAttribute('data-clone')) {
+      throw new TypeError('addSlide() expects a <wa-carousel-item>.');
+    }
+
+    const slides = this.getSlides();
+    const lastSlide = slides[slides.length - 1];
+    this.insertBefore(slide, lastSlide?.nextElementSibling ?? null);
+  }
+
+  /** Removes the real slide at the specified index. */
+  removeSlide(index: number) {
+    if (!Number.isInteger(index)) {
+      return;
+    }
+
+    const slides = this.getSlides();
+    const slide = slides[index];
+
+    if (!slide) {
+      return;
+    }
+
+    const lastIndexAfterRemoval = Math.max(0, slides.length - 2);
+
+    if (index < this.activeSlide) {
+      this.activeSlide = Math.max(0, this.activeSlide - 1);
+    } else if (index === this.activeSlide) {
+      this.activeSlide = clamp(this.activeSlide, 0, lastIndexAfterRemoval);
+    }
+
+    slide.remove();
+  }
+
   /**
    * Scrolls the carousel to the slide specified by `index`.
    *

--- a/packages/webawesome/src/components/carousel/carousel.ts
+++ b/packages/webawesome/src/components/carousel/carousel.ts
@@ -521,8 +521,12 @@ export default class WaCarousel extends WebAwesomeElement {
 
   /** Adds a carousel item as the last real slide. */
   addSlide(slide: WaCarouselItem) {
-    if (!this.isCarouselItem(slide) || slide.hasAttribute('data-clone')) {
+    if (!this.isCarouselItem(slide)) {
       throw new TypeError('addSlide() expects a <wa-carousel-item>.');
+    }
+
+    if (slide.hasAttribute('data-clone')) {
+      throw new TypeError('addSlide() cannot add a cloned carousel item.');
     }
 
     const slides = this.getSlides();


### PR DESCRIPTION
Builds off #2595, clarifies the error `addSlide()` throws when passed a cloned item , and adds a changelog entry.

Fixes #2173 