### PR TITLE
Prevent `<wa-dropdown>` submenus from overflowing the viewport on mobile

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -54,6 +54,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 - Fixed a bug in `<wa-tooltip>` where tooltips with `trigger="manual"` closed when pressing <kbd>Escape</kbd>
 - Fixed the `hint` part in `<wa-textarea>`, which sat on the slot inside an unexposed wrapper and couldn't be positioned by custom layouts. The part now lives on that wrapper, so `::part(hint)` selects the hint and the character count together [issue:2614]
 - Fixed the missing Custom States table in the `<wa-dropdown-item>` docs. The `active`, `checked`, `disabled`, `has-submenu`, and `submenu-open` states already worked, but went undocumented
+- Fixed a bug in `<wa-dropdown>` where submenus could extend beyond the viewport on narrow screens. When neither side has room, the submenu now shifts over the menu to stay fully visible
 
 :::
 

--- a/packages/webawesome/src/components/dropdown-item/dropdown-item.ts
+++ b/packages/webawesome/src/components/dropdown-item/dropdown-item.ts
@@ -117,7 +117,7 @@ export default class WaDropdownItem extends WebAwesomeElement {
   connectedCallback() {
     super.connectedCallback();
     this.addEventListener?.('click', this.handleHostClick);
-    this.addEventListener?.('mouseenter', this.handleMouseEnter.bind(this));
+    this.addEventListener?.('pointerenter', this.handlePointerEnter);
     this.shadowRoot?.addEventListener?.('click', this.handleClick, { capture: true });
     this.shadowRoot?.addEventListener?.('slotchange', this.handleSlotChange);
   }
@@ -126,7 +126,7 @@ export default class WaDropdownItem extends WebAwesomeElement {
     super.disconnectedCallback();
     this.closeSubmenu();
     this.removeEventListener?.('click', this.handleHostClick);
-    this.removeEventListener?.('mouseenter', this.handleMouseEnter);
+    this.removeEventListener?.('pointerenter', this.handlePointerEnter);
     this.shadowRoot?.removeEventListener?.('click', this.handleClick, { capture: true });
     this.shadowRoot?.removeEventListener?.('slotchange', this.handleSlotChange);
   }
@@ -329,13 +329,16 @@ export default class WaDropdownItem extends WebAwesomeElement {
     }
   };
 
