### PR TITLE
Fix Safari not applying host:focus::part styles on form controls

### DIFF
--- a/packages/webawesome/docs/docs/form-controls.md
+++ b/packages/webawesome/docs/docs/form-controls.md
@@ -194,5 +194,8 @@ Instead, the following [custom states](https://developer.mozilla.org/en-US/docs/
 - `:state(valid)` - the form control is valid
 - `:state(user-invalid)` - the form control is invalid and the user has interacted with it
 - `:state(user-valid)` - the form control is valid and the user has interacted with it
+- `:state(focused)` - the form control has focus
+
+Use `:state(focused)` or `:focus-within` when styling `::part(...)` on focus. Safari does not restyle `host:focus::part(...)` when focus is delegated into the shadow tree.
 
 These custom states work alongside the browser's built-in pseudo classes for validation: [`:required`](https://developer.mozilla.org/en-US/docs/Web/CSS/:required), [`:optional`](https://developer.mozilla.org/en-US/docs/Web/CSS/:optional), [`:invalid`](https://developer.mozilla.org/en-US/docs/Web/CSS/:invalid), [`:valid`](https://developer.mozilla.org/en-US/docs/Web/CSS/:valid), [`:user-invalid`](https://developer.mozilla.org/en-US/docs/Web/CSS/:user-invalid), and [`:user-valid`](https://developer.mozilla.org/en-US/docs/Web/CSS/:user-valid).

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -33,6 +33,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 :::added
 
+- Added the `focused` custom state to form controls so `:state(focused)` matches when the control has focus. This is the reliable hook for `::part(...)` focus styles; Safari does not restyle `host:focus::part(...)` when focus is delegated into the shadow tree
 - Added version 3.0.0 of the [official Web Awesome Figma Design Kit](/docs/resources/figma)
 - Added the `filterOptions` column option to `<wa-data-grid>` to supply a `set`/`includes-*` filter picker's values yourself, enabling value pickers in server mode and custom ordering/labeling in client mode
 - Added the `href`, `target`, `rel`, and `download` attributes to `<wa-dropdown-item>` so items can navigate when selected
@@ -44,6 +45,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 :::fixed
 
+- Fixed a Safari bug where `host:focus::part(...)` styles did not apply on form controls that use `delegatesFocus`. Focusing the inner control now sets `:state(focused)`, which forces the part styles to recalculate so floating labels and other `:focus::part` rules work
 - Fixed native table row headers (`<th scope="row">`) rendering at a smaller font size than the cells beside them, which knocked their text out of vertical alignment. The smaller type is now scoped to column headers
 - Fixed the focus ring on `<wa-otp-input>` animating its width and offset, which re-ran the animation on every keystroke as the active segment advanced. It now fades in at a fixed size, matching `<wa-input>` and the other form controls
 - Fixed a bug in `<wa-toast>` that caused center placements to render incorrectly on narrow screens [issue:2701]

--- a/packages/webawesome/src/components/input/input.test.ts
+++ b/packages/webawesome/src/components/input/input.test.ts
@@ -573,6 +573,33 @@ describe('<wa-input>', () => {
           await el.updateComplete;
           expect(el.customStates.has('blank')).to.be.false;
         });
+
+        it('should apply :focus::part styles when focused', async () => {
+          const el = await fixture<WaInput>(html`<wa-input label="Name"></wa-input>`);
+          const style = document.createElement('style');
+          style.textContent = `
+            wa-input::part(label) { color: rgb(0, 0, 0); }
+            wa-input:focus::part(label) { color: rgb(255, 0, 0); }
+          `;
+          document.body.append(style);
+
+          expect(el.customStates.has('focused')).to.be.false;
+
+          el.focus();
+          await el.updateComplete;
+
+          const label = el.shadowRoot!.querySelector('[part~="form-control-label"]')!;
+          expect(el.customStates.has('focused')).to.be.true;
+          expect(getComputedStyle(label).color).to.equal('rgb(255, 0, 0)');
+
+          el.blur();
+          await aTimeout(50);
+          await el.updateComplete;
+
+          expect(el.customStates.has('focused')).to.be.false;
+          expect(getComputedStyle(label).color).to.equal('rgb(0, 0, 0)');
+          style.remove();
+        });
       });
 
       describe('when type="number"', () => {

--- a/packages/webawesome/src/components/input/input.ts
+++ b/packages/webawesome/src/components/input/input.ts
@@ -52,6 +52,7 @@ import styles from './input.styles.js';
  * @csspart end - The container that wraps the `end` slot.
  *
  * @cssstate blank - The input is empty.
+ * @cssstate focused - The input has focus.
  */
 @customElement('wa-input')
 export default class WaInput extends WebAwesomeFormAssociatedElement {

--- a/packages/webawesome/src/components/known-date/known-date.ts
+++ b/packages/webawesome/src/components/known-date/known-date.ts
@@ -57,6 +57,7 @@ const generateId = (): string => uniqueId('wa-known-date-');
  * @csspart field-input - The native `<input>` inside a field.
  *
  * @cssstate blank - The known date has no committed value.
+ * @cssstate focused - The known date has focus.
  * @cssstate disabled - The known date is disabled.
  */
 @customElement('wa-known-date')

--- a/packages/webawesome/src/components/select/select.ts
+++ b/packages/webawesome/src/components/select/select.ts
@@ -83,6 +83,7 @@ import styles from './select.styles.js';
  * @cssproperty [--tag-max-size=10ch] - When using `multiple`, the max size of tags before their content is truncated.
  *
  * @cssstate blank - The select is empty.
+ * @cssstate focused - The select has focus.
  */
 @customElement('wa-select')
 export default class WaSelect extends WebAwesomeFormAssociatedElement {

--- a/packages/webawesome/src/components/textarea/textarea.ts
+++ b/packages/webawesome/src/components/textarea/textarea.ts
@@ -40,6 +40,7 @@ import styles from './textarea.styles.js';
  * @csspart count - The character count element, rendered when the `with-count` attribute is present.
  *
  * @cssstate blank - The textarea is empty.
+ * @cssstate focused - The textarea has focus.
  */
 @customElement('wa-textarea')
 export default class WaTextarea extends WebAwesomeFormAssociatedElement {

--- a/packages/webawesome/src/components/time-input/time-input.ts
+++ b/packages/webawesome/src/components/time-input/time-input.ts
@@ -107,6 +107,7 @@ const SINGLE_GROUP = 'single';
  * @cssproperty [--column-width=3em] - Width of each popup column.
  *
  * @cssstate blank - The time picker has no committed value.
+ * @cssstate focused - The time picker has focus.
  * @cssstate open - The popup is open.
  * @cssstate disabled - The time picker is disabled.
  */

--- a/packages/webawesome/src/internal/webawesome-form-associated-element.ts
+++ b/packages/webawesome/src/internal/webawesome-form-associated-element.ts
@@ -118,6 +118,8 @@ export class WebAwesomeFormAssociatedElement
     if ('addEventListener' in this) {
       // eslint-disable-next-line
       this.addEventListener('invalid', this.emitInvalid);
+      this.addEventListener('focusin', this.handleHostFocusIn);
+      this.addEventListener('focusout', this.handleHostFocusOut);
     }
   }
   states: CustomStateSet;
@@ -149,6 +151,20 @@ export class WebAwesomeFormAssociatedElement
     // An "invalid" event counts as interacted, this is usually triggered by a button "submitting"
     this.hasInteracted = true;
     this.dispatchEvent(new WaInvalidEvent());
+  };
+
+  // Safari does not restyle host:focus::part(...) when focus is delegated into the shadow tree.
+  // Reflecting focus into a custom state forces that recalc so :focus::part rules apply.
+  private handleHostFocusIn = () => {
+    this.customStates.set('focused', true);
+  };
+
+  private handleHostFocusOut = () => {
+    requestAnimationFrame(() => {
+      if (!this.matches(':focus-within')) {
+        this.customStates.set('focused', false);
+      }
+    });
   };
 
   protected willUpdate(changedProperties: Parameters<LitElement['willUpdate']>[0]) {


### PR DESCRIPTION
Fixes #2742

## Bug

Safari does not restyle `host:focus::part(...)` when `delegatesFocus` moves focus into a form control's shadow tree. `el.matches(':focus')` is true, but rules like this never apply:

```css
wa-input:focus::part(label) { color: crimson; }
wa-input:state(blank):not(:focus)::part(label) {
  top: calc(var(--wa-form-control-height) / 2 - 0.5lh);
  font-size: inherit;
}
```

Chrome shrinks and recolors the floating label. Safari leaves it inside the field, overlapping the value.

`:focus-within::part(...)` works. Toggling any custom state on `focusin` also forces the `:focus::part` rules to recalculate.

## Repro

```html
<!DOCTYPE html>
<html lang="en">
<head>
  <link rel="stylesheet" href="https://ka-f.webawesome.com/webawesome@3.11.0/styles/themes/default.css">
  <script type="module" src="https://ka-f.webawesome.com/webawesome@3.11.0/webawesome.loader.js"></script>
  <style>
    wa-input { position: relative; }
    wa-input::part(label) {
      position: absolute;
      top: -0.5lh;
      font-size: var(--wa-font-size-smaller);
      background: white;
      padding-inline: 0.25em;
    }
    wa-input:focus::part(label) { color: crimson; }
    wa-input:state(blank):not(:focus)::part(label) {
      top: calc(var(--wa-form-control-height) / 2 - 0.5lh);
      font-size: inherit;
    }
  </style>
</head>
<body>
  <wa-input label="Name"></wa-input>
</body>
</html>
```

Focus the empty input in Safari. The label stays inside the field.

## Fix

On `focusin` / `focusout`, form controls now set `:state(focused)`. That custom-state change restyles the host so existing `host:focus::part(...)` consumer CSS (and Matter-style floating labels) start working in Safari.

Authors can also target `:state(focused)` directly. `<wa-number-input>` already documented this state; `<wa-slider>` already set it. This makes it real for the rest of the form controls.

## Test

`input.test.ts` now asserts that `wa-input:focus::part(label)` changes the label color after focus, and that `:state(focused)` is set and cleared.