### PR TITLE
Docs: Align Side Labels in the Label Position Example

### DIFF
--- a/packages/webawesome/docs/docs/components/input.md
+++ b/packages/webawesome/docs/docs/components/input.md
@@ -154,7 +154,7 @@ Use the `start` and `end` slots to add presentational elements like `<wa-icon>` 
 Use [CSS parts](#css-parts) to customize the way form controls are drawn. This example uses CSS grid to position the label to the left of the control, but the possible orientations are nearly endless. The same technique works for inputs, textareas, radio groups, and similar form controls. The label part is a flex container, so align it with `justify-content` rather than `text-align`.
 
 :::info
-<strong>Labels sit at the end of their column so every one is the same distance from its field.</strong><br />
+**Labels sit at the end of their column so every one is the same distance from its field.**
 Start-aligned labels leave a different-sized gap on each row, which makes it harder to see which label belongs to which field.
 :::
 

--- a/packages/webawesome/docs/docs/components/input.md
+++ b/packages/webawesome/docs/docs/components/input.md
@@ -151,12 +151,12 @@ Use the `start` and `end` slots to add presentational elements like `<wa-icon>` 
 
 ### Customizing Label Position
 
-Use [CSS parts](#css-parts) to customize the way form controls are drawn. This example uses CSS grid to position the label to the left of the control, but the possible orientations are nearly endless. The same technique works for inputs, textareas, radio groups, and similar form controls.
+Use [CSS parts](#css-parts) to customize the way form controls are drawn. This example uses CSS grid to position the label to the left of the control, but the possible orientations are nearly endless. The same technique works for inputs, textareas, radio groups, and similar form controls. The label part is a flex container, so use `justify-content` to align its text. `text-align` has no effect.
 
 ```html {.example}
 <div class="label-on-left">
   <wa-input label="Name" hint="Enter your name"></wa-input>
-  <wa-input label="Email" type="email" hint="Enter your email"></wa-input>
+  <wa-input label="Email address" type="email" hint="Enter your email"></wa-input>
   <wa-textarea label="Bio" hint="Tell us something about yourself"></wa-textarea>
 </div>
 
@@ -178,7 +178,7 @@ Use [CSS parts](#css-parts) to customize the way form controls are drawn. This e
     }
 
     ::part(form-control-label) {
-      text-align: right;
+      justify-content: end;
     }
 
     ::part(hint) {

--- a/packages/webawesome/docs/docs/components/input.md
+++ b/packages/webawesome/docs/docs/components/input.md
@@ -177,6 +177,14 @@ Use [CSS parts](#css-parts) to customize the way form controls are drawn. This e
       align-items: center;
     }
 
+    wa-textarea {
+      align-items: start;
+
+      &::part(form-control-label) {
+        padding-block-start: var(--wa-form-control-padding-block);
+      }
+    }
+
     ::part(form-control-label) {
       justify-content: end;
     }

--- a/packages/webawesome/docs/docs/components/input.md
+++ b/packages/webawesome/docs/docs/components/input.md
@@ -151,7 +151,12 @@ Use the `start` and `end` slots to add presentational elements like `<wa-icon>` 
 
 ### Customizing Label Position
 
-Use [CSS parts](#css-parts) to customize the way form controls are drawn. This example uses CSS grid to position the label to the left of the control, but the possible orientations are nearly endless. The same technique works for inputs, textareas, radio groups, and similar form controls. The label part is a flex container, so use `justify-content` to align its text. `text-align` has no effect.
+Use [CSS parts](#css-parts) to customize the way form controls are drawn. This example uses CSS grid to position the label to the left of the control, but the possible orientations are nearly endless. The same technique works for inputs, textareas, radio groups, and similar form controls. The label part is a flex container, so align it with `justify-content` rather than `text-align`.
+
+:::info
+<strong>Labels sit at the end of their column so every one is the same distance from its field.</strong><br />
+Start-aligned labels leave a different-sized gap on each row, which makes it harder to see which label belongs to which field.
+:::
 
 ```html {.example}
 <div class="label-on-left">

--- a/packages/webawesome/docs/docs/components/number-input.md
+++ b/packages/webawesome/docs/docs/components/number-input.md
@@ -169,7 +169,12 @@ Use the `start` and `end` slots to add presentational elements like `<wa-icon>` 
 
 ### Customizing Label Position
 
-Use [CSS parts](#css-parts) to customize the way form controls are drawn. This example uses CSS grid to position the label to the left of the control, but the possible orientations are nearly endless. The same technique works for inputs, textareas, radio groups, and similar form controls. The label part is a flex container, so use `justify-content` to align its text. `text-align` has no effect.
+Use [CSS parts](#css-parts) to customize the way form controls are drawn. This example uses CSS grid to position the label to the left of the control, but the possible orientations are nearly endless. The same technique works for inputs, textareas, radio groups, and similar form controls. The label part is a flex container, so align it with `justify-content` rather than `text-align`.
+
+:::info
+<strong>Labels sit at the end of their column so every one is the same distance from its field.</strong><br />
+Start-aligned labels leave a different-sized gap on each row, which makes it harder to see which label belongs to which field.
+:::
 
 ```html {.example}
 <div class="label-on-left">

--- a/packages/webawesome/docs/docs/components/number-input.md
+++ b/packages/webawesome/docs/docs/components/number-input.md
@@ -169,7 +169,7 @@ Use the `start` and `end` slots to add presentational elements like `<wa-icon>` 
 
 ### Customizing Label Position
 
-Use [CSS parts](#css-parts) to customize the way form controls are drawn. This example uses CSS grid to position the label to the left of the control, but the possible orientations are nearly endless. The same technique works for inputs, textareas, radio groups, and similar form controls.
+Use [CSS parts](#css-parts) to customize the way form controls are drawn. This example uses CSS grid to position the label to the left of the control, but the possible orientations are nearly endless. The same technique works for inputs, textareas, radio groups, and similar form controls. The label part is a flex container, so use `justify-content` to align its text. `text-align` has no effect.
 
 ```html {.example}
 <div class="label-on-left">
@@ -194,7 +194,7 @@ Use [CSS parts](#css-parts) to customize the way form controls are drawn. This e
     }
 
     ::part(form-control-label) {
-      text-align: right;
+      justify-content: end;
     }
 
     ::part(hint) {

--- a/packages/webawesome/docs/docs/components/number-input.md
+++ b/packages/webawesome/docs/docs/components/number-input.md
@@ -172,7 +172,8 @@ Use the `start` and `end` slots to add presentational elements like `<wa-icon>` 
 Use [CSS parts](#css-parts) to customize the way form controls are drawn. This example uses CSS grid to position the label to the left of the control, but the possible orientations are nearly endless. The same technique works for inputs, textareas, radio groups, and similar form controls. The label part is a flex container, so align it with `justify-content` rather than `text-align`.
 
 :::info
-<strong>Labels sit at the end of their column so every one is the same distance from its field.</strong><br />
+**Labels sit at the end of their column so every one is the same distance from its field.**
+
 Start-aligned labels leave a different-sized gap on each row, which makes it harder to see which label belongs to which field.
 :::
 

--- a/packages/webawesome/docs/docs/components/number-input.md
+++ b/packages/webawesome/docs/docs/components/number-input.md
@@ -173,7 +173,6 @@ Use [CSS parts](#css-parts) to customize the way form controls are drawn. This e
 
 :::info
 **Labels sit at the end of their column so every one is the same distance from its field.**
-
 Start-aligned labels leave a different-sized gap on each row, which makes it harder to see which label belongs to which field.
 :::
 


### PR DESCRIPTION
The "Customizing Label Position" example on the input and number input pages never aligned its labels the way its own CSS claimed. Fixed here. Closes #2614.

### What was broken

The example set `text-align: right` on the label part. The label part is a flex container, and `text-align` does not move a flex container's contents sideways. The rule did nothing, so the labels stayed left while the code said right. `justify-content: end` is the property that works here.

### Changes

| What | Before | After |
| --- | --- | --- |
| Label alignment | `text-align: right`, which did nothing | `justify-content: end` |
| Textarea label position | Centered against the full height of the box | Sits on the first line of text |
| Second input's label | `Email` | `Email address` |

### Why the label text changed

"Name", "Email", and "Bio" are nearly the same width. Right-aligning them shifts two labels by a few pixels. The fix would be invisible, and someone would file the same bug again. "Email address" is long enough to make the alignment obvious.

### The textarea label

It used to float halfway down a tall box, nowhere near the line you type on. Now it lines up with the first line of text. Single-line inputs keep their centered labels, since for them the middle of the box is the line of text.

`align-items: baseline` looks like the elegant answer but is not. The browser builds the field's baseline from the bottom edge of the box, so every label drops to the bottom.

### Docs text

Both pages now say the label part is a flex container and takes `justify-content`, not `text-align`. That is the part that tripped up the person who reported this. There is also a short note explaining why the labels align to the end.

No changelog entry, since nothing outside `docs/` changed.
