### PR TITLE
Tag: Make Remove Button Keyboard Operable

### DIFF
--- a/packages/webawesome/docs/docs/components/tag.md
+++ b/packages/webawesome/docs/docs/components/tag.md
@@ -102,10 +102,15 @@ Use the `pill` attribute to give tags rounded edges.
 
 ### Removable
 
-Use the `with-remove` attribute to add a remove button to the tag. The button carries a built-in `Remove` label for assistive technology, and activating it emits the `wa-remove` event so you can handle the removal.
+Use the `with-remove` attribute to add a remove button to the tag. The button carries a built-in `Remove` label for assistive technology, and activating it emits the `wa-remove` event so you can handle the removal. The button is reachable with <kbd>Tab</kbd> and activates with <kbd>Enter</kbd> or <kbd>Space</kbd>.
+
+:::info
+<strong>`wa-remove` only announces the intent</strong><br />
+Removing the tag is up to you. Move focus to the tag's container afterwards (give it `tabindex="-1"`) so keyboard users aren't left on a removed element.
+:::
 
 ```html {.example}
-<div class="tags-removable">
+<div class="tags-removable wa-cluster wa-gap-2xs" tabindex="-1">
   <wa-tag size="xs" with-remove>Extra Small</wa-tag>
   <wa-tag size="s" with-remove>Small</wa-tag>
   <wa-tag size="m" with-remove>Medium</wa-tag>
@@ -113,19 +118,21 @@ Use the `with-remove` attribute to add a remove button to the tag. The button ca
   <wa-tag size="xl" with-remove>Extra Large</wa-tag>
 </div>
 
+<wa-divider></wa-divider>
+
+<wa-button id="tags-reset" appearance="filled">Reset</wa-button>
+
 <script>
   const div = document.querySelector('.tags-removable');
+  const tags = [...div.children];
 
   div.addEventListener('wa-remove', event => {
-    const tag = event.target;
-    tag.style.opacity = '0';
-    setTimeout(() => (tag.style.opacity = '1'), 2000);
+    event.target.remove();
+    div.focus();
+  });
+
+  document.getElementById('tags-reset').addEventListener('click', () => {
+    div.replaceChildren(...tags);
   });
 </script>
-
-<style>
-  .tags-removable wa-tag {
-    transition: opacity var(--wa-transition-normal);
-  }
-</style>
 ```

--- a/packages/webawesome/docs/docs/components/tag.md
+++ b/packages/webawesome/docs/docs/components/tag.md
@@ -104,11 +104,6 @@ Use the `pill` attribute to give tags rounded edges.
 
 Use the `with-remove` attribute to add a remove button to the tag. The button carries a built-in `Remove` label for assistive technology, and activating it emits the `wa-remove` event so you can handle the removal. The button is reachable with <kbd>Tab</kbd> and activates with <kbd>Enter</kbd> or <kbd>Space</kbd>.
 
-:::info
-<strong>`wa-remove` only announces the intent</strong><br />
-Removing the tag is up to you. Move focus to the tag's container afterwards (give it `tabindex="-1"`) so keyboard users aren't left on a removed element.
-:::
-
 ```html {.example}
 <div class="tags-removable wa-cluster wa-gap-2xs" tabindex="-1">
   <wa-tag size="xs" with-remove>Extra Small</wa-tag>
@@ -136,3 +131,8 @@ Removing the tag is up to you. Move focus to the tag's container afterwards (giv
   });
 </script>
 ```
+
+:::info
+<strong>`wa-remove` only announces the intent</strong><br />
+Removing the tag is up to you. Move focus to the tag's container afterwards (give it `tabindex="-1"`) so keyboard users aren't left on a removed element.
+:::

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -39,7 +39,10 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 :::
 
 :::changed
+
 - Improved accessibility of `<wa-dropdown>` by adding `aria-posinset` and `aria-setsize` so supportive screen readers can correctly announce the number of dropdown items []
+- Improved keyboard support for `<wa-tag with-remove>`: the remove button is now reachable with <kbd>Tab</kbd> and activates with <kbd>Enter</kbd> or <kbd>Space</kbd>
+
 :::
 
 ## 3.11.0

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -41,7 +41,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 :::changed
 
 - Improved accessibility of `<wa-dropdown>` by adding `aria-posinset` and `aria-setsize` so supportive screen readers can correctly announce the number of dropdown items []
-- Improved keyboard support for `<wa-tag with-remove>`: the remove button is now reachable with <kbd>Tab</kbd> and activates with <kbd>Enter</kbd> or <kbd>Space</kbd>
+- Improved keyboard support for `<wa-tag with-remove>`: the remove button is now reachable with <kbd>Tab</kbd> and activates with <kbd>Enter</kbd> or <kbd>Space</kbd> [pr:2717]
 
 :::
 

--- a/packages/webawesome/src/components/select/select.test.ts
+++ b/packages/webawesome/src/components/select/select.test.ts
@@ -1101,6 +1101,56 @@ describe('<wa-select>', () => {
         expect(el.value).to.equal('');
         await resetMouse();
       });
