### PR TITLE
Fix duplicate banner landmark in wa-card

### DIFF
--- a/packages/webawesome/src/components/card/card.test.ts
+++ b/packages/webawesome/src/components/card/card.test.ts
@@ -22,6 +22,19 @@ describe('<wa-card>', () => {
           await expect(el).to.be.accessible();
         });
 
+        it('should pass accessibility tests with a page header and card header', async () => {
+          const el = await fixture<HTMLDivElement>(html`
+            <div>
+              <header>Site header</header>
+              <wa-card>
+                <div slot="header">Card header</div>
+                Card content
+              </wa-card>
+            </div>
+          `);
+          await expect(el).to.be.accessible();
+        });
+
         it('should pass accessibility tests with footer', async () => {
           const el = await fixture<WaCard>(html`
             <wa-card>

--- a/packages/webawesome/src/components/card/card.ts
+++ b/packages/webawesome/src/components/card/card.ts
@@ -108,7 +108,7 @@ export default class WaCard extends WebAwesomeElement {
     return html`
       <slot name="media" part="media" class="media"></slot>
 
-      <header
+      <div
         part="header"
         class=${classMap({
           header: true,
@@ -117,7 +117,7 @@ export default class WaCard extends WebAwesomeElement {
       >
         <slot name="header"></slot>
         <slot name="header-actions"></slot>
-      </header>
+      </div>
 
       <div part="body" class="body"><slot></slot></div>
 


### PR DESCRIPTION
Fixes #2723.

Replaces the card’s internal <header> with a non-landmark container and adds an accessibility regression test.