### PR TITLE
updated tab interaction for accordion

### DIFF
--- a/packages/webawesome/docs/docs/components/accordion.md
+++ b/packages/webawesome/docs/docs/components/accordion.md
@@ -336,3 +336,7 @@ Listen for the `wa-expand` or `wa-collapse` events and call `event.preventDefaul
   });
 </script>
 ```
+
+## Accessibility Considerations
+
+Every enabled header is part of the page's normal tab sequence. `Tab` and `Shift + Tab` move through each header along with the rest of the page, per the [W3C accordion pattern](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/examples/accordion/). When the header is in focus, the arrow keys are a shortcut for moving between headers. The Up and Down keys move from the previous to the next header, Home and End keys jump to the first and last header.

--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -29,6 +29,14 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 
 {% include "changelog-email-signup.njk" %}
 
+## Unreleased
+
+:::fixed
+
+- Fixed `<wa-accordion>` removing headers from the page's tab sequence via a roving tabindex; `Tab` and `Shift + Tab` now move through every header, matching the [W3C accordion pattern](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/examples/accordion/). Arrow keys and Home/End remain as shortcuts for moving between headers.
+
+:::
+
 ## 3.12.0
 
 :::added

--- a/packages/webawesome/src/components/accordion-item/accordion-item.test.ts
+++ b/packages/webawesome/src/components/accordion-item/accordion-item.test.ts
@@ -49,6 +49,12 @@ describe('<wa-accordion-item>', () => {
           const button = el.shadowRoot!.querySelector('[part~="button"]')!;
           expect(button.getAttribute('tabindex')).to.equal('-1');
         });
+
+        it('should set tabindex to 0 on the button when not disabled', async () => {
+          const el = await fixture<WaAccordionItem>(html`<wa-accordion-item label="Test">Content</wa-accordion-item>`);
+          const button = el.shadowRoot!.querySelector('[part~="button"]')!;
+          expect(button.getAttribute('tabindex')).to.equal('0');
+        });
       });
 
       describe('properties', () => {

--- a/packages/webawesome/src/components/accordion-item/accordion-item.ts
+++ b/packages/webawesome/src/components/accordion-item/accordion-item.ts
@@ -65,9 +65,6 @@ export default class WaAccordionItem extends WebAwesomeElement {
   /** @internal Set by the parent accordion to control the heading level of the trigger. */
   @property({ attribute: 'heading-level', reflect: true }) headingLevel = '3';
 
-  /** @internal Set by the parent accordion to control the roving tab index. */
-  @property({ type: Boolean, attribute: false }) isTabbable = true;
-
   /** @internal Set by the parent accordion to control icon placement. */
   @property({ attribute: 'icon-placement', reflect: true }) iconPlacement: 'start' | 'end' = 'end';
 
@@ -188,7 +185,7 @@ export default class WaAccordionItem extends WebAwesomeElement {
         aria-expanded=${this.expanded ? 'true' : 'false'}
         aria-controls="panel"
         aria-disabled=${this.disabled ? 'true' : 'false'}
-        tabindex=${this.disabled || !this.isTabbable ? '-1' : '0'}
+        tabindex=${this.disabled ? '-1' : '0'}
         @click=${this.handleTriggerClick}
         @keydown=${this.handleTriggerKeyDown}
       >

--- a/packages/webawesome/src/components/accordion/accordion.test.ts
+++ b/packages/webawesome/src/components/accordion/accordion.test.ts
@@ -409,6 +409,27 @@ describe('<wa-accordion>', () => {
           await expectEvent(el, 'wa-collapse', () => sendKeys({ press: 'Enter' }));
           expect(item.expanded).to.be.false;
         });
+
+        it('should keep every enabled header tabbable at once instead of using a roving tabindex', async () => {
+          const el = await fixture<WaAccordion>(html`
+            <wa-accordion>
+              <wa-accordion-item label="One">Content one</wa-accordion-item>
+              <wa-accordion-item label="Two">Content two</wa-accordion-item>
+            </wa-accordion>
+          `);
+          const [first, second] = el.querySelectorAll<WaAccordionItem>('wa-accordion-item');
+          const firstButton = first.shadowRoot!.querySelector<HTMLButtonElement>('[part~="button"]')!;
+          const secondButton = second.shadowRoot!.querySelector<HTMLButtonElement>('[part~="button"]')!;
+
+          expect(firstButton.getAttribute('tabindex')).to.equal('0');
+          expect(secondButton.getAttribute('tabindex')).to.equal('0');
+
+          secondButton.focus();
+          await el.updateComplete;
+
+          expect(firstButton.getAttribute('tabindex')).to.equal('0');
+          expect(secondButton.getAttribute('tabindex')).to.equal('0');
+        });
       });
 
       describe('nested accordions', () => {

--- a/packages/webawesome/src/components/accordion/accordion.ts
+++ b/packages/webawesome/src/components/accordion/accordion.ts
@@ -62,12 +62,6 @@ export default class WaAccordion extends WebAwesomeElement {
     return item.closest('wa-accordion') === this;
   }
 
-  private initRovingTabIndex() {
-    this.getFocusableItems().forEach((item, index) => {
-      item.isTabbable = index === 0;
-    });
-  }
-
   private handleSlotChange() {
     if (this.didSSR) {
       const promises: Promise<boolean>[] = [];
@@ -90,19 +84,6 @@ export default class WaAccordion extends WebAwesomeElement {
     this.syncIconPlacement();
     this.syncHeadingLevel();
     this.syncAppearance();
-    this.initRovingTabIndex();
-  }
-
-  private handleFocusIn(event: FocusEvent) {
-    const items = this.getFocusableItems();
-    const path = event.composedPath();
-    const closestItem = path.find(
-      (el): el is WaAccordionItem => el instanceof Element && el.tagName.toLowerCase() === 'wa-accordion-item',
-    );
-    if (!closestItem || !this.ownsItem(closestItem)) return;
-    const focusedItem = items.find(item => item === closestItem);
-    if (!focusedItem) return;
-    items.forEach(item => (item.isTabbable = item === focusedItem));
   }
 
   private handleKeyDown(event: KeyboardEvent) {
@@ -115,7 +96,7 @@ export default class WaAccordion extends WebAwesomeElement {
     );
     if (!closestItem || !this.ownsItem(closestItem)) return;
 
-    const currentIndex = items.findIndex(item => item.isTabbable);
+    const currentIndex = items.findIndex(item => item === closestItem);
     let nextIndex = currentIndex;
 
     switch (event.key) {
@@ -139,7 +120,6 @@ export default class WaAccordion extends WebAwesomeElement {
         return;
     }
 
-    items.forEach((item, index) => (item.isTabbable = index === nextIndex));
     items[nextIndex].focus();
   }
 
@@ -205,7 +185,6 @@ export default class WaAccordion extends WebAwesomeElement {
       <slot
         @slotchange=${this.handleSlotChange}
         @wa-accordion-item-trigger=${this.handleItemTrigger}
-        @focusin=${this.handleFocusIn}
         @keydown=${this.handleKeyDown}
       ></slot>
     `;


### PR DESCRIPTION
PR for #2764

Removed the `isTabbable` property and a few methods to make the accordion headers a part of the page's normal tab sequence