+
+      describe('tag tab order', () => {
+        it('should not make tag remove buttons tab stops', async () => {
+          const container = await fixture<HTMLDivElement>(html`
+            <div>
+              <wa-select multiple .value=${['a', 'b']}>
+                <wa-option value="a">A</wa-option>
+                <wa-option value="b">B</wa-option>
+              </wa-select>
+              <button id="after">After</button>
+            </div>
+          `);
+          const select = container.querySelector<WaSelect>('wa-select')!;
+          const after = container.querySelector<HTMLButtonElement>('#after')!;
+          await select.updateComplete;
+
+          select.focus();
+          expect(select.shadowRoot!.querySelectorAll('wa-tag')).to.have.length(2);
+          expect(document.activeElement).to.equal(select);
+          await sendKeys({ press: 'Tab' });
+
+          expect(document.activeElement).to.equal(after);
+        });
+
+        it('should not make tag remove buttons tab stops when getTag is overridden', async () => {
+          const container = await fixture<HTMLDivElement>(html`
+            <div>
+              <wa-select multiple .value=${['a', 'b']}>
+                <wa-option value="a">A</wa-option>
+                <wa-option value="b">B</wa-option>
+              </wa-select>
+              <button id="after">After</button>
+            </div>
+          `);
+          const select = container.querySelector<WaSelect>('wa-select')!;
+          const after = container.querySelector<HTMLButtonElement>('#after')!;
+
+          select.getTag = option => `<wa-tag with-remove>${option.label}</wa-tag>`;
+          select.requestUpdate();
+          await select.updateComplete;
+          await aTimeout(0);
+
+          select.focus();
+          expect(select.shadowRoot!.querySelectorAll('wa-tag')).to.have.length(2);
+          expect(document.activeElement).to.equal(select);
+          await sendKeys({ press: 'Tab' });
+
+          expect(document.activeElement).to.equal(after);
+        });
+      });
     });
   }
 

--- a/packages/webawesome/src/components/select/select.ts
+++ b/packages/webawesome/src/components/select/select.ts
@@ -27,6 +27,7 @@ import type WaOption from '../option/option.js';
 import '../popup/popup.js';
 import type WaPopup from '../popup/popup.js';
 import '../tag/tag.js';
+import type WaTag from '../tag/tag.js';
 import styles from './select.styles.js';
 
 /**
@@ -302,6 +303,7 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
           ?pill=${this.pill}
           size=${this.size}
           with-remove
+          .isRemoveTabbable=${false}
           data-value=${option.value}
           @wa-remove=${(event: WaRemoveEvent) => this.handleTagRemove(event, option)}
         >
@@ -877,6 +879,10 @@ export default class WaSelect extends WebAwesomeFormAssociatedElement {
 
     if (changedProperties.has('value') || changedProperties.has('displayLabel')) {
       this.customStates.set('blank', !this.value && !this.displayLabel);
+    }
+
+    if (this.multiple) {
+      this.shadowRoot?.querySelectorAll<WaTag>('wa-tag').forEach(tag => (tag.isRemoveTabbable = false));
     }
   }
 

--- a/packages/webawesome/src/components/tag/tag.test.ts
+++ b/packages/webawesome/src/components/tag/tag.test.ts
@@ -1,4 +1,5 @@
 import { expect } from '@open-wc/testing';
+import { sendKeys } from '@web/test-runner-commands';
 import { html } from 'lit';
 import { expectEvent } from '../../internal/test/expect-event.js';
 import { fixtures } from '../../internal/test/fixture.js';
@@ -84,6 +85,88 @@ describe('<wa-tag>', () => {
           const removeButton = el.shadowRoot!.querySelector<HTMLElement>('wa-button')!;
 
           await expectEvent(el, 'wa-remove', () => removeButton.click());
+        });
+      });
+
+      describe('keyboard', () => {
+        it('should reach the remove button with Tab', async () => {
+          const container = await fixture<HTMLDivElement>(html`
+            <div>
+              <button>Before</button>
+              <wa-tag with-remove>Test</wa-tag>
+              <button id="after">After</button>
+            </div>
+          `);
+          const before = container.querySelector('button')!;
+          const tag = container.querySelector<WaTag>('wa-tag')!;
+          const removeButton = tag.shadowRoot!.querySelector('wa-button')!;
+          const after = container.querySelector<HTMLButtonElement>('#after')!;
+
+          before.focus();
+          await sendKeys({ press: 'Tab' });
+
+          expect(document.activeElement).to.equal(tag);
+          expect(tag.shadowRoot!.activeElement).to.equal(removeButton);
+
+          await sendKeys({ press: 'Tab' });
+          expect(document.activeElement).to.equal(after);
+        });
+
+        it('should emit wa-remove when Enter is pressed on the remove button', async () => {
+          const container = await fixture<HTMLDivElement>(html`
+            <div>
+              <button>Before</button>
+              <wa-tag with-remove>Test</wa-tag>
+            </div>
+          `);
+          const before = container.querySelector('button')!;
+          const tag = container.querySelector<WaTag>('wa-tag')!;
+
+          before.focus();
+          await sendKeys({ press: 'Tab' });
+
+          await expectEvent(tag, 'wa-remove', async () => {
+            await sendKeys({ press: 'Enter' });
+          });
+        });
+
+        it('should emit wa-remove when Space is pressed on the remove button', async () => {
+          const container = await fixture<HTMLDivElement>(html`
+            <div>
+              <button>Before</button>
+              <wa-tag with-remove>Test</wa-tag>
+            </div>
+          `);
+          const before = container.querySelector('button')!;
+          const tag = container.querySelector<WaTag>('wa-tag')!;
+
+          before.focus();
+          await sendKeys({ press: 'Tab' });
+
+          await expectEvent(tag, 'wa-remove', async () => {
+            await sendKeys({ press: 'Space' });
+          });
+        });
+
+        it('should skip the remove button when isRemoveTabbable is false', async () => {
+          const container = await fixture<HTMLDivElement>(html`
+            <div>
+              <button id="before">Before</button>
+              <wa-tag with-remove>Test</wa-tag>
+              <button id="after">After</button>
+            </div>
+          `);
+          const before = container.querySelector<HTMLButtonElement>('#before')!;
+          const after = container.querySelector<HTMLButtonElement>('#after')!;
+          const tag = container.querySelector<WaTag>('wa-tag')!;
+
+          tag.isRemoveTabbable = false;
+          await tag.updateComplete;
+
+          before.focus();
+          await sendKeys({ press: 'Tab' });
+
+          expect(document.activeElement).to.equal(after);
         });
       });
 

--- a/packages/webawesome/src/components/tag/tag.ts
+++ b/packages/webawesome/src/components/tag/tag.ts
@@ -54,6 +54,9 @@ export default class WaTag extends WebAwesomeElement {
   /** Makes the tag removable and shows a remove button. */
   @property({ attribute: 'with-remove', type: Boolean }) withRemove = false;
 
