### PR TITLE
Docs: Fix the CSS Part Anatomy Diagram for Property-Driven components

### DIFF
--- a/packages/webawesome/docs/assets/scripts/component-anatomy.js
+++ b/packages/webawesome/docs/assets/scripts/component-anatomy.js
@@ -158,6 +158,8 @@ class ComponentAnatomy extends HTMLElement {
     const clone = contextRoot ? contextRoot.cloneNode(true) : document.createElement(tag);
     stripIdentity(clone);
     const subject = this.#findSubject(clone, tag);
+    // Quiet: the lookup above already warned about an ambiguous example.
+    const liveSubject = contextRoot ? this.#findSubject(contextRoot, tag, true) : null;
     this.#dimContext(clone, subject);
     this.#subject = subject;
 
@@ -190,6 +192,9 @@ class ComponentAnatomy extends HTMLElement {
     this.#scrollGap = this.#spacePx('--wa-space-m');
 
     await this.#whenReady(tag, clone, subject);
+
+    // Not at clone time: this module runs from <head>, so the clone predates the example's own script.
+    if (liveSubject && this.#copyLiveProperties(liveSubject, subject)) await this.#settle(subject);
 
     this.#wireRows();
     this.#relayout();
@@ -227,17 +232,46 @@ class ComponentAnatomy extends HTMLElement {
 
   // The documented element within the clone: the marked child, else the first tag, else the clone. Warns on
   // the ambiguous cases so a mis-marked example fails loudly.
-  #findSubject(clone, tag) {
+  #findSubject(clone, tag, quiet = false) {
     const marked = clone.querySelectorAll('[data-anatomy-subject]');
-    if (marked.length > 1) {
+    if (marked.length > 1 && !quiet) {
       console.warn(`[component-anatomy] Multiple [data-anatomy-subject] in the <${tag}> example; using the first.`);
     }
     if (marked.length) return marked[0];
     const matches = clone.matches?.(tag) ? [clone] : [...clone.querySelectorAll(tag)];
-    if (matches.length > 1) {
+    if (matches.length > 1 && !quiet) {
       console.warn(`[component-anatomy] ${matches.length} <${tag}> but none marked data-anatomy-subject; add it.`);
     }
     return matches[0] || clone;
+  }
+
+  // `cloneNode` copies attributes, not properties, so a property-driven component (Data Grid's `data` and
+  // `columns`) clones empty. Setters can reach past their own value — wa-checkbox's `checked` also writes
+  // `valueHasChanged` and the private `_checked`, defeating the attribute fallback the state toggles reset
+  // through — so assign only what genuinely differs, and restore the `state: true` properties afterwards.
+  #copyLiveProperties(source, target) {
+    const properties = source?.constructor?.elementProperties;
+    if (!properties || !target) return false;
+
+    const internal = [];
+    const pending = [];
+    for (const [name, options] of properties) {
+      if (options.attribute !== false) continue;
+      if (options.state === true) internal.push([name, target[name]]);
+      else if (target[name] !== source[name]) pending.push([name, source[name]]);
+    }
+    if (!pending.length) return false;
+
+    for (const [name, value] of pending) target[name] = value;
+
+    for (const [name, value] of internal) {
+      try {
+        target[name] = value;
+      } catch {
+        /* getter-only, like `validity` — nothing to restore */
+      }
+    }
+    return true;
   }
 
   // Fade the subject's siblings (and a group parent's own label/hint chrome). One level at a time, never an

--- a/packages/webawesome/docs/assets/styles/anatomy.css
+++ b/packages/webawesome/docs/assets/styles/anatomy.css
@@ -56,6 +56,7 @@ component-anatomy {
   --background-dot-spacing: 1rem;
   --background-dot-color: color-mix(in oklab, var(--wa-color-text-normal), transparent 92%);
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
   place-items: center;
   min-height: 8rem;
   padding: var(--wa-space-xl);
@@ -70,7 +71,9 @@ component-anatomy {
   border-start-end-radius: var(--stage-radius);
 }
 
-/* Definite width so fluid components fill it; inline content centers via text-align, block/flex via margin. */
+/* Definite width so fluid components fill it; inline content centers via text-align, block/flex via margin.
+   The percentage needs the stage's definite track above — a `place-items: center` item sizes the track from
+   itself, which silently turns every clamp here into a no-op. */
 .anatomy-subject {
   inline-size: min(100%, 24rem);
   text-align: center;
@@ -102,6 +105,16 @@ component-anatomy {
 /* A breadcrumb reads as one line; size it to its content (up to the stage) instead of the 24rem default. */
 .anatomy-subject:has(wa-breadcrumb) {
   inline-size: fit-content;
+}
+
+/* A tab group's nav needs more than 24rem before its tabs start clipping. */
+.anatomy-subject:has(wa-tab-group) {
+  inline-size: min(100%, 28rem);
+}
+
+/* A data grid is fluid and its toolbar needs the room — at 24rem the columns menu clips. */
+.anatomy-subject:has(wa-data-grid) {
+  inline-size: 100%;
 }
 
 .anatomy-regions {


### PR DESCRIPTION
The anatomy diagram on the Data Grid page was rendering an empty grid.

### The Diagram's Clone had no Data
The diagram clones a live example onto its stage. `cloneNode` copies attributes but not properties. So the clone came up empty and stayed empty.

`#copyLiveProperties` copies those across once both sides have settled.

### Width
The Anatomy subject was capped at 24rem, which is what clipped the Data Grid example. The tab group was clipping before this branch, too. This updated CSS should resolve those.
