### PR TITLE
add nonce to wa-page

### DIFF
--- a/packages/webawesome/src/components/page/page.ts
+++ b/packages/webawesome/src/components/page/page.ts
@@ -358,6 +358,12 @@ export default class WaPage extends WebAwesomeElement {
       this.view === 'mobile' &&
       (this.hasSlotController.test('navigation-footer') || this.hasSlotController.test('mobile-navigation-footer'));
 
+
+      // Hopefully there is a future with container queries where the `<style>` tag can go away and we can do sizing with proper container query variables. Until then...this is the best we got.
+      // Use the nonce on the element, if it doesn't exist, fallback to window.litNonce for strict CSPs.
+      // @ts-expect-error - error because globalThis.litNonce
+      let nonce = (this.nonce || globalThis.litNonce || null) as string | null
+
     return html`
       <a href="#main-content" part="skip-to-content" class="wa-visually-hidden">
         <slot name="skip-to-content">Skip to content</slot>
@@ -366,12 +372,7 @@ export default class WaPage extends WebAwesomeElement {
       <!-- unsafeHTML needed for SSR until this is solved: https://github.com/lit/lit/issues/4696 -->
       ${unsafeHTML(`
         <style
-          nonce="${
-            // Hopefully there is a future with container queries where the `<style>` tag can go away and we can do sizing with proper container query variables. Until then...this is the best we got.
-            // Use the nonce on the element, if it doesn't exist, fallback to window.litNonce for strict CSPs.
-            // @ts-expect-error - error because globalThis.litNonce
-            ifDefined(this.nonce || globalThis.litNonce)
-          }"
+          ${/* ifDefined not supported in unsafeHTML */ nonce ? "" : nonce="${nonce}"}
           id="mobile-styles"
         >
           ${mobileStyles(toLength(this.mobileBreakpoint))}

--- a/packages/webawesome/src/components/page/page.ts
+++ b/packages/webawesome/src/components/page/page.ts
@@ -188,6 +188,11 @@ export default class WaPage extends WebAwesomeElement {
   @property({ attribute: 'view', reflect: true }) view: 'mobile' | 'desktop' = 'desktop';
 
   /**
+   * Sets a `nonce` for the injected `<style>` tag used for handling media queries. The style tag will use `window.litNonce` if `nonce` isn't defined on `<wa-page>`
+   */
+  @property({ reflect: true }) nonce: string | undefined;
+
+  /**
    * Whether or not the navigation drawer is open. Note, the navigation drawer is only "open" on mobile views.
    */
   @property({ attribute: 'nav-open', reflect: true, type: Boolean }) navOpen = false;
@@ -360,7 +365,15 @@ export default class WaPage extends WebAwesomeElement {
 
       <!-- unsafeHTML needed for SSR until this is solved: https://github.com/lit/lit/issues/4696 -->
       ${unsafeHTML(`
-        <style id="mobile-styles">
+        <style
+          nonce="${
+            // Hopefully there is a future with container queries where the `<style>` tag can go away and we can do sizing with proper container query variables. Until then...this is the best we got.
+            // Use the nonce on the element, if it doesn't exist, fallback to window.litNonce for strict CSPs.
+            // @ts-expect-error - error because globalThis.litNonce
+            ifDefined(this.nonce || globalThis.litNonce)
+          }"
+          id="mobile-styles"
+        >
           ${mobileStyles(toLength(this.mobileBreakpoint))}
         </style>
       `)}


### PR DESCRIPTION
Support CSPs that have `unsafe-inline` by supporting a `nonce` attribute.