+  /** @internal Set by parent controls (`<wa-select>`, `<wa-combobox>`) that must remain a single tab stop. */
+  @property({ type: Boolean, attribute: false }) isRemoveTabbable = true;
+
   private handleRemoveClick() {
     this.dispatchEvent(new WaRemoveEvent());
   }
@@ -71,7 +74,7 @@ export default class WaTag extends WebAwesomeElement {
               appearance="plain"
               size=${this.size}
               @click=${this.handleRemoveClick}
-              tabindex="-1"
+              tabindex=${this.isRemoveTabbable ? '0' : '-1'}
             >
               <wa-icon name="xmark" library="system" variant="solid" label=${this.localize.term('remove')}></wa-icon>
             </wa-button>


### PR DESCRIPTION
You could remove a `<wa-tag>` with the mouse, but not the keyboard - the remove button was skipped when you tabbed through.

Now you can use Tab to select it, then press Enter or Space to remove the `<wa-tag>`.

### Why it wasn't just a one-line fix

The remove button was intentionally skipped. `<wa-select multiple>` puts its tags inside the select itself, so making the remove button focusable everywhere would mean a `<wa-select>` with eight tags becomes nine Tab stops instead of one. 

That breaks how form controls are supposed to work, and it's the same reason the `<wa-select>`'s clear button and its dropdown list are skipped as well.

There's a second problem in `<wa-select>`. When it has tags, the select shows focus as an outline around the whole control. Tab to a `<wa-tag>'s remove button, and that outline stays put while a tiny second outline appears — so the focus ring looks like it didn't move.

### How it works

`<wa-tag>` gets an internal setting that controls whether its remove button is a Tab stop. It's on by default, so a `<wa-tag>` on its own behaves correctly. `<wa-select>` turns it off for the tags it renders, so the select stays a single Tab stop.

`<wa-select>` turns it off in two places. 
1. Once in the template, which covers the normal case. 
1. Once after every render, which covers people who've customized their tags with `getTag` — that option can return raw HTML, and a template setting can't reach into raw HTML.

The setting is a JavaScript property with no matching HTML attribute. That's deliberate: an attribute would show up in the public API docs and people would start using it, and then we couldn't change it.

### Revised tests

For `<wa-tag>`: Tab reaches the ×, Enter removes the tag, Space removes the tag, and turning the setting off skips the × again. Each test presses a real Tab key and checks where focus actually went, rather than reading an attribute and assuming.

For `<wa-select>`: tags don't become Tab stops, including when someone customizes `getTag`. Both tests also check that the `<wa-tag>`s actually rendered and that focus actually reached the select first, so they can't pass by accident.

### Docs
The Removable example now actually removes the `<wa-tag>` and moves focus to the container, instead of just fading the tag out and leaving focus on an invisible element. There's a Reset button so you can try it more than once.

## Companion PRs
- https://github.com/shoelace-style/webawesome-pro/pull/287
