### PR TITLE
Docs: Size Content Width Tokens Using `rem`

### DIFF
--- a/packages/webawesome/docs/assets/styles/docs.css
+++ b/packages/webawesome/docs/assets/styles/docs.css
@@ -124,13 +124,11 @@ wa-page:not([view='mobile']) > main {
   margin-inline: auto;
 }
 
-/* Anchor wa-prose's line-length to the docs' reading-column token instead
- * of its 65ch default. The override has to land on .wa-prose itself —
- * upstream prose.css declares --wa-prose-line-length on :where(.wa-prose),
- * and a value declared on the element wins over an inherited value even
- * at 0 specificity. */
+/* Docs reading column, kept in ch (a reading measure). Must land on .wa-prose itself:
+ * upstream sets --wa-prose-line-length on :where(.wa-prose) at 0 specificity, so an
+ * own-element declaration is needed to win over the inherited value. */
 #content > .wa-prose {
-  --wa-prose-line-length: var(--content-width-m);
+  --wa-prose-line-length: round(up, 110ch, 1px);
 }
 
 #content {

--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -6,10 +6,10 @@
   :root {
     /* max-width for fixed width app-based pages
      * We round() these to avoid obscure component rendering bugs caused by widths with fractional pixels */
-    --content-width-l: round(up, 132ch, 1px);
-    --content-width-m: round(up, 110ch, 1px);
-    --content-width-s: round(up, 80ch, 1px);
-    --content-width-xs: round(up, 50ch, 1px);
+    --content-width-l: round(up, 83rem, 1px);
+    --content-width-m: round(up, 70rem, 1px);
+    --content-width-s: round(up, 50rem, 1px);
+    --content-width-xs: round(up, 31.5rem, 1px);
     --content-width-full: 100%;
     --content-flow-spacing: 8ch;
     --content-padding-inline: var(--wa-space-2xl);


### PR DESCRIPTION
This work closes https://github.com/shoelace-style/webawesome/issues/2610.

The issue surfaced as a wrapping bug: the hero's "Components" split button dropped its search icon onto a second line for some reporters on Windows/Edge/Firefox, while others couldn't reproduce it at all. That platform split was the tell.

The dropped icon was one visible symptom of the whole content column rendering narrower on machines with a tighter default UI font than macOS.

### Root Cause
- `--content-width-*` are documented as "max-width for fixed width app-based pages," but they were defined in `ch`
- `ch` is the width of a `0` in the system font. The content inside doesn't follow its brand headings, and buttons render in a fixed webfont that's identical everywhere.
- So on a narrower system font, the container shrinks, and the content doesn't. 
- Every view that sizes off these tokens cramps

### The Fix
- Redefine `--content-width-xs/s/m/l` in `rem`. These are layout widths, so `rem` is the right unit; the `round()` wrapper ensures they round to whole pixels regardless of the root font size. The same fractional-pixel guard the tokens always had.
- Docs prose keeps a `ch` reading measure. It was borrowing `--content-width-m`, so it's pinned to an explicit `round(up, 110ch, 1px)` in a separate commit ahead of the token change, leaving prose behavior untouched.

### Scope
- This resolves the issue for WA docs, marketing pages, and app views
- Mac widths shift by at most ~`11px`, so nothing visibly moves there
- `--line-length-*` reading measures, and `--content-flow-spacing` along with other `ch` unit rules are left untouched
