### PR TITLE
Docs: Fix the Default Focus Ring on Scrollable Code Blocks

### DIFF
--- a/packages/webawesome/docs/assets/styles/utils.css
+++ b/packages/webawesome/docs/assets/styles/utils.css
@@ -1208,6 +1208,15 @@
   /* #endregion */
   /* #endregion */
 
+  /* #region code blocks */
+  /* Browsers make an overflowing code block a tab stop so it can be scrolled by keyboard. */
+  /* Blocks with a copy button scroll the inner <code>, but the ring stays on the pre, which would clip an inset one. */
+  pre:is(:focus-visible, :has(> code:focus-visible)) {
+    outline: var(--wa-focus-ring);
+    outline-offset: var(--wa-focus-ring-offset);
+  }
+  /* #endregion */
+
   /* #region resets */
   code.appearance-plain {
     background: transparent;


### PR DESCRIPTION
### Problem
Scrollable code blocks were showing the browser's default focus ring instead of ours. 

Chrome and Firefox make an overflowing scroll container a tab stop when it has no focusable children. That's how keyboard users scroll the block. **But we never styled `:focus-visible` for it.** 

### Solution
This adds one rule to `docs/assets/styles/utils.css`, which the app, docs, and site all import.

- The ring hangs on the `<pre>` rather than on the element that actually scrolls. 
- Blocks with a copy button scroll the inner `<code>`, and an inset ring there gets its corners clipped by the `<pre>`'s own radius.

### Where It Shows
- The Quick Start and CDN code blocks — the rounded dark panel from the original report
- Component docs examples (see 4 of the 18 blocks on `/docs/components/button` overflow at desktop width)
- Anywhere a block starts overflowing, so narrow viewports and zoomed-in reading hit it far more than a wide desktop does

---

### Known Gap
Safari doesn't implement keyboard-focusable scroll containers ([WebKit 277290](https://bugs.webkit.org/show_bug.cgi?id=277290)), so these blocks aren't keyboard-scrollable there at all. 

That's pre-existing and unrelated to this change. Fixing it needs a conditional `tabindex="0"`.

Plenty of docs sites already do this. 
- Tailwind and Vue put `tabindex="0"` on every `<pre>`
- Astro's Starlight adds it only to the blocks that actually overflow. 


FWIW, Starlight has the better version IMHO. A blanket `tabindex` would turn all 18 blocks on a component page into tab stops, including those with nothing to scroll to.
