### PR TITLE
Color picker bug fixes and transparent swatch example

### DIFF
--- a/packages/webawesome/docs/docs/components/color-picker.md
+++ b/packages/webawesome/docs/docs/components/color-picker.md
@@ -108,6 +108,20 @@ picker.swatches = [
 ];
 ```
 
+To offer a fully transparent option, include the `transparent` keyword as a swatch. It renders with a checkerboard pattern, and selecting it sets the value to black with zero alpha, e.g. `#00000000`.
+
+```html {.example}
+<wa-color-picker
+  label="Select a color"
+  opacity
+  swatches="transparent; #d0021b; #f5a623; #f8e71c; #7ed321; #4a90e2; #9013fe; #000;"
+></wa-color-picker>
+```
+
+:::info
+Transparent swatches require the `opacity` attribute. Without it, the alpha channel is discarded and selecting the swatch yields opaque black.
+:::
+
 ### Placement
 
 Set the `placement` attribute to control where the dropdown opens. The actual position may shift to keep the panel inside the viewport.

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -58,7 +58,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 - Fixed `<wa-page>` documenting `skip-links` and `skip-link` CSS parts that don't render; replaced them with the `skip-to-content` part it actually exposes [pr:2633]
 - Fixed `x-label` and `y-label` attributes not working on `<wa-chart>` and its variants
 - Fixed a bug in `<wa-color-picker>` where an initial value with alpha, e.g. `#f5a62315` with `opacity`, would lose its alpha channel on load [issue:2550]
-- Fixed a bug in `<wa-color-picker>` where selecting a swatch with the keyboard didn't emit `change` and `input` events
+- Fixed a bug in `<wa-color-picker>` where selecting a swatch with the keyboard didn't emit `change` and `input` events [pr:2665]
 - Fixed a bug in `<wa-color-picker>` where an initial value with alpha but without `opacity` would render the trigger as transparent even though the value was opaque
 
 :::

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -58,6 +58,8 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 - Fixed `<wa-page>` documenting `skip-links` and `skip-link` CSS parts that don't render; replaced them with the `skip-to-content` part it actually exposes [pr:2633]
 - Fixed `x-label` and `y-label` attributes not working on `<wa-chart>` and its variants
 - Fixed a bug in `<wa-color-picker>` where an initial value with alpha, e.g. `#f5a62315` with `opacity`, would lose its alpha channel on load [issue:2550]
+- Fixed a bug in `<wa-color-picker>` where selecting a swatch with the keyboard didn't emit `change` and `input` events
+- Fixed a bug in `<wa-color-picker>` where an initial value with alpha but without `opacity` would render the trigger as transparent even though the value was opaque
 
 :::
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -59,7 +59,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 - Fixed `x-label` and `y-label` attributes not working on `<wa-chart>` and its variants
 - Fixed a bug in `<wa-color-picker>` where an initial value with alpha, e.g. `#f5a62315` with `opacity`, would lose its alpha channel on load [issue:2550]
 - Fixed a bug in `<wa-color-picker>` where selecting a swatch with the keyboard didn't emit `change` and `input` events [pr:2665]
-- Fixed a bug in `<wa-color-picker>` where an initial value with alpha but without `opacity` would render the trigger as transparent even though the value was opaque
+- Fixed a bug in `<wa-color-picker>` where an initial value with alpha but without `opacity` would render the trigger as transparent even though the value was opaque [pr:2665]
 
 :::
 

--- a/packages/webawesome/src/components/color-picker/color-picker.test.ts
+++ b/packages/webawesome/src/components/color-picker/color-picker.test.ts
@@ -18,6 +18,13 @@ describe('<wa-color-picker>', () => {
           expect(trigger?.style.color).to.equal('rgb(0, 0, 0)');
         });
 
