### PR TITLE
Docs: Sync Installation Snippets with the Home View Quick Start

### DIFF
--- a/packages/webawesome/docs/docs/index.md
+++ b/packages/webawesome/docs/docs/index.md
@@ -15,9 +15,18 @@ You can load Web Awesome via CDN or by installing it locally. If you’re using 
 The CDN is the fastest way to get started with Web Awesome. Just copy and paste the following into the `<head>` of your HTML to get started!
 
 ```html
-<link rel="stylesheet" href="{% cdnUrl 'styles/webawesome.css' %}" />
+<!-- Required: default theme + autoloader -->
+<link rel="stylesheet" href="{% cdnUrl 'styles/themes/default.css' %}" />
 <script type="module" src="{% cdnUrl 'webawesome.loader.js' %}"></script>
+
+<!-- Recommended: utility classes ("CSS Utilities") -->
+<link rel="stylesheet" href="{% cdnUrl 'styles/utilities.css' %}" />
+
+<!-- Optional: CSS reset ("Native Styles") -->
+<link rel="stylesheet" href="{% cdnUrl 'styles/native.css' %}" />
 ```
+
+Prefer one line? `styles/webawesome.css` pulls in the theme, utility classes, and native styles together.
 
 Now you can [use any Web Awesome component](/docs/components)! Try putting a button on the page:
 
@@ -53,6 +62,7 @@ Once a component has been imported, you can use it in your HTML normally. Compon
 :::pro
 **Using Web Awesome Pro?** Visit [your workspaces](/workspaces) for personalized installation docs.
 :::
+
 ## Get the Download (Advanced)
 
 You can download Web Awesome from npm and self-host it.
@@ -90,14 +100,14 @@ If you're self-hosting Web Awesome, you'll need to set up your pages to referenc
 
 <!-- Option 2: pick and choose styles -->
 
-<!-- theme (required) -->
+<!-- Required: theme -->
 <link rel="stylesheet" href="/dist/styles/themes/default.css" />
 
-<!-- native styles (optional) -->
-<link rel="stylesheet" href="/dist/styles/native.css" />
-
-<!-- CSS utilities (optional) -->
+<!-- Recommended: utility classes ("CSS Utilities") -->
 <link rel="stylesheet" href="/dist/styles/utilities.css" />
+
+<!-- Optional: CSS reset ("Native Styles") -->
+<link rel="stylesheet" href="/dist/styles/native.css" />
 ```
 
 If you choose to use a theme other than the default theme, be sure to add the corresponding class (e.g. `.wa-theme-awesome`) to your `<html>` element so that the class is applied.


### PR DESCRIPTION
This is a follow-up to the Home View Quick Start change in https://github.com/shoelace-style/webawesome-pro/pull/275.

It aligns the installation page with that change.  The CDN quick start and the home page hero previously gave opposite advice for the same scenario — one a single `webawesome.css` link, the other three itemized links — so a reader who pasted from the home page and then opened the docs saw two different recommended setups.

### CDN Section
- Itemized the snippet to match the Home View hero, with the same `Required` / `Recommended` / `Optional` labels. 
- Added a one-line pointer to `styles/webawesome.css` for readers who'd rather have a single link, as prose rather than a second code block, so the itemized version stays the obvious default.

### Self-Hosting Section
Same relabeling in the pick-and-choose block, and moved utilities above native styles to match. Previously these read `theme (required)`, `native styles (optional)`, `CSS utilities (optional)`.

The npm and bundler paths are untouched and still import `styles/webawesome.css` as a single line — one import is idiomatic with a bundler, and every framework page already agrees on it.

| Before | After |
|--------|--------|
| <img width="2488" height="1980" alt="image" src="https://github.com/user-attachments/assets/cf5bbc32-619a-4dfe-8138-d8782f7a8b47" /> | <img width="2488" height="1980" alt="image" src="https://github.com/user-attachments/assets/ba9bfb55-dec6-4a5f-92cf-50d98d45c6e9" /> | 
