### PR TITLE
Docs: Restore Toast Anatomy + Other Metadata

### DIFF
--- a/packages/webawesome/docs/docs/components/toast-item.md
+++ b/packages/webawesome/docs/docs/components/toast-item.md
@@ -3,7 +3,7 @@ title: Toast Item
 layout: component
 category: Feedback
 parent: toast
-isProComponent: false
+hasAnatomy: true
 synonyms:
   - notification item
   - alert item
@@ -13,7 +13,7 @@ use-cases:
   - toast message
 ---
 
-```html {.example}
+```html {.example .anatomy}
 <wa-toast-item variant="brand" duration="0">
   <wa-icon slot="icon" name="bell"></wa-icon>
   This is how a toast item looks!

--- a/packages/webawesome/docs/docs/components/toast.md
+++ b/packages/webawesome/docs/docs/components/toast.md
@@ -1,8 +1,8 @@
 ---
 title: Toast
 layout: component
+hasAnatomy: false
 category: Feedback
-isProComponent: false
 synonyms:
   - notification
   - snackbar


### PR DESCRIPTION
A Companion to the Pro-side deletion in https://github.com/shoelace-style/webawesome-pro/pull/281...

The orphaned Pro `toast.md` / `toast-item.md` carried anatomy front matter that the Core pages never received, so deleting them alone would quietly drop Toast Item's anatomy diagram. This ports the config to Core's docs.

### Anatomy Fixes
- `toast.md` gets `hasAnatomy: false`: the container has nothing visible to diagram. 
- `toast-item.md` gets `hasAnatomy: true` and its first example is flagged `{.example .anatomy}`. 

### Pro Fixes
This also drops `isProComponent: false` from both pages. No other free component page declares it, and every consumer treats it as `false` by default.
