### PR TITLE
Catch Documented CSS Parts That Never Render

### DIFF
--- a/.github/workflows/css_parts.yml
+++ b/.github/workflows/css_parts.yml
@@ -1,6 +1,6 @@
-# Fails if any component renders a `part="…"` attribute with no matching `@csspart`,
-# keeping the rendered and documented CSS part surfaces from drifting apart. Static
-# analysis only — no build or dev server needed.
+# Fails if any component renders a `part="…"` attribute with no matching `@csspart`, or
+# documents a `@csspart` that nothing renders, keeping the rendered and documented CSS part
+# surfaces from drifting apart. Static analysis only — no build or dev server needed.
 
 name: CSS Parts
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -83,6 +83,12 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 - Fixed a regression in `<wa-icon>` that reintroduced `fill: currentColor` on the internal SVG in 3.8.0 [issue:2636] [pr:2677]
 - Fixed a bug in Native Styles where elements like `<button>` didn't pick up inverted colors inside `.wa-invert` [issue:2533] [pr:2678]
 - Fixed `<wa-color-picker>` rendering the `form-control`, `form-control-input`, and `hint` CSS parts without documenting them, and corrected the `color-picker` part's description to name the dropdown panel it actually targets [issue:2624]
+- Fixed several components documenting CSS parts that never render, so `::part()` selectors targeting them silently did nothing [issue:2624]
+  - `<wa-page>` — removed `dialog-wrapper`
+  - `<wa-radio-group>` — removed `radios`; `form-control-input` is the wrapper around the grouped radios
+  - `<wa-slider>` — renamed `tooltip__content` to `tooltip__body`, and now forwards the `tooltip__tooltip` part it already documented
+  - `<wa-textarea>` — removed `form-control-input`, which it never rendered
+  - `<wa-video>` — removed `progress`; the progress bar is the slider's `timeline-indicator` part
 
 :::
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -82,6 +82,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 - Fixed a bug in `<wa-tree>` where pressing [[Enter]] or [[Space]] while focus was inside a tree item, e.g. on a link or a button slotted into it, threw a "Cannot read properties of undefined" error and swallowed the keypress instead of letting the focused element handle it [issue:2673] [pr:2674]
 - Fixed a regression in `<wa-icon>` that reintroduced `fill: currentColor` on the internal SVG in 3.8.0 [issue:2636] [pr:2677]
 - Fixed a bug in Native Styles where elements like `<button>` didn't pick up inverted colors inside `.wa-invert` [issue:2533] [pr:2678]
+- Fixed `<wa-color-picker>` rendering the `form-control`, `form-control-input`, and `hint` CSS parts without documenting them, and corrected the `color-picker` part's description to name the dropdown panel it actually targets [issue:2624]
 
 :::
 

--- a/packages/webawesome/scripts/check-css-parts.js
+++ b/packages/webawesome/scripts/check-css-parts.js
@@ -1,10 +1,11 @@
 /**
  * Guards the component CSS-part surface statically (no build):
  *   1. every rendered `part=` has a matching `@csspart`, so docs can't drift from render;
- *   2. every component that renders `base` also exposes its canonical `<name>` (or `<name>-wrapper`) part.
+ *   2. every `@csspart` is actually rendered, so docs can't promise a part that does nothing;
+ *   3. every component that renders `base` also exposes its canonical `<name>` (or `<name>-wrapper`) part.
  *
- * Documented-but-unrendered isn't checked — `part=${expr}` can't be resolved statically, so it
- * produces too many false positives.
+ * Check 2 can't see `part=${expr}`, so any component that builds a part name dynamically is skipped
+ * for it rather than reported with false positives.
  */
 import { globby } from 'globby';
 import { readFile } from 'node:fs/promises';
