### PR TITLE
Site Search: Drop the Chevrons

### DIFF
--- a/packages/webawesome/docs/_includes/search.njk
+++ b/packages/webawesome/docs/_includes/search.njk
@@ -29,8 +29,6 @@
                 <div class="site-search-result-details">
                   <div class="site-search-result-title wa-font-size-s">Components</div>
                 </div>
-                <wa-icon class="site-search-result-caret" name="chevron-right" variant="regular"
-                  aria-hidden="true"></wa-icon>
               </a>
             </li>
             <li class="site-search-result" role="option" id="suggested-item-2" data-selected="false">
@@ -40,8 +38,6 @@
                 <div class="site-search-result-details">
                   <div class="site-search-result-title wa-font-size-s">CSS Utilities</div>
                 </div>
-                <wa-icon class="site-search-result-caret" name="chevron-right" variant="regular"
-                  aria-hidden="true"></wa-icon>
               </a>
             </li>
             <li class="site-search-result" role="option" id="suggested-item-3" data-selected="false">
@@ -51,8 +47,6 @@
                 <div class="site-search-result-details">
                   <div class="site-search-result-title wa-font-size-s">Theming</div>
                 </div>
-                <wa-icon class="site-search-result-caret" name="chevron-right" variant="regular"
-                  aria-hidden="true"></wa-icon>
               </a>
             </li>
             <li class="site-search-result" role="option" id="suggested-item-4" data-selected="false">
@@ -62,8 +56,6 @@
                 <div class="site-search-result-details">
                   <div class="site-search-result-title wa-font-size-s">Using with AI</div>
                 </div>
-                <wa-icon class="site-search-result-caret" name="chevron-right" variant="regular"
-                  aria-hidden="true"></wa-icon>
               </a>
             </li>
             <li class="site-search-result" role="option" id="suggested-item-5" data-selected="false">
@@ -73,8 +65,6 @@
                 <div class="site-search-result-details">
                   <div class="site-search-result-title wa-font-size-s">Changelog</div>
                 </div>
-                <wa-icon class="site-search-result-caret" name="chevron-right" variant="regular"
-                  aria-hidden="true"></wa-icon>
               </a>
             </li>
             <li class="site-search-result" role="option" id="suggested-item-6" data-selected="false">
@@ -84,8 +74,6 @@
                 <div class="site-search-result-details">
                   <div class="site-search-result-title wa-font-size-s">Help &amp; Support</div>
                 </div>
-                <wa-icon class="site-search-result-caret" name="chevron-right" variant="regular"
-                  aria-hidden="true"></wa-icon>
               </a>
             </li>
           </ul>

--- a/packages/webawesome/docs/assets/scripts/search.js
+++ b/packages/webawesome/docs/assets/scripts/search.js
@@ -688,7 +688,6 @@ async function updateResults(query = '') {
           <div class="site-search-result-description wa-font-size-s"></div>
           <div class="site-search-result-url wa-font-size-xs"></div>
         </div>
-        <wa-icon class="site-search-result-caret" name="chevron-right" variant="regular" aria-hidden="true"></wa-icon>
       `;
       a.querySelector('.site-search-result-title').textContent = displayTitle;
       a.querySelector('.site-search-result-description').textContent = displayDescription;

--- a/packages/webawesome/docs/assets/styles/search.css
+++ b/packages/webawesome/docs/assets/styles/search.css
@@ -147,14 +147,6 @@
     color: var(--wa-color-on-quiet);
     transition: color var(--wa-transition-normal) var(--wa-transition-easing);
   }
-
-  .site-search-result-caret {
-    flex: 0 0 auto;
-    font-size: var(--wa-font-size-s);
-    color: var(--wa-color-on-quiet);
-    opacity: 0;
-    transition: opacity var(--wa-transition-normal) var(--wa-transition-easing);
-  }
 }
 
 .wa-dark .site-search-result {
@@ -192,7 +184,6 @@
       opacity: 1;
     }
 
-    .site-search-result-caret,
     .site-search-recent-remove {
       opacity: 1;
     }
@@ -210,7 +201,6 @@
     opacity: 1;
   }
 
-  .site-search-result-caret,
   .site-search-recent-remove {
     opacity: 1;
   }
@@ -235,7 +225,7 @@
   --wa-form-control-height: 2em;
 
   flex: 0 0 auto;
-  /* Lands where the other lists put their chevron */
+  /* Same inset as the anchor's trailing padding */
   margin-inline-end: var(--wa-space-s);
   font-size: var(--wa-font-size-s);
   opacity: 0;


### PR DESCRIPTION
Removes the chevron from every row in the site search dialog. Follow-up to #2760, which removed it from recent searches only. Rebased onto `next` now that #2760 has merged.

A chevron means "this opens something in place", like a section expanding or a panel sliding in. Every row here opens a different page and closes the dialog. The arrow was pointing at the wrong idea.

### What changes

- Quick Links, search results, and recent searches no longer show a chevron.
- Nothing else about the rows changes.
- The `.site-search-result-caret` class is now unused and deleted.

### A small bonus

Search result descriptions get about 29 pixels back per row. That is the chevron plus the gap in front of it. One example, same search:

| | Description shown |
| --- | --- |
| Before | Buttons represent actions the user can take, such as sub... |
| After | Buttons represent actions the user can take, such as submitti... |

### Worth knowing

On phones and tablets the chevron was already invisible. It only appeared when you hovered a row with a mouse, or moved to it with arrow keys. Touch users have never seen it, so nothing changes for them.