+        it('should ignore alpha in the initial value when opacity is not enabled', async () => {
+          const el = await fixture<WaColorPicker>(html` <wa-color-picker value="#ff000080"></wa-color-picker> `);
+          const trigger = el.shadowRoot!.querySelector<HTMLButtonElement>('[part~="trigger"]');
+          expect(el.value).to.equal('#ff0000');
+          expect(trigger?.style.color).to.equal('rgb(255, 0, 0)');
+        });
+
         it('should show opacity slider when opacity is enabled', async () => {
           const el = await fixture<WaColorPicker>(html` <wa-color-picker opacity></wa-color-picker> `);
           const opacitySlider = el.shadowRoot!.querySelector('[part*="opacity-slider"]')!;
@@ -159,6 +166,44 @@ describe('<wa-color-picker>', () => {
 
           expect(changeHandler).to.have.been.calledOnce;
           expect(inputHandler).to.have.been.calledOnce;
+        });
+
+        it('should emit change and input when selecting a swatch with the keyboard', async () => {
+          const el = await fixture<WaColorPicker>(html`
+            <wa-color-picker swatches="red; green; blue;"></wa-color-picker>
+          `);
+          const trigger = el.shadowRoot!.querySelector<HTMLButtonElement>('[part~="trigger"]')!;
+          const swatch = el.shadowRoot!.querySelector<HTMLElement>('[part~="swatch"]')!;
+          const changeHandler = sinon.spy();
+          const inputHandler = sinon.spy();
+
+          el.addEventListener('change', changeHandler);
+          el.addEventListener('input', inputHandler);
+
+          await clickOnElement(trigger); // open the dropdown
+          await aTimeout(200); // wait for the dropdown to open
+          swatch.focus();
+          await sendKeys({ press: 'Enter' });
+          await el.updateComplete;
+
+          expect(el.value).to.equal('#ff0000');
+          expect(changeHandler).to.have.been.calledOnce;
+          expect(inputHandler).to.have.been.calledOnce;
+        });
+
+        it('should set a fully transparent value when selecting a transparent swatch with opacity enabled', async () => {
+          const el = await fixture<WaColorPicker>(html`
+            <wa-color-picker opacity swatches="transparent;"></wa-color-picker>
+          `);
+          const trigger = el.shadowRoot!.querySelector<HTMLButtonElement>('[part~="trigger"]')!;
+
+          await clickOnElement(trigger); // open the dropdown
+          await aTimeout(200); // wait for the dropdown to open
+          const swatch = el.shadowRoot!.querySelector<HTMLElement>('[part~="swatch"]')!;
+          await clickOnElement(swatch); // click on the swatch
+          await el.updateComplete;
+
+          expect(el.value).to.equal('#00000000');
         });
 
         it('should render the correct format when selecting a swatch of a different format', async () => {

--- a/packages/webawesome/src/components/color-picker/color-picker.ts
+++ b/packages/webawesome/src/components/color-picker/color-picker.ts
@@ -851,7 +851,7 @@ export default class WaColorPicker extends WebAwesomeFormAssociatedElement {
         this.hue = newColor.hsva.h;
         this.saturation = newColor.hsva.s;
         this.brightness = newColor.hsva.v;
-        this.alpha = newColor.hsva.a * 100;
+        this.alpha = this.opacity ? newColor.hsva.a * 100 : 100;
         this.syncValues();
       } else {
         this.inputValue = oldValue ?? '';
@@ -1329,8 +1329,12 @@ export default class WaColorPicker extends WebAwesomeFormAssociatedElement {
                       role="button"
                       aria-label=${swatch.label}
                       @click=${() => this.selectSwatch(swatch.color)}
-                      @keydown=${(event: KeyboardEvent) =>
-                        !this.disabled && event.key === 'Enter' && this.setColor(parsedColor.hexa)}
+                      @keydown=${(event: KeyboardEvent) => {
+                        if (event.key === 'Enter' || event.key === ' ') {
+                          event.preventDefault();
+                          this.selectSwatch(swatch.color);
+                        }
+                      }}
                     >
                       <div class="swatch-color" style=${styleMap({ backgroundColor: parsedColor.hexa })}></div>
                     </div>


### PR DESCRIPTION
This PR fixes a couple of color picker bugs I noticed as I was verifying support for transparent color swatch selection. It also adds an example of how to select transparent colors to the docs [as requested here](https://github.com/shoelace-style/webawesome/discussions/2569).

From the changelog:

- Fixed a bug in `<wa-color-picker>` where selecting a swatch with the keyboard didn't emit `change` and `input` events
- Fixed a bug in `<wa-color-picker>` where an initial value with alpha but without `opacity` would render the trigger as transparent even though the value was opaque