### PR TITLE
Fix textarea structure to support custom styles like other form controls

### DIFF
--- a/packages/webawesome/docs/docs/components/input.md
+++ b/packages/webawesome/docs/docs/components/input.md
@@ -177,7 +177,7 @@ Use [CSS parts](#css-parts) to customize the way form controls are drawn. This e
       align-items: center;
     }
 
-    ::part(label) {
+    ::part(form-control-label) {
       text-align: right;
     }
 

--- a/packages/webawesome/docs/docs/components/number-input.md
+++ b/packages/webawesome/docs/docs/components/number-input.md
@@ -193,7 +193,7 @@ Use [CSS parts](#css-parts) to customize the way form controls are drawn. This e
       align-items: center;
     }
 
-    ::part(label) {
+    ::part(form-control-label) {
       text-align: right;
     }
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -35,7 +35,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 - Fixed the focus ring on `<wa-otp-input>` animating its width and offset, which re-ran the animation on every keystroke as the active segment advanced. It now fades in at a fixed size, matching `<wa-input>` and the other form controls
 - Fixed a bug in `<wa-toast>` that caused center placements to render incorrectly on narrow screens [issue:2701]
-- Fixed the `hint` part in `<wa-textarea>` which was nested inside an unexposed wrapper, preventing custom layouts from affecting it
+- Fixed the `hint` part in `<wa-textarea>`, which sat on the slot inside an unexposed wrapper and couldn't be positioned by custom layouts. The part now lives on that wrapper, so `::part(hint)` selects the hint and the character count together [issue:2614]
 
 :::
 

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -35,11 +35,14 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 - Fixed the focus ring on `<wa-otp-input>` animating its width and offset, which re-ran the animation on every keystroke as the active segment advanced. It now fades in at a fixed size, matching `<wa-input>` and the other form controls
 - Fixed a bug in `<wa-toast>` that caused center placements to render incorrectly on narrow screens [issue:2701]
+- Fixed the `hint` part in `<wa-textarea>` which was nested inside an unexposed wrapper, preventing custom layouts from affecting it
 
 :::
 
 :::changed
+
 - Improved accessibility of `<wa-dropdown>` by adding `aria-posinset` and `aria-setsize` so supportive screen readers can correctly announce the number of dropdown items []
+
 :::
 
 ## 3.11.0

--- a/packages/webawesome/src/components/textarea/textarea.styles.ts
+++ b/packages/webawesome/src/components/textarea/textarea.styles.ts
@@ -135,13 +135,18 @@ export default css`
    * Footer (hint + character count)
    */
 
-  .footer {
+  /*
+   * This element carries the hint part, so the shared form control styles apply to it. Those styles set display:block
+   * and hide the element when it has no hint, both of which have to be undone when a character count is present.
+   */
+  .footer.has-slotted,
+  .footer.has-count {
     display: flex;
     align-items: baseline;
     gap: 1em;
   }
 
-  .footer.has-count [part='hint'] {
+  .footer.has-count .hint {
     flex: 1 1 auto;
     min-width: 0;
   }

--- a/packages/webawesome/src/components/textarea/textarea.styles.ts
+++ b/packages/webawesome/src/components/textarea/textarea.styles.ts
@@ -146,7 +146,9 @@ export default css`
     gap: 1em;
   }
 
+  /* Slots default to display:contents, which would leave the hint unable to shrink below its content */
   .footer.has-count .hint {
+    display: block;
     flex: 1 1 auto;
     min-width: 0;
   }

--- a/packages/webawesome/src/components/textarea/textarea.test.ts
+++ b/packages/webawesome/src/components/textarea/textarea.test.ts
@@ -145,10 +145,24 @@ describe('<wa-textarea>', () => {
           const el = await fixture<WaTextarea>(
             html`<wa-textarea hint="Some hint" with-count maxlength="10"></wa-textarea>`,
           );
-          const hint = el.shadowRoot!.querySelector('[part~="hint"]')! as HTMLElement;
+          const footer = el.shadowRoot!.querySelector('[part~="hint"]')! as HTMLElement;
+          const hint = el.shadowRoot!.querySelector('.hint')! as HTMLElement;
           const count = el.shadowRoot!.querySelector('[part~="count"]')! as HTMLElement;
-          expect(getComputedStyle(hint).display).to.equal('flex');
+          expect(getComputedStyle(footer).display).to.equal('flex');
           expect(count.getBoundingClientRect().top).to.be.lessThan(hint.getBoundingClientRect().bottom);
+        });
+
+        it('should keep the character count inside the control when the hint cannot wrap', async () => {
+          const el = await fixture<WaTextarea>(
+            html`<wa-textarea
+              style="width: 300px"
+              hint="Supercalifragilisticexpialidocious-antidisestablishmentarianism-pneumonoultramicroscopicsilicovolcanoconiosis"
+              with-count
+              maxlength="10"
+            ></wa-textarea>`,
+          );
+          const count = el.shadowRoot!.querySelector('[part~="count"]')! as HTMLElement;
+          expect(count.getBoundingClientRect().right).to.be.at.most(el.getBoundingClientRect().right);
         });
       });
 

