### PR TITLE
fix seo metadata stuff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2733,9 +2733,9 @@
       }
     },
     "node_modules/@shoelace-style/localize": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@shoelace-style/localize/-/localize-3.2.2.tgz",
-      "integrity": "sha512-h3+2/cFWGaw3KQUwintkP4Cy3PtrVW//ysr9DM5nOfIXYekgrHwsELk/nyxc8hmjVP/Kcon7KCzvUtSwUBipfQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@shoelace-style/localize/-/localize-3.2.3.tgz",
+      "integrity": "sha512-pWoZywizMilenLfQcpE9bjaqi7WKiQXJB42cxvmSPwYS76U776wJ7B5QQ0P28yVit1vpHuFZzq1CtfVFv32jaQ==",
       "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
@@ -13896,7 +13896,7 @@
         "@lit/context": "^1.1.6",
         "@lit/react": "^1.0.8",
         "@shoelace-style/animations": "^1.2.0",
-        "@shoelace-style/localize": "^3.2.2",
+        "@shoelace-style/localize": "^3.2.3",
         "chart.js": "^4.5.1",
         "composed-offset-position": "^0.0.6",
         "lit": "^3.2.1",
@@ -14983,12 +14983,6 @@
         "lit": "^3.1.2",
         "lit-html": "^3.1.2"
       }
-    },
-    "packages/webawesome/node_modules/@shoelace-style/localize": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@shoelace-style/localize/-/localize-3.2.3.tgz",
-      "integrity": "sha512-pWoZywizMilenLfQcpE9bjaqi7WKiQXJB42cxvmSPwYS76U776wJ7B5QQ0P28yVit1vpHuFZzq1CtfVFv32jaQ==",
-      "license": "MIT"
     },
     "packages/webawesome/node_modules/define-lazy-prop": {
       "version": "3.0.0",

--- a/packages/webawesome/docs/.eleventy.js
+++ b/packages/webawesome/docs/.eleventy.js
@@ -158,7 +158,8 @@ export default async function (eleventyConfig) {
     // default image, the explicit override if provided, otherwise null (suppresses emission).
     // data.ogImage technically is always defined above. So instead of checking if data.ogImage == null, do an explicit check for if its equal to siteMetadata.image
     ogImageWidth: data => data.ogImageWidth || (data.ogImage === siteMetadata.image ? siteMetadata.imageWidth : null),
-    ogImageHeight: data => data.ogImageHeight || (data.ogImage === siteMetadata.image ? siteMetadata.imageHeight : null),
+    ogImageHeight: data =>
+      data.ogImageHeight || (data.ogImage === siteMetadata.image ? siteMetadata.imageHeight : null),
     ogUrl: data => {
       // Strip template extensions: downstream consumers (e.g. webawesome-app) set
       // `permalink: /foo.njk` for two-pass SSR, so page.url carries an `.njk` resolution

--- a/packages/webawesome/docs/.eleventy.js
+++ b/packages/webawesome/docs/.eleventy.js
@@ -156,8 +156,9 @@ export default async function (eleventyConfig) {
     ogImage: data => data.ogImage || siteMetadata.image,
     // Only emit dimensions when we know them: use the default if the page is using the
     // default image, the explicit override if provided, otherwise null (suppresses emission).
-    ogImageWidth: data => data.ogImageWidth || (data.ogImage ? null : siteMetadata.imageWidth),
-    ogImageHeight: data => data.ogImageHeight || (data.ogImage ? null : siteMetadata.imageHeight),
+    // data.ogImage technically is always defined above. So instead of checking if data.ogImage == null, do an explicit check for if its equal to siteMetadata.image
+    ogImageWidth: data => data.ogImageWidth || (data.ogImage === siteMetadata.image ? siteMetadata.imageWidth : null),
+    ogImageHeight: data => data.ogImageHeight || (data.ogImage === siteMetadata.image ? siteMetadata.imageHeight : null),
     ogUrl: data => {
       // Strip template extensions: downstream consumers (e.g. webawesome-app) set
       // `permalink: /foo.njk` for two-pass SSR, so page.url carries an `.njk` resolution

--- a/packages/webawesome/docs/_layouts/component.njk
+++ b/packages/webawesome/docs/_layouts/component.njk
@@ -1,8 +1,9 @@
+{% set component = getComponent('wa-' + page.fileSlug) %}
+{% set description = component.summary %}
+{% set ogDescription = component.summary %}
 {% extends '../_layouts/docs.njk' %}
 {% from "pro-badge.njk" import proBadge %}
 {% from "macros/component-badges.njk" import componentMetaBadges %}
-{% set component = getComponent('wa-' + page.fileSlug) %}
-{% set description = component.summary %}
 
 {# Component header #}
 {% block beforeContent %}


### PR DESCRIPTION
Also worth noting `og:description` is undefined for all our component docs since that comes later in the build. That is displayed on a page using `{{ component.summary }}`, it never sets a `description` or `ogDescription`, so things like:

https://webawesome.com/docs/components/button

have no `og:description` as a result.

I'll leave it to our SEO expert @talbs if we should fix this.