### PR TITLE
Fix the fixed icons

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -63,7 +63,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 - Fixed a bug in `<wa-color-picker>` where an initial value with alpha, e.g. `#f5a62315` with `opacity`, would lose its alpha channel on load [issue:2550]
 - Fixed a bug in `<wa-color-picker>` where selecting a swatch with the keyboard didn't emit `change` and `input` events [pr:2665]
 - Fixed a bug in `<wa-color-picker>` where an initial value with alpha but without `opacity` would render the trigger as transparent even though the value was opaque [pr:2665]
-- Fixed a regression in `<wa-icon>` that reintroduced `fill: currentColor` on the internal SVG in 3.8.0, breaking stroke-based icon libraries like Lucide and preventing mutators from overriding the fill. Font Awesome's fill is now applied by the default library, so custom libraries receive their SVGs exactly as authored [issue:1733]
+- Fixed a regression in `<wa-icon>` that reintroduced `fill: currentColor` on the internal SVG in 3.8.0 [issue:1733]
 
 :::
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -63,6 +63,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 - Fixed a bug in `<wa-color-picker>` where an initial value with alpha, e.g. `#f5a62315` with `opacity`, would lose its alpha channel on load [issue:2550]
 - Fixed a bug in `<wa-color-picker>` where selecting a swatch with the keyboard didn't emit `change` and `input` events [pr:2665]
 - Fixed a bug in `<wa-color-picker>` where an initial value with alpha but without `opacity` would render the trigger as transparent even though the value was opaque [pr:2665]
+- Fixed a regression in `<wa-icon>` that reintroduced `fill: currentColor` on the internal SVG in 3.8.0, breaking stroke-based icon libraries like Lucide and preventing mutators from overriding the fill. Font Awesome's fill is now applied by the default library, so custom libraries receive their SVGs exactly as authored [issue:1733]
 
 :::
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -63,7 +63,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 - Fixed a bug in `<wa-color-picker>` where an initial value with alpha, e.g. `#f5a62315` with `opacity`, would lose its alpha channel on load [issue:2550]
 - Fixed a bug in `<wa-color-picker>` where selecting a swatch with the keyboard didn't emit `change` and `input` events [pr:2665]
 - Fixed a bug in `<wa-color-picker>` where an initial value with alpha but without `opacity` would render the trigger as transparent even though the value was opaque [pr:2665]
-- Fixed a regression in `<wa-icon>` that reintroduced `fill: currentColor` on the internal SVG in 3.8.0 [issue:1733]
+- Fixed a regression in `<wa-icon>` that reintroduced `fill: currentColor` on the internal SVG in 3.8.0 [issue:2636]
 
 :::
 

--- a/packages/webawesome/src/components/icon/icon.styles.ts
+++ b/packages/webawesome/src/components/icon/icon.styles.ts
@@ -52,7 +52,9 @@ export default css`
   /* #endregion */
 
   svg {
-    fill: currentColor;
+    /* NOTE: Avoid setting fill here. A stylesheet rule beats SVG presentation attributes, breaking stroke-based
+       libraries like Lucide (fill="none" stroke="currentColor") and attribute-based mutators (issue #1733). The default
+       library applies fill="currentColor" in its mutator instead. */
     height: 1em;
     overflow: visible;
     width: auto;

--- a/packages/webawesome/src/components/icon/icon.test.ts
+++ b/packages/webawesome/src/components/icon/icon.test.ts
@@ -8,7 +8,7 @@ import { fixtures } from '../../internal/test/fixture.js';
 import { registerIconLibrary } from '../../../dist-cdn/webawesome.js';
 import type WaIcon from './icon.js';
 import type { IconAnimation } from './icon.js';
-import { getIconFolder } from './library.default.js';
+import defaultLibrary, { getIconFolder } from './library.default.js';
 
 // Captures the autoWidth argument passed to a resolver so we can assert the canvas="auto" coupling.
 let probeAutoWidth: boolean | undefined;
@@ -27,6 +27,14 @@ const testLibraryIcons = {
   'bad-icon': `<div></div>`,
 };
 
+// Mimics stroke-based libraries like Lucide and Feather, whose SVGs style themselves entirely through
+// presentation attributes on the root element.
+const strokeIcon = `
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+    <path d="M4 4h16v16H4z"></path>
+  </svg>
+`;
+
 describe('<wa-icon>', () => {
   before(() => {
     registerIconLibrary('test-library', {
@@ -42,6 +50,10 @@ describe('<wa-icon>', () => {
         return '';
       },
       mutator: (svg: SVGElement) => svg.setAttribute('fill', 'currentColor'),
+    });
+
+    registerIconLibrary('stroke-library', {
+      resolver: () => `data:image/svg+xml,${encodeURIComponent(strokeIcon)}`,
     });
 
     registerIconLibrary('autowidth-probe', {
@@ -92,6 +104,23 @@ describe('<wa-icon>', () => {
 
     it('falls back to "solid" for an unknown family', () => {
       expect(getIconFolder('icon-name', 'not-a-real-family', 'solid')).to.equal('solid');
+    });
+  });
+
+  // Font Awesome fill handling lives in the default library's mutator, not the component stylesheet, so that
+  // other libraries receive their SVG exactly as authored. A stylesheet fill regressed twice (issue #1733).
+  describe('default library fill handling', () => {
+    it('adds fill="currentColor" to icons that do not specify a fill', () => {
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      defaultLibrary.mutator!(svg);
+      expect(svg.getAttribute('fill')).to.equal('currentColor');
+    });
+
+    it('respects an existing fill attribute', () => {
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      svg.setAttribute('fill', 'none');
+      defaultLibrary.mutator!(svg);
+      expect(svg.getAttribute('fill')).to.equal('none');
     });
   });
 
@@ -185,6 +214,19 @@ describe('<wa-icon>', () => {
           expect(svg?.getAttribute('fill')).to.equal('currentColor');
         });
 
+        // Guards issue #1733: a fill rule in the component stylesheet overrides the presentation attributes that
+        // stroke-based libraries (Lucide, Feather, etc.) rely on, turning their icons into filled blobs.
+        it('should not force a fill on stroke-based library icons', async () => {
+          const el = await fixture<WaIcon>(html`<wa-icon library="stroke-library"></wa-icon>`);
+          const listener = oneEvent(el, 'wa-load');
+          el.name = 'square';
+          await listener;
+          await elementUpdated(el);
+          const svg = el.shadowRoot!.querySelector('svg')!;
+          expect(svg.getAttribute('fill')).to.equal('none');
+          expect(getComputedStyle(svg).fill).to.equal('none');
+        });
+
         it('should render icons from an async resolver', async () => {
           registerIconLibrary('async-library', {
             resolver: async name => {
@@ -217,7 +259,7 @@ describe('<wa-icon>', () => {
       });
 
       describe('sprite sheets', () => {
-        it.only('should produce a <use> element with the correct href', async () => {
+        it('should produce a <use> element with the correct href', async () => {
           // With SSR, this `registerIconLibrary` won't cross the server  boundary.
           registerIconLibrary('sprite', {
             resolver: name => `/docs/assets/images/sprite.svg#${name}`,
