### PR TITLE
Fix popover dragging bug

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -52,6 +52,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 - Fixed a bug in `<wa-data-grid>` that caused an expanded row detail's space to stay reserved at its old position after changing pages, sorting, or filtering
 - Fixed a bug in `<wa-data-grid>` that caused the empty and loading states to be invisible in some cases [issue:2734]
 - Fixed `<wa-data-grid>` showing its empty state behind the loading overlay while a server request was in flight
+- Fixed a bug in `<wa-popover>` where dragging to select text inside the popover closed it if the cursor was released outside of it
 - Fixed a bug in `<wa-tooltip>` where canceling the `wa-hide` event didn't keep the tooltip open [pr:2721]
 - Fixed a bug in `<wa-tooltip>` where tooltips with `trigger="manual"` closed when pressing [[Escape]] [pr:2721]
 - Fixed the `hint` part in `<wa-textarea>`, which sat on a slot inside an unexposed wrapper; `::part(hint)` now selects the hint and the character count together [issue:2614] [pr:2720]

--- a/packages/webawesome/src/components/popover/popover.test.ts
+++ b/packages/webawesome/src/components/popover/popover.test.ts
@@ -1,5 +1,5 @@
 import { aTimeout, expect, waitUntil } from '@open-wc/testing';
-import { sendKeys } from '@web/test-runner-commands';
+import { sendKeys, sendMouse } from '@web/test-runner-commands';
 import { html } from 'lit';
 import sinon from 'sinon';
 import { expectEvent } from '../../internal/test/expect-event.js';
@@ -350,6 +350,35 @@ describe('<wa-popover>', () => {
       await waitUntil(() => !popover.open);
 
       expect(popover.open).to.be.false;
+    });
+
+    it('should stay open when a drag starts inside the popover and ends outside', async () => {
+      const el = await fixtures[0]<HTMLDivElement>(html`
+        <div style="padding: 200px;">
+          <wa-button id="anchor">Anchor</wa-button>
+          <wa-popover for="anchor">Select this text by dragging</wa-popover>
+        </div>
+      `);
+      const popover = el.querySelector<WaPopover>('wa-popover')!;
+
+      popover.open = true;
+      await waitUntil(() => popover.open);
+      await aTimeout(200);
+
+      // Press inside the popover's visible panel, then release outside of it. The host is display: contents, so
+      // measure the popup that actually renders the content.
+      const panel = popover.shadowRoot!.querySelector('wa-popup')!.shadowRoot!.querySelector('[part~="popup"]')!;
+      const inside = panel.getBoundingClientRect();
+      await sendMouse({
+        type: 'move',
+        position: [Math.floor(inside.x + inside.width / 2), Math.floor(inside.y + inside.height / 2)],
+      });
+      await sendMouse({ type: 'down' });
+      await sendMouse({ type: 'move', position: [Math.floor(inside.x + inside.width / 2), 1] });
+      await sendMouse({ type: 'up' });
+      await aTimeout(200);
+
+      expect(popover.open).to.be.true;
     });
 
     it('should close when a data-popover="close" button is clicked', async () => {

--- a/packages/webawesome/src/components/popover/popover.ts
+++ b/packages/webawesome/src/components/popover/popover.ts
@@ -91,6 +91,7 @@ export default class WaPopover extends WebAwesomeElement {
   @property({ attribute: 'without-arrow', type: Boolean, reflect: true }) withoutArrow = false;
 
   private eventController = new AbortController();
+  private pressStartedInside = false;
 
   connectedCallback() {
     super.connectedCallback();
@@ -117,6 +118,7 @@ export default class WaPopover extends WebAwesomeElement {
 
     // Cleanup events in case the popover is removed while open
     document.removeEventListener('keydown', this.handleDocumentKeyDown);
+    document.removeEventListener('pointerdown', this.handleDocumentPointerDown, { capture: true });
     unregisterDismissible(this);
     this.eventController.abort();
   }
@@ -166,7 +168,22 @@ export default class WaPopover extends WebAwesomeElement {
     }
   };
 
+  private handleDocumentPointerDown = (event: PointerEvent) => {
+    // Remember whether the press started inside the popover. A click event targets the common ancestor of the
+    // pointerdown and pointerup elements, so a drag that starts inside and ends outside reports a target outside the
+    // popover. Only the originating press should decide whether this is an outside click.
+    this.pressStartedInside = event.composedPath().includes(this);
+  };
+
   private handleDocumentClick = (event: PointerEvent) => {
+    const pressStartedInside = this.pressStartedInside;
+    this.pressStartedInside = false;
+
+    // Ignore presses that began inside the popover, such as dragging to select text and releasing outside of it
+    if (pressStartedInside) {
+      return;
+    }
+
     // Ignore clicks on the anchor so it will be closed by the anchor's click handler
     if (this.anchor && event.composedPath().includes(this.anchor)) {
       return;
@@ -193,6 +210,10 @@ export default class WaPopover extends WebAwesomeElement {
       openPopovers.forEach(popover => (popover.open = false));
 
       document.addEventListener('keydown', this.handleDocumentKeyDown, { signal: this.eventController.signal });
+      document.addEventListener('pointerdown', this.handleDocumentPointerDown, {
+        capture: true,
+        signal: this.eventController.signal,
+      });
       document.addEventListener('click', this.handleDocumentClick, { signal: this.eventController.signal });
 
       // Show the dialog non-modally. Set the `open` attribute instead of calling show(): show() runs the native
@@ -229,7 +250,9 @@ export default class WaPopover extends WebAwesomeElement {
       }
 
       document.removeEventListener('keydown', this.handleDocumentKeyDown);
+      document.removeEventListener('pointerdown', this.handleDocumentPointerDown, { capture: true });
       document.removeEventListener('click', this.handleDocumentClick);
+      this.pressStartedInside = false;
 
       openPopovers.delete(this);
       unregisterDismissible(this);


### PR DESCRIPTION
Fixes a bug in `<wa-popover>` where dragging to select text inside the popover closed it if the cursor was released outside of the popover's body.