### PR TITLE
Fix tooltip closing on slotted content

### DIFF
--- a/packages/webawesome/src/components/tooltip/tooltip.test.ts
+++ b/packages/webawesome/src/components/tooltip/tooltip.test.ts
@@ -474,6 +474,43 @@ describe('<wa-tooltip>', () => {
       await waitUntil(() => !tooltip.open);
       expect(tooltip.open).to.be.false;
     });
+
+    it('should remain open when the pointer moves onto content forwarded through a parent slot', async () => {
+      const el = await fixtures[0]<HTMLDivElement>(html`<div></div>`);
+      const shadowRoot = el.attachShadow({ mode: 'open' });
+      shadowRoot.innerHTML = `
+        <wa-button id="forwarded-hover-btn">Hover me</wa-button>
+        <wa-tooltip for="forwarded-hover-btn" trigger="hover" show-delay="0" hide-delay="0">
+          <slot name="content"></slot>
+        </wa-tooltip>
+      `;
+
+      const childLink = document.createElement('a');
+      childLink.id = 'forwarded-tooltip-link';
+      childLink.slot = 'content';
+      childLink.href = '#';
+      childLink.textContent = 'Forwarded link inside the tooltip';
+      childLink.style.cssText = 'display: inline-block; padding: 1rem;';
+      el.append(childLink);
+
+      const tooltip = shadowRoot.querySelector<WaTooltip>('wa-tooltip')!;
+      const anchor = shadowRoot.querySelector<HTMLElement>('#forwarded-hover-btn')!;
+      expect(childLink.assignedSlot?.parentElement).to.equal(tooltip);
+      await tooltip.updateComplete;
+
+      await moveMouseOnElement(anchor);
+      await waitUntil(() => tooltip.open);
+      expect(tooltip.open).to.be.true;
+
+      await moveMouseOnElement(childLink);
+      await aTimeout(tooltip.hideDelay + 50);
+
+      expect(tooltip.open).to.be.true;
+
+      await moveMouseOnElement(document.body, 'top', 0, 0);
+      await waitUntil(() => !tooltip.open);
+      expect(tooltip.open).to.be.false;
+    });
   });
 
   describe('light dismiss', () => {

--- a/packages/webawesome/src/components/tooltip/tooltip.ts
+++ b/packages/webawesome/src/components/tooltip/tooltip.ts
@@ -15,6 +15,29 @@ import WaPopup from '../popup/popup.js';
 import styles from './tooltip.styles.js';
 
 /**
+ * Checks containment in the composed tree, including nodes assigned through one or more slots.
+ */
+function containsComposedNode(ancestor: Node, node: Node | null) {
+  while (node) {
+    if (node === ancestor) {
+      return true;
+    }
+
+    if (node instanceof Element && node.assignedSlot) {
+      node = node.assignedSlot;
+    } else if (node.parentNode) {
+      node = node.parentNode;
+    } else if (node instanceof ShadowRoot) {
+      node = node.host;
+    } else {
+      node = null;
+    }
+  }
+
+  return false;
+}
+
+/**
  * @summary Tooltips display brief contextual information when the user hovers, focuses, or taps a target element.
  * @documentation https://webawesome.com/docs/components/tooltip
  * @status stable
@@ -269,8 +292,8 @@ export default class WaTooltip extends WebAwesomeElement {
     // the anchor or the tooltip itself. Relying on `:hover` matching here is unreliable in Chrome when the pointer
     // moves onto a slotted child element of the tooltip, since the host's `:hover` state can briefly report false
     // during that transition.
-    const movedIntoAnchor = Boolean(relatedTarget && this.anchor?.contains(relatedTarget));
-    const movedIntoTooltip = Boolean(relatedTarget && this.contains(relatedTarget));
+    const movedIntoAnchor = Boolean(relatedTarget && this.anchor && containsComposedNode(this.anchor, relatedTarget));
+    const movedIntoTooltip = Boolean(relatedTarget && containsComposedNode(this, relatedTarget));
 
     if (movedIntoAnchor || movedIntoTooltip) {
       return;


### PR DESCRIPTION
Fixes #2745
Added a composed-tree containment helper that traverses slot assignments and shadow-root hosts, and replaced the tooltip hover mouseout containment checks with it. Added a focused regression test for content forwarded through a parent slot.

