### PR TITLE
Native Styles: Align Table Row Headers with Their Cells

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -33,6 +33,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 :::fixed
 
+- Fixed native table row headers (`<th scope="row">`) rendering at a smaller font size than the cells beside them, which knocked their text out of vertical alignment. The smaller type is now scoped to column headers
 - Fixed the focus ring on `<wa-otp-input>` animating its width and offset, which re-ran the animation on every keystroke as the active segment advanced. It now fades in at a fixed size, matching `<wa-input>` and the other form controls
 - Fixed a bug in `<wa-toast>` that caused center placements to render incorrectly on narrow screens [issue:2701]
 - Fixed a bug in `<wa-data-grid>` that caused an expanded row detail's space to stay reserved at its old position after changing pages, sorting, or filtering

--- a/packages/webawesome/docs/docs/utilities/native.md
+++ b/packages/webawesome/docs/docs/utilities/native.md
@@ -360,6 +360,45 @@ Structure tabular data with `<table>` and related elements like `<caption>`, `<t
 </table>
 ```
 
+Add `scope="col"` to column headers and `scope="row"` to the first cell in a row so assistive technology knows which cells each header describes. Row headers keep the body font size, so their text aligns with the cells beside them.
+
+```html {.example}
+<table>
+  <caption>
+    Coffee brewing methods
+  </caption>
+  <thead>
+    <tr>
+      <th scope="col">Method</th>
+      <th scope="col">Grind</th>
+      <th scope="col">Brew Time</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th scope="row">French Press</th>
+      <td>Coarse</td>
+      <td>4 minutes</td>
+    </tr>
+    <tr>
+      <th scope="row">Pour Over</th>
+      <td>Medium</td>
+      <td>3 minutes</td>
+    </tr>
+    <tr>
+      <th scope="row">Espresso</th>
+      <td>Fine</td>
+      <td>30 seconds</td>
+    </tr>
+    <tr>
+      <th scope="row">Cold Brew</th>
+      <td>Extra coarse</td>
+      <td>12 hours</td>
+    </tr>
+  </tbody>
+</table>
+```
+
 Add the `wa-hover-rows` class to highlight table rows on hover and the `wa-zebra-rows` class to add alternating row colors to your table.
 
 ```html {.example}

--- a/packages/webawesome/src/styles/native.css
+++ b/packages/webawesome/src/styles/native.css
@@ -436,13 +436,13 @@
   }
 
   th {
-    font-size: var(--wa-font-size-smaller);
     font-weight: var(--wa-font-weight-bold);
 
-    /* Adds a stronger border below column headers only
-     * Row headers are avoided with [scope="row"]
-     * or when the next sibling is a non-header cell */
+    /* Column headers only, ruled out by [scope="row"] or by a following non-header cell.
+     * Row headers keep the body font size because padding here is em-relative, so smaller
+     * type would pull their text out of alignment with the cells beside them. */
     &:not([scope='row']):not(:has(+ td)) {
+      font-size: var(--wa-font-size-smaller);
       border-block-end: var(--wa-border-style) var(--wa-border-width-s) var(--wa-color-border-normal);
     }
   }


### PR DESCRIPTION
`<th scope="row">` was picking up `--wa-font-size-smaller`, the type treatment meant for column headers. That made the row-header text inconsistent with the  `<td>`s sitting next to it.

### What Went Wrong
- `native.css` already tells column headers apart from row headers. The stronger bottom border is scoped with `:not([scope='row']):not(:has(+ td))`. `font-size` just sat outside that block and hit every `th`.
- It misaligns twice over, which is why you can see it at all. `td, th` share `padding: 0.75em` and `vertical-align: top`, so shrinking the font shrinks the padding *and* the line box. 

### The Fix
- Move `font-size` into the column-header block, next to the border it should have been sitting with. 
- Row headers stay bold and take the body size.

### Docs
The native tables page had no `scope="row"` example, so nothing pointed anyone at the attribute that settles this. So I added one.
