### PR TITLE
Fix VoiceOver reports the wrong dropdown item count

### DIFF
--- a/packages/webawesome/src/components/dropdown/dropdown.test.ts
+++ b/packages/webawesome/src/components/dropdown/dropdown.test.ts
@@ -59,6 +59,26 @@ describe('<wa-dropdown>', () => {
           const menu = el.shadowRoot!.querySelector('#menu')!;
           expect(menu.getAttribute('role')).to.equal('menu');
         });
+
+        it('should exclude labels and dividers from the reported menu item count', async () => {
+          const el = await fixture<WaDropdown>(html`
+            <wa-dropdown>
+              <wa-button slot="trigger">Dropdown</wa-button>
+              <h3>Type</h3>
+              <wa-dropdown-item>Phone</wa-dropdown-item>
+              <wa-dropdown-item>Tablet</wa-dropdown-item>
+              <wa-dropdown-item>Desktop</wa-dropdown-item>
+              <wa-divider></wa-divider>
+              <wa-dropdown-item>More options</wa-dropdown-item>
+            </wa-dropdown>
+          `);
+          await el.updateComplete;
+
+          const items = [...el.querySelectorAll('wa-dropdown-item')];
+          await waitUntil(() => items.every(item => item.hasAttribute('aria-posinset')));
+          expect(items.map(item => item.getAttribute('aria-posinset'))).to.deep.equal(['1', '2', '3', '4']);
+          expect(items.map(item => item.getAttribute('aria-setsize'))).to.deep.equal(['4', '4', '4', '4']);
+        });
       });
 
       describe('properties', () => {

--- a/packages/webawesome/src/components/dropdown/dropdown.ts
+++ b/packages/webawesome/src/components/dropdown/dropdown.ts
@@ -523,6 +523,8 @@ export default class WaDropdown extends WebAwesomeElement {
     const hasSubmenu = items.some(item => item.hasSubmenu);
 
     items.forEach((item, index) => {
+      item.setAttribute('aria-posinset', String(index + 1));
+      item.setAttribute('aria-setsize', String(items.length));
       item.active = index === 0;
       item.checkboxAdjacent = hasCheckbox;
       item.submenuAdjacent = hasSubmenu;


### PR DESCRIPTION
 fix voiceover announcing the wrong dropdown item count when a dropdown, includes non-item elements like a divider. Root cause: mixed children caused assistive technologies to count the wrong items. 
 Fix: sets aria-posinset and aria-setsize on top-level wa-dropdown-item elements using only filtered dropdown
 Testing: added regression test, browser verification, manual voiceover check confirmed 3 of 4.
 Fixes #2697
