### PR TITLE
Docs: Restore the Code Blocks on the CSS Utilities Page

### DIFF
--- a/packages/webawesome/docs/docs/utilities/index.njk
+++ b/packages/webawesome/docs/docs/utilities/index.njk
@@ -31,46 +31,43 @@ anything else. Otherwise, follow these instructions to include the utilities sty
   <wa-tab panel="hosted"><wa-icon name="rocket-launch" variant="regular"></wa-icon> Hosted Projects</wa-tab>
 
   <wa-tab-panel name="cdn">
-    {% markdown %}
-    Add the following stylesheet to the `<head>` section of your pages:
+{% markdown %}
+Add the following stylesheet to the `<head>` section of your pages:
 
-      ```html
-      <link rel="stylesheet" href="{% cdnUrl 'styles/utilities.css' %}">
-      ```
-      {% endmarkdown %}
+```html
+<link rel="stylesheet" href="{% cdnUrl 'styles/utilities.css' %}">
+```
+{% endmarkdown %}
   </wa-tab-panel>
 
   <wa-tab-panel name="npm">
-    {% markdown %}
-    After installing `@awesome.me/webawesome`, import the following stylesheet into your app:
+{% markdown %}
+After installing `@awesome.me/webawesome`, import the following stylesheet into your app:
 
-    ```js
-    import '@awesome.me/webawesome/dist/styles/utilities.css';
-    ```
-    {% endmarkdown %}
+```js
+import '@awesome.me/webawesome/dist/styles/utilities.css';
+```
+{% endmarkdown %}
   </wa-tab-panel>
 
   <wa-tab-panel name="self-hosted">
-    {% markdown %}
-    Add the following stylesheet to the `<head>` section of your pages:
+{% markdown %}
+Add the following stylesheet to the `<head>` section of your pages:
 
-      ```html
-      <link rel="stylesheet" href="/dist/styles/utilities.css">
-      ```
-      {% endmarkdown %}
+```html
+<link rel="stylesheet" href="/dist/styles/utilities.css">
+```
+{% endmarkdown %}
   </wa-tab-panel>
 
   <wa-tab-panel name="hosted">
-    {% markdown %}
-    If you're using a [hosted project](/workspaces), CSS utilities can be toggled on from your project settings.
+{% markdown %}
+If you're using a [hosted project](/workspaces), CSS utilities can be toggled on from your project settings.
 
-    1. Head over to your project's <wa-tag class="tag-ui" appearance="outlined"><wa-icon name="gear"
-        variant="regular"></wa-icon> Settings</wa-tag>.
-    2. Next to <wa-tag class="tag-ui" appearance="outlined">Features</wa-tag>, select the <wa-tag class="tag-ui"
-      appearance="outlined">CSS utilities</wa-tag> checkbox.
-    3. <wa-tag class="tag-ui" appearance="outlined">Save Changes</wa-tag> to immediately update anywhere you're using
-    your project.
-    {% endmarkdown %}
+1. Head over to your project's <wa-tag class="tag-ui" appearance="outlined"><wa-icon name="gear" variant="regular"></wa-icon> Settings</wa-tag>.
+2. Next to <wa-tag class="tag-ui" appearance="outlined">Features</wa-tag>, select the <wa-tag class="tag-ui" appearance="outlined">CSS utilities</wa-tag> checkbox.
+3. <wa-tag class="tag-ui" appearance="outlined">Save Changes</wa-tag> to immediately update anywhere you're using your project.
+{% endmarkdown %}
   </wa-tab-panel>
 </wa-tab-group>
 


### PR DESCRIPTION
The install instructions on the [CSS Utilities](https://webawesome.com/docs/utilities/) page were rendering as grey text instead of code blocks. This puts them back. The numbered steps in the Hosted Projects tab were broken the same way, and are fixed too.

### What was wrong

Each tab under "Using CSS Utilities" holds a snippet you copy into your project. All four rendered as plain text on a single line. The three steps in the Hosted Projects tab ran together as one paragraph.

### Why it happened

The page wraps its tab content in `{% markdown %}` blocks. Those blocks were indented to line up with the surrounding HTML.

Markdown allows at most three spaces before a code fence, which is the line of three backticks that opens a code block. Past three spaces, it stops being a fence. Markdown would normally fall back to treating deeply indented text as code anyway. Eleventy, the tool that builds the docs site, switches that fallback off. So the snippets fell through to a plain paragraph, and the backticks turned into inline text.

### What changed

The four `{% markdown %}` blocks in `docs/docs/utilities/index.njk` now start at the left margin. This matches `docs/docs/themes.njk`, which uses the same tab layout and renders correctly. Nothing outside this one docs page changed.

### What I checked

I rebuilt the docs and scanned every page for the same failure, looking for broken fences, stray backticks, lists flattened into paragraphs, and block elements swallowed by a paragraph.

| Checked | Scope | Result |
| --- | --- | --- |
| Built free docs pages | 141 | Clean |
| Built pro docs pages | 272 | One page fixed separately in `webawesome-pro` |
| Source files (free, pro, app) | 449 | No over-indented code fences |
