### PR TITLE
Docs: Support Pro View

### DIFF
--- a/packages/webawesome/docs/_includes/subheader-links.njk
+++ b/packages/webawesome/docs/_includes/subheader-links.njk
@@ -12,4 +12,6 @@
   <wa-button appearance="plain" size="s" href="{{ site.urls.support }}/" data-track-event="navigation:header_link_click" data-track-destination="help">
     Help
   </wa-button>
+  {# Pro-only; the partial ships in webawesome-pro and is absent from open-source builds #}
+  {% include "site/pro-nav-link.njk" ignore missing %}
 </div>

--- a/packages/webawesome/docs/docs/color-palettes.njk
+++ b/packages/webawesome/docs/docs/color-palettes.njk
@@ -24,7 +24,7 @@ hasOutline: false
   <div class="wa-stack">
     <div class="wa-stack wa-gap-2xs">
       <strong>
-        <a href="/purchase?from=pro-docs&context=color-palettes">Unlock every color palette with {{ site.namePro }}!</a>
+        <a href="/pro?from=pro-docs&context=color-palettes">Unlock every color palette with {{ site.namePro }}!</a>
       </strong>
 
       <wa-details appearance="plain">
@@ -34,7 +34,7 @@ hasOutline: false
         <div class="wa-stack wa-gap-xl">
           {% include "pro-perks.njk" ignore missing %}
 
-          <wa-button href="/purchase?from=pro-docs&context=color-palettes">
+          <wa-button href="/pro?from=pro-docs&context=color-palettes">
             Get {{ site.namePro }}
             <wa-icon slot="end" name="arrow-right"></wa-icon>
           </wa-button>

--- a/packages/webawesome/docs/docs/themes.njk
+++ b/packages/webawesome/docs/docs/themes.njk
@@ -24,7 +24,7 @@ layout: page
   <div class="wa-stack">
     <div class="wa-stack wa-gap-2xs">
       <strong>
-        <a href="/purchase?from=pro-docs&context=themes">Unlock every theme with {{ site.namePro }}!</a>
+        <a href="/pro?from=pro-docs&context=themes">Unlock every theme with {{ site.namePro }}!</a>
       </strong>
 
       <wa-details appearance="plain">
@@ -34,7 +34,7 @@ layout: page
         <div class="wa-stack wa-gap-xl">
           {% include "pro-perks.njk" ignore missing %}
 
-          <wa-button href="/purchase?from=pro-docs&context=themes">
+          <wa-button href="/pro?from=pro-docs&context=themes">
             Get {{ site.namePro }}
             <wa-icon slot="end" name="arrow-right"></wa-icon>
           </wa-button>

--- a/packages/webawesome/docs/index.md
+++ b/packages/webawesome/docs/index.md
@@ -234,9 +234,9 @@ hasFramedMain: false
             <h3 class="wa-heading-m">Get More with {{ site.namePro }}!</h3>
             <p>Unlock Pro-only themes, components, patterns, and great services like the Theme Builder.</p>
           </div>
-          <wa-button class="wa-dark" size="s" href="/purchase">
+          <wa-button class="wa-dark" size="s" href="/pro?from=docs-landing">
             <wa-icon slot="start" name="rocket-launch"></wa-icon>
-            Purchase Pro
+            Get Pro
           </wa-button>
         {% endif %}
       {% endraw %}


### PR DESCRIPTION
A small companion to https://github.com/shoelace-style/webawesome-pro/pull/296 that preps a few places for the new `/pro` explaining Web Awesome Pro more clearly:

- The subheader gains a Pro nav link hook.
- The themes, color palettes, and docs index upsells link to `/pro` with `from` and `context` query params for attribution.