### PR TITLE
fix(tree): don't throw on Enter/Space when focus is inside a tree item

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -63,6 +63,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 - Fixed a bug in `<wa-color-picker>` where an initial value with alpha, e.g. `#f5a62315` with `opacity`, would lose its alpha channel on load [issue:2550]
 - Fixed a bug in `<wa-color-picker>` where selecting a swatch with the keyboard didn't emit `change` and `input` events [pr:2665]
 - Fixed a bug in `<wa-color-picker>` where an initial value with alpha but without `opacity` would render the trigger as transparent even though the value was opaque [pr:2665]
+- Fixed a bug in `<wa-tree>` where pressing [[Enter]] or [[Space]] while focus was inside a tree item, e.g. on a link or a button slotted into it, threw a "Cannot read properties of undefined" error and swallowed the keypress instead of letting the focused element handle it [issue:2673]
 
 :::
 

--- a/packages/webawesome/src/components/tree/tree.test.ts
+++ b/packages/webawesome/src/components/tree/tree.test.ts
@@ -468,6 +468,66 @@ describe('<wa-tree>', () => {
             });
           });
         });
+
+        describe('when focus is inside a tree item instead of on it', () => {
+          const uncaughtErrors: string[] = [];
+          const collectUncaughtError = (event: ErrorEvent) => {
+            event.preventDefault();
+            uncaughtErrors.push(event.message);
+          };
+
+          beforeEach(() => {
+            uncaughtErrors.length = 0;
+            window.addEventListener('error', collectUncaughtError);
+          });
+
+          afterEach(() => {
+            window.removeEventListener('error', collectUncaughtError);
+          });
+
+          async function fixtureWithLink() {
+            const tree = await fixture<WaTree>(html`
+              <wa-tree>
+                <wa-tree-item><a href="#node-1">Node 1</a></wa-tree-item>
+                <wa-tree-item>Node 2</wa-tree-item>
+              </wa-tree>
+            `);
+            const link = tree.querySelector('a')!;
+
+            link.focus();
+            await tree.updateComplete;
+
+            return { tree, link };
+          }
+
+          it('should not throw when Enter is pressed', async () => {
+            const { tree } = await fixtureWithLink();
+
+            await sendKeys({ press: 'Enter' });
+
+            expect(uncaughtErrors).to.be.empty;
+            expect(tree.selectedItems.length).to.eq(0);
+          });
+
+          it('should not throw when Space is pressed', async () => {
+            const { tree } = await fixtureWithLink();
+
+            await sendKeys({ press: ' ' });
+
+            expect(uncaughtErrors).to.be.empty;
+            expect(tree.selectedItems.length).to.eq(0);
+          });
+
+          it('should let the focused element handle Enter', async () => {
+            const { link } = await fixtureWithLink();
+            const clickSpy = sinon.spy((event: MouseEvent) => event.preventDefault());
+            link.addEventListener('click', clickSpy);
+
+            await sendKeys({ press: 'Enter' });
+
+            expect(clickSpy).to.have.been.calledOnce;
+          });
+        });
       });
 
       describe('events', () => {

--- a/packages/webawesome/src/components/tree/tree.ts
+++ b/packages/webawesome/src/components/tree/tree.ts
@@ -249,9 +249,17 @@ export default class WaTree extends WebAwesomeElement {
     const isRtl = this.localize.dir() === 'rtl';
 
     if (items.length > 0) {
-      event.preventDefault();
       const activeItemIndex = items.findIndex(item => item.matches(':focus'));
       const activeItem: WaTreeItem | undefined = items[activeItemIndex];
+
+      // Enter and Space select the focused node, so there's nothing to do when no tree item has focus. This happens
+      // when focus is inside a tree item instead of on it, e.g. on a link or a button slotted into the item. Let the
+      // event through so the focused element can handle it.
+      if (!activeItem && (event.key === 'Enter' || event.key === ' ')) {
+        return;
+      }
+
+      event.preventDefault();
 
       const focusItemAt = (index: number) => {
         const item = items[clamp(index, 0, items.length - 1)];
@@ -297,7 +305,7 @@ export default class WaTree extends WebAwesomeElement {
         focusItemAt(items.length - 1);
       } else if (event.key === 'Enter' || event.key === ' ') {
         // Selects the focused node.
-        if (!activeItem.disabled) {
+        if (activeItem && !activeItem.disabled) {
           this.selectItem(activeItem);
         }
       }


### PR DESCRIPTION
Fixes #2673.

### The bug

`WaTree.handleKeyDown()` resolves the focused node with `items.findIndex(item => item.matches(':focus'))`. When focus is **inside** a tree item rather than **on** it — e.g. on a link or a button slotted into the item — no `<wa-tree-item>` matches `:focus` (it only matches `:focus-within`), `findIndex()` returns `-1`, and `activeItem` is `undefined`.

Every branch of the handler guards for that (`if (!activeItem || activeItem.disabled || …)`) except Enter/Space, so pressing either threw:

```
TypeError: Cannot read properties of undefined (reading 'disabled')
    at WaTree.handleKeyDown (chunk.7H62LFN3.js:228:25)
```

`event.preventDefault()` also ran *before* `activeItem` was resolved, so the keypress was swallowed as well — a link inside a tree item could never be activated with <kbd>Enter</kbd>, error or not.

Repro (also included as a test):

```html
<wa-tree>
  <wa-tree-item><a href="https://webawesome.com/">Tab to me, then press Enter</a></wa-tree-item>
  <wa-tree-item>Node 2</wa-tree-item>
</wa-tree>
```

### The change

`packages/webawesome/src/components/tree/tree.ts`

- Resolve `activeItem` before calling `event.preventDefault()`, and return early for <kbd>Enter</kbd>/<kbd>Space</kbd> when there is no active item. Nothing can be selected in that case, so the event is left alone and the focused element keeps its default behavior (the link is followed, the button is clicked).
- Add the missing `activeItem &&` guard in the Enter/Space branch, matching the ArrowLeft/ArrowRight branches. Redundant after the early return, but it keeps the branch type-safe and consistent with its neighbors.

Arrow keys, <kbd>Home</kbd> and <kbd>End</kbd> are deliberately untouched: they still `preventDefault()` and still fall back to `focusItemAt(-1 + 1)` / `clamp()` when nothing is focused, which is how focus enters the tree today.

This lines up with the existing escape hatch in the same handler for `input` and `textarea` ("prevents the component from hijacking nested form controls that exist inside tree items") — links and buttons simply weren't covered by it.

### Tests

`packages/webawesome/src/components/tree/tree.test.ts` — new `keyboard navigation > when focus is inside a tree item instead of on it` block:

- <kbd>Enter</kbd> with focus on a slotted link doesn't throw and selects nothing
- <kbd>Space</kbd> with focus on a slotted link doesn't throw and selects nothing
- <kbd>Enter</kbd> reaches the link, i.e. the click isn't cancelled by the tree

All three fail on `next` (the first two as `Uncaught TypeError: Cannot read properties of undefined (reading 'disabled')`) and pass with the fix.

Verified locally in Chromium, both rendering modes: `CSR_ONLY` across the whole suite (2458 passing, 0 failures) and `SSR_ONLY` for `tree.test.ts` (44 passing). `prettier --check` and `cspell` are clean on the changed files.

### Changelog

Entry added under **Unreleased → Fixed** referencing #2673.

### Context

We hit this in production in an app sidebar built as `<wa-tree selection="leaf">` where each `<wa-tree-item>` wraps an `<a>`: users navigating the sidebar by keyboard generated a steady trickle of these `TypeError`s, and their <kbd>Enter</kbd> press did nothing.
