### PR TITLE
Fix form label position examples

### DIFF
--- a/packages/webawesome/docs/docs/components/input.md
+++ b/packages/webawesome/docs/docs/components/input.md
@@ -177,11 +177,11 @@ Use [CSS parts](#css-parts) to customize the way form controls are drawn. This e
       align-items: center;
     }
 
-    ::part(label) {
+    & ::part(form-control-label) {
       text-align: right;
     }
 
-    ::part(hint) {
+    & ::part(hint) {
       grid-column: 2;
     }
   }

--- a/packages/webawesome/docs/docs/components/number-input.md
+++ b/packages/webawesome/docs/docs/components/number-input.md
@@ -193,11 +193,11 @@ Use [CSS parts](#css-parts) to customize the way form controls are drawn. This e
       align-items: center;
     }
 
-    ::part(label) {
+    & ::part(form-control-label) {
       text-align: right;
     }
 
-    ::part(hint) {
+    & ::part(hint) {
       grid-column: 2;
     }
   }


### PR DESCRIPTION
Fixes #2614.

## Summary

- make the nested `::part()` rules explicit descendants of `.label-on-left`
- use the canonical `form-control-label` part instead of its deprecated alias
- apply the same correction to the equivalent Number Input example

## Testing

- `npx prettier --check --log-level=warn packages/webawesome/docs/docs/components/input.md packages/webawesome/docs/docs/components/number-input.md`
- `SKIP_SLOW_STEPS=true npm run build`
- `git diff --check`