### PR TITLE
Off with their head[ers and footers]!

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -53,6 +53,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 - Fixed a bug in `<wa-tooltip>` where tooltips with `trigger="manual"` closed when pressing <kbd>Escape</kbd>
 - Fixed the `hint` part in `<wa-textarea>`, which sat on the slot inside an unexposed wrapper and couldn't be positioned by custom layouts. The part now lives on that wrapper, so `::part(hint)` selects the hint and the character count together [issue:2614]
 - Fixed the missing Custom States table in the `<wa-dropdown-item>` docs. The `active`, `checked`, `disabled`, `has-submenu`, and `submenu-open` states already worked, but went undocumented
+- Fixed a bug in `<wa-card>`, `<wa-dialog>`, and `<wa-drawer>` that added duplicate `banner` and `contentinfo` landmarks to the page [issue:2723]
 
 :::
 

--- a/packages/webawesome/src/components/card/card.test.ts
+++ b/packages/webawesome/src/components/card/card.test.ts
@@ -32,6 +32,21 @@ describe('<wa-card>', () => {
           await expect(el).to.be.accessible();
         });
 
+        it('should not create duplicate landmarks when the page has its own header and footer', async () => {
+          const el = await fixture(html`
+            <div>
+              <header>Site header</header>
+              <wa-card>
+                <div slot="header">Card header</div>
+                Body content
+                <div slot="footer">Card footer</div>
+              </wa-card>
+              <footer>Site footer</footer>
+            </div>
+          `);
+          await expect(el).to.be.accessible();
+        });
+
         it('should pass accessibility tests with media', async () => {
           const el = await fixture<WaCard>(html`
             <wa-card>

--- a/packages/webawesome/src/components/card/card.ts
+++ b/packages/webawesome/src/components/card/card.ts
@@ -108,7 +108,7 @@ export default class WaCard extends WebAwesomeElement {
     return html`
       <slot name="media" part="media" class="media"></slot>
 
-      <header
+      <div
         part="header"
         class=${classMap({
           header: true,
@@ -117,11 +117,11 @@ export default class WaCard extends WebAwesomeElement {
       >
         <slot name="header"></slot>
         <slot name="header-actions"></slot>
-      </header>
+      </div>
 
       <div part="body" class="body"><slot></slot></div>
 
-      <footer
+      <div
         part="footer"
         class=${classMap({
           footer: true,
@@ -130,7 +130,7 @@ export default class WaCard extends WebAwesomeElement {
       >
         <slot name="footer"></slot>
         <slot name="footer-actions"></slot>
-      </footer>
+      </div>
     `;
   }
 }

--- a/packages/webawesome/src/components/dialog/dialog.test.ts
+++ b/packages/webawesome/src/components/dialog/dialog.test.ts
@@ -29,6 +29,21 @@ describe('<wa-dialog>', () => {
 
           expect(document.activeElement).to.equal(input);
         });
+
+        it('should not create duplicate landmarks when the page has its own header and footer', async () => {
+          const el = await fixture(html`
+            <div>
+              <header>Site header</header>
+              <wa-dialog label="Test dialog" open>
+                Dialog content
+                <div slot="footer">Dialog footer</div>
+              </wa-dialog>
+              <footer>Site footer</footer>
+            </div>
+          `);
+          await el.querySelector<WaDialog>('wa-dialog')!.updateComplete;
+          await expect(el).to.be.accessible();
+        });
       });
 
       describe('properties', () => {

--- a/packages/webawesome/src/components/dialog/dialog.ts
+++ b/packages/webawesome/src/components/dialog/dialog.ts
@@ -268,7 +268,7 @@ export default class WaDialog extends WebAwesomeElement {
       >
         ${hasHeader
           ? html`
-              <header part="header" class="header">
+              <div part="header" class="header">
                 <h2 part="title" class="title" id="title">
                   <!-- If there's no label, use an invisible character to prevent the header from collapsing -->
                   <slot name="label"> ${this.label.length > 0 ? this.label : String.fromCharCode(8203)} </slot>
@@ -290,16 +290,16 @@ export default class WaDialog extends WebAwesomeElement {
                     ></wa-icon>
                   </wa-button>
                 </div>
-              </header>
+              </div>
             `
           : ''}
 
         <div part="body" class="body"><slot></slot></div>
 
         <!-- Use a hidden element so we still get "slotchange" events. -->
-        <footer part="footer" class="footer" ?hidden=${!hasFooter}>
+        <div part="footer" class="footer" ?hidden=${!hasFooter}>
           <slot name="footer"></slot>
-        </footer>
+        </div>
       </dialog>
     `;
   }

--- a/packages/webawesome/src/components/drawer/drawer.test.ts
+++ b/packages/webawesome/src/components/drawer/drawer.test.ts
@@ -29,6 +29,21 @@ describe('<wa-drawer>', () => {
 
           expect(document.activeElement).to.equal(input);
         });
+
+        it('should not create duplicate landmarks when the page has its own header and footer', async () => {
+          const el = await fixture(html`
+            <div>
+              <header>Site header</header>
+              <wa-drawer label="Test drawer" open>
+                Drawer content
+                <div slot="footer">Drawer footer</div>
+              </wa-drawer>
+              <footer>Site footer</footer>
+            </div>
+          `);
+          await el.querySelector<WaDrawer>('wa-drawer')!.updateComplete;
+          await expect(el).to.be.accessible();
+        });
       });
 
       describe('properties', () => {

--- a/packages/webawesome/src/components/drawer/drawer.ts
+++ b/packages/webawesome/src/components/drawer/drawer.ts
@@ -282,7 +282,7 @@ export default class WaDrawer extends WebAwesomeElement {
       >
         ${hasHeader
           ? html`
-              <header part="header" class="header">
+              <div part="header" class="header">
                 <h2 part="title" class="title" id="title">
                   <!-- If there's no label, use an invisible character to prevent the header from collapsing -->
                   <slot name="label"> ${this.label.length > 0 ? this.label : String.fromCharCode(8203)} </slot>
@@ -304,15 +304,15 @@ export default class WaDrawer extends WebAwesomeElement {
                     ></wa-icon>
                   </wa-button>
                 </div>
-              </header>
+              </div>
             `
           : ''}
 
         <div part="body" class="body"><slot></slot></div>
 
-        <footer part="footer" class="footer" ?hidden=${!hasFooter}>
+        <div part="footer" class="footer" ?hidden=${!hasFooter}>
           <slot name="footer"></slot>
-        </footer>
+        </div>
       </dialog>
     `;
   }


### PR DESCRIPTION
Using header and footer inside of these components was causing an accessibility violation as described in #2723. This reverts the affected components to use `<div>` elements internally, allowing consumers to slot their own structured content in and preventing the duplicate landmarks bug reported by Axe.