### PR TITLE
OTP Input: Align Focus Ring with Other Inputs

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -29,6 +29,14 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 {% include "changelog-email-signup.njk" %}
 
+## Unreleased
+
+:::fixed
+
+- Fixed the focus ring on `<wa-otp-input>` animating its width and offset, which re-ran the animation on every keystroke as the active segment advanced. It now fades in at a fixed size, matching `<wa-input>` and the other form controls
+
+:::
+
 ## 3.11.0
 
 <small><time datetime="2026-07-30">July 30th, 2026</time></small>

--- a/packages/webawesome/src/components/otp-input/otp-input.styles.ts
+++ b/packages/webawesome/src/components/otp-input/otp-input.styles.ts
@@ -46,24 +46,13 @@ export default css`
   /* Focus ring on the active segment, and on every segment in a multi-character selection */
   .segments:focus-within .segment--active,
   .segments:focus-within .segment--selected {
-    outline: var(--wa-focus-ring-style) var(--wa-focus-ring-width) var(--wa-color-focus);
-    outline-offset: var(--wa-focus-ring-offset);
+    outline-color: var(--wa-color-focus);
   }
 
   /* Readonly has no per-segment active/selected state (see render()), so every segment rings
      at once to show the control as a whole has focus. */
   :host(:state(readonly)) .segments:focus-within .segment {
-    outline: var(--wa-focus-ring-style) var(--wa-focus-ring-width) var(--wa-color-focus);
-    outline-offset: var(--wa-focus-ring-offset);
-  }
-
-  /* Contained segments sit flush with zero gap and have no border of their own, so a ring drawn
-     outside the segment edge (the default, positive offset) bleeds into the neighboring segment.
-     Draw it inward instead so it stays within this segment's own box. */
-  :host([appearance='contained']) .segments:focus-within .segment--active,
-  :host([appearance='contained']) .segments:focus-within .segment--selected,
-  :host([appearance='contained']:state(readonly)) .segments:focus-within .segment {
-    outline-offset: calc(-1 * var(--wa-focus-ring-width));
+    outline-color: var(--wa-color-focus);
   }
 
   /* Hidden real input — off-screen but focusable.
@@ -95,15 +84,12 @@ export default css`
     font-variant-numeric: tabular-nums;
     position: relative;
     user-select: none;
-    /* Zero-width outline present at all times so the focus ring can grow in smoothly
-       instead of popping in the instant .segment--active/--selected starts matching. */
-    outline: var(--wa-focus-ring-style) 0 var(--wa-color-focus);
+    outline: var(--wa-focus-ring-style) var(--wa-focus-ring-width) transparent;
+    outline-offset: var(--wa-focus-ring-offset);
     transition:
       background-color var(--wa-transition-normal),
       border-color var(--wa-transition-normal),
-      outline-color var(--wa-transition-fast),
-      outline-width var(--wa-transition-fast),
-      outline-offset var(--wa-transition-fast);
+      outline-color var(--wa-transition-fast);
     transition-timing-function: var(--wa-transition-easing);
   }
 
@@ -161,7 +147,7 @@ export default css`
     border-radius: var(--segment-border-radius, var(--wa-form-control-border-radius));
     background-color: var(--wa-form-control-background-color);
     overflow: hidden;
-    /* The focus ring is drawn inward here (see outline-offset above), so there's no outward bleed
+    /* The focus ring is drawn inward here (see outline-offset below), so there's no outward bleed
        to reserve room for. .segments is also the visible bordered box in this appearance, so the
        padding/negative-margin bleed trick from the base rule would visibly shift and inflate it. */
     padding: 0;
@@ -171,6 +157,10 @@ export default css`
   :host([appearance='contained']) .segment {
     border: none;
     border-radius: 0;
+    /* Contained segments sit flush with zero gap and have no border of their own, so a ring drawn
+       outside the segment edge (the default, positive offset) bleeds into the neighboring segment.
+       Draw it inward instead so it stays within this segment's own box. */
+    outline-offset: calc(-1 * var(--wa-focus-ring-width));
   }
 
   /* Dividers between contained segments */

--- a/packages/webawesome/src/components/otp-input/otp-input.test.ts
+++ b/packages/webawesome/src/components/otp-input/otp-input.test.ts
@@ -411,7 +411,6 @@ describe('<wa-otp-input>', () => {
           const el = await fixture<WaOtpInput>(html`<wa-otp-input appearance="contained" value="1"></wa-otp-input>`);
           el.focus();
           await el.updateComplete;
-          await aTimeout(200); // let the outline-offset transition settle
           const active = el.shadowRoot!.querySelector('.segment--active') as HTMLElement;
           expect(getComputedStyle(active).outlineOffset).to.equal('-3px');
         });
@@ -420,7 +419,6 @@ describe('<wa-otp-input>', () => {
           const el = await fixture<WaOtpInput>(html`<wa-otp-input appearance="outlined" value="1"></wa-otp-input>`);
           el.focus();
           await el.updateComplete;
-          await aTimeout(200);
           const active = el.shadowRoot!.querySelector('.segment--active') as HTMLElement;
           expect(getComputedStyle(active).outlineOffset).to.equal('1px');
         });


### PR DESCRIPTION
### The Issue

`<wa-otp-input>` was the only form control animating its focus ring's geometry: `outline-width` and `outline-offset` alongside `outline-color`. 

Because the ring lives on the active segment, that animation re-ran on every keystroke as the caret advanced: a 6-digit code meant a dozen grow/shrink animations in about two seconds, with no `prefers-reduced-motion` gate. 

Every other input keeps a full-width transparent outline and fades only the color, a convention set in https://github.com/shoelace-style/webawesome/pull/2625.

### The Fix
- `.segment` now carries `outline: var(--wa-focus-ring-style) var(--wa-focus-ring-width) transparent` with a static `outline-offset`, and transitions `outline-color` only.
- The `contained` appearance's inward offset moved off `:focus-within` onto the base rule, so ring geometry is static per appearance and only the color animates
- Dropped two `aTimeout(200)` waits in the tests that existed to let the offset transition settle
