### PR TITLE
Docs: Re-Aim Deep Links After Components Upgrade

### DIFF
--- a/packages/webawesome/docs/assets/scripts/scroll.js
+++ b/packages/webawesome/docs/assets/scripts/scroll.js
@@ -56,10 +56,27 @@ allDefined().then(() => {
   const scrollY = sessionStorage.getItem(key);
 
   // Only restore when reloading, otherwise clear it
-  if (navigationType === 'reload' && scrollY) {
+  const didRestoreScroll = navigationType === 'reload' && scrollY;
+
+  if (didRestoreScroll) {
     window.scrollTo(0, scrollY);
   } else {
     sessionStorage.removeItem(key);
+  }
+
+  // The browser aims fragment navigation at the pre-upgrade layout, which is taller than the
+  // settled one, so a deep link lands well past its target. A restored position outranks it:
+  // ours on reload, or the browser's own on back/forward.
+  const id = location.hash.slice(1);
+  const isScrollAlreadyRestored = didRestoreScroll || navigationType === 'back_forward';
+
+  if (id && !isScrollAlreadyRestored) {
+    const target = document.getElementById(id);
+    const headerHeight = document.querySelector('wa-page > header')?.clientHeight ?? 0;
+
+    if (target) {
+      window.scrollTo(0, target.getBoundingClientRect().top + window.scrollY - headerHeight);
+    }
   }
 
   // After restoring, keep tabs on the page's scroll position for next reload

--- a/packages/webawesome/docs/assets/scripts/scroll.js
+++ b/packages/webawesome/docs/assets/scripts/scroll.js
@@ -65,18 +65,24 @@ allDefined().then(() => {
   }
 
   // The browser aims fragment navigation at the pre-upgrade layout, which is taller than the
-  // settled one, so a deep link lands well past its target. A restored position outranks it:
-  // ours on reload, or the browser's own on back/forward.
+  // settled one, so a deep link lands well past its target.
   const id = location.hash.slice(1);
   const isScrollAlreadyRestored = didRestoreScroll || navigationType === 'back_forward';
 
   if (id && !isScrollAlreadyRestored) {
-    const target = document.getElementById(id);
-    const headerHeight = document.querySelector('wa-page > header')?.clientHeight ?? 0;
+    // allDefined() covers definition plus a frame, not each element's own render.
+    const upgraded = [...document.querySelectorAll('*')].filter(el => el.updateComplete);
 
-    if (target) {
-      window.scrollTo(0, target.getBoundingClientRect().top + window.scrollY - headerHeight);
-    }
+    Promise.allSettled(upgraded.map(el => el.updateComplete))
+      .then(() => new Promise(requestAnimationFrame))
+      .then(() => {
+        const target = document.getElementById(id);
+        const headerHeight = document.querySelector('wa-page > header').clientHeight;
+
+        if (target) {
+          window.scrollTo(0, target.getBoundingClientRect().top + window.scrollY - headerHeight);
+        }
+      });
   }
 
   // After restoring, keep tabs on the page's scroll position for next reload


### PR DESCRIPTION
Links with a `#` in them, like `/support#client-projects`, can drop you in the wrong place on the page. This fixes that.

The page is about 3,200px taller before the components load. The browser jumps to the `#` using that taller version. Then the page shrinks, and your target ends up roughly 3,700px above the top of the screen, with nothing to scroll you back.

### The Fix
`scroll.js` already waited for components before restoring your scroll position on a reload. It never did the same for `#` links. Now it does, offset by the sticky header so the heading isn't tucked underneath it.

Two guards worth knowing about:
- If a scroll position was already restored, that wins. Covers reloads, and back or forward, where the browser puts you back where you were.
- `allDefined()` only waits for components to be defined, plus one frame. It doesn't wait for them to finish rendering. So this waits for every component's render as well, then takes a frame, before measuring anything.

### What This Doesn't Change
Both unchanged from before this PR: 
- clicking an anchor while the page is still loading
- clicking back or forward with no `#`.