### PR TITLE
Switch: Move Focus Ring from `thumb` to `control`

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -1284,6 +1284,7 @@ Many of these changes and improvements were the direct result of feedback from u
 - Fixed a bug in `<wa-carousel>` that caused interactive elements to be activated when dragging
 - Fixed a bug in `<wa-tab-group>` that prevented changing tabs by setting `active` on `<wa-tab>` elements
 - Fixed a bug in `<wa-tab-group>` that caused an error when removed from the DOM too quickly
+- Fixed the focus ring on `<wa-switch>`, which was drawn around the thumb inside the track and was easy to miss. It now surrounds the whole control
 - Fixed a bug in `<wa-textarea>` causing scroll jumping when using `resize="auto"`
 - Fixed a bug with certain bundlers when using dynamic imports
 

--- a/packages/webawesome/src/components/switch/switch.styles.ts
+++ b/packages/webawesome/src/components/switch/switch.styles.ts
@@ -66,7 +66,7 @@ export default css`
   }
 
   /* Focus */
-  label:not(.disabled) .input:focus-visible ~ .switch .thumb {
+  label:not(.disabled) .input:focus-visible ~ .switch {
     outline: var(--wa-focus-ring);
     outline-offset: var(--wa-focus-ring-offset);
   }


### PR DESCRIPTION
### The Issue
`<wa-switch>` drew its focus ring around the `thumb`, inside the track (`control`). 

The ring came out at exactly the track's height. So it was physically contained by the control it was meant to indicate, and more `outline-offset` only buried it further under the track's fill.

It also put the ring's contrast against that fill instead of the page. `--wa-color-focus` on the checked track measures **1.53:1**, well under the 3:1 WCAG 1.4.11 asks of a focus indicator (1.43:1 on the marketing site's orange). The checked state was the worst case, which is the one people notice.

| Before | After |
|--------|--------|
| <img width="1564" height="660" alt="CleanShot 2026-08-18 at 17 52 23@2x" src="https://github.com/user-attachments/assets/017acbbb-5e4d-4034-ae7b-0c553bf7d4ce" /> | <img width="1538" height="638" alt="CleanShot 2026-08-18 at 17 52 10@2x" src="https://github.com/user-attachments/assets/b3ce7bd8-16ea-42fb-b833-4f4ffc311689" /> | 

### The Fix
The ring now goes on the `control`, matching how WA already works: `<wa-checkbox>` and `<wa-radio>` both ring their `control` part, not the checkmark or dot inside it. The switch was the only one of the three ringing an inner indicator.

### How Other Libraries Handle It
| Library | Focus ring on |
| --- | --- |
| [Material Web](https://github.com/material-components/material-web/blob/main/switch/internal/switch.ts) | track |
| [Spectrum](https://github.com/adobe/spectrum-css/blob/main/components/switch/index.css) | track |
| [Carbon](https://github.com/carbon-design-system/carbon/blob/main/packages/styles/scss/components/toggle/_toggle.scss) | track |
| [shadcn/ui](https://github.com/shadcn-ui/ui/blob/main/apps/v4/registry/new-york-v4/ui/switch.tsx) (Radix) | track |
| [Fluent UI](https://github.com/microsoft/fluentui/blob/master/packages/react-components/react-switch/library/src/components/Switch/useSwitchStyles.styles.ts) | root |
| [Primer](https://github.com/primer/react/blob/main/packages/react/src/ToggleSwitch/ToggleSwitch.module.css) | track |
| [Shoelace](https://github.com/shoelace-style/shoelace/blob/next/src/components/switch/switch.styles.ts) | thumb |

Six of seven ring the whole control. Shoelace is the outlier, and it's where this behavior came from.

For sizing, we're in normal company: shadcn also uses a 3px ring, and Primer uses a 3px `outline-offset` to WA's 1px.