@@ -438,22 +480,28 @@ describe('<wa-icon>', () => {
 
         it('should pass autoWidth=true to the resolver for canvas="auto"', async () => {
           probeAutoWidth = undefined;
-          const el = await fixture<WaIcon>(html`<wa-icon library="autowidth-probe" name="x" canvas="auto"></wa-icon>`);
-          await oneEvent(el, 'wa-load');
+          const el = await fixture<WaIcon>(html`<wa-icon library="autowidth-probe" canvas="auto"></wa-icon>`);
+          const listener = oneEvent(el, 'wa-load');
+          el.name = 'x';
+          await listener;
           expect(probeAutoWidth).to.be.true;
         });
 
         it('should pass autoWidth=true to the resolver for the deprecated auto-width attribute', async () => {
           probeAutoWidth = undefined;
-          const el = await fixture<WaIcon>(html`<wa-icon library="autowidth-probe" name="x" auto-width></wa-icon>`);
-          await oneEvent(el, 'wa-load');
+          const el = await fixture<WaIcon>(html`<wa-icon library="autowidth-probe" auto-width></wa-icon>`);
+          const listener = oneEvent(el, 'wa-load');
+          el.name = 'x';
+          await listener;
           expect(probeAutoWidth).to.be.true;
         });
 
         it('should pass autoWidth=false to the resolver by default', async () => {
           probeAutoWidth = undefined;
-          const el = await fixture<WaIcon>(html`<wa-icon library="autowidth-probe" name="x"></wa-icon>`);
-          await oneEvent(el, 'wa-load');
+          const el = await fixture<WaIcon>(html`<wa-icon library="autowidth-probe"></wa-icon>`);
+          const listener = oneEvent(el, 'wa-load');
+          el.name = 'x';
+          await listener;
           expect(probeAutoWidth).to.be.false;
         });
       });

--- a/packages/webawesome/src/components/icon/library.default.ts
+++ b/packages/webawesome/src/components/icon/library.default.ts
@@ -162,6 +162,13 @@ const library: IconLibrary = {
     return getIconUrl(name, family, variant);
   },
   mutator: (svg, hostEl) => {
+    // FA 7.x files set fill="currentColor" on each path, but older self-hosted dumps have no fill attribute, so we
+    // set it on the root when absent. This belongs here, not in icon.styles.ts, where it would override other
+    // libraries' fills (issue #1733).
+    if (!svg.hasAttribute('fill')) {
+      svg.setAttribute('fill', 'currentColor');
+    }
+
     // Duotone families
     if (hostEl?.family && !svg.hasAttribute('data-duotone-initialized')) {
       const { family, variant } = hostEl;


### PR DESCRIPTION
Fixes #2636. This was the same root cause as #1733, which was fixed in #1784 and reintroduced in 3.8.0 so we could, uh, fix it again!

The component stylesheet set `fill: currentColor` on the internal SVG, causing stroke-based libraries like Lucide to render with filled blobs. The fill now gets applied by the default library's mutator instead, and only when the SVG doesn't declare its own.

To prevent having to fix this fix again again 🙃 , I've added regression tests for both.

@calahatras thanks for the [bug report](https://github.com/shoelace-style/webawesome/issues/2636)! Can you verify the PR preview is rendering what you'd expect now?

Also pinging @talbs for his 🦅 👁️  on this one.