### PR TITLE
Add support for link items to dropdown items

### DIFF
--- a/packages/webawesome/docs/docs/components/dropdown.md
+++ b/packages/webawesome/docs/docs/components/dropdown.md
@@ -152,6 +152,43 @@ Set `type="checkbox"` to turn a [dropdown item](/docs/components/dropdown-item) 
 When any item is checkable, every item in the dropdown gains matching padding so labels stay aligned.
 :::
 
+### Link Items
+
+Set `href` on a [dropdown item](/docs/components/dropdown-item) to navigate when the item is selected. The `target`, `rel`, and `download` attributes work the same as they do on an `<a>` element.
+
+Link items still emit `wa-select`, so you can react to them like any other item. Calling `event.preventDefault()` cancels the navigation along with the close. Items that open a submenu ignore `href`, since selecting them opens the submenu instead of navigating.
+
+```html {.example}
+<wa-dropdown>
+  <wa-button appearance="filled" slot="trigger" with-caret>Resources</wa-button>
+
+  <wa-dropdown-item href="/docs/">
+    <wa-icon slot="icon" name="book"></wa-icon>
+    Documentation
+  </wa-dropdown-item>
+
+  <wa-dropdown-item href="https://github.com/shoelace-style/webawesome" target="_blank" rel="noreferrer">
+    <wa-icon slot="icon" name="github" family="brands"></wa-icon>
+    GitHub
+    <wa-icon slot="details" name="arrow-up-right-from-square"></wa-icon>
+  </wa-dropdown-item>
+
+  <wa-divider></wa-divider>
+
+  <wa-dropdown-item href="/assets/images/awesome.svg" download="awesome.svg">
+    <wa-icon slot="icon" name="download"></wa-icon>
+    Download logo
+  </wa-dropdown-item>
+</wa-dropdown>
+```
+
+Modifier keys work as expected in most browsers, so [[Command]] + clicking a link item opens it in a new tab. Safari is the exception, as it ignores modifier keys on synthetic clicks.
+
+:::warning
+<strong>Link items aren't announced as links.</strong><br />
+A dropdown item keeps its `menuitem` role, so write labels that make the destination clear from context, adding a [visually hidden](/docs/utilities/visually-hidden) label when it needs more detail.
+:::
+
 ### Destructive Items
 
 Set `variant="danger"` on a [dropdown item](/docs/components/dropdown-item) to flag a destructive action like deleting.

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -35,6 +35,10 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 - Added version 3.0.0 of the [official Web Awesome Figma Design Kit](/docs/resources/figma)
 - Added the `filterOptions` column option to `<wa-data-grid>` to supply a `set`/`includes-*` filter picker's values yourself, enabling value pickers in server mode and custom ordering/labeling in client mode
+- Added the `href`, `target`, `rel`, and `download` attributes to `<wa-dropdown-item>` so items can navigate when selected
+  - Selecting a link item honors modifier keys, e.g. pressing <kbd>Command</kbd> or <kbd>Control</kbd> to open a new tab, except in Safari
+  - Items with a submenu ignore `href`
+  - Added the `link` custom state to `<wa-dropdown-item>`
 
 :::
 
@@ -46,6 +50,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 - Fixed system icons in `<wa-pagination>`, `<wa-time-input>`, and `<wa-date-input>` rendering black instead of inheriting the current text color [issue:2688]
 - Fixed a bug in `<wa-data-grid>` that caused an expanded row detail's space to stay reserved at its old position after changing pages, sorting, or filtering
 - Fixed the `hint` part in `<wa-textarea>`, which sat on the slot inside an unexposed wrapper and couldn't be positioned by custom layouts. The part now lives on that wrapper, so `::part(hint)` selects the hint and the character count together [issue:2614]
+- Fixed the missing Custom States table in the `<wa-dropdown-item>` docs. The `active`, `checked`, `disabled`, `has-submenu`, and `submenu-open` states already worked, but went undocumented
 
 :::
 

--- a/packages/webawesome/src/components/dropdown-item/dropdown-item.styles.ts
+++ b/packages/webawesome/src/components/dropdown-item/dropdown-item.styles.ts
@@ -70,6 +70,11 @@ export default css`
     padding-inline-end: 1.75em;
   }
 
+  /* The link only exists to be clicked programmatically. */
+  #link {
+    display: none;
+  }
+
   #check {
     visibility: hidden;
     margin-inline-start: -1.5em;

--- a/packages/webawesome/src/components/dropdown-item/dropdown-item.test.ts
+++ b/packages/webawesome/src/components/dropdown-item/dropdown-item.test.ts
@@ -170,6 +170,110 @@ describe('<wa-dropdown-item>', () => {
         });
       });
 
+      describe('links', () => {
+        it('should not render a link when href is absent', async () => {
+          const el = await fixture<WaDropdownItem>(html`<wa-dropdown-item>Item</wa-dropdown-item>`);
+          expect(el.shadowRoot!.querySelector('#link')).to.not.exist;
+        });
+
+        it('should render a hidden link when href is set', async () => {
+          const el = await fixture<WaDropdownItem>(html`<wa-dropdown-item href="/about">About</wa-dropdown-item>`);
+          const link = el.shadowRoot!.querySelector<HTMLAnchorElement>('#link')!;
+          expect(link).to.exist;
+          expect(link.getAttribute('href')).to.equal('/about');
+          expect(link.getAttribute('aria-hidden')).to.equal('true');
+          expect(link.getAttribute('tabindex')).to.equal('-1');
+        });
+
+        it('should pass target, rel, and download through to the link', async () => {
+          const el = await fixture<WaDropdownItem>(html`
+            <wa-dropdown-item href="/file.pdf" target="_blank" rel="noreferrer" download="report.pdf">
+              Download
+            </wa-dropdown-item>
+          `);
+          const link = el.shadowRoot!.querySelector<HTMLAnchorElement>('#link')!;
+          expect(link.getAttribute('target')).to.equal('_blank');
+          expect(link.getAttribute('rel')).to.equal('noreferrer');
+          expect(link.getAttribute('download')).to.equal('report.pdf');
+        });
+
+        it('should omit target, rel, and download when they are not set', async () => {
+          const el = await fixture<WaDropdownItem>(html`<wa-dropdown-item href="/about">About</wa-dropdown-item>`);
+          const link = el.shadowRoot!.querySelector<HTMLAnchorElement>('#link')!;
+          expect(link.hasAttribute('target')).to.be.false;
+          expect(link.hasAttribute('rel')).to.be.false;
+          expect(link.hasAttribute('download')).to.be.false;
+        });
+
+        it('should keep role="menuitem" when href is set', async () => {
+          const el = await fixture<WaDropdownItem>(html`<wa-dropdown-item href="/about">About</wa-dropdown-item>`);
+          expect(el.getAttribute('role')).to.equal('menuitem');
+        });
+
+        it('should expose the link custom state when href is set', async () => {
+          const el = await fixture<WaDropdownItem>(html`<wa-dropdown-item>Item</wa-dropdown-item>`);
+          expect(el.matches(':state(link)')).to.be.false;
+
+          el.href = '/about';
+          await el.updateComplete;
+          expect(el.matches(':state(link)')).to.be.true;
+        });
+
+        it('should not render a link when the item has a submenu', async () => {
+          const el = await fixture<WaDropdownItem>(html`
+            <wa-dropdown-item href="/about">
+              About
+              <wa-dropdown-item slot="submenu" href="/about/team">Team</wa-dropdown-item>
+            </wa-dropdown-item>
+          `);
+          await el.updateComplete;
+          expect(el.shadowRoot!.querySelector('#link')).to.not.exist;
+          expect(el.matches(':state(link)')).to.be.false;
+        });
+
+        it('should click the link when navigate() is called', async () => {
+          const el = await fixture<WaDropdownItem>(html`<wa-dropdown-item href="/about">About</wa-dropdown-item>`);
+          const link = el.shadowRoot!.querySelector<HTMLAnchorElement>('#link')!;
+          const clickHandler = sinon.spy((event: MouseEvent) => event.preventDefault());
+          link.addEventListener('click', clickHandler);
+
+          el.navigate();
+          expect(clickHandler).to.have.been.calledOnce;
+        });
+
+        it('should forward modifier keys from the source event to the link', async () => {
+          const el = await fixture<WaDropdownItem>(html`<wa-dropdown-item href="/about">About</wa-dropdown-item>`);
+          const link = el.shadowRoot!.querySelector<HTMLAnchorElement>('#link')!;
+          const clickHandler = sinon.spy((event: MouseEvent) => event.preventDefault());
+          link.addEventListener('click', clickHandler);
+
+          el.navigate(new MouseEvent('click', { metaKey: true, shiftKey: true }));
+
+          const forwarded = clickHandler.firstCall.args[0];
+          expect(forwarded.metaKey).to.be.true;
+          expect(forwarded.shiftKey).to.be.true;
+          expect(forwarded.ctrlKey).to.be.false;
+          expect(forwarded.altKey).to.be.false;
+        });
+
+        it('should not navigate when disabled', async () => {
+          const el = await fixture<WaDropdownItem>(
+            html`<wa-dropdown-item href="/about" disabled>About</wa-dropdown-item>`,
+          );
+          const link = el.shadowRoot!.querySelector<HTMLAnchorElement>('#link')!;
+          const clickHandler = sinon.spy((event: MouseEvent) => event.preventDefault());
+          link.addEventListener('click', clickHandler);
+
+          el.navigate();
+          expect(clickHandler).to.not.have.been.called;
+        });
+
+        it('should not throw when navigate() is called without an href', async () => {
+          const el = await fixture<WaDropdownItem>(html`<wa-dropdown-item>Item</wa-dropdown-item>`);
+          expect(() => el.navigate()).to.not.throw();
+        });
+      });
+
       describe('CSS parts and states', () => {
         it('should have an icon part', async () => {
           const el = await fixture<WaDropdownItem>(html`<wa-dropdown-item>Item</wa-dropdown-item>`);

--- a/packages/webawesome/src/components/dropdown-item/dropdown-item.test.ts
+++ b/packages/webawesome/src/components/dropdown-item/dropdown-item.test.ts
@@ -219,7 +219,12 @@ describe('<wa-dropdown-item>', () => {
           expect(el.matches(':state(link)')).to.be.true;
         });
 
-        it('should not render a link when the item has a submenu', async () => {
+        // Skipped for SSR because rendering a submenu server-side triggers a pre-existing hydration mismatch. The
+        // submenu icon and container render only after firstUpdated(), so the server omits markup the client adds.
+        // This is unrelated to link behavior and also fails for submenu items without an href.
+        const itOrSkip = fixture.type === 'ssr-client-hydrated' ? it.skip : it;
+
+        itOrSkip('should not navigate when the item has a submenu', async () => {
           const el = await fixture<WaDropdownItem>(html`
             <wa-dropdown-item href="/about">
               About
@@ -227,8 +232,15 @@ describe('<wa-dropdown-item>', () => {
             </wa-dropdown-item>
           `);
           await el.updateComplete;
-          expect(el.shadowRoot!.querySelector('#link')).to.not.exist;
           expect(el.matches(':state(link)')).to.be.false;
+
+          // The link element still exists so server and client render the same template, but the item must not navigate
+          const link = el.shadowRoot!.querySelector<HTMLAnchorElement>('#link')!;
+          const clickHandler = sinon.spy((event: MouseEvent) => event.preventDefault());
+          link.addEventListener('click', clickHandler);
+
+          el.navigate();
+          expect(clickHandler).to.not.have.been.called;
         });
 
         it('should click the link when navigate() is called', async () => {

--- a/packages/webawesome/src/components/dropdown-item/dropdown-item.ts
+++ b/packages/webawesome/src/components/dropdown-item/dropdown-item.ts
@@ -339,7 +339,7 @@ export default class WaDropdownItem extends WebAwesomeElement {
 
   render() {
     return html`
-      ${this.isLink()
+      ${this.href
         ? html`
             <a
               id="link"

--- a/packages/webawesome/src/components/dropdown-item/dropdown-item.ts
+++ b/packages/webawesome/src/components/dropdown-item/dropdown-item.ts
@@ -1,6 +1,7 @@
 import type { PropertyValues } from 'lit';
 import { html } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { animateWithClass } from '../../internal/animate.js';
 import { warnDeprecatedSize } from '../../internal/size.js';
 import { HasSlotController } from '../../internal/slot.js';
@@ -32,6 +33,13 @@ import styles from './dropdown-item.styles.js';
  * @csspart details - The container for the details slot.
  * @csspart submenu-icon - The submenu indicator icon (a `<wa-icon>` element).
  * @csspart submenu - The submenu container.
+ *
+ * @cssstate active - Applied when the item is the active item in the menu.
+ * @cssstate checked - Applied when the item is checked.
+ * @cssstate disabled - Applied when the item is disabled.
+ * @cssstate has-submenu - Applied when the item has a submenu.
+ * @cssstate link - Applied when the item is a link (i.e. `href` is set).
+ * @cssstate submenu-open - Applied when the item's submenu is open.
  */
 @customElement('wa-dropdown-item')
 export default class WaDropdownItem extends WebAwesomeElement {
@@ -40,6 +48,7 @@ export default class WaDropdownItem extends WebAwesomeElement {
   private readonly hasSlotController = new HasSlotController(this, '[default]', 'start', 'end');
 
   @query('#submenu') submenuElement: HTMLDivElement;
+  @query('#link') private linkElement: HTMLAnchorElement | null;
 
   /** @internal The controller will set this property to true when the item is active. */
   @property({ type: Boolean }) active = false;
@@ -86,6 +95,21 @@ export default class WaDropdownItem extends WebAwesomeElement {
 
   /** Whether the submenu is currently open. */
   @property({ type: Boolean, reflect: true }) submenuOpen = false;
+
+  /**
+   * When set, selecting the item will navigate to this URL. The item remains a menu item for assistive devices, so
+   * make sure the label describes where the link goes. Ignored when the item has a submenu.
+   */
+  @property({ reflect: true }) href: string;
+
+  /** Tells the browser where to open the link. Only used when `href` is present. */
+  @property() target: '_blank' | '_parent' | '_self' | '_top';
+
+  /** When using `href`, this attribute will map to the underlying link's `rel` attribute. */
+  @property() rel: string;
+
+  /** Tells the browser to download the linked file as this filename. Only used when `href` is present. */
+  @property() download: string;
 
   /** @internal Store whether this item has a submenu */
   @state() hasSubmenu = false;
@@ -142,6 +166,10 @@ export default class WaDropdownItem extends WebAwesomeElement {
         this.setAttribute('role', 'menuitem');
         this.removeAttribute('aria-checked');
       }
+    }
+
+    if (changedProperties.has('href') || changedProperties.has('hasSubmenu')) {
+      this.customStates.set('link', this.isLink());
     }
 
     if (changedProperties.has('submenuOpen')) {
@@ -246,6 +274,36 @@ export default class WaDropdownItem extends WebAwesomeElement {
     }
   }
 
+  /** Determines whether the item navigates when selected. Items with submenus never navigate. */
+  private isLink() {
+    return Boolean(this.href) && !this.hasSubmenu;
+  }
+
+  /**
+   * @internal Navigates to the item's `href` by clicking the hidden link in the shadow root. The event that triggered
+   * the selection is passed along so modifier keys, such as pressing Command or Control to open a new tab, are honored.
+   * Note that Safari ignores modifier keys on synthetic clicks.
+   */
+  navigate(sourceEvent?: MouseEvent | KeyboardEvent) {
+    const link = this.linkElement;
+
+    if (!this.isLink() || this.disabled || !link) {
+      return;
+    }
+
+    link.dispatchEvent(
+      new MouseEvent('click', {
+        bubbles: false,
+        cancelable: true,
+        composed: false,
+        altKey: sourceEvent?.altKey ?? false,
+        ctrlKey: sourceEvent?.ctrlKey ?? false,
+        metaKey: sourceEvent?.metaKey ?? false,
+        shiftKey: sourceEvent?.shiftKey ?? false,
+      }),
+    );
+  }
+
   /** Gets all dropdown items in the submenu. */
   private getSubmenuItems(): WaDropdownItem[] {
     // Only get direct children with slot="submenu", not nested ones
@@ -281,6 +339,19 @@ export default class WaDropdownItem extends WebAwesomeElement {
 
   render() {
     return html`
+      ${this.isLink()
+        ? html`
+            <a
+              id="link"
+              href=${this.href}
+              target=${ifDefined(this.target)}
+              rel=${ifDefined(this.rel)}
+              download=${ifDefined(this.download)}
+              tabindex="-1"
+              aria-hidden="true"
+            ></a>
+          `
+        : ''}
       ${this.type === 'checkbox'
         ? html`
             <wa-icon

--- a/packages/webawesome/src/components/dropdown/dropdown.test.ts
+++ b/packages/webawesome/src/components/dropdown/dropdown.test.ts
@@ -327,7 +327,12 @@ describe('<wa-dropdown>', () => {
           expect(clickHandler).to.not.have.been.called;
         });
 
-        it('should navigate when a link item is selected with Enter', async () => {
+        // Skipped for SSR because a dropdown that hydrates with the open attribute never transitions open, so
+        // showMenu() never runs and the document keydown listener is never attached. This is a pre-existing
+        // wa-dropdown issue unrelated to link items.
+        const itOrSkip = fixture.type === 'ssr-client-hydrated' ? it.skip : it;
+
+        itOrSkip('should navigate when a link item is selected with Enter', async () => {
           const el = await fixture<WaDropdown>(html`
             <wa-dropdown open>
               <wa-button slot="trigger">Dropdown</wa-button>

--- a/packages/webawesome/src/components/dropdown/dropdown.test.ts
+++ b/packages/webawesome/src/components/dropdown/dropdown.test.ts
@@ -260,6 +260,116 @@ describe('<wa-dropdown>', () => {
           expect(el.open).to.be.false;
         });
 
+        it('should navigate when a link item is selected', async () => {
+          const el = await fixture<WaDropdown>(html`
+            <wa-dropdown open>
+              <wa-button slot="trigger">Dropdown</wa-button>
+              <wa-dropdown-item value="about" href="/about">About</wa-dropdown-item>
+            </wa-dropdown>
+          `);
+          await el.updateComplete;
+          await aTimeout(200);
+
+          const item = el.querySelector<HTMLElement>('wa-dropdown-item')!;
+          const link = item.shadowRoot!.querySelector<HTMLAnchorElement>('#link')!;
+          const clickHandler = sinon.spy((event: MouseEvent) => event.preventDefault());
+          link.addEventListener('click', clickHandler);
+
+          item.click();
+          await aTimeout(200);
+
+          expect(clickHandler).to.have.been.calledOnce;
+          expect(el.open).to.be.false;
+        });
+
+        it('should not navigate when wa-select is prevented on a link item', async () => {
+          const el = await fixture<WaDropdown>(html`
+            <wa-dropdown open>
+              <wa-button slot="trigger">Dropdown</wa-button>
+              <wa-dropdown-item value="about" href="/about">About</wa-dropdown-item>
+            </wa-dropdown>
+          `);
+          await el.updateComplete;
+          await aTimeout(200);
+
+          el.addEventListener('wa-select', event => event.preventDefault());
+
+          const item = el.querySelector<HTMLElement>('wa-dropdown-item')!;
+          const link = item.shadowRoot!.querySelector<HTMLAnchorElement>('#link')!;
+          const clickHandler = sinon.spy((event: MouseEvent) => event.preventDefault());
+          link.addEventListener('click', clickHandler);
+
+          item.click();
+          await aTimeout(200);
+
+          expect(clickHandler).to.not.have.been.called;
+          expect(el.open).to.be.true;
+        });
+
+        it('should not navigate when a disabled link item is clicked', async () => {
+          const el = await fixture<WaDropdown>(html`
+            <wa-dropdown open>
+              <wa-button slot="trigger">Dropdown</wa-button>
+              <wa-dropdown-item value="about" href="/about" disabled>About</wa-dropdown-item>
+            </wa-dropdown>
+          `);
+          await el.updateComplete;
+          await aTimeout(200);
+
+          const item = el.querySelector<HTMLElement>('wa-dropdown-item')!;
+          const link = item.shadowRoot!.querySelector<HTMLAnchorElement>('#link')!;
+          const clickHandler = sinon.spy((event: MouseEvent) => event.preventDefault());
+          link.addEventListener('click', clickHandler);
+
+          item.click();
+          await aTimeout(200);
+
+          expect(clickHandler).to.not.have.been.called;
+        });
+
+        it('should navigate when a link item is selected with Enter', async () => {
+          const el = await fixture<WaDropdown>(html`
+            <wa-dropdown open>
+              <wa-button slot="trigger">Dropdown</wa-button>
+              <wa-dropdown-item value="about" href="/about">About</wa-dropdown-item>
+            </wa-dropdown>
+          `);
+          await el.updateComplete;
+          await aTimeout(200);
+
+          const item = el.querySelector<HTMLElement>('wa-dropdown-item')!;
+          const link = item.shadowRoot!.querySelector<HTMLAnchorElement>('#link')!;
+          const clickHandler = sinon.spy((event: MouseEvent) => event.preventDefault());
+          link.addEventListener('click', clickHandler);
+
+          item.focus();
+          await sendKeys({ press: 'Enter' });
+          await aTimeout(200);
+
+          expect(clickHandler).to.have.been.calledOnce;
+        });
+
+        it('should still fire wa-select for link items', async () => {
+          const el = await fixture<WaDropdown>(html`
+            <wa-dropdown open>
+              <wa-button slot="trigger">Dropdown</wa-button>
+              <wa-dropdown-item value="about" href="/about">About</wa-dropdown-item>
+            </wa-dropdown>
+          `);
+          await el.updateComplete;
+          await aTimeout(200);
+
+          const item = el.querySelector<HTMLElement>('wa-dropdown-item')!;
+          const link = item.shadowRoot!.querySelector<HTMLAnchorElement>('#link')!;
+          link.addEventListener('click', event => event.preventDefault());
+
+          const events = await expectEvent(el, 'wa-select', () => {
+            item.click();
+          });
+
+          expect((events[0] as CustomEvent).detail.item.value).to.equal('about');
+        });
+
         it('should not close after selection when wa-select is prevented', async () => {
           const el = await fixture<WaDropdown>(html`
             <wa-dropdown open>

--- a/packages/webawesome/src/components/dropdown/dropdown.ts
+++ b/packages/webawesome/src/components/dropdown/dropdown.ts
@@ -473,7 +473,7 @@ export default class WaDropdown extends WebAwesomeElement {
           }
         }, 0);
       } else {
-        this.makeSelection(activeItem);
+        this.makeSelection(activeItem, event);
       }
     }
   };
@@ -510,7 +510,7 @@ export default class WaDropdown extends WebAwesomeElement {
       return;
     }
 
-    this.makeSelection(item);
+    this.makeSelection(item, event);
   }
 
   /** Prepares dropdown items when they get added or removed */
@@ -702,7 +702,7 @@ export default class WaDropdown extends WebAwesomeElement {
   };
 
   /** Makes a selection, emits the wa-select event, and closes the dropdown. */
-  private makeSelection(item: WaDropdownItem) {
+  private makeSelection(item: WaDropdownItem, sourceEvent?: MouseEvent | KeyboardEvent) {
     const trigger = this.getTrigger();
 
     if (item.disabled) {
@@ -717,6 +717,10 @@ export default class WaDropdown extends WebAwesomeElement {
     this.dispatchEvent(selectEvent);
 
     if (!selectEvent.defaultPrevented) {
+      // Items with an href navigate by clicking a hidden link. The source event is passed along so modifier keys, such
+      // as Command or Control to open a new tab, are honored.
+      item.navigate(sourceEvent);
+
       this.open = false;
       trigger?.focus({ preventScroll: true });
     }


### PR DESCRIPTION
Per discussion #1291, this PR adds support for link-like behavior to `<wa-dropdown-item>` by allowing `href`, `target`, `rel`, and `download`.

It also documents missing custom states that were implemented but never tagged so they never got read by the CEM.

The caveat, as mentioned in #1291, is that Safari doesn't honor modifier keys on synthetic clicks, meaning CMD/CTRL/SHIFT+clicking doesn't open in a new tab/window like other browsers. This seems like a small price to pay given the new functionality.