### PR TITLE
Select: Make Clear Button's Focus Ring Fit Inside Field

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -66,6 +66,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 - Improved accessibility of `<wa-dropdown>` by adding `aria-posinset` and `aria-setsize` so supportive screen readers can correctly announce the number of dropdown items [issue:2697]
 - Improved accessibility of `<wa-input type="password">` by making the toggle password button focusable [issue:2727]
+- Improved the click target of the clear button in `<wa-select>`, which now spans the full height of the control
 - Improved `<wa-tooltip>` so it correctly light dismisses when the user presses the target or clicks anywhere else on the page [discuss:1921]
 - Updated `<wa-data-grid>` to TanStack Table 9 internally (the grid's public API, state format, and behavior are unchanged)
 

--- a/packages/webawesome/src/components/select/select.styles.ts
+++ b/packages/webawesome/src/components/select/select.styles.ts
@@ -203,9 +203,12 @@ export default css`
 
   /* Clear button */
   [part~='clear-button'] {
+    flex: 0 0 auto;
     display: inline-flex;
+    align-self: stretch;
     align-items: center;
     justify-content: center;
+    inline-size: 1.5em;
     font-size: inherit;
     color: var(--wa-color-neutral-on-quiet);
     border: none;
@@ -213,7 +216,10 @@ export default css`
     padding: 0;
     transition: color var(--wa-transition-normal);
     cursor: pointer;
-    margin-inline-start: var(--wa-form-control-padding-inline);
+    /* The box is wider than the glyph, so overhang half that growth on each side. Keeps the glyph
+       on the same trailing axis as the segmented-field pickers' clear buttons. */
+    margin-inline-start: calc(var(--wa-form-control-padding-inline) - 0.125em);
+    margin-inline-end: -0.125em;
 
     &:focus {
       outline: none;


### PR DESCRIPTION
`<wa-select>`'s clear button was 20×16 inside a 43px field, so clicking near the top or bottom border didn't clear — only the middle band did. It's now 24×41 and spans the full height of the control.

The glyph doesn't move. The box grew wider than the icon, so half that growth overhangs on each side, keeping it on the same trailing axis as `<wa-time-input>`'s clear button.

Dropped the focus styling from the earlier version of this PR, since the button isn't focusable by design.
