### PR TITLE
Textarea: Follow-ups to Hint Part Fix

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -35,7 +35,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 - Fixed the focus ring on `<wa-otp-input>` animating its width and offset, which re-ran the animation on every keystroke as the active segment advanced. It now fades in at a fixed size, matching `<wa-input>` and the other form controls
 - Fixed a bug in `<wa-toast>` that caused center placements to render incorrectly on narrow screens [issue:2701]
-- Fixed the `hint` part in `<wa-textarea>` which was nested inside an unexposed wrapper, preventing custom layouts from affecting it
+- Fixed the `hint` part in `<wa-textarea>`, which sat on the slot inside an unexposed wrapper and couldn't be positioned by custom layouts. The part now lives on that wrapper, so `::part(hint)` selects the hint and the character count together [issue:2614]
 
 :::
 

--- a/packages/webawesome/src/components/textarea/textarea.styles.ts
+++ b/packages/webawesome/src/components/textarea/textarea.styles.ts
@@ -146,7 +146,9 @@ export default css`
     gap: 1em;
   }
 
+  /* Slots default to display:contents, which would leave the hint unable to shrink below its content */
   .footer.has-count .hint {
+    display: block;
     flex: 1 1 auto;
     min-width: 0;
   }

--- a/packages/webawesome/src/components/textarea/textarea.test.ts
+++ b/packages/webawesome/src/components/textarea/textarea.test.ts
@@ -150,6 +150,19 @@ describe('<wa-textarea>', () => {
           expect(getComputedStyle(hint).display).to.equal('flex');
           expect(count.getBoundingClientRect().top).to.be.lessThan(hint.getBoundingClientRect().bottom);
         });
+
+        it('should keep the character count inside the control when the hint cannot wrap', async () => {
+          const el = await fixture<WaTextarea>(
+            html`<wa-textarea
+              style="width: 300px"
+              hint="Supercalifragilisticexpialidocious-antidisestablishmentarianism-pneumonoultramicroscopicsilicovolcanoconiosis"
+              with-count
+              maxlength="10"
+            ></wa-textarea>`,
+          );
+          const count = el.shadowRoot!.querySelector('[part~="count"]')! as HTMLElement;
+          expect(count.getBoundingClientRect().right).to.be.at.most(el.getBoundingClientRect().right);
+        });
       });
 
       describe('events', () => {

--- a/packages/webawesome/src/components/textarea/textarea.test.ts
+++ b/packages/webawesome/src/components/textarea/textarea.test.ts
@@ -145,9 +145,10 @@ describe('<wa-textarea>', () => {
           const el = await fixture<WaTextarea>(
             html`<wa-textarea hint="Some hint" with-count maxlength="10"></wa-textarea>`,
           );
-          const hint = el.shadowRoot!.querySelector('[part~="hint"]')! as HTMLElement;
+          const footer = el.shadowRoot!.querySelector('[part~="hint"]')! as HTMLElement;
+          const hint = el.shadowRoot!.querySelector('.hint')! as HTMLElement;
           const count = el.shadowRoot!.querySelector('[part~="count"]')! as HTMLElement;
-          expect(getComputedStyle(hint).display).to.equal('flex');
+          expect(getComputedStyle(footer).display).to.equal('flex');
           expect(count.getBoundingClientRect().top).to.be.lessThan(hint.getBoundingClientRect().bottom);
         });
 

--- a/packages/webawesome/src/components/textarea/textarea.ts
+++ b/packages/webawesome/src/components/textarea/textarea.ts
@@ -487,10 +487,7 @@ export default class WaTextarea extends WebAwesomeFormAssociatedElement {
         class=${classMap({
           footer: true,
           'has-count': this.withCount,
-          // The shared form control styles hide the hint part when both of these are absent, which would also hide the
-          // character count, so has-hint keeps the footer visible when a count is shown without a hint.
           'has-slotted': hasHint,
-          'has-hint': this.withCount,
         })}
       >
         <slot id="hint" name="hint" class="hint" aria-hidden=${hasHint ? 'false' : 'true'}>${this.hint}</slot>

--- a/packages/webawesome/src/styles/component/form-control.styles.ts
+++ b/packages/webawesome/src/styles/component/form-control.styles.ts
@@ -36,7 +36,7 @@ export default css`
     margin-block-start: 0.5em;
     font-size: var(--wa-font-size-smaller);
 
-    &:not(.has-slotted, .has-hint) {
+    &:not(.has-slotted, .has-hint, .has-count) {
       display: none;
     }
   }


### PR DESCRIPTION
A few follow-ups to https://github.com/shoelace-style/webawesome/pull/2720. 

The first one is an actual regression. The other three are small.

### The Regression
Once `part="hint"` came off the slot, the slot fell back to its UA default of `display: contents`. This means no box. So `.footer.has-count .hint { flex: 1 1 auto; min-width: 0 }` was styling nothing.

You see it with a hint that can't wrap. In a 300px textarea, the character count lands about 162px past the right edge of the control. Prior to this, it stayed put.

I added `display: block,` to the slot, which fixes it. And I added a test that fails without that line.

### Smaller Cleanups
- In a test, `should lay the hint and character count out on one line` was checking the count against its own parent, which is always true. It passed with the two stacked on top of each other. Now it checks the `.hint` slot.
- `'has-hint': this.withCount` says there's a hint when there's only a count. It's load-bearing, but it lies. `form-control.styles.ts` takes `.has-count` in the same `:not()` now, so the flag can go.
- Changelog entry gets `[issue:2614]`, and says out loud that `::part(hint)` covers the hint and the character count both.
