### PR TITLE
Fix code example clipping

### DIFF
--- a/packages/webawesome/docs/assets/styles/code-examples.css
+++ b/packages/webawesome/docs/assets/styles/code-examples.css
@@ -27,11 +27,6 @@
   container-name: code-example;
   isolation: isolate;
 
-  /* Skip rendering (layout, paint, and the boot/measure work of the components inside) for examples that are off-screen
-    until they scroll near the viewport. */
-  content-visibility: auto;
-  contain-intrinsic-size: auto 400px;
-
   &:has(+ *) {
     margin-block-end: var(--wa-content-spacing);
   }


### PR DESCRIPTION
This is something I introduced to improve the performance of the Data Grid docs page, but it causes clipping around code example buttons (and other content that may overflow).

<img width="1562" height="394" alt="CleanShot 2026-08-06 at 16 08 05@2x" src="https://github.com/user-attachments/assets/14eb13b3-864f-453b-930e-dec3af7dc5d6" />
