### PR TITLE
Tidy Up Loose Ends Post-Focus Ring Work

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -58,6 +58,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 - Fixed the missing Custom States table in the `<wa-dropdown-item>` docs. The `active`, `checked`, `disabled`, `has-submenu`, and `submenu-open` states already worked, but went undocumented
 - Fixed a bug in `<wa-card>`, `<wa-dialog>`, and `<wa-drawer>` that added duplicate `banner` and `contentinfo` landmarks to the page [issue:2723]
 - Fixed a bug in `<wa-dropdown>` where submenus could extend beyond the viewport on narrow screens. When neither side has room, the submenu now shifts over the menu to stay fully visible
+- Fixed the focus ring on `<wa-switch>`, which was drawn around the thumb inside the track and was easy to miss. It now surrounds the whole control
 
 :::
 
@@ -1285,7 +1286,6 @@ Many of these changes and improvements were the direct result of feedback from u
 - Fixed a bug in `<wa-carousel>` that caused interactive elements to be activated when dragging
 - Fixed a bug in `<wa-tab-group>` that prevented changing tabs by setting `active` on `<wa-tab>` elements
 - Fixed a bug in `<wa-tab-group>` that caused an error when removed from the DOM too quickly
-- Fixed the focus ring on `<wa-switch>`, which was drawn around the thumb inside the track and was easy to miss. It now surrounds the whole control
 - Fixed a bug in `<wa-textarea>` causing scroll jumping when using `resize="auto"`
 - Fixed a bug with certain bundlers when using dynamic imports
 

--- a/packages/webawesome/src/components/input/input.styles.ts
+++ b/packages/webawesome/src/components/input/input.styles.ts
@@ -208,7 +208,6 @@ export default css`
     cursor: pointer;
     margin-inline-start: var(--wa-form-control-padding-inline);
 
-    /* Extends the pointer target to the full height of the field */
     &::after {
       content: '';
       position: absolute;

--- a/packages/webawesome/src/components/input/input.styles.ts
+++ b/packages/webawesome/src/components/input/input.styles.ts
@@ -206,7 +206,10 @@ export default css`
     padding: 0;
     transition: var(--wa-transition-normal) color;
     cursor: pointer;
-    margin-inline-start: var(--wa-form-control-padding-inline);
+    /* The box is wider than the glyph, so overhang half of that growth on each side. Keeps the
+       glyph flush with the field's trailing padding edge, like every other form control. */
+    margin-inline-start: calc(var(--wa-form-control-padding-inline) - 0.125em);
+    margin-inline-end: -0.125em;
 
     &::after {
       content: '';

--- a/packages/webawesome/src/components/switch/switch.styles.ts
+++ b/packages/webawesome/src/components/switch/switch.styles.ts
@@ -66,7 +66,7 @@ export default css`
   }
 
   /* Focus */
-  label:not(.disabled) .input:focus-visible ~ .switch {
+  label:not(.disabled) .input:focus-visible ~ [part~='control'] {
     outline: var(--wa-focus-ring);
     outline-offset: var(--wa-focus-ring-offset);
   }


### PR DESCRIPTION
Four small follow-ups to https://github.com/shoelace-style/webawesome/pull/2736 and https://github.com/shoelace-style/webawesome/pull/2749.

- The changelog entry for the switch focus ring landed under `3.0.0-alpha.5` instead of Unreleased. Moved to where it belongs.
-`<wa-switch>`'s focus rule selected `~ .switch`, which reads like the `switch` part but actually matches `<span part="control">`. The `switch` part is the outer `<label>`. It's the same element either way, now named honestly, and it matches how `<wa-checkbox>` selects `[part~='control']`.
- Dropped a redundant comment above the `::after` in `<wa-input>`.
- `<wa-input>`'s icon buttons grew a box for their focus ring, which pushed their glyphs 2px inboard of the trailing padding edge every other form control sits on. Compensated with margins so the box grows around the glyph instead of shoving it.

