### PR TITLE
Docs: Keep Sidebar's Pro Badge Scoped to Pro Components

### DIFF
--- a/packages/webawesome/docs/_includes/sidebar.njk
+++ b/packages/webawesome/docs/_includes/sidebar.njk
@@ -15,10 +15,10 @@
 {%- macro sidebarComponent(page, suppressProBadge=false) -%}
   {%- set component = page.data.component -%}
   {%- set isExperimental = component and component.status == 'experimental' -%}
-  {%- set isPro = page.data.isProComponent and not suppressProBadge -%}
-  {%- if isPro %}<span class="wa-split">{% endif -%}
+  {%- set hasProBadge = true if (page.data.isProComponent and not suppressProBadge) else false -%}
+  {%- if hasProBadge %}<span class="wa-split">{% endif -%}
   <a{% if isExperimental %} class="wa-cluster wa-gap-xs"{% endif %} href="{{ page.url }}">{{ page.data.title }}{% if isExperimental %} <wa-icon name="flask" aria-hidden="true" class="icon-shrink de-emphasize"></wa-icon>{% endif %}</a>
-  {%- if isPro %} {{ proBadge() }}</span>{% endif -%}
+  {%- if hasProBadge %} {{ proBadge() }}</span>{% endif -%}
 {%- endmacro %}
 
 {%- set sortedComponentPages = collections.componentPages | sort(false, false, 'data.title') -%}


### PR DESCRIPTION
Every page under `/docs/patterns/*/` badges *every* component in the sidebar as Pro, free ones included. It's baked in at build time, so signed-out visitors see it too.

### Cause
The `sidebarComponent` macro sets a local named `isPro`. For free components that expression evaluates to `undefined` rather than `false`, and Nunjucks treats an undefined local as unset and falls through to the page context — where pattern pages carry their own `isPro: true` from the data cascade.

### Fix
Renamed the local to `hasProBadge` and coerced it to a real boolean. The rename fixes today's collision; the coercion looks redundant but isn't — it's what stops an undefined local from reaching the context again under some future variable name.