--- a/packages/webawesome/src/components/textarea/textarea.test.ts
+++ b/packages/webawesome/src/components/textarea/textarea.test.ts
@@ -116,6 +116,40 @@ describe('<wa-textarea>', () => {
           const hint = el.shadowRoot!.querySelector('[part~="hint"]')!;
           expect(hint.textContent).to.contain('Some hint');
         });
+
+        it('should render the hint part as a top-level child so it can be positioned in custom layouts', async () => {
+          const el = await fixture<WaTextarea>(html`<wa-textarea hint="Some hint"></wa-textarea>`);
+          const hint = el.shadowRoot!.querySelector('[part~="hint"]')!;
+          expect(hint.parentNode).to.equal(el.shadowRoot);
+        });
+
+        it('should hide the hint part when there is no hint', async () => {
+          const el = await fixture<WaTextarea>(html`<wa-textarea></wa-textarea>`);
+          const hint = el.shadowRoot!.querySelector('[part~="hint"]')!;
+          expect(getComputedStyle(hint).display).to.equal('none');
+        });
+
+        it('should show the hint part when a hint is provided', async () => {
+          const el = await fixture<WaTextarea>(html`<wa-textarea hint="Some hint"></wa-textarea>`);
+          const hint = el.shadowRoot!.querySelector('[part~="hint"]')!;
+          expect(getComputedStyle(hint).display).to.not.equal('none');
+        });
+
+        it('should keep the character count visible when there is no hint', async () => {
+          const el = await fixture<WaTextarea>(html`<wa-textarea with-count maxlength="10"></wa-textarea>`);
+          const count = el.shadowRoot!.querySelector('[part~="count"]')! as HTMLElement;
+          expect(count.getBoundingClientRect().height).to.be.greaterThan(0);
+        });
+
+        it('should lay the hint and character count out on one line', async () => {
+          const el = await fixture<WaTextarea>(
+            html`<wa-textarea hint="Some hint" with-count maxlength="10"></wa-textarea>`,
+          );
+          const hint = el.shadowRoot!.querySelector('[part~="hint"]')! as HTMLElement;
+          const count = el.shadowRoot!.querySelector('[part~="count"]')! as HTMLElement;
+          expect(getComputedStyle(hint).display).to.equal('flex');
+          expect(count.getBoundingClientRect().top).to.be.lessThan(hint.getBoundingClientRect().bottom);
+        });
       });
 
       describe('events', () => {

--- a/packages/webawesome/src/components/textarea/textarea.ts
+++ b/packages/webawesome/src/components/textarea/textarea.ts
@@ -483,21 +483,17 @@ export default class WaTextarea extends WebAwesomeFormAssociatedElement {
       </div>
 
       <div
+        part="hint"
         class=${classMap({
           footer: true,
           'has-count': this.withCount,
+          // The shared form control styles hide the hint part when both of these are absent, which would also hide the
+          // character count, so has-hint keeps the footer visible when a count is shown without a hint.
+          'has-slotted': hasHint,
+          'has-hint': this.withCount,
         })}
       >
-        <slot
-          id="hint"
-          name="hint"
-          part="hint"
-          aria-hidden=${hasHint ? 'false' : 'true'}
-          class=${classMap({
-            'has-slotted': hasHint,
-          })}
-          >${this.hint}</slot
-        >
+        <slot id="hint" name="hint" class="hint" aria-hidden=${hasHint ? 'false' : 'true'}>${this.hint}</slot>
 
         ${this.withCount
           ? html`

--- a/packages/webawesome/src/components/textarea/textarea.ts
+++ b/packages/webawesome/src/components/textarea/textarea.ts
@@ -487,10 +487,7 @@ export default class WaTextarea extends WebAwesomeFormAssociatedElement {
         class=${classMap({
           footer: true,
           'has-count': this.withCount,
-          // The shared form control styles hide the hint part when both of these are absent, which would also hide the
-          // character count, so has-hint keeps the footer visible when a count is shown without a hint.
           'has-slotted': hasHint,
-          'has-hint': this.withCount,
         })}
       >
         <slot id="hint" name="hint" class="hint" aria-hidden=${hasHint ? 'false' : 'true'}>${this.hint}</slot>

--- a/packages/webawesome/src/styles/component/form-control.styles.ts
+++ b/packages/webawesome/src/styles/component/form-control.styles.ts
@@ -36,7 +36,7 @@ export default css`
     margin-block-start: 0.5em;
     font-size: var(--wa-font-size-smaller);
 
-    &:not(.has-slotted, .has-hint) {
+    &:not(.has-slotted, .has-hint, .has-count) {
       display: none;
     }
   }


### PR DESCRIPTION
The textarea has a `<div class="footer">` that surrounds the hint. The `hint` part itself was on the slot, which is an antipattern. This PR fixes that, allowing for consistent label styling, e.g.:

Before
<img width="1548" height="976" alt="before" src="https://github.com/user-attachments/assets/675bac63-30f9-4d43-8672-847c1b12afa6" />


After
<img width="1562" height="974" alt="after" src="https://github.com/user-attachments/assets/4e0c2690-987a-4a4b-b171-6acd0e3c2f70" />

I noticed this when reviewing https://github.com/shoelace-style/webawesome/issues/2614, which I _think_ is what the OP is referring to.

Closes #2614