### PR TITLE
Docs: Make Pro Callouts Visually Consistent

### DIFF
--- a/packages/webawesome/docs/docs/color-palettes.njk
+++ b/packages/webawesome/docs/docs/color-palettes.njk
@@ -20,8 +20,7 @@ hasOutline: false
 {% if not currentUser or not currentUser.hasPro %}
 {% endraw %}
 <wa-callout class="pro wa-brand-orange">
-  <wa-icon slot="icon" name="hand-wave" animation="shake"
-    style="--animation-delay: 2s; --animation-duration: 4s;"></wa-icon>
+  <wa-icon slot="icon" name="crown" family="duotone" variant="regular" class="duotone-illustrated"></wa-icon>
   <div class="wa-stack">
     <div class="wa-stack wa-gap-2xs">
       <strong>

--- a/packages/webawesome/docs/docs/resources/migrating-from-shoelace.md
+++ b/packages/webawesome/docs/docs/resources/migrating-from-shoelace.md
@@ -24,8 +24,8 @@ This guide is for developers with a working Shoelace 2.x project who want to upg
 
 If you're brand new to Web Awesome, the [Getting Started](/docs/) guide is a better starting point.
 
-<wa-callout class="pro">
-  <wa-icon slot="icon" name="hand-wave" animation="shake" style="--animation-delay: 2s; --animation-duration: 4s;"></wa-icon>
+<wa-callout class="pro wa-brand-orange">
+  <wa-icon slot="icon" name="crown" family="duotone" variant="regular" class="duotone-illustrated"></wa-icon>
   <strong>A Few Components Now Live In Web Awesome Pro</strong>
    Comboboxes, File Inputs, and Charts moved to <a href="#whats-in-web-awesome-pro">Web&nbsp;Awesome&nbsp;Pro</a>. We mark them clearly with a
   <wa-badge appearance="accent" pill class="pro" data-pro-badge>Pro</wa-badge>

--- a/packages/webawesome/docs/docs/themes.njk
+++ b/packages/webawesome/docs/docs/themes.njk
@@ -20,8 +20,7 @@ layout: page
 {% if not currentUser or not currentUser.hasPro %}
 {% endraw %}
 <wa-callout class="pro wa-brand-orange">
-  <wa-icon slot="icon" name="hand-wave" animation="shake"
-    style="--animation-delay: 2s; --animation-duration: 4s;"></wa-icon>
+  <wa-icon slot="icon" name="crown" family="duotone" variant="regular" class="duotone-illustrated"></wa-icon>
   <div class="wa-stack">
     <div class="wa-stack wa-gap-2xs">
       <strong>


### PR DESCRIPTION
This work touches up the Pro-minded callouts throughout our docs to look more similar:

- swapping the hand-wave icon for the duotone crown
- adding the missing wa-brand-orange class in the migration guide