### PR TITLE
Restore dropdown focus after Escape

### DIFF
--- a/packages/webawesome/docs/docs/resources/changelog.md
+++ b/packages/webawesome/docs/docs/resources/changelog.md
@@ -36,6 +36,7 @@ Web Awesome follows <a href="https://semver.org/" class="appearance-plain">Seman
 - Fixed a bug in `<wa-page>` where empty contents for `navigation-footer` would reserve space for a navigation footer in the mobile navigation drawer.
 - Fixed a bug in `<wa-page>` where the header did not have a background set. [pr:2690]
 - Fixed a bug in `.wa-visually-hidden` utility where it did not set a `top` and `left` causing unexpected overflows. [pr:2765]
+- Fixed `<wa-dropdown>` losing trigger focus after closing with [[Escape]]. [issue:2766]
 - Fixed `<wa-accordion>` removing headers from the page's tab sequence via a roving tabindex; `Tab` and `Shift + Tab` now move through every header, matching the [W3C accordion pattern](https://www.w3.org/WAI/ARIA/apg/patterns/accordion/examples/accordion/). Arrow keys and Home/End remain as shortcuts for moving between headers.
 
 :::

--- a/packages/webawesome/src/components/dropdown/dropdown.test.ts
+++ b/packages/webawesome/src/components/dropdown/dropdown.test.ts
@@ -2,6 +2,7 @@ import { aTimeout, expect, waitUntil } from '@open-wc/testing';
 import { sendKeys, setViewport } from '@web/test-runner-commands';
 import { html } from 'lit';
 import sinon from 'sinon';
+import { getDeepestActiveElement } from '../../internal/active-elements.js';
 import { expectEvent } from '../../internal/test/expect-event.js';
 import { clientFixture, fixtures } from '../../internal/test/fixture.js';
 import type WaDropdownItem from '../dropdown-item/dropdown-item.js';
@@ -451,14 +452,21 @@ describe('<wa-dropdown>', () => {
           `);
 
           const trigger = el.querySelector<HTMLElement>('[slot="trigger"]')!;
+          const firstItem = el.querySelector('wa-dropdown-item')!;
+          el.style.setProperty('--hide-duration', '100ms');
           trigger.click();
           await waitUntil(() => el.open);
           await aTimeout(200);
 
+          const afterHide = new Promise(resolve => el.addEventListener('wa-after-hide', resolve, { once: true }));
           await sendKeys({ press: 'Escape' });
-          await waitUntil(() => !el.open);
+          await aTimeout(50);
 
+          expect(getDeepestActiveElement()).to.equal(firstItem);
+
+          await afterHide;
           expect(el.open).to.be.false;
+          expect(getDeepestActiveElement()).to.equal(trigger.shadowRoot!.querySelector('[part~="base"]'));
         });
 
         it('should navigate items with ArrowDown', async () => {

--- a/packages/webawesome/src/components/dropdown/dropdown.ts
+++ b/packages/webawesome/src/components/dropdown/dropdown.ts
@@ -60,6 +60,7 @@ export default class WaDropdown extends WebAwesomeElement {
   private userTypedQuery = '';
   private userTypedTimeout: ReturnType<typeof setTimeout>;
   private openSubmenuStack: WaDropdownItem[] = [];
+  private triggerToRestoreFocus: HTMLButtonElement | WaButton | null = null;
 
   @query('slot:not([name])') defaultSlot: HTMLSlotElement;
   @query('#menu') private menu: HTMLDivElement;
@@ -290,9 +291,12 @@ export default class WaDropdown extends WebAwesomeElement {
     this.dispatchEvent(hideEvent);
     if (hideEvent.defaultPrevented) {
       this.open = true;
+      this.triggerToRestoreFocus = null;
       return;
     }
 
+    const trigger = this.triggerToRestoreFocus;
+    this.triggerToRestoreFocus = null;
     this.open = false;
     openDropdowns.delete(this);
     unregisterDismissible(this);
@@ -307,6 +311,7 @@ export default class WaDropdown extends WebAwesomeElement {
     // Sometimes this ends up out of sync. So make sure it aligns with `open`
     this.popup.active = this.open; // Hide using wa-popup
     this.dispatchEvent(new WaAfterHideEvent());
+    trigger?.focus({ preventScroll: true });
   }
 
   /** Handles key down events when the menu is open */
@@ -319,8 +324,8 @@ export default class WaDropdown extends WebAwesomeElement {
       event.preventDefault();
       event.stopPropagation();
 
+      this.triggerToRestoreFocus = trigger;
       this.open = false;
-      trigger?.focus({ preventScroll: true });
       return;
     }
 


### PR DESCRIPTION
[#2766](https://github.com/shoelace-style/webawesome/issues/2766)

Closing a keyboard-opened dropdown restored trigger focus before its hide animation finished, allowing focus to fall to the page body. Focus now returns after the dropdown closes.

+semver:patch
