### PR TITLE
Site Search: Remove Individual Recent Searches

### DIFF
--- a/packages/webawesome/docs/_includes/search.njk
+++ b/packages/webawesome/docs/_includes/search.njk
@@ -14,7 +14,9 @@
     </header>
 
     {# Body #}
-    <div id="site-search-body">
+    {# Opts out of Chrome's keyboard-focusable scrollers — that's for regions with
+       no focusable content, and the extra tab stop rings the whole dialog. #}
+    <div id="site-search-body" tabindex="-1">
       {# Default state — Suggested starts + Recent searches #}
       <div id="site-search-default" class="wa-stack wa-gap-0">
         <div id="site-search-suggested-list" class="site-search-listing" role="listbox" aria-label="Suggested">

--- a/packages/webawesome/docs/_includes/search.njk
+++ b/packages/webawesome/docs/_includes/search.njk
@@ -126,6 +126,8 @@
       </div>
     </div>
 
+    <div id="site-search-live-region" class="wa-visually-hidden" role="status" aria-live="polite"></div>
+
     <footer class="wa-flank:end wa-flex-nowrap wa-color-text-quiet">
       <div class="wa-cluster wa-flex-nowrap">
         <small class="wa-cluster wa-flex-nowrap wa-gap-xs">

--- a/packages/webawesome/docs/assets/scripts/search.js
+++ b/packages/webawesome/docs/assets/scripts/search.js
@@ -180,14 +180,7 @@ function renderRecentSearches() {
     // setAttribute, not a template literal — the query is user-supplied
     remove.querySelector('wa-icon').setAttribute('label', `Remove ${query} from recent searches`);
 
-    // Outside the anchor so every chevron in the dialog shares one vertical line
-    const caret = document.createElement('wa-icon');
-    caret.className = 'site-search-result-caret';
-    caret.setAttribute('name', 'chevron-right');
-    caret.setAttribute('variant', 'regular');
-    caret.setAttribute('aria-hidden', 'true');
-
-    li.append(a, remove, caret);
+    li.append(a, remove);
     recentListbox.appendChild(li);
   });
 }
@@ -513,7 +506,7 @@ function handleDefaultListClick(event) {
     return;
   }
 
-  // From the row, not the target — the caret sits outside the anchor. Assumes one
+  // From the row, not the target — the anchor doesn't span it. Assumes one
   // non-anchor control per row, guarded above.
   const link = event.target.closest('li')?.querySelector('a');
   if (!link) return;

--- a/packages/webawesome/docs/assets/scripts/search.js
+++ b/packages/webawesome/docs/assets/scripts/search.js
@@ -317,6 +317,10 @@ function handleKeyDown(event) {
   const activeList = getActiveList();
   if (!input || !activeList) return;
 
+  // List keys belong to the input. Without this the Enter interception below
+  // swallows activation for every other focusable in the dialog.
+  if (event.target !== input) return;
+
   // Handle keyboard selections
   if (['ArrowDown', 'ArrowUp', 'Home', 'End', 'Enter'].includes(event.key)) {
     event.preventDefault();

--- a/packages/webawesome/docs/assets/scripts/search.js
+++ b/packages/webawesome/docs/assets/scripts/search.js
@@ -88,6 +88,11 @@ function getElements() {
   };
 }
 
+function announce(message) {
+  const liveRegion = document.getElementById('site-search-live-region');
+  if (liveRegion) liveRegion.textContent = message;
+}
+
 // Returns the visible options container for keyboard nav: the results listbox
 // when there's an active query, otherwise the default-state container which
 // wraps both the Suggested and Recent sublists.
@@ -112,16 +117,24 @@ function loadRecentSearches() {
   }
 }
 
+function saveRecentSearches(queries) {
+  try {
+    if (queries.length > 0) {
+      localStorage.setItem(recentSearchesKey, JSON.stringify(queries));
+    } else {
+      localStorage.removeItem(recentSearchesKey);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function saveRecentSearch(query) {
   const trimmed = (query || '').trim();
   if (!trimmed) return;
-  try {
-    const current = loadRecentSearches();
-    const next = [trimmed, ...current.filter(q => q !== trimmed)].slice(0, recentSearchesMax);
-    localStorage.setItem(recentSearchesKey, JSON.stringify(next));
-  } catch {
-    // localStorage unavailable or full — skip silently
-  }
+  const current = loadRecentSearches();
+  saveRecentSearches([trimmed, ...current.filter(q => q !== trimmed)].slice(0, recentSearchesMax));
 }
 
 function renderRecentSearches() {
@@ -139,11 +152,13 @@ function renderRecentSearches() {
 
   queries.forEach((query, index) => {
     const li = document.createElement('li');
-    li.className = 'site-search-result';
+    li.className = 'site-search-result site-search-recent';
     li.setAttribute('role', 'option');
     li.id = `recent-item-${index + 1}`;
     li.dataset.recentQuery = query;
     li.setAttribute('data-selected', 'false');
+    // Beats name-from-contents, so the row doesn't absorb the button's label
+    li.setAttribute('aria-label', query);
 
     const a = document.createElement('a');
     a.href = '#';
@@ -153,14 +168,74 @@ function renderRecentSearches() {
       <div class="site-search-result-details">
         <div class="site-search-result-title wa-font-size-s"></div>
       </div>
-      <wa-icon class="site-search-result-caret" name="chevron-right" variant="regular" aria-hidden="true"></wa-icon>
     `;
     // textContent — never innerHTML — for the user-supplied query string
     a.querySelector('.site-search-result-title').textContent = query;
 
-    li.appendChild(a);
+    const remove = document.createElement('wa-button');
+    remove.className = 'site-search-recent-remove';
+    remove.dataset.recentRemove = '';
+    remove.setAttribute('appearance', 'plain');
+    remove.innerHTML = `<wa-icon name="xmark" variant="regular"></wa-icon>`;
+    // setAttribute, not a template literal — the query is user-supplied
+    remove.querySelector('wa-icon').setAttribute('label', `Remove ${query} from recent searches`);
+
+    // Outside the anchor so every chevron in the dialog shares one vertical line
+    const caret = document.createElement('wa-icon');
+    caret.className = 'site-search-result-caret';
+    caret.setAttribute('name', 'chevron-right');
+    caret.setAttribute('variant', 'regular');
+    caret.setAttribute('aria-hidden', 'true');
+
+    li.append(a, remove, caret);
     recentListbox.appendChild(li);
   });
+}
+
+// In place, not a re-render: the neighbour inheriting focus is already upgraded
+// and can take it synchronously. A rebuilt wa-button could not.
+function removeRecentSearch(li, selectionMethod) {
+  const query = li?.dataset.recentQuery;
+  if (!query) return;
+
+  const remaining = loadRecentSearches().filter(q => q !== query);
+  const wasSelected = li.getAttribute('data-selected') === 'true';
+  const hadFocus = li.contains(document.activeElement);
+  const next = li.nextElementSibling ?? li.previousElementSibling;
+
+  if (!saveRecentSearches(remaining)) return;
+  li.remove();
+
+  const { input, recentContainer, recentDivider } = getElements();
+  if (remaining.length === 0) {
+    if (recentContainer) recentContainer.hidden = true;
+    if (recentDivider) recentDivider.hidden = true;
+  }
+
+  trackEvent('navigation:search_recent_remove', {
+    remaining: remaining.length,
+    selection_method: selectionMethod,
+  });
+
+  announce(
+    remaining.length > 0
+      ? `Removed “${query}” from recent searches.`
+      : `Removed “${query}”. No recent searches remain.`,
+  );
+
+  if (!input) return;
+
+  // Otherwise focus falls to the body, outside the dialog
+  if (hadFocus) (next?.querySelector('[data-recent-remove]') ?? input).focus();
+
+  if (!wasSelected) return;
+
+  if (next) {
+    next.setAttribute('data-selected', 'true');
+    input.setAttribute('aria-activedescendant', next.id);
+  } else {
+    input.setAttribute('aria-activedescendant', '');
+  }
 }
 
 function trackQuerySubmit(query, resultSelectedValue) {
@@ -321,6 +396,16 @@ function handleKeyDown(event) {
   // swallows activation for every other focusable in the dialog.
   if (event.target !== input) return;
 
+  // Backspace too: MacBooks have no forward-delete key. Untrimmed on purpose —
+  // whitespace still renders recents, and it's the user's to edit.
+  if (event.shiftKey && ['Delete', 'Backspace'].includes(event.key) && !input.value) {
+    const selectedRecent = activeList.querySelector('.site-search-recent[data-selected="true"]');
+    if (!selectedRecent) return;
+    event.preventDefault();
+    removeRecentSearch(selectedRecent, 'keyboard');
+    return;
+  }
+
   // Handle keyboard selections
   if (['ArrowDown', 'ArrowUp', 'Home', 'End', 'Enter'].includes(event.key)) {
     event.preventDefault();
@@ -421,7 +506,16 @@ function selectResult(link, selectionMethod) {
 // Click handler for the default-state list. Defers to handleDefaultSelection
 // so keyboard Enter can share the same logic with a known selection_method.
 function handleDefaultListClick(event) {
-  const link = event.target.closest('a');
+  const removeButton = event.target.closest('[data-recent-remove]');
+  if (removeButton) {
+    event.preventDefault();
+    removeRecentSearch(removeButton.closest('li'), 'mouse_click');
+    return;
+  }
+
+  // From the row, not the target — the caret sits outside the anchor. Assumes one
+  // non-anchor control per row, guarded above.
+  const link = event.target.closest('li')?.querySelector('a');
   if (!link) return;
   event.preventDefault();
   handleDefaultSelection(link, 'mouse_click');

--- a/packages/webawesome/docs/assets/styles/search.css
+++ b/packages/webawesome/docs/assets/styles/search.css
@@ -105,19 +105,23 @@
   margin: 0;
 }
 
-/* Result row — layout (cluster/gap) comes from utility classes on the anchor */
+/* Result row — layout (cluster/gap) comes from utility classes on the anchor.
+   The row carries the background so recent rows can seat a button inside it. */
 .site-search-result {
+  --row-bg-neutral: var(--wa-color-neutral-fill-quiet);
+  --row-bg-brand: var(--wa-color-brand-fill-quiet);
+
+  display: flex;
+  align-items: center;
+  border-radius: var(--wa-border-radius-m);
+  transition: background-color var(--wa-transition-normal) var(--wa-transition-easing);
+
   > a {
+    flex: 1 1 auto;
+    min-width: 0;
     text-decoration: none;
     padding: var(--wa-space-xs) var(--wa-space-s);
-    border-radius: var(--wa-border-radius-m);
     color: inherit;
-    transition: background-color var(--wa-transition-normal) var(--wa-transition-easing);
-  }
-
-  > a:focus-visible {
-    outline: var(--wa-focus-ring);
-    outline-offset: -2px;
   }
 
   .site-search-result-icon {
@@ -153,42 +157,124 @@
   }
 }
 
-@media (hover: hover) {
-  .site-search-result > a:hover {
-    background: var(--wa-color-neutral-fill-quiet);
+.wa-dark .site-search-result {
+  --row-bg-neutral: var(--wa-color-neutral-fill-normal);
+  --row-bg-brand: var(--wa-color-brand-fill-normal);
+}
 
+/* Source order is load-bearing: equal specificity, and removeRecentSearch leaves
+   a row both selected and focused, so focus must come last. */
+@media (hover: hover) {
+  .site-search-result:hover {
+    background-color: var(--row-bg-neutral);
+  }
+}
+
+.site-search-result[data-selected='true'] {
+  background-color: var(--row-bg-brand);
+}
+
+/* Neutral so a tabbed row never reads as the arrow-selected one. Ungated by the
+   hover query — keyboards get attached to touch devices. */
+.site-search-result:focus-within {
+  background-color: var(--row-bg-neutral);
+}
+
+/* Duplicated only because :hover must stay behind the media query */
+@media (hover: hover) {
+  .site-search-result:hover {
     .site-search-result-icon,
     .site-search-result-url {
       color: var(--wa-color-brand-fill-loud);
+    }
+
+    .site-search-result-icon {
       opacity: 1;
     }
 
-    .site-search-result-caret {
+    .site-search-result-caret,
+    .site-search-recent-remove {
       opacity: 1;
     }
-  }
-
-  .wa-dark .site-search-result > a:hover {
-    background: var(--wa-color-neutral-fill-normal);
   }
 }
 
-.site-search-result[data-selected='true'] > a {
-  background: var(--wa-color-brand-fill-quiet);
-
+.site-search-result[data-selected='true'],
+.site-search-result:focus-within {
   .site-search-result-icon,
   .site-search-result-url {
     color: var(--wa-color-brand-fill-loud);
+  }
+
+  .site-search-result-icon {
     opacity: 1;
   }
 
-  .site-search-result-caret {
+  .site-search-result-caret,
+  .site-search-recent-remove {
     opacity: 1;
   }
 }
 
-.wa-dark .site-search-result[data-selected='true'] > a {
-  background: var(--wa-color-brand-fill-normal);
+/* native.css rings every anchor, but the anchor stops short of the remove button.
+   Safe to kill only because the rule below rings the row instead. */
+.site-search-result > a:focus-visible {
+  outline: none;
+}
+
+/* Anchor-scoped, so a focused remove button shows only its own ring. */
+.site-search-result:has(> a:focus-visible) {
+  outline: var(--wa-focus-ring);
+  outline-offset: -2px;
+}
+
+/* Anchor gives up its trailing padding so the button and caret cluster together */
+.site-search-recent > a {
+  padding-inline-end: var(--wa-space-2xs);
+}
+
+.site-search-recent > .site-search-result-caret {
+  margin-inline: var(--wa-space-2xs) var(--wa-space-s);
+}
+
+.site-search-recent-remove {
+  --remove-color: var(--wa-color-on-quiet);
+  /* wa-button rings icon buttons 2px outside, so a full-height control leaves the
+     ring nowhere to go. 2em fits ring and all, and tracks the font-size above. */
+  --wa-form-control-height: 2em;
+
+  flex: 0 0 auto;
+  font-size: var(--wa-font-size-s);
+  opacity: 0;
+  transition: opacity var(--wa-transition-normal) var(--wa-transition-easing);
+
+  /* `plain` paints a fill on hover and active; stating it transparent here covers
+     every state at once. */
+  &::part(base) {
+    background-color: transparent;
+    color: var(--remove-color);
+    transition: color var(--wa-transition-normal) var(--wa-transition-easing);
+  }
+
+  /* :focus-within, not :focus-visible — wa-button delegates focus into its shadow
+     root, so the host never reliably matches :focus-visible itself. */
+  &:focus-within,
+  &:active {
+    --remove-color: var(--wa-color-danger-on-quiet);
+  }
+}
+
+@media (hover: hover) {
+  .site-search-recent-remove:hover {
+    --remove-color: var(--wa-color-danger-on-quiet);
+  }
+}
+
+/* No hover on touch, and this is the only pointer affordance for removing */
+@media not (hover: hover) {
+  .site-search-recent-remove {
+    opacity: 1;
+  }
 }
 
 #site-search-empty {

--- a/packages/webawesome/docs/assets/styles/search.css
+++ b/packages/webawesome/docs/assets/styles/search.css
@@ -228,15 +228,6 @@
   outline-offset: -2px;
 }
 
-/* Anchor gives up its trailing padding so the button and caret cluster together */
-.site-search-recent > a {
-  padding-inline-end: var(--wa-space-2xs);
-}
-
-.site-search-recent > .site-search-result-caret {
-  margin-inline: var(--wa-space-2xs) var(--wa-space-s);
-}
-
 .site-search-recent-remove {
   --remove-color: var(--wa-color-on-quiet);
   /* wa-button rings icon buttons 2px outside, so a full-height control leaves the
@@ -244,6 +235,8 @@
   --wa-form-control-height: 2em;
 
   flex: 0 0 auto;
+  /* Lands where the other lists put their chevron */
+  margin-inline-end: var(--wa-space-s);
   font-size: var(--wa-font-size-s);
   opacity: 0;
   transition: opacity var(--wa-transition-normal) var(--wa-transition-easing);


### PR DESCRIPTION
Recent searches now have an X that removes them one at a time. Before this, a typo like `fart` stayed in the list until five more searches pushed it out.

### Removing a search

- Hover a recent search, or arrow onto it, and an X appears at the end of the row.
- Click the X to remove that search.
- From the keyboard, press Shift+Delete on the selected row.
- Shift+Backspace does the same, because MacBooks have no forward-delete key.

Recent rows also lost their chevron. A chevron says "this opens a page", and these rows do not open anything. They put the text back in the search box and run the search again.

### Two bugs this uncovered

Both existed before this change. Both are fixed here.

| What you did | Before | After |
| --- | --- | --- |
| Tab to a row, press Enter | Opened whichever row the arrow keys were on | Opens the row you are actually on |
| Tab with recent searches showing | Stopped on the scrolling area first, drawing a ring across the whole dialog | Goes straight to the first Quick Link |

### How the rows are built now

- The row highlight moved off the link and onto the row itself.
- That is what lets it run underneath the X.
- Quick Links and search results share the same row class.
- Their appearance is unchanged. I compared screenshots before and after and they matched exactly.

### Screen readers and keyboard

- Each row is announced with its query and nothing else.
- The X carries its own name, like `Remove dialog from recent searches`.
- Removing a search is spoken out loud.
- Focus lands on the next row's X, or the search box if the list is now empty.