@@ -18,12 +19,30 @@ const root = dirname(__dirname);
 // Static `part=` attributes only. The lookbehind rejects `exportparts=` and `[part=…]` selectors.
 const RENDERED_PART = /(?<![\w[])part=(["'])([^"'$]+)\1/g;
 const DECLARED_PART = /@csspart\s+(\S+)/g;
+// Tombstones for parts that no longer render, kept so the docs can explain the removal.
+const DEPRECATED_PART = /@csspart\s+(\S+)\s*-\s*Deprecated\b/g;
+// A part name built from an expression, e.g. `part=${...}` or `part="page ${...}"`.
+const DYNAMIC_PART = /(?<![\w[])part=(?:\$\{|(["'])[^"']*\$\{)/;
+// `exportparts="inner:outer, bare"` republishes a child's parts under this component's names.
+const EXPORTED_PARTS = /exportparts=(["'])([^"'$]+)\1/g;
 
 function collect(source, regex, group) {
   const out = new Set();
   for (const match of source.matchAll(regex)) {
     // One attribute can name several parts: `part="foo bar"`.
     for (const token of match[group].trim().split(/\s+/)) if (token) out.add(token);
+  }
+  return out;
+}
+
+// The name a forwarded part is exposed under: the far side of `inner:outer`, or the whole token.
+function collectExported(source) {
+  const out = new Set();
+  for (const match of source.matchAll(EXPORTED_PARTS)) {
+    for (const entry of match[2].split(',')) {
+      const exposed = entry.split(':').pop().trim();
+      if (exposed) out.add(exposed);
+    }
   }
   return out;
 }
@@ -60,6 +79,7 @@ export async function check(options = {}) {
 
   const failures = [];
   const staleAllowlist = [];
+  const unverifiable = [];
 
   for (const dir of dirs.sort()) {
     const name = basename(dir);
@@ -67,6 +87,8 @@ export async function check(options = {}) {
 
     const rendered = collect(source, RENDERED_PART, 2);
     const declared = collect(source, DECLARED_PART, 1);
+    const deprecated = collect(source, DEPRECATED_PART, 1);
+    const exported = collectExported(source);
     const allowed = new Set(allowlist[name] ?? []);
 
     const undocumented = [...rendered].filter(part => !declared.has(part));
@@ -75,11 +97,19 @@ export async function check(options = {}) {
     // Flag allowlist entries that are now documented, so the list can't rot.
     for (const part of allowed) if (!undocumented.includes(part)) staleAllowlist.push(`${name}: ${part}`);
 
+    const isDynamic = DYNAMIC_PART.test(source);
+    if (isDynamic) unverifiable.push({ name, declared: declared.size });
+
+    const phantoms = isDynamic
+      ? []
+      : [...declared].filter(part => !rendered.has(part) && !exported.has(part) && !deprecated.has(part)).sort();
+
     const missingCanonical =
       rendered.has('base') && !SLOT_BASE.has(name) && !hasCanonicalPart(name, rendered, declared);
 
     const problems = [];
     if (gaps.length > 0) problems.push(`undocumented part(s): ${gaps.join(', ')}`);
+    if (phantoms.length > 0) problems.push(`documented but never rendered: ${phantoms.join(', ')}`);
     if (missingCanonical) problems.push(`missing canonical part (\`${name}\` or \`${name}-wrapper\`)`);
 
     if (problems.length > 0) {
@@ -97,14 +127,24 @@ export async function check(options = {}) {
     console.log('');
   }
 
+  if (unverifiable.length > 0) {
+    const total = unverifiable.reduce((sum, entry) => sum + entry.declared, 0);
+    const summary = unverifiable.map(entry => `${entry.name} (${entry.declared})`).join(', ');
+    console.log(`ℹ️  ${unverifiable.length} component(s) build part names dynamically, so ${total} documented`);
+    console.log(`    part(s) can't be verified as rendered: ${summary}`);
+    console.log('');
+  }
+
   if (failures.length > 0) {
     console.log(`FAILED: part issues across ${failures.length} component(s).`);
-    console.log('Add a matching `@csspart <name> - <description>` for any stray `part=`, and give each');
-    console.log('component a canonical `<name>` (or `<name>-wrapper`) part on its outer element.');
+    console.log('Add a matching `@csspart <name> - <description>` for any stray `part=`. For a documented');
+    console.log("part nothing renders, either render it or drop the tag — unless it's forwarded via");
+    console.log('`exportparts` or is a `Deprecated.` tombstone, both of which are already exempt. And give');
+    console.log('each component a canonical `<name>` (or `<name>-wrapper`) part on its outer element.');
     process.exit(1);
   }
 
-  console.log('PASSED: every rendered part is documented, and every component exposes its canonical part.');
+  console.log('PASSED: rendered parts and documented parts match, and every component exposes its canonical part.');
 }
 
 function isRunAsMain() {

--- a/packages/webawesome/scripts/check-css-parts.js
+++ b/packages/webawesome/scripts/check-css-parts.js
@@ -37,10 +37,9 @@ async function readComponentSource(dir) {
   return contents.join('\n');
 }
 
-// Rendered but undocumented on purpose — pre-existing gaps to document separately.
-const DEFAULT_ALLOWLIST = {
-  'color-picker': ['form-control', 'form-control-input', 'hint'],
-};
+// Rendered but undocumented on purpose — pre-existing gaps to document separately. Empty here; the
+// Pro package passes its own through `check({ allowlist })`.
+const DEFAULT_ALLOWLIST = {};
 
 // These render `base` on a `<slot>` rather than a wrapper element. Parts don't belong on slots, and
 // the host does the styling, so they get no component-named part until the legacy `base` is removed.

--- a/packages/webawesome/scripts/design-skill/references/layouts-page.md
+++ b/packages/webawesome/scripts/design-skill/references/layouts-page.md
@@ -609,4 +609,4 @@ Style internal regions with `::part()` from outside the component (e.g. `wa-page
 | `footer`                 | The page footer.                                                                                              |
 | `drawer`                 | The mobile navigation `<wa-drawer>`. (Drawer internals are also exposed via `drawer__*` parts.)              |
 
-(Also exposed: `skip-links`, `skip-link`, `dialog-wrapper`.)
+(Also exposed: `skip-to-content`, the visually hidden skip link.)

--- a/packages/webawesome/src/components/color-picker/color-picker.ts
+++ b/packages/webawesome/src/components/color-picker/color-picker.ts
@@ -67,10 +67,13 @@ declare const EyeDropper: EyeDropperConstructor;
  * @event wa-invalid - Emitted when the form control has been checked for validity and its constraints aren't satisfied.
  *
  * @csspart base - Deprecated. Use the `color-picker` part instead.
- * @csspart color-picker - The component's outer wrapper.
+ * @csspart color-picker - The dropdown panel that holds the grid, sliders, and swatches.
  * @csspart trigger - The color picker's dropdown trigger.
  * @csspart trigger-container - The container that wraps the color picker's trigger.
+ * @csspart form-control - Alias on `trigger-container`, matching other form controls.
  * @csspart form-control-label - The label.
+ * @csspart form-control-input - Alias on `trigger`, matching other form controls.
+ * @csspart hint - The hint's wrapper.
  * @csspart swatches - The container that holds the swatches.
  * @csspart swatch - Each individual swatch.
  * @csspart grid - The color grid.

--- a/packages/webawesome/src/components/color-picker/color-picker.ts
+++ b/packages/webawesome/src/components/color-picker/color-picker.ts
@@ -70,9 +70,9 @@ declare const EyeDropper: EyeDropperConstructor;
  * @csspart color-picker - The dropdown panel that holds the grid, sliders, and swatches.
  * @csspart trigger - The color picker's dropdown trigger.
  * @csspart trigger-container - The container that wraps the color picker's trigger.
- * @csspart form-control - Alias on `trigger-container`, matching other form controls.
+ * @csspart form-control - The form control that wraps the label, input, and hint.
  * @csspart form-control-label - The label.
- * @csspart form-control-input - Alias on `trigger`, matching other form controls.
+ * @csspart form-control-input - The color picker's trigger button.
  * @csspart hint - The hint's wrapper.
  * @csspart swatches - The container that holds the swatches.
  * @csspart swatch - Each individual swatch.

--- a/packages/webawesome/src/components/page/page.ts
+++ b/packages/webawesome/src/components/page/page.ts
@@ -109,7 +109,6 @@ function toLength(px: number | string): string {
  * @csspart aside - The right hand side of the page. Used for things like table of contents, ads, etc.
  * @csspart skip-to-content - The "skip to content" link that lets keyboard users bypass navigation.
  * @csspart footer - The footer of the page. This is always below the initial viewport size.
- * @csspart dialog-wrapper - A wrapper around elements such as dialogs or other modal-like elements.
  *
  * @cssproperty [--menu-width=auto] - The width of the page's "menu" section.
  * @cssproperty [--main-width=1fr] - The width of the page's "main" section.

--- a/packages/webawesome/src/components/radio-group/radio-group.ts
+++ b/packages/webawesome/src/components/radio-group/radio-group.ts
@@ -34,8 +34,7 @@ import styles from './radio-group.styles.js';
  *
  * @csspart form-control - The form control that wraps the label, input, and hint.
  * @csspart form-control-label - The label.
- * @csspart form-control-input - The input's wrapper.
- * @csspart radios - The wrapper than surrounds radio items, styled as a flex container by default.
+ * @csspart form-control-input - The element that wraps the grouped radios, styled as a flex container by default.
  * @csspart hint - The hint's wrapper.
  */
 @customElement('wa-radio-group')

--- a/packages/webawesome/src/components/slider/slider.ts
+++ b/packages/webawesome/src/components/slider/slider.ts
@@ -53,7 +53,7 @@ import styles from './slider.styles.js';
  * @csspart thumb-max - The max value thumb in a range slider.
  * @csspart tooltip - The tooltip, a `<wa-tooltip>` element.
  * @csspart tooltip__tooltip - The tooltip's `tooltip` part.
- * @csspart tooltip__content - The tooltip's `content` part.
+ * @csspart tooltip__body - The tooltip's `body` part.
  * @csspart tooltip__arrow - The tooltip's `arrow` part.
  *
  * @cssstate disabled - Applied when the slider is disabled.
@@ -879,6 +879,7 @@ export default class WaSlider extends WebAwesomeFormAssociatedElement {
               part="tooltip"
               exportparts="
                 base:tooltip__base,
+                tooltip:tooltip__tooltip,
                 body:tooltip__body,
                 arrow:tooltip__arrow
               "

--- a/packages/webawesome/src/components/textarea/textarea.ts
+++ b/packages/webawesome/src/components/textarea/textarea.ts
@@ -32,7 +32,6 @@ import styles from './textarea.styles.js';
  *
  * @csspart form-control-label - The label.
  * @csspart label - Deprecated. Use the `form-control-label` part instead.
- * @csspart form-control-input - The input's wrapper.
  * @csspart hint - The hint's wrapper.
  * @csspart textarea - The internal `<textarea>` control.
  * @csspart base - Deprecated. Use the `textarea-wrapper` part instead.


### PR DESCRIPTION
This work closes out the CSS-parts audit from #2624. 

`check-css-parts` verified that every rendered `part=` had a matching `@csspart`, but not the reverse. So a documented part that nothing renders passed silently, and `::part()` selectors targeting it did nothing with no warning.

### The Updated Check
`check-css-parts` now runs both directions, with three exemptions, so the new one is usable: 

- components that build part names dynamically (`part=${...}` can't be resolved statically)
- parts forwarded via `exportparts`
- `Deprecated.` tombstones like `base`

The dynamic exemption skips a whole component, so the check reports how many documented parts it couldn't verify rather than implying full coverage.

### What the Updated Check Caught

| Component | Part | Change | Note |
| --- | --- | --- | --- |
| `<wa-page>` | `dialog-wrapper` | **removed** | No such element; `<wa-page>` has no dialog handling at all |
| `<wa-radio-group>` | `radios` | **removed** | Second name for the slot already carrying `form-control-input` |
| `<wa-textarea>` | `form-control-input` | **removed** | The wrapper element doesn't exist |
| `<wa-video>` ([Pro PR](https://github.com/shoelace-style/webawesome-pro/pull/283)) | `progress` | **removed** | The progress bar is the timeline slider's `timeline-indicator` |
| `<wa-color-picker>` | `form-control` | **added** | Rendered on `trigger-container` all along |
| `<wa-color-picker>` | `form-control-input` | **added** | Rendered on `trigger` all along |
| `<wa-color-picker>` | `hint` | **added** | Rendered all along |
| `<wa-slider>` | `tooltip__tooltip` | **added** | Newly forwarded via `tooltip:tooltip__tooltip` — the docs already promised it |
| `<wa-slider>` | `tooltip__content` → `tooltip__body` | **renamed** | `<wa-tooltip>` has a `body` part, never a `content` one |
| `<wa-color-picker>` | `color-picker` | _reworded_ | "The component's outer wrapper" → the dropdown panel it actually targets |
| `<wa-radio-group>` | `form-control-input` | _reworded_ | Absorbed the flex-container detail from the deleted `radios` tag |

