### PR TITLE
Deprecate the `label` CSS Part in Favor of `form-control-label`

### DIFF
--- a/packages/webawesome/custom-elements-manifest.js
+++ b/packages/webawesome/custom-elements-manifest.js
@@ -135,15 +135,22 @@ export default {
       },
     },
     {
-      // Flag `base` in the manifest so editors and other CEM consumers see the deprecation, not just the docs.
-      name: 'wa-deprecate-base-part',
+      // Flag legacy duplicate parts in the manifest so editors and other CEM consumers see the
+      // deprecation, not just the docs: `base` everywhere, and `label` on form controls that also
+      // expose the canonical `form-control-label`.
+      name: 'wa-deprecate-legacy-parts',
       packageLinkPhase({ customElementsManifest }) {
         customElementsManifest?.modules?.forEach(mod => {
           mod.declarations?.forEach(declaration => {
+            const hasFormControlLabel = declaration.cssParts?.some(part => part.name === 'form-control-label');
             declaration.cssParts?.forEach(part => {
               if (part.name === 'base') {
                 part.deprecated =
                   'Use the part named after the component instead. This part will be removed in a future major version.';
+              }
+              if (part.name === 'label' && hasFormControlLabel) {
+                part.deprecated =
+                  'Use the `form-control-label` part instead. This part will be removed in a future major version.';
               }
             });
           });

--- a/packages/webawesome/custom-elements-manifest.js
+++ b/packages/webawesome/custom-elements-manifest.js
@@ -142,6 +142,9 @@ export default {
       packageLinkPhase({ customElementsManifest }) {
         customElementsManifest?.modules?.forEach(mod => {
           mod.declarations?.forEach(declaration => {
+            // We can only tell both parts exist on the component, not that they're on the same element
+            // (the manifest doesn't track that). True for every form control today; revisit if one ever
+            // adds a `label` that isn't the form-control label.
             const hasFormControlLabel = declaration.cssParts?.some(part => part.name === 'form-control-label');
             declaration.cssParts?.forEach(part => {
               if (part.name === 'base') {

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -69,6 +69,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 :::deprecated
 
 - The generic `base` CSS part is deprecated in favor of the part named after the component. Existing `::part(base)` selectors keep working and will until the next major version; `base` now appears as deprecated in each component's CSS Parts table.
+- On form controls, the `label` CSS part is deprecated in favor of `form-control-label`. Existing `::part(label)` selectors keep working until the next major version; `label` now appears as deprecated in those components' CSS Parts tables.
 
 :::
 

--- a/packages/webawesome/scripts/check-css-parts.js
+++ b/packages/webawesome/scripts/check-css-parts.js
@@ -37,14 +37,9 @@ async function readComponentSource(dir) {
   return contents.join('\n');
 }
 
-// Rendered but undocumented on purpose — pending API-shape decisions (form-control label naming).
-// Drop each as it's resolved.
+// Rendered but undocumented on purpose — pre-existing gaps to document separately.
 const DEFAULT_ALLOWLIST = {
-  'color-picker': ['form-control', 'form-control-input', 'form-control-label', 'hint'],
-  input: ['form-control-label'],
-  select: ['label'],
-  textarea: ['form-control-label'],
-  'time-input': ['label'],
+  'color-picker': ['form-control', 'form-control-input', 'hint'],
 };
 
 // These render `base` on a `<slot>` rather than a wrapper element. Parts don't belong on slots, and

--- a/packages/webawesome/src/components/checkbox-group/checkbox-group.ts
+++ b/packages/webawesome/src/components/checkbox-group/checkbox-group.ts
@@ -27,7 +27,7 @@ import styles from './checkbox-group.styles.js';
  * @slot hint - Text that describes how to use the checkbox group. Alternatively, you can use the `hint` attribute.
  *
  * @csspart form-control - The form control that wraps the label, group, and hint.
- * @csspart form-control-label - The label's wrapper.
+ * @csspart form-control-label - The label.
  * @csspart form-control-input - The element that wraps the grouped checkboxes, exposed as a `role="group"`.
  * @csspart hint - The hint's wrapper.
  *

--- a/packages/webawesome/src/components/color-picker/color-picker.ts
+++ b/packages/webawesome/src/components/color-picker/color-picker.ts
@@ -70,6 +70,7 @@ declare const EyeDropper: EyeDropperConstructor;
  * @csspart color-picker - The component's outer wrapper.
  * @csspart trigger - The color picker's dropdown trigger.
  * @csspart trigger-container - The container that wraps the color picker's trigger.
+ * @csspart form-control-label - The label.
  * @csspart swatches - The container that holds the swatches.
  * @csspart swatch - Each individual swatch.
  * @csspart grid - The color grid.

--- a/packages/webawesome/src/components/input/input.ts
+++ b/packages/webawesome/src/components/input/input.ts
@@ -40,7 +40,8 @@ import styles from './input.styles.js';
  * @event wa-clear - Emitted when the clear button is activated.
  * @event wa-invalid - Emitted when the form control has been checked for validity and its constraints aren't satisfied.
  *
- * @csspart label - The label
+ * @csspart form-control-label - The label.
+ * @csspart label - Deprecated. Use the `form-control-label` part instead.
  * @csspart hint - The hint's wrapper.
  * @csspart base - Deprecated. Use the `input-wrapper` part instead.
  * @csspart input-wrapper - The component's outer wrapper.

--- a/packages/webawesome/src/components/known-date/known-date.ts
+++ b/packages/webawesome/src/components/known-date/known-date.ts
@@ -43,7 +43,7 @@ const generateId = (): string => uniqueId('wa-known-date-');
  * @csspart form-control-label - The wrapper inside the legend that styles the visible label text.
  * @csspart form-control-input - Alias on the fields row matching other form controls.
  * @csspart hint - The hint's wrapper.
- * @csspart label - Alias on the legend's inner label wrapper.
+ * @csspart label - Deprecated. Use the `form-control-label` part instead.
  * @csspart base - Deprecated. Use the `known-date` part instead.
  * @csspart known-date - The component's outer wrapper.
  * @csspart fieldset - The `<fieldset>` element grouping the three fields (or a `role="group"` div).

--- a/packages/webawesome/src/components/number-input/number-input.ts
+++ b/packages/webawesome/src/components/number-input/number-input.ts
@@ -39,8 +39,8 @@ import styles from './number-input.styles.js';
  *  value from changing.
  * @event wa-invalid - Emitted when the form control has been checked for validity and its constraints aren't satisfied.
  *
- * @csspart label - The label element.
- * @csspart form-control-label - Alias for the label element.
+ * @csspart form-control-label - The label.
+ * @csspart label - Deprecated. Use the `form-control-label` part instead.
  * @csspart hint - The hint element.
  * @csspart base - Deprecated. Use the `number-input` part instead.
  * @csspart number-input - The component's outer wrapper.

--- a/packages/webawesome/src/components/radio-group/radio-group.ts
+++ b/packages/webawesome/src/components/radio-group/radio-group.ts
@@ -33,7 +33,7 @@ import styles from './radio-group.styles.js';
  * @event wa-invalid - Emitted when the form control has been checked for validity and its constraints aren't satisfied.
  *
  * @csspart form-control - The form control that wraps the label, input, and hint.
- * @csspart form-control-label - The label's wrapper.
+ * @csspart form-control-label - The label.
  * @csspart form-control-input - The input's wrapper.
  * @csspart radios - The wrapper than surrounds radio items, styled as a flex container by default.
  * @csspart hint - The hint's wrapper.

--- a/packages/webawesome/src/components/select/select.ts
+++ b/packages/webawesome/src/components/select/select.ts
@@ -61,7 +61,8 @@ import styles from './select.styles.js';
  * @event wa-invalid - Emitted when the form control has been checked for validity and its constraints aren't satisfied.
  *
  * @csspart form-control - The form control that wraps the label, input, and hint.
- * @csspart form-control-label - The label's wrapper.
+ * @csspart form-control-label - The label.
+ * @csspart label - Deprecated. Use the `form-control-label` part instead.
  * @csspart form-control-input - The select's wrapper.
  * @csspart hint - The hint's wrapper.
  * @csspart combobox - The container the wraps the start, end, value, clear icon, and expand button.

--- a/packages/webawesome/src/components/textarea/textarea.ts
+++ b/packages/webawesome/src/components/textarea/textarea.ts
@@ -30,7 +30,8 @@ import styles from './textarea.styles.js';
  * @event input - Emitted when the control receives input.
  * @event wa-invalid - Emitted when the form control has been checked for validity and its constraints aren't satisfied.
  *
- * @csspart label - The label
+ * @csspart form-control-label - The label.
+ * @csspart label - Deprecated. Use the `form-control-label` part instead.
  * @csspart form-control-input - The input's wrapper.
  * @csspart hint - The hint's wrapper.
  * @csspart textarea - The internal `<textarea>` control.

--- a/packages/webawesome/src/components/time-input/time-input.ts
+++ b/packages/webawesome/src/components/time-input/time-input.ts
@@ -79,7 +79,8 @@ const SINGLE_GROUP = 'single';
  * @event wa-invalid - Emitted when the form control has been checked for validity and its constraints aren't satisfied.
  *
  * @csspart form-control - The form control that wraps the label, input, and hint.
- * @csspart form-control-label - The label's wrapper.
+ * @csspart form-control-label - The label.
+ * @csspart label - Deprecated. Use the `form-control-label` part instead.
  * @csspart form-control-input - The input's wrapper.
  * @csspart hint - The hint's wrapper.
  * @csspart base - Deprecated. Use the `time-input` part instead.


### PR DESCRIPTION
This work closes the last open item in shoelace-style/webawesome#2624: the `form-control label` part was documented five different ways across components. 

This makes `form-control-label` the one canonical part on every form control and soft-deprecates the duplicate `label` part the same way `base` was.

### Canonical Docs
Every form control that renders both parts now documents `form-control-label` as the label and marks `label` deprecated.

 `<wa-input>`, `<wa-textarea>`, `<wa-number-input>`, `<wa-select>`, `<wa-time-input>`, and `<wa-known-date>`. `<wa-color-picker>`, `<wa-checkbox-group>`, and `<wa-radio-group>` render only `form-control-label` and document it as canonical. 

`label` stays canonical on non-form-control components like `<wa-button>` and `<wa-checkbox>`, where it isn't a duplicate.

### Manifest Flag
Extended the manifest plugin (`wa-deprecate-base-part` → `wa-deprecate-legacy-parts`) to flag `label` deprecated whenever a component also exposes `form-control-label`. 

That's the same rule the docs use, so it auto-covers every form control and drives the muted, sorted-to-bottom row in the CSS Parts table. This also surfaces the deprecation to editors, `llms.txt`, and the agent skill, not just the rendered docs.

### Guardrail and Changelog
- Dropped the now-resolved `label` / `form-control-label` entries from `check-css-parts.js` (they were explicitly tracking this pending decision)
- Added a `:::deprecated` changelog entry.

## Companion PRs
- https://github.com/shoelace-style/webawesome-pro/pull/270