-  /** Handles mouse enter to open the submenu */
-  private handleMouseEnter() {
-    if (this.hasSubmenu && !this.disabled) {
+  /** Handles pointer enter to open the submenu on hover */
+  private handlePointerEnter = (event: PointerEvent) => {
+    // Only open on hover from a mouse. Taps on touch devices fire a synthetic mouseenter right before the click, and
+    // opening here would let the click land on the just-opened submenu when it overlaps the item. Touch and pen users
+    // open submenus with the click instead.
+    if (event.pointerType === 'mouse' && this.hasSubmenu && !this.disabled) {
       this.notifyParentOfOpening();
       this.submenuOpen = true;
     }
-  }
+  };
 
   render() {
     return html`

--- a/packages/webawesome/src/components/dropdown/dropdown.test.ts
+++ b/packages/webawesome/src/components/dropdown/dropdown.test.ts
@@ -712,21 +712,22 @@ describe('<wa-dropdown>', () => {
   });
 
   describe('submenu positioning', () => {
-    const submenuFixture = () => fixtures[0]<WaDropdown>(html`
-      <wa-dropdown>
-        <wa-button slot="trigger">Menu</wa-button>
-        <wa-dropdown-item id="parent-item">
-          Email Template Previews
-          <wa-dropdown-item slot="submenu">Received</wa-dropdown-item>
-          <wa-dropdown-item slot="submenu">Approval Needed</wa-dropdown-item>
-          <wa-dropdown-item slot="submenu">Needs Scheduled</wa-dropdown-item>
-          <wa-dropdown-item slot="submenu">Scheduled</wa-dropdown-item>
-          <wa-dropdown-item slot="submenu">Awaiting Payment</wa-dropdown-item>
-          <wa-dropdown-item slot="submenu">New User Welcome</wa-dropdown-item>
-          <wa-dropdown-item slot="submenu">Reset Password</wa-dropdown-item>
-        </wa-dropdown-item>
-      </wa-dropdown>
-    `);
+    const submenuFixture = () =>
+      fixtures[0]<WaDropdown>(html`
+        <wa-dropdown>
+          <wa-button slot="trigger">Menu</wa-button>
+          <wa-dropdown-item id="parent-item">
+            Email Template Previews
+            <wa-dropdown-item slot="submenu">Received</wa-dropdown-item>
+            <wa-dropdown-item slot="submenu">Approval Needed</wa-dropdown-item>
+            <wa-dropdown-item slot="submenu">Needs Scheduled</wa-dropdown-item>
+            <wa-dropdown-item slot="submenu">Scheduled</wa-dropdown-item>
+            <wa-dropdown-item slot="submenu">Awaiting Payment</wa-dropdown-item>
+            <wa-dropdown-item slot="submenu">New User Welcome</wa-dropdown-item>
+            <wa-dropdown-item slot="submenu">Reset Password</wa-dropdown-item>
+          </wa-dropdown-item>
+        </wa-dropdown>
+      `);
 
     async function openSubmenu(el: WaDropdown) {
       el.open = true;

--- a/packages/webawesome/src/components/dropdown/dropdown.test.ts
+++ b/packages/webawesome/src/components/dropdown/dropdown.test.ts
@@ -3,7 +3,7 @@ import { sendKeys, setViewport } from '@web/test-runner-commands';
 import { html } from 'lit';
 import sinon from 'sinon';
 import { expectEvent } from '../../internal/test/expect-event.js';
-import { fixtures } from '../../internal/test/fixture.js';
+import { clientFixture, fixtures } from '../../internal/test/fixture.js';
 import type WaDropdownItem from '../dropdown-item/dropdown-item.js';
 import type WaDropdown from './dropdown.js';
 
@@ -653,7 +653,7 @@ describe('<wa-dropdown>', () => {
 
   describe('trigger interaction', () => {
     it('should toggle open when the trigger is clicked', async () => {
-      const el = await fixtures[0]<WaDropdown>(html`
+      const el = await clientFixture<WaDropdown>(html`
         <wa-dropdown>
           <wa-button slot="trigger">Dropdown</wa-button>
           <wa-dropdown-item>One</wa-dropdown-item>
@@ -674,7 +674,7 @@ describe('<wa-dropdown>', () => {
 
   describe('dismissible stack', () => {
     it('should only close the dropdown when pressing Escape on a dropdown with a popover inside', async () => {
-      const el = await fixtures[0]<HTMLDivElement>(html`
+      const el = await clientFixture<HTMLDivElement>(html`
         <div>
           <wa-dropdown id="test-dropdown">
             <wa-button slot="trigger">Dropdown</wa-button>
@@ -713,7 +713,7 @@ describe('<wa-dropdown>', () => {
 
   describe('submenu positioning', () => {
     const submenuFixture = () =>
-      fixtures[0]<WaDropdown>(html`
+      clientFixture<WaDropdown>(html`
         <wa-dropdown>
           <wa-button slot="trigger">Menu</wa-button>
           <wa-dropdown-item id="parent-item">

--- a/packages/webawesome/src/components/dropdown/dropdown.test.ts
+++ b/packages/webawesome/src/components/dropdown/dropdown.test.ts
@@ -1,9 +1,10 @@
 import { aTimeout, expect, waitUntil } from '@open-wc/testing';
-import { sendKeys } from '@web/test-runner-commands';
+import { sendKeys, setViewport } from '@web/test-runner-commands';
 import { html } from 'lit';
 import sinon from 'sinon';
 import { expectEvent } from '../../internal/test/expect-event.js';
 import { fixtures } from '../../internal/test/fixture.js';
+import type WaDropdownItem from '../dropdown-item/dropdown-item.js';
 import type WaDropdown from './dropdown.js';
 
 describe('<wa-dropdown>', () => {
@@ -707,6 +708,71 @@ describe('<wa-dropdown>', () => {
       await aTimeout(200);
 
       expect(dropdown.open).to.be.false;
+    });
+  });
+
+  describe('submenu positioning', () => {
+    const submenuFixture = () => fixtures[0]<WaDropdown>(html`
+      <wa-dropdown>
+        <wa-button slot="trigger">Menu</wa-button>
+        <wa-dropdown-item id="parent-item">
+          Email Template Previews
+          <wa-dropdown-item slot="submenu">Received</wa-dropdown-item>
+          <wa-dropdown-item slot="submenu">Approval Needed</wa-dropdown-item>
+          <wa-dropdown-item slot="submenu">Needs Scheduled</wa-dropdown-item>
+          <wa-dropdown-item slot="submenu">Scheduled</wa-dropdown-item>
+          <wa-dropdown-item slot="submenu">Awaiting Payment</wa-dropdown-item>
+          <wa-dropdown-item slot="submenu">New User Welcome</wa-dropdown-item>
+          <wa-dropdown-item slot="submenu">Reset Password</wa-dropdown-item>
+        </wa-dropdown-item>
+      </wa-dropdown>
+    `);
+
+    async function openSubmenu(el: WaDropdown) {
+      el.open = true;
+      await waitUntil(() => el.open);
+      await aTimeout(200);
+
+      const parentItem = el.querySelector<WaDropdownItem>('#parent-item')!;
+      parentItem.submenuOpen = true;
+      await waitUntil(() => parentItem.submenuElement?.style.left !== '');
+      await aTimeout(100);
+      return parentItem;
+    }
+
+    it('should keep submenus inside the viewport on narrow screens', async () => {
+      const originalViewport = { width: window.innerWidth, height: window.innerHeight };
+      await setViewport({ width: 342, height: 700 });
+
+      try {
+        const el = await submenuFixture();
+        const parentItem = await openSubmenu(el);
+
+        const rect = parentItem.submenuElement.getBoundingClientRect();
+        expect(rect.width).to.be.greaterThan(0);
+        expect(rect.left).to.be.at.least(0);
+        expect(rect.right).to.be.at.most(window.innerWidth);
+
+        // The submenu should overlap the menu instead of being squeezed beside it, so no item wraps to multiple lines.
+        const itemHeights = [...parentItem.querySelectorAll<WaDropdownItem>('[slot="submenu"]')].map(
+          item => item.getBoundingClientRect().height,
+        );
+        expect(Math.max(...itemHeights)).to.be.lessThan(Math.min(...itemHeights) * 1.5);
+      } finally {
+        await setViewport(originalViewport);
+      }
+    });
+
+    it('should place submenus beside the parent item when there is room', async () => {
+      const el = await submenuFixture();
+      const parentItem = await openSubmenu(el);
+
+      const rect = parentItem.submenuElement.getBoundingClientRect();
+      const itemRect = parentItem.getBoundingClientRect();
+      expect(parentItem.submenuElement.getAttribute('data-placement')).to.match(/^right/);
+      // Allow for the intentional 5px overlap from the offset middleware.
+      expect(rect.left).to.be.at.least(itemRect.right - 6);
+      expect(rect.right).to.be.at.most(window.innerWidth);
     });
   });
 });

--- a/packages/webawesome/src/components/dropdown/dropdown.ts
+++ b/packages/webawesome/src/components/dropdown/dropdown.ts
@@ -624,6 +624,7 @@ export default class WaDropdown extends WebAwesomeElement {
         }),
         shift({
           padding: 8,
+          crossAxis: true,
         }),
       ],
     }).then(({ x, y, placement }) => {


### PR DESCRIPTION
On narrow mobile screens, submenus could render partially offscreen because neither side of the parent menu had room. They now shift over the menu to stay fully visible, with desktop behavior unchanged.

Fixes #